### PR TITLE
chore(compiler): add t hash injection

### DIFF
--- a/.changeset/t-hash-injection.md
+++ b/.changeset/t-hash-injection.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/compiler': patch
+---
+
+patch: inject compile-time hashes into standalone t() calls

--- a/packages/compiler/src/passes/__tests__/runtimeTranslatePass.test.ts
+++ b/packages/compiler/src/passes/__tests__/runtimeTranslatePass.test.ts
@@ -600,7 +600,6 @@ describe('runtimeTranslatePass', () => {
     //   const gt = useGT(); gt("Callback string");
     //   t("Standalone string");
     // → both appear in Promise.all, AND the useGT injection (hash) still works
-    //   because t() uses runtimeOnlyEntries, not the counter-based aggregators
     it('t() does not disrupt useGT callback counter alignment', () => {
       const { runtimeCalls } = transform(`
         import { useGT, t } from 'gt-react';
@@ -722,6 +721,100 @@ describe('runtimeTranslatePass', () => {
 
       // Injection pass still ran — $_hash was injected into the callback
       expect(output).toContain('$_hash');
+    });
+
+    it('injects compile-time hash into standalone t() calls', () => {
+      const state = initializeState({}, 'test.tsx');
+      const ast = parser.parse(
+        `
+        import { t } from 'gt-react';
+        const msg = t("Hello world", { $context: "greeting" });
+      `,
+        {
+          sourceType: 'module',
+          plugins: ['jsx', 'typescript'],
+        }
+      );
+
+      traverse(ast, collectionPass(state));
+      traverse(ast, injectionPass(state));
+
+      const calls: t.CallExpression[] = [];
+      traverse(ast, {
+        CallExpression(path) {
+          if (t.isIdentifier(path.node.callee, { name: 't' })) {
+            calls.push(path.node);
+          }
+        },
+      });
+
+      expect(calls).toHaveLength(1);
+      expect(getOptionValue(calls[0], '$context')).toBe('greeting');
+      expect(getOptionValue(calls[0], '$_hash')).toBeDefined();
+    });
+
+    it('does not inject compile-time hash into msg() calls', () => {
+      const state = initializeState({}, 'test.tsx');
+      const ast = parser.parse(
+        `
+        import { msg } from 'gt-react';
+        const value = msg("Hello world");
+      `,
+        {
+          sourceType: 'module',
+          plugins: ['jsx', 'typescript'],
+        }
+      );
+
+      traverse(ast, collectionPass(state));
+      traverse(ast, injectionPass(state));
+
+      const calls: t.CallExpression[] = [];
+      traverse(ast, {
+        CallExpression(path) {
+          if (t.isIdentifier(path.node.callee, { name: 'msg' })) {
+            calls.push(path.node);
+          }
+        },
+      });
+
+      expect(calls).toHaveLength(1);
+      expect(getOptionValue(calls[0], '$_hash')).toBeUndefined();
+    });
+
+    it('keeps useGT callback hash alignment when standalone t() appears first', () => {
+      const state = initializeState({}, 'test.tsx');
+      const ast = parser.parse(
+        `
+        import { useGT, t } from 'gt-react';
+        const standalone = t("Standalone string");
+        const gt = useGT();
+        const callback = gt("Callback string");
+      `,
+        {
+          sourceType: 'module',
+          plugins: ['jsx', 'typescript'],
+        }
+      );
+
+      traverse(ast, collectionPass(state));
+      traverse(ast, injectionPass(state));
+
+      const calls: Record<string, t.CallExpression[]> = { t: [], gt: [] };
+      traverse(ast, {
+        CallExpression(path) {
+          if (t.isIdentifier(path.node.callee, { name: 't' })) {
+            calls.t.push(path.node);
+          } else if (t.isIdentifier(path.node.callee, { name: 'gt' })) {
+            calls.gt.push(path.node);
+          }
+        },
+      });
+
+      expect(calls.t).toHaveLength(1);
+      expect(calls.gt).toHaveLength(1);
+      expect(getOptionValue(calls.t[0], '$_hash')).toBeDefined();
+      expect(getOptionValue(calls.gt[0], '$_hash')).toBeDefined();
     });
 
     // devHotReload: false — no runtime translate calls injected at all

--- a/packages/compiler/src/processing/collection/processCallExpression.ts
+++ b/packages/compiler/src/processing/collection/processCallExpression.ts
@@ -26,7 +26,7 @@ import { registerTranslationComponent } from '../../transform/registration/regis
 import { getCalleeNameFromJsxExpressionParam } from '../../transform/jsx-children/utils/getCalleeNameFromJsxExpressionParam';
 import { createErrorLocation } from '../../utils/errors';
 import hashSource from '../../utils/calculateHash';
-import type { DataFormat } from 'generaltranslation/types';
+import { registerStandaloneTranslation } from '../../transform/registration/registerStandaloneTranslation';
 
 /**
  * Process call expressions
@@ -78,12 +78,12 @@ export function processCallExpression(
       type === 'generaltranslation' &&
       canonicalName === GT_OTHER_FUNCTIONS.msg
     ) {
-      handleStandaloneTranslation(callExpr, state);
+      handleStandaloneTranslation(callExpr, state, false);
     } else if (
       type === 'generaltranslation' &&
       canonicalName === GT_OTHER_FUNCTIONS.t
     ) {
-      handleStandaloneTranslation(callExpr, state);
+      handleStandaloneTranslation(callExpr, state, true);
     }
   };
 }
@@ -292,11 +292,11 @@ function handleReactInvocation(
 /**
  * Handle standalone translation functions: t() and msg()
  * Same argument structure as useGT_callback (message string + options object).
- * Pushes to runtimeOnlyEntries — bypasses the counter system so injection is unaffected.
  */
 function handleStandaloneTranslation(
   callExpr: t.CallExpression,
-  state: TransformState
+  state: TransformState,
+  injectHash: boolean
 ) {
   // Reuse the same validation as useGT_callback (identical argument structure)
   const params = validateUseGTCallback(callExpr, state);
@@ -309,24 +309,14 @@ function handleStandaloneTranslation(
     return;
   }
 
-  // Calculate hash
-  const hash =
-    params.hash ??
-    hashSource({
-      source: params.content,
-      ...(params.id && { id: params.id }),
-      ...(params.context && { context: params.context }),
-      ...(params.maxChars != null && { maxChars: params.maxChars }),
-      dataFormat: (params.format || 'ICU') as DataFormat,
-    });
-
-  // Push to runtime-only entries (no counter, no injection pass involvement)
-  state.stringCollector.pushRuntimeOnlyContent({
-    message: params.content,
-    hash,
+  registerStandaloneTranslation({
+    state,
+    content: params.content,
+    hash: params.hash,
     id: params.id,
     context: params.context,
     maxChars: params.maxChars,
     format: params.format,
+    injectHash,
   });
 }

--- a/packages/compiler/src/processing/injection/processCallExpression.ts
+++ b/packages/compiler/src/processing/injection/processCallExpression.ts
@@ -19,6 +19,8 @@ import { createErrorLocation } from '../../utils/errors';
 import { injectUseGTCallbackParameters } from '../../transform/injection/callbacks/injectUseGTCallbackParameters';
 import { injectUseTranslationsCallbackParameters } from '../../transform/injection/callbacks/injectUseTranslationsCallbackParameters';
 import { injectUseMessagesCallbackParameters } from '../../transform/injection/callbacks/injectUseMessagesCallbackParameters';
+import { injectStandaloneTFunctionParameters } from '../../transform/injection/injectStandaloneTFunctionParameters';
+
 /**
  * Process call expression:
  */
@@ -66,7 +68,7 @@ export function processCallExpression(
       type === 'generaltranslation' &&
       canonicalName === GT_OTHER_FUNCTIONS.t
     ) {
-      // TODO: Handle t() function
+      injectStandaloneTFunctionParameters(callExpr, state);
     }
   };
 }

--- a/packages/compiler/src/state/StringCollector.ts
+++ b/packages/compiler/src/state/StringCollector.ts
@@ -55,7 +55,7 @@ export class StringCollector {
   private hashAggregators: Map<number, TranslationHash> = new Map();
   /** Global counter incremented for each useGT/getGT call encountered */
   private globalCallCounter: number = 0;
-  /** Runtime-only entries for t(), msg(), tagged templates — bypasses the counter system */
+  /** Runtime-only entries for standalone strings consumed by runtime translate */
   private runtimeOnlyEntries: TranslationContent[] = [];
 
   /**
@@ -198,8 +198,7 @@ export class StringCollector {
   }
 
   /**
-   * Add a runtime-only translation entry (for t(), msg(), tagged templates).
-   * These bypass the counter system and are only consumed by the runtime translate pass.
+   * Add a runtime-only translation entry for the runtime translate pass.
    */
   pushRuntimeOnlyContent(content: TranslationContent): void {
     this.runtimeOnlyEntries.push(content);

--- a/packages/compiler/src/transform/injection/callbacks/injectUseGTCallbackParameters.ts
+++ b/packages/compiler/src/transform/injection/callbacks/injectUseGTCallbackParameters.ts
@@ -1,6 +1,8 @@
 import { TransformState } from '../../../state/types';
 import * as t from '@babel/types';
 import { validateUseGTCallback } from '../../validation/validateTranslationFunctionCallback';
+import { injectHashIntoTranslationOptions } from '../injectHashIntoTranslationOptions';
+
 /**
  * Injects parameters into invocation of useGT_callback(..., { $_hash })
  * @param parentIdentifier - identifier from callback declaration (ie maps to useGT() call)
@@ -29,26 +31,5 @@ export function injectUseGTCallbackParameters(
   }
 
   // Inject parameters into invocation
-  const newEntry = t.objectProperty(
-    t.stringLiteral('$_hash'),
-    t.stringLiteral(translationHash.hash)
-  );
-  if (callExpr.arguments.length === 1) {
-    // add a new object to arguments
-    callExpr.arguments.push(t.objectExpression([newEntry]));
-  } else if (callExpr.arguments.length === 2) {
-    if (t.isObjectExpression(callExpr.arguments[1])) {
-      // add a new object to second argument
-      callExpr.arguments[1].properties.push(newEntry);
-    } else if (t.isExpression(callExpr.arguments[1])) {
-      // convert identifier to object expression with spread
-      callExpr.arguments[1] = t.objectExpression([
-        t.spreadElement(callExpr.arguments[1]),
-        newEntry,
-      ]);
-    } else if (t.isArgumentPlaceholder(callExpr.arguments[1])) {
-      // add a new object to second argument
-      callExpr.arguments[1] = t.objectExpression([newEntry]);
-    }
-  }
+  injectHashIntoTranslationOptions(callExpr, translationHash.hash);
 }

--- a/packages/compiler/src/transform/injection/injectHashIntoTranslationOptions.ts
+++ b/packages/compiler/src/transform/injection/injectHashIntoTranslationOptions.ts
@@ -1,0 +1,36 @@
+import * as t from '@babel/types';
+import { USEGT_CALLBACK_OPTIONS } from '../../utils/constants/gt/constants';
+
+/**
+ * Inject $_hash into the second options argument for string translation calls.
+ */
+export function injectHashIntoTranslationOptions(
+  callExpr: t.CallExpression,
+  hash: string
+): void {
+  const newEntry = t.objectProperty(
+    t.stringLiteral(USEGT_CALLBACK_OPTIONS.$_hash),
+    t.stringLiteral(hash)
+  );
+
+  if (callExpr.arguments.length === 1) {
+    callExpr.arguments.push(t.objectExpression([newEntry]));
+    return;
+  }
+
+  if (callExpr.arguments.length !== 2) {
+    return;
+  }
+
+  const optionsArg = callExpr.arguments[1];
+  if (t.isObjectExpression(optionsArg)) {
+    optionsArg.properties.push(newEntry);
+  } else if (t.isExpression(optionsArg)) {
+    callExpr.arguments[1] = t.objectExpression([
+      t.spreadElement(optionsArg),
+      newEntry,
+    ]);
+  } else if (t.isArgumentPlaceholder(optionsArg)) {
+    callExpr.arguments[1] = t.objectExpression([newEntry]);
+  }
+}

--- a/packages/compiler/src/transform/injection/injectStandaloneTFunctionParameters.ts
+++ b/packages/compiler/src/transform/injection/injectStandaloneTFunctionParameters.ts
@@ -1,0 +1,34 @@
+import { TransformState } from '../../state/types';
+import * as t from '@babel/types';
+import { validateUseGTCallback } from '../validation/validateTranslationFunctionCallback';
+import { injectHashIntoTranslationOptions } from './injectHashIntoTranslationOptions';
+
+/**
+ * Injects $_hash into standalone t() invocations.
+ */
+export function injectStandaloneTFunctionParameters(
+  callExpr: t.CallExpression,
+  state: TransformState
+): void {
+  const params = validateUseGTCallback(callExpr, state);
+  state.errorTracker.addErrors(params.errors);
+  if (
+    params.errors.length > 0 ||
+    params.content === undefined ||
+    params.hasDeriveContext
+  ) {
+    return;
+  }
+
+  const counterId = state.stringCollector.incrementCounter();
+  if (params.hash !== undefined) {
+    return;
+  }
+
+  const translationHash = state.stringCollector.getTranslationHash(counterId);
+  if (translationHash === undefined) {
+    return;
+  }
+
+  injectHashIntoTranslationOptions(callExpr, translationHash.hash);
+}

--- a/packages/compiler/src/transform/injection/injectStandaloneTFunctionParameters.ts
+++ b/packages/compiler/src/transform/injection/injectStandaloneTFunctionParameters.ts
@@ -20,6 +20,8 @@ export function injectStandaloneTFunctionParameters(
     return;
   }
 
+  // Keep this aligned with collection, which registers every injectable t() call
+  // even when the call already has $_hash.
   const counterId = state.stringCollector.incrementCounter();
   if (params.hash !== undefined) {
     return;
@@ -27,6 +29,9 @@ export function injectStandaloneTFunctionParameters(
 
   const translationHash = state.stringCollector.getTranslationHash(counterId);
   if (translationHash === undefined) {
+    state.logger.logError(
+      `[injectStandaloneTFunctionParameters] No hash found for counterId=${counterId}. Counter alignment may be broken.`
+    );
     return;
   }
 

--- a/packages/compiler/src/transform/registration/registerStandaloneTranslation.ts
+++ b/packages/compiler/src/transform/registration/registerStandaloneTranslation.ts
@@ -1,0 +1,52 @@
+import { TransformState } from '../../state/types';
+import hashSource from '../../utils/calculateHash';
+import type { DataFormat } from 'generaltranslation/types';
+
+/**
+ * Track standalone string translation invocations such as t() and msg().
+ */
+export function registerStandaloneTranslation({
+  state,
+  content,
+  context,
+  id,
+  maxChars,
+  hash,
+  format,
+  injectHash,
+}: {
+  state: TransformState;
+  content: string;
+  context?: string;
+  id?: string;
+  maxChars?: number;
+  hash?: string;
+  format?: string;
+  injectHash?: boolean;
+}): void {
+  hash ??= hashSource({
+    source: content,
+    ...(id && { id }),
+    ...(context && { context }),
+    ...(maxChars != null && { maxChars }),
+    dataFormat: (format || 'ICU') as DataFormat,
+  });
+
+  state.stringCollector.pushRuntimeOnlyContent({
+    message: content,
+    hash,
+    id,
+    context,
+    maxChars,
+    format,
+  });
+
+  if (!injectHash) {
+    return;
+  }
+
+  const counterId = state.stringCollector.incrementCounter();
+  state.stringCollector.setTranslationHash(counterId, {
+    hash,
+  });
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements compile-time hash injection into standalone `t()` calls, mirroring the existing hash injection for `useGT`/`getGT` callback invocations. It refactors the shared injection logic into `injectHashIntoTranslationOptions`, adds `registerStandaloneTranslation` to hook `t()` into the counter-based aggregator system, and adds three new test cases to validate alignment between the collection and injection passes.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — counter alignment between collection and injection passes is correctly maintained for all early-return conditions, and the new tests validate the key alignment scenario.

No P0 or P1 issues found. The refactoring is clean: shared injection logic is correctly extracted, msg() remains excluded from the counter system, t() is properly registered with injectHash=true, and the early-return guards in both passes are symmetric so counter alignment cannot drift.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/compiler/src/transform/registration/registerStandaloneTranslation.ts | New file: registers t()/msg() into the runtime-only entries and optionally participates in the counter-based hash aggregator for hash injection; logic is correct and symmetric with the injection pass. |
| packages/compiler/src/transform/injection/injectStandaloneTFunctionParameters.ts | New file: injects $_hash into standalone t() calls; counter is incremented unconditionally (aligned with collection pass) and an error is logged on hash-lookup failure. |
| packages/compiler/src/transform/injection/injectHashIntoTranslationOptions.ts | New shared utility extracted from injectUseGTCallbackParameters; handles 1-arg (push new object) and 2-arg (ObjectExpression, spread, or ArgumentPlaceholder) cases; 0-arg silently no-ops but is prevented by upstream validation. |
| packages/compiler/src/processing/collection/processCallExpression.ts | handleStandaloneTranslation now accepts injectHash flag; msg() passes false, t() passes true, correctly differentiating hash participation. |
| packages/compiler/src/processing/injection/processCallExpression.ts | Replaces the TODO placeholder for t() with injectStandaloneTFunctionParameters; msg() correctly remains unhandled. |
| packages/compiler/src/transform/injection/callbacks/injectUseGTCallbackParameters.ts | Refactored to delegate hash injection to the new shared injectHashIntoTranslationOptions; behavior unchanged. |
| packages/compiler/src/passes/__tests__/runtimeTranslatePass.test.ts | Adds three new test cases covering hash injection into t(), no injection into msg(), and counter alignment when t() precedes useGT() callbacks. |
| packages/compiler/src/state/StringCollector.ts | Minor doc-comment update clarifying that runtimeOnlyEntries is for the runtime translate pass; no logic changes. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant AST
    participant CollectionPass as Collection Pass
    participant RST as registerStandaloneTranslation
    participant SC as StringCollector
    participant InjectionPass as Injection Pass
    participant ISTFP as injectStandaloneTFunctionParameters
    participant IH as injectHashIntoTranslationOptions

    Note over AST,IH: Pass 1 - Collection

    AST->>CollectionPass: t call with string and context
    CollectionPass->>CollectionPass: validateUseGTCallback()
    CollectionPass->>RST: registerStandaloneTranslation injectHash true
    RST->>SC: pushRuntimeOnlyContent
    RST->>SC: incrementCounter returns N
    RST->>SC: setTranslationHash N hash

    Note over AST,IH: Pass 2 - Injection

    AST->>InjectionPass: same t call
    InjectionPass->>ISTFP: injectStandaloneTFunctionParameters
    ISTFP->>ISTFP: validateUseGTCallback()
    ISTFP->>SC: incrementCounter returns N
    ISTFP->>SC: getTranslationHash N
    ISTFP->>IH: injectHashIntoTranslationOptions
    IH->>AST: t call now includes dollar hash
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix greptile"](https://github.com/generaltranslation/gt/commit/048cd65ff819d1bd6d9981196d8cc17f894ab4e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29685233)</sub>

<!-- /greptile_comment -->