### PR TITLE
refactor: split GTFormatter from GT to reduce client bundle size

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,6 +67,16 @@
         "default": "./dist/index.mjs"
       }
     },
+    "./format": {
+      "require": {
+        "types": "./dist/format.d.cts",
+        "default": "./dist/format.cjs"
+      },
+      "import": {
+        "types": "./dist/format.d.mts",
+        "default": "./dist/format.mjs"
+      }
+    },
     "./id": {
       "require": {
         "types": "./dist/id.d.cts",
@@ -110,6 +120,9 @@
   },
   "typesVersions": {
     "*": {
+      "format": [
+        "./dist/format.d.cts"
+      ],
       "internal": [
         "./dist/internal.d.cts"
       ],
@@ -127,6 +140,9 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
+      "generaltranslation/format": [
+        "/dist/format"
+      ],
       "generaltranslation/internal": [
         "/dist/internal"
       ],

--- a/packages/core/src/format.ts
+++ b/packages/core/src/format.ts
@@ -1,0 +1,622 @@
+// `generaltranslation` language toolkit
+// © 2026, General Translation, Inc.
+
+import _requiresTranslation from './locales/requiresTranslation';
+import _determineLocale from './locales/determineLocale';
+import {
+  _formatNum,
+  _formatCurrency,
+  _formatList,
+  _formatRelativeTime,
+  _formatRelativeTimeFromDate,
+  _formatDateTime,
+  _formatListToParts,
+  _formatCutoff,
+  _formatMessageICU,
+  _formatMessageString,
+} from './formatting/format';
+import { CustomMapping, FormatVariables } from './types';
+import _isSameLanguage from './locales/isSameLanguage';
+import _getLocaleProperties, {
+  LocaleProperties,
+} from './locales/getLocaleProperties';
+import _getLocaleEmoji from './locales/getLocaleEmoji';
+import { _isValidLocale, _standardizeLocale } from './locales/isValidLocale';
+import { _getLocaleName } from './locales/getLocaleName';
+import { _getLocaleDirection } from './locales/getLocaleDirection';
+import { libraryDefaultLocale } from './internal';
+import _isSameDialect from './locales/isSameDialect';
+import _isSupersetLocale from './locales/isSupersetLocale';
+import {
+  noSourceLocaleProvidedError,
+  noTargetLocaleProvidedError,
+  invalidLocaleError,
+  invalidLocalesError,
+} from './logging/errors';
+import {
+  _getRegionProperties,
+  CustomRegionMapping,
+} from './locales/getRegionProperties';
+import { _resolveAliasLocale } from './locales/resolveAliasLocale';
+import { _resolveCanonicalLocale } from './locales/resolveCanonicalLocale';
+import { CutoffFormatOptions } from './formatting/custom-formats/CutoffFormat/types';
+import { StringFormat } from './types-dir/jsx/content';
+
+/**
+ * Type representing the constructor parameters for the GTFormatter class.
+ */
+export type GTFormatterConstructorParams = {
+  sourceLocale?: string;
+  targetLocale?: string;
+  locales?: string[];
+  customMapping?: CustomMapping;
+};
+
+/**
+ * GTFormatter is a lightweight class for locale management and formatting.
+ * It provides all formatting and locale utility methods without the API client overhead.
+ * Use this instead of GT on the client side to reduce bundle size.
+ *
+ * @class GTFormatter
+ */
+export class GTFormatter {
+  /** Source locale for translations */
+  sourceLocale?: string;
+
+  /** Target locale for translations */
+  targetLocale?: string;
+
+  /** Array of supported locales */
+  locales?: string[];
+
+  /** Array of locales used for rendering variables */
+  _renderingLocales: string[] = [];
+
+  /** Custom mapping for locale codes to their names */
+  customMapping?: CustomMapping;
+
+  /** Lazily derived reverse custom mapping for alias locales */
+  reverseCustomMapping?: Record<string, string>;
+
+  /** Lazily derived custom mapping for regions */
+  customRegionMapping?: CustomRegionMapping;
+
+  constructor(params: GTFormatterConstructorParams = {}) {
+    this.setConfig(params);
+  }
+
+  setConfig({
+    sourceLocale,
+    targetLocale,
+    locales,
+    customMapping,
+  }: GTFormatterConstructorParams) {
+    // ----- Standardize locales ----- //
+
+    // source locale
+    if (sourceLocale) {
+      this.sourceLocale = _standardizeLocale(sourceLocale);
+      if (!_isValidLocale(this.sourceLocale, customMapping))
+        throw new Error(invalidLocaleError(this.sourceLocale));
+    }
+
+    // target locale
+    if (targetLocale) {
+      this.targetLocale = _standardizeLocale(targetLocale);
+      if (!_isValidLocale(this.targetLocale, customMapping))
+        throw new Error(invalidLocaleError(this.targetLocale));
+    }
+
+    // rendering locales
+    this._renderingLocales = [];
+    if (this.sourceLocale) this._renderingLocales.push(this.sourceLocale);
+    if (this.targetLocale) this._renderingLocales.push(this.targetLocale);
+    this._renderingLocales.push(libraryDefaultLocale);
+
+    // locales
+    if (locales) {
+      const result: string[] = [];
+      const invalidLocales: string[] = [];
+      locales.forEach((locale) => {
+        const standardizedLocale = _standardizeLocale(locale);
+        if (_isValidLocale(standardizedLocale)) {
+          result.push(standardizedLocale);
+        } else {
+          invalidLocales.push(locale);
+        }
+      });
+      if (invalidLocales.length > 0) {
+        throw new Error(invalidLocalesError(invalidLocales));
+      }
+      this.locales = result;
+    }
+
+    // ----- Other properties ----- //
+    if (customMapping) {
+      this.customMapping = customMapping;
+      this.reverseCustomMapping = Object.fromEntries(
+        Object.entries(customMapping)
+          .filter(
+            ([, value]) => value && typeof value === 'object' && 'code' in value
+          )
+          .map(([key, value]) => [(value as { code: string }).code, key])
+      );
+    }
+  }
+
+  // -------------- Formatting -------------- //
+
+  formatCutoff(
+    value: string,
+    options?: {
+      locales?: string | string[];
+    } & CutoffFormatOptions
+  ): string {
+    return _formatCutoff({
+      value,
+      locales: options?.locales || this._renderingLocales,
+      options,
+    });
+  }
+
+  formatMessage(
+    message: string,
+    options?: {
+      locales?: string | string[];
+      variables?: FormatVariables;
+      dataFormat?: StringFormat;
+    }
+  ): string {
+    if (options?.dataFormat === 'STRING') return _formatMessageString(message);
+    return _formatMessageICU(
+      message,
+      options?.locales || this._renderingLocales,
+      options?.variables
+    );
+  }
+
+  formatNum(
+    number: number,
+    options?: {
+      locales?: string | string[];
+    } & Intl.NumberFormatOptions
+  ): string {
+    return _formatNum({
+      value: number,
+      locales: options?.locales || this._renderingLocales,
+      options,
+    });
+  }
+
+  formatDateTime(
+    date: Date,
+    options?: {
+      locales?: string | string[];
+    } & Intl.DateTimeFormatOptions
+  ): string {
+    return _formatDateTime({
+      value: date,
+      locales: options?.locales || this._renderingLocales,
+      options,
+    });
+  }
+
+  formatCurrency(
+    value: number,
+    currency: string,
+    options?: {
+      locales?: string | string[];
+    } & Intl.NumberFormatOptions
+  ): string {
+    return _formatCurrency({
+      value,
+      currency,
+      locales: options?.locales || this._renderingLocales,
+      options,
+    });
+  }
+
+  formatList(
+    array: Array<string | number>,
+    options?: {
+      locales?: string | string[];
+    } & Intl.ListFormatOptions
+  ) {
+    return _formatList({
+      value: array,
+      locales: options?.locales || this._renderingLocales,
+      options,
+    });
+  }
+
+  formatListToParts<T>(
+    array: Array<T>,
+    options?: {
+      locales?: string | string[];
+    } & Intl.ListFormatOptions
+  ): Array<T | string> {
+    return _formatListToParts<T>({
+      value: array,
+      locales: options?.locales || this._renderingLocales,
+      options,
+    });
+  }
+
+  formatRelativeTime(
+    value: number,
+    unit: Intl.RelativeTimeFormatUnit,
+    options?: {
+      locales?: string | string[];
+    } & Omit<Intl.RelativeTimeFormatOptions, 'locales'>
+  ): string {
+    return _formatRelativeTime({
+      value,
+      unit,
+      locales: options?.locales || this._renderingLocales,
+      options,
+    });
+  }
+
+  formatRelativeTimeFromDate(
+    date: Date,
+    options?: {
+      locales?: string | string[];
+      baseDate?: Date;
+    } & Omit<Intl.RelativeTimeFormatOptions, 'locales'>
+  ): string {
+    const { locales, baseDate, ...intlOptions } = options || {};
+    return _formatRelativeTimeFromDate({
+      date,
+      baseDate: baseDate ?? new Date(),
+      locales: locales || this._renderingLocales,
+      options: intlOptions,
+    });
+  }
+
+  // -------------- Locale Properties -------------- //
+
+  getLocaleName(locale = this.targetLocale): string {
+    if (!locale) throw new Error(noTargetLocaleProvidedError('getLocaleName'));
+    return _getLocaleName(locale, this.sourceLocale, this.customMapping);
+  }
+
+  getLocaleEmoji(locale = this.targetLocale): string {
+    if (!locale) throw new Error(noTargetLocaleProvidedError('getLocaleEmoji'));
+    return _getLocaleEmoji(locale, this.customMapping);
+  }
+
+  getLocaleProperties(locale = this.targetLocale): LocaleProperties {
+    if (!locale)
+      throw new Error(noTargetLocaleProvidedError('getLocaleProperties'));
+    return _getLocaleProperties(locale, this.sourceLocale, this.customMapping);
+  }
+
+  getRegionProperties(
+    region = this.getLocaleProperties().regionCode,
+    customMapping?: CustomRegionMapping
+  ): { code: string; name: string; emoji: string } {
+    if (!customMapping) {
+      if (this.customMapping && !this.customRegionMapping) {
+        const customRegionMapping: CustomRegionMapping = {};
+        for (const [locale, lp] of Object.entries(this.customMapping)) {
+          if (
+            lp &&
+            typeof lp === 'object' &&
+            lp.regionCode &&
+            !customRegionMapping[lp.regionCode]
+          ) {
+            const { regionName: name, emoji } = lp;
+            customRegionMapping[lp.regionCode] = {
+              locale,
+              ...(name && { name }),
+              ...(emoji && { emoji }),
+            };
+          }
+        }
+        this.customRegionMapping = customRegionMapping;
+      }
+      customMapping = this.customRegionMapping;
+    }
+    return _getRegionProperties(region, this.targetLocale, customMapping);
+  }
+
+  requiresTranslation(
+    sourceLocale = this.sourceLocale,
+    targetLocale = this.targetLocale,
+    approvedLocales: string[] | undefined = this.locales,
+    customMapping: CustomMapping | undefined = this.customMapping
+  ): boolean {
+    if (!sourceLocale)
+      throw new Error(noSourceLocaleProvidedError('requiresTranslation'));
+    if (!targetLocale)
+      throw new Error(noTargetLocaleProvidedError('requiresTranslation'));
+    return _requiresTranslation(
+      sourceLocale,
+      targetLocale,
+      approvedLocales,
+      customMapping
+    );
+  }
+
+  determineLocale(
+    locales: string | string[],
+    approvedLocales: string[] | undefined = this.locales || [],
+    customMapping: CustomMapping | undefined = this.customMapping
+  ): string | undefined {
+    return _determineLocale(locales, approvedLocales, customMapping);
+  }
+
+  getLocaleDirection(locale = this.targetLocale): 'ltr' | 'rtl' {
+    if (!locale)
+      throw new Error(noTargetLocaleProvidedError('getLocaleDirection'));
+    return _getLocaleDirection(locale);
+  }
+
+  isValidLocale(
+    locale = this.targetLocale,
+    customMapping: CustomMapping | undefined = this.customMapping
+  ): boolean {
+    if (!locale) throw new Error(noTargetLocaleProvidedError('isValidLocale'));
+    return _isValidLocale(locale, customMapping);
+  }
+
+  resolveCanonicalLocale(
+    locale: string | undefined = this.targetLocale,
+    customMapping: CustomMapping | undefined = this.customMapping
+  ): string {
+    if (!locale)
+      throw new Error(noTargetLocaleProvidedError('resolveCanonicalLocale'));
+    return _resolveCanonicalLocale(locale, customMapping);
+  }
+
+  resolveAliasLocale(
+    locale: string,
+    customMapping: CustomMapping | undefined = this.customMapping
+  ): string {
+    if (!locale)
+      throw new Error(noTargetLocaleProvidedError('resolveAliasLocale'));
+    return _resolveAliasLocale(locale, customMapping);
+  }
+
+  standardizeLocale(locale = this.targetLocale): string {
+    if (!locale)
+      throw new Error(noTargetLocaleProvidedError('standardizeLocale'));
+    return _standardizeLocale(locale);
+  }
+
+  isSameDialect(...locales: (string | string[])[]): boolean {
+    return _isSameDialect(...locales);
+  }
+
+  isSameLanguage(...locales: (string | string[])[]): boolean {
+    return _isSameLanguage(...locales);
+  }
+
+  isSupersetLocale(superLocale: string, subLocale: string): boolean {
+    return _isSupersetLocale(superLocale, subLocale);
+  }
+}
+
+// ============================================================ //
+//                    Standalone utility functions               //
+// ============================================================ //
+
+export function formatCutoff(
+  value: string,
+  options?: {
+    locales?: string | string[];
+  } & CutoffFormatOptions
+): string {
+  return _formatCutoff({ value, locales: options?.locales, options });
+}
+
+export function formatMessage(
+  message: string,
+  options?: {
+    locales?: string | string[];
+    variables?: FormatVariables;
+    dataFormat?: StringFormat;
+  }
+): string {
+  switch (options?.dataFormat) {
+    case 'STRING':
+      return _formatMessageString(message);
+    default:
+      return _formatMessageICU(message, options?.locales, options?.variables);
+  }
+}
+
+export function formatNum(
+  number: number,
+  options: {
+    locales: string | string[];
+  } & Intl.NumberFormatOptions
+): string {
+  return _formatNum({
+    value: number,
+    locales: options.locales,
+    options,
+  });
+}
+
+export function formatDateTime(
+  date: Date,
+  options?: {
+    locales?: string | string[];
+  } & Intl.DateTimeFormatOptions
+): string {
+  return _formatDateTime({
+    value: date,
+    locales: options?.locales,
+    options,
+  });
+}
+
+export function formatCurrency(
+  value: number,
+  currency: string,
+  options: {
+    locales: string | string[];
+  } & Intl.NumberFormatOptions
+): string {
+  return _formatCurrency({
+    value,
+    currency,
+    locales: options.locales,
+    options,
+  });
+}
+
+export function formatList(
+  array: Array<string | number>,
+  options: {
+    locales: string | string[];
+  } & Intl.ListFormatOptions
+): string {
+  return _formatList({
+    value: array,
+    locales: options.locales,
+    options,
+  });
+}
+
+export function formatListToParts<T>(
+  array: Array<T>,
+  options?: {
+    locales?: string | string[];
+  } & Intl.ListFormatOptions
+): Array<T | string> {
+  return _formatListToParts<T>({
+    value: array,
+    locales: options?.locales,
+    options: options,
+  });
+}
+
+export function formatRelativeTime(
+  value: number,
+  unit: Intl.RelativeTimeFormatUnit,
+  options: {
+    locales: string | string[];
+  } & Omit<Intl.RelativeTimeFormatOptions, 'locales'>
+): string {
+  return _formatRelativeTime({
+    value,
+    unit,
+    locales: options.locales,
+    options,
+  });
+}
+
+export function formatRelativeTimeFromDate(
+  date: Date,
+  options: {
+    locales: string | string[];
+    baseDate?: Date;
+  } & Omit<Intl.RelativeTimeFormatOptions, 'locales'>
+): string {
+  const { locales, baseDate, ...intlOptions } = options;
+  return _formatRelativeTimeFromDate({
+    date,
+    baseDate: baseDate ?? new Date(),
+    locales,
+    options: intlOptions,
+  });
+}
+
+export function getLocaleName(
+  locale: string,
+  defaultLocale?: string,
+  customMapping?: CustomMapping
+): string {
+  return _getLocaleName(locale, defaultLocale, customMapping);
+}
+
+export function getLocaleEmoji(
+  locale: string,
+  customMapping?: CustomMapping
+): string {
+  return _getLocaleEmoji(locale, customMapping);
+}
+
+export function getLocaleProperties(
+  locale: string,
+  defaultLocale?: string,
+  customMapping?: CustomMapping
+): LocaleProperties {
+  return _getLocaleProperties(locale, defaultLocale, customMapping);
+}
+
+export function getRegionProperties(
+  region: string,
+  defaultLocale?: string,
+  customMapping?: CustomRegionMapping
+): { code: string; name: string; emoji: string } {
+  return _getRegionProperties(region, defaultLocale, customMapping);
+}
+
+export function requiresTranslation(
+  sourceLocale: string,
+  targetLocale: string,
+  approvedLocales?: string[],
+  customMapping?: CustomMapping
+): boolean {
+  return _requiresTranslation(
+    sourceLocale,
+    targetLocale,
+    approvedLocales,
+    customMapping
+  );
+}
+
+export function determineLocale(
+  locales: string | string[],
+  approvedLocales: string[] | undefined = [],
+  customMapping: CustomMapping | undefined = undefined
+): string | undefined {
+  return _determineLocale(locales, approvedLocales, customMapping);
+}
+
+export function getLocaleDirection(locale: string): 'ltr' | 'rtl' {
+  return _getLocaleDirection(locale);
+}
+
+export function isValidLocale(
+  locale: string,
+  customMapping?: CustomMapping
+): boolean {
+  return _isValidLocale(locale, customMapping);
+}
+
+export function resolveAliasLocale(
+  locale: string,
+  customMapping?: CustomMapping
+): string {
+  return _resolveAliasLocale(locale, customMapping);
+}
+
+export function resolveCanonicalLocale(
+  locale: string,
+  customMapping?: CustomMapping
+): string {
+  return _resolveCanonicalLocale(locale, customMapping);
+}
+
+export function standardizeLocale(locale: string): string {
+  return _standardizeLocale(locale);
+}
+
+export function isSameDialect(...locales: (string | string[])[]): boolean {
+  return _isSameDialect(...locales);
+}
+
+export function isSameLanguage(...locales: (string | string[])[]): boolean {
+  return _isSameLanguage(...locales);
+}
+
+export function isSupersetLocale(
+  superLocale: string,
+  subLocale: string
+): boolean {
+  return _isSupersetLocale(superLocale, subLocale);
+}

--- a/packages/core/src/format.ts
+++ b/packages/core/src/format.ts
@@ -44,6 +44,11 @@ import { StringFormat } from './types-dir/jsx/content';
 
 /**
  * Type representing the constructor parameters for the GTFormatter class.
+ * @typedef {Object} GTFormatterConstructorParams
+ * @property {string} [sourceLocale] - The default source locale for translations
+ * @property {string} [targetLocale] - The default target locale for translations
+ * @property {string[]} [locales] - Array of supported locales
+ * @property {CustomMapping} [customMapping] - Custom mapping of locale codes to their names
  */
 export type GTFormatterConstructorParams = {
   sourceLocale?: string;
@@ -146,6 +151,35 @@ export class GTFormatter {
 
   // -------------- Formatting -------------- //
 
+  /**
+   * Formats a string with cutoff behavior, applying a terminator when the string exceeds the maximum character limit.
+   *
+   * This method uses the formatter instance's rendering locales by default for locale-specific terminator selection,
+   * but can be overridden with custom locales in the options.
+   *
+   * @param {string} value - The string value to format with cutoff behavior.
+   * @param {Object} [options] - Configuration options for cutoff formatting.
+   * @param {string | string[]} [options.locales] - The locales to use for terminator selection. Defaults to instance's rendering locales.
+   * @param {number} [options.maxChars] - The maximum number of characters to display.
+   * - Undefined values are treated as no cutoff.
+   * - Negative values follow .slice() behavior and terminator will be added before the value.
+   * - 0 will result in an empty string.
+   * - If cutoff results in an empty string, no terminator is added.
+   * @param {CutoffFormatStyle} [options.style='ellipsis'] - The style of the terminator.
+   * @param {string} [options.terminator] - Optional override the terminator to use.
+   * @param {string} [options.separator] - Optional override the separator to use between the terminator and the value.
+   * - If no terminator is provided, then separator is ignored.
+   * @returns {string} The formatted string with terminator applied if cutoff occurs.
+   *
+   * @example
+   * const gt = new GTFormatter({ targetLocale: 'en-US' });
+   * gt.formatCutoff('Hello, world!', { maxChars: 8 });
+   * // Returns: 'Hello, w...'
+   *
+   * @example
+   * gt.formatCutoff('Hello, world!', { maxChars: -3 });
+   * // Returns: '...ld!'
+   */
   formatCutoff(
     value: string,
     options?: {
@@ -159,6 +193,22 @@ export class GTFormatter {
     });
   }
 
+  /**
+   * Formats a message according to the specified locales and options.
+   *
+   * @param {string} message - The message to format.
+   * @param {string | string[]} [locales='en'] - The locales to use for formatting.
+   * @param {FormatVariables} [variables={}] - The variables to use for formatting.
+   * @param {StringFormat} [dataFormat='ICU'] - The format of the message.
+   * @returns {string} The formatted message.
+   *
+   * @example
+   * gt.formatMessage('Hello {name}', { name: 'John' });
+   * // Returns: "Hello John"
+   *
+   * gt.formatMessage('Hello {name}', { name: 'John' }, { locales: ['fr'] });
+   * // Returns: "Bonjour John"
+   */
   formatMessage(
     message: string,
     options?: {
@@ -175,6 +225,19 @@ export class GTFormatter {
     );
   }
 
+  /**
+   * Formats a number according to the specified locales and options.
+   *
+   * @param {number} number - The number to format
+   * @param {Object} [options] - Additional options for number formatting
+   * @param {string | string[]} [options.locales] - The locales to use for formatting
+   * @param {Intl.NumberFormatOptions} [options] - Additional Intl.NumberFormat options
+   * @returns {string} The formatted number
+   *
+   * @example
+   * gt.formatNum(1234.56, { style: 'currency', currency: 'USD' });
+   * // Returns: "$1,234.56"
+   */
   formatNum(
     number: number,
     options?: {
@@ -188,6 +251,19 @@ export class GTFormatter {
     });
   }
 
+  /**
+   * Formats a date according to the specified locales and options.
+   *
+   * @param {Date} date - The date to format
+   * @param {Object} [options] - Additional options for date formatting
+   * @param {string | string[]} [options.locales] - The locales to use for formatting
+   * @param {Intl.DateTimeFormatOptions} [options] - Additional Intl.DateTimeFormat options
+   * @returns {string} The formatted date
+   *
+   * @example
+   * gt.formatDateTime(new Date(), { dateStyle: 'full', timeStyle: 'long' });
+   * // Returns: "Thursday, March 14, 2024 at 2:30:45 PM GMT-7"
+   */
   formatDateTime(
     date: Date,
     options?: {
@@ -201,6 +277,20 @@ export class GTFormatter {
     });
   }
 
+  /**
+   * Formats a currency value according to the specified locales and options.
+   *
+   * @param {number} value - The currency value to format
+   * @param {string} currency - The currency code (e.g., 'USD', 'EUR')
+   * @param {Object} [options] - Additional options for currency formatting
+   * @param {string | string[]} [options.locales] - The locales to use for formatting
+   * @param {Intl.NumberFormatOptions} [options] - Additional Intl.NumberFormat options
+   * @returns {string} The formatted currency value
+   *
+   * @example
+   * gt.formatCurrency(1234.56, 'USD', { style: 'currency' });
+   * // Returns: "$1,234.56"
+   */
   formatCurrency(
     value: number,
     currency: string,
@@ -216,6 +306,19 @@ export class GTFormatter {
     });
   }
 
+  /**
+   * Formats a list of items according to the specified locales and options.
+   *
+   * @param {Array<string | number>} array - The list of items to format
+   * @param {Object} [options] - Additional options for list formatting
+   * @param {string | string[]} [options.locales] - The locales to use for formatting
+   * @param {Intl.ListFormatOptions} [options] - Additional Intl.ListFormat options
+   * @returns {string} The formatted list
+   *
+   * @example
+   * gt.formatList(['apple', 'banana', 'orange'], { type: 'conjunction' });
+   * // Returns: "apple, banana, and orange"
+   */
   formatList(
     array: Array<string | number>,
     options?: {
@@ -229,6 +332,18 @@ export class GTFormatter {
     });
   }
 
+  /**
+   * Formats a list of items according to the specified locales and options.
+   * @param {Array<T>} array - The list of items to format
+   * @param {Object} [options] - Additional options for list formatting
+   * @param {string | string[]} [options.locales] - The locales to use for formatting
+   * @param {Intl.ListFormatOptions} [options] - Additional Intl.ListFormat options
+   * @returns {Array<T | string>} The formatted list parts
+   *
+   * @example
+   * gt.formatListToParts(['apple', 42, { foo: 'bar' }], { type: 'conjunction', style: 'short', locales: ['en'] });
+   * // Returns: ['apple', ', ', 42, ' and ', '{ foo: "bar" }']
+   */
   formatListToParts<T>(
     array: Array<T>,
     options?: {
@@ -242,6 +357,20 @@ export class GTFormatter {
     });
   }
 
+  /**
+   * Formats a relative time value according to the specified locales and options.
+   *
+   * @param {number} value - The relative time value to format
+   * @param {Intl.RelativeTimeFormatUnit} unit - The unit of time (e.g., 'second', 'minute', 'hour', 'day', 'week', 'month', 'year')
+   * @param {Object} options - Additional options for relative time formatting
+   * @param {string | string[]} [options.locales] - The locales to use for formatting
+   * @param {Intl.RelativeTimeFormatOptions} [options] - Additional Intl.RelativeTimeFormat options
+   * @returns {string} The formatted relative time string
+   *
+   * @example
+   * gt.formatRelativeTime(-1, 'day', { locales: ['en-US'], numeric: 'auto' });
+   * // Returns: "yesterday"
+   */
   formatRelativeTime(
     value: number,
     unit: Intl.RelativeTimeFormatUnit,
@@ -257,6 +386,18 @@ export class GTFormatter {
     });
   }
 
+  /**
+   * Formats a relative time string from a Date, automatically selecting the best unit.
+   *
+   * @param {Date} date - The date to format relative to now
+   * @param {Object} [options] - Additional options for relative time formatting
+   * @param {string | string[]} [options.locales] - The locales to use for formatting
+   * @returns {string} The formatted relative time string (e.g., "2 hours ago", "in 3 days")
+   *
+   * @example
+   * gt.formatRelativeTimeFromDate(new Date(Date.now() - 3600000));
+   * // Returns: "1 hour ago"
+   */
   formatRelativeTimeFromDate(
     date: Date,
     options?: {
@@ -275,28 +416,121 @@ export class GTFormatter {
 
   // -------------- Locale Properties -------------- //
 
+  /**
+   * Retrieves the display name of a locale code using Intl.DisplayNames, returning an empty string if no name is found.
+   *
+   * @param {string} [locale=this.targetLocale] - A BCP-47 locale code
+   * @returns {string} The display name corresponding to the code
+   * @throws {Error} If no target locale is provided
+   *
+   * @example
+   * gt.getLocaleName('es-ES');
+   * // Returns: "Spanish (Spain)"
+   */
   getLocaleName(locale = this.targetLocale): string {
     if (!locale) throw new Error(noTargetLocaleProvidedError('getLocaleName'));
     return _getLocaleName(locale, this.sourceLocale, this.customMapping);
   }
 
+  /**
+   * Retrieves an emoji based on a given locale code.
+   * Uses the locale's region (if present) to select an emoji or falls back on default emojis.
+   *
+   * @param {string} [locale=this.targetLocale] - A BCP-47 locale code (e.g., 'en-US', 'fr-CA')
+   * @returns {string} The emoji representing the locale or its region
+   * @throws {Error} If no target locale is provided
+   *
+   * @example
+   * gt.getLocaleEmoji('es-ES');
+   * // Returns: "🇪🇸"
+   */
   getLocaleEmoji(locale = this.targetLocale): string {
     if (!locale) throw new Error(noTargetLocaleProvidedError('getLocaleEmoji'));
     return _getLocaleEmoji(locale, this.customMapping);
   }
 
+  /**
+   * Generates linguistic details for a given locale code.
+   *
+   * This function returns information about the locale,
+   * script, and region of a given language code both in a standard form and in a maximized form (with likely script and region).
+   * The function provides these names in both your default language and native forms, and an associated emoji.
+   *
+   * @param {string} [locale=this.targetLocale] - The locale code to get properties for (e.g., "de-AT").
+   * @returns {LocaleProperties} - An object containing detailed information about the locale.
+   *
+   * @property {string} code - The full locale code, e.g., "de-AT".
+   * @property {string} name - Language name in the default display language, e.g., "Austrian German".
+   * @property {string} nativeName - Language name in the locale's native language, e.g., "Österreichisches Deutsch".
+   * @property {string} languageCode - The base language code, e.g., "de".
+   * @property {string} languageName - The language name in the default display language, e.g., "German".
+   * @property {string} nativeLanguageName - The language name in the native language, e.g., "Deutsch".
+   * @property {string} nameWithRegionCode - Language name with region in the default language, e.g., "German (AT)".
+   * @property {string} nativeNameWithRegionCode - Language name with region in the native language, e.g., "Deutsch (AT)".
+   * @property {string} regionCode - The region code from maximization, e.g., "AT".
+   * @property {string} regionName - The region name in the default display language, e.g., "Austria".
+   * @property {string} nativeRegionName - The region name in the native language, e.g., "Österreich".
+   * @property {string} scriptCode - The script code from maximization, e.g., "Latn".
+   * @property {string} scriptName - The script name in the default display language, e.g., "Latin".
+   * @property {string} nativeScriptName - The script name in the native language, e.g., "Lateinisch".
+   * @property {string} maximizedCode - The maximized locale code, e.g., "de-Latn-AT".
+   * @property {string} maximizedName - Maximized locale name with likely script in the default language, e.g., "Austrian German (Latin)".
+   * @property {string} nativeMaximizedName - Maximized locale name in the native language, e.g., "Österreichisches Deutsch (Lateinisch)".
+   * @property {string} minimizedCode - Minimized locale code, e.g., "de-AT" (or "de" for "de-DE").
+   * @property {string} minimizedName - Minimized language name in the default language, e.g., "Austrian German".
+   * @property {string} nativeMinimizedName - Minimized language name in the native language, e.g., "Österreichisches Deutsch".
+   * @property {string} emoji - The emoji associated with the locale's region, if applicable.
+   */
   getLocaleProperties(locale = this.targetLocale): LocaleProperties {
     if (!locale)
       throw new Error(noTargetLocaleProvidedError('getLocaleProperties'));
     return _getLocaleProperties(locale, this.sourceLocale, this.customMapping);
   }
 
+  /**
+   * Retrieves multiple properties for a given region code, including:
+   * - `code`: the original region code
+   * - `name`: the localized display name
+   * - `emoji`: the associated flag or symbol
+   *
+   * Behavior:
+   * - Accepts ISO 3166-1 alpha-2 or UN M.49 region codes (e.g., `"US"`, `"FR"`, `"419"`).
+   * - Uses the instance's `targetLocale` to localize the region name for the user.
+   * - If `customMapping` contains a `name` or `emoji` for the region, those override the default values.
+   * - Otherwise, uses `Intl.DisplayNames` to get the localized region name, falling back to `libraryDefaultLocale`.
+   * - Falls back to the region code as `name` if display name resolution fails.
+   * - Falls back to a default emoji if no emoji mapping is found in built-in data or `customMapping`.
+   *
+   * @param {string} [region=this.getLocaleProperties().regionCode] - The region code to look up (e.g., `"US"`, `"GB"`, `"DE"`).
+   * @param {CustomRegionMapping} [customMapping] - Optional mapping of region codes to custom names and/or emojis.
+   * @returns {{ code: string, name: string, emoji: string }} An object containing:
+   *  - `code`: the input region code
+   *  - `name`: the localized or custom region name
+   *  - `emoji`: the matching emoji flag or symbol
+   *
+   * @throws {Error} If no target locale is available to determine region properties.
+   *
+   * @example
+   * const gt = new GTFormatter({ targetLocale: 'en-US' });
+   * gt.getRegionProperties('US');
+   * // => { code: 'US', name: 'United States', emoji: '🇺🇸' }
+   *
+   * @example
+   * const gt = new GTFormatter({ targetLocale: 'fr-FR' });
+   * gt.getRegionProperties('US');
+   * // => { code: 'US', name: 'États-Unis', emoji: '🇺🇸' }
+   *
+   * @example
+   * gt.getRegionProperties('US', { US: { name: 'USA', emoji: '🗽' } });
+   * // => { code: 'US', name: 'USA', emoji: '🗽' }
+   */
   getRegionProperties(
     region = this.getLocaleProperties().regionCode,
     customMapping?: CustomRegionMapping
   ): { code: string; name: string; emoji: string } {
     if (!customMapping) {
       if (this.customMapping && !this.customRegionMapping) {
+        // Lazy derive custom region mapping from customMapping
         const customRegionMapping: CustomRegionMapping = {};
         for (const [locale, lp] of Object.entries(this.customMapping)) {
           if (
@@ -317,9 +551,27 @@ export class GTFormatter {
       }
       customMapping = this.customRegionMapping;
     }
-    return _getRegionProperties(region, this.targetLocale, customMapping);
+    return _getRegionProperties(
+      region,
+      this.targetLocale, // this.targetLocale because we want it in the user's language
+      customMapping
+    );
   }
 
+  /**
+   * Determines whether a translation is required based on the source and target locales.
+   *
+   * @param {string} [sourceLocale=this.sourceLocale] - The locale code for the original content
+   * @param {string} [targetLocale=this.targetLocale] - The locale code to translate into
+   * @param {string[]} [approvedLocales=this.locales] - Optional array of approved target locales
+   * @returns {boolean} True if translation is required, false otherwise
+   * @throws {Error} If no source locale is provided
+   * @throws {Error} If no target locale is provided
+   *
+   * @example
+   * gt.requiresTranslation('en-US', 'es-ES');
+   * // Returns: true
+   */
   requiresTranslation(
     sourceLocale = this.sourceLocale,
     targetLocale = this.targetLocale,
@@ -338,6 +590,17 @@ export class GTFormatter {
     );
   }
 
+  /**
+   * Determines the best matching locale from the provided approved locales list.
+   *
+   * @param {string | string[]} locales - A single locale or array of locales in preference order
+   * @param {string[]} [approvedLocales=this.locales] - Array of approved locales in preference order
+   * @returns {string | undefined} The best matching locale or undefined if no match is found
+   *
+   * @example
+   * gt.determineLocale(['fr-CA', 'fr-FR'], ['en-US', 'fr-FR', 'es-ES']);
+   * // Returns: "fr-FR"
+   */
   determineLocale(
     locales: string | string[],
     approvedLocales: string[] | undefined = this.locales || [],
@@ -346,12 +609,35 @@ export class GTFormatter {
     return _determineLocale(locales, approvedLocales, customMapping);
   }
 
+  /**
+   * Gets the text direction for a given locale code.
+   *
+   * @param {string} [locale=this.targetLocale] - A BCP-47 locale code
+   * @returns {'ltr' | 'rtl'} 'rtl' if the locale is right-to-left, otherwise 'ltr'
+   * @throws {Error} If no target locale is provided
+   *
+   * @example
+   * gt.getLocaleDirection('ar-SA');
+   * // Returns: "rtl"
+   */
   getLocaleDirection(locale = this.targetLocale): 'ltr' | 'rtl' {
     if (!locale)
       throw new Error(noTargetLocaleProvidedError('getLocaleDirection'));
     return _getLocaleDirection(locale);
   }
 
+  /**
+   * Checks if a given BCP 47 locale code is valid.
+   *
+   * @param {string} [locale=this.targetLocale] - The BCP 47 locale code to validate
+   * @param {CustomMapping} [customMapping=this.customMapping] - The custom mapping to use for validation
+   * @returns {boolean} True if the locale code is valid, false otherwise
+   * @throws {Error} If no target locale is provided
+   *
+   * @example
+   * gt.isValidLocale('en-US');
+   * // Returns: true
+   */
   isValidLocale(
     locale = this.targetLocale,
     customMapping: CustomMapping | undefined = this.customMapping
@@ -360,6 +646,12 @@ export class GTFormatter {
     return _isValidLocale(locale, customMapping);
   }
 
+  /**
+   * Resolves the canonical locale for a given locale.
+   * @param locale - The locale to resolve the canonical locale for
+   * @param customMapping - The custom mapping to use for resolving the canonical locale
+   * @returns The canonical locale
+   */
   resolveCanonicalLocale(
     locale: string | undefined = this.targetLocale,
     customMapping: CustomMapping | undefined = this.customMapping
@@ -369,6 +661,12 @@ export class GTFormatter {
     return _resolveCanonicalLocale(locale, customMapping);
   }
 
+  /**
+   * Resolves the alias locale for a given locale.
+   * @param locale - The locale to resolve the alias locale for
+   * @param customMapping - The custom mapping to use for resolving the alias locale
+   * @returns The alias locale
+   */
   resolveAliasLocale(
     locale: string,
     customMapping: CustomMapping | undefined = this.customMapping
@@ -378,29 +676,116 @@ export class GTFormatter {
     return _resolveAliasLocale(locale, customMapping);
   }
 
+  /**
+   * Standardizes a BCP 47 locale code to ensure correct formatting.
+   *
+   * @param {string} [locale=this.targetLocale] - The BCP 47 locale code to standardize
+   * @returns {string} The standardized locale code or empty string if invalid
+   * @throws {Error} If no target locale is provided
+   *
+   * @example
+   * gt.standardizeLocale('en_us');
+   * // Returns: "en-US"
+   */
   standardizeLocale(locale = this.targetLocale): string {
     if (!locale)
       throw new Error(noTargetLocaleProvidedError('standardizeLocale'));
     return _standardizeLocale(locale);
   }
 
+  /**
+   * Checks if multiple BCP 47 locale codes represent the same dialect.
+   *
+   * @param {...(string | string[])} locales - The BCP 47 locale codes to compare
+   * @returns {boolean} True if all codes represent the same dialect, false otherwise
+   *
+   * @example
+   * gt.isSameDialect('en-US', 'en-GB');
+   * // Returns: false
+   *
+   * gt.isSameDialect('en', 'en-US');
+   * // Returns: true
+   */
   isSameDialect(...locales: (string | string[])[]): boolean {
     return _isSameDialect(...locales);
   }
 
+  /**
+   * Checks if multiple BCP 47 locale codes represent the same language.
+   *
+   * @param {...(string | string[])} locales - The BCP 47 locale codes to compare
+   * @returns {boolean} True if all codes represent the same language, false otherwise
+   *
+   * @example
+   * gt.isSameLanguage('en-US', 'en-GB');
+   * // Returns: true
+   */
   isSameLanguage(...locales: (string | string[])[]): boolean {
     return _isSameLanguage(...locales);
   }
 
+  /**
+   * Checks if a locale is a superset of another locale.
+   *
+   * @param {string} superLocale - The locale to check if it is a superset
+   * @param {string} subLocale - The locale to check if it is a subset
+   * @returns {boolean} True if superLocale is a superset of subLocale, false otherwise
+   *
+   * @example
+   * gt.isSupersetLocale('en', 'en-US');
+   * // Returns: true
+   *
+   * gt.isSupersetLocale('en-US', 'en');
+   * // Returns: false
+   */
   isSupersetLocale(superLocale: string, subLocale: string): boolean {
     return _isSupersetLocale(superLocale, subLocale);
   }
 }
 
 // ============================================================ //
-//                    Standalone utility functions               //
+//                    Utility methods                           //
 // ============================================================ //
 
+// -------------- Formatting -------------- //
+
+/**
+ * Formats a string with cutoff behavior, applying a terminator when the string exceeds the maximum character limit.
+ *
+ * This standalone function provides cutoff formatting functionality without requiring a GT instance.
+ * The locales parameter is required for proper terminator selection based on the target language.
+ *
+ * @param {string} value - The string value to format with cutoff behavior.
+ * @param {Object} [options] - Configuration options for cutoff formatting.
+ * @param {string | string[]} [options.locales] - The locales to use for terminator selection.
+ * @param {number} [options.maxChars] - The maximum number of characters to display.
+ * - Undefined values are treated as no cutoff.
+ * - Negative values follow .slice() behavior and terminator will be added before the value.
+ * - 0 will result in an empty string.
+ * - If cutoff results in an empty string, no terminator is added.
+ * @param {CutoffFormatStyle} [options.style='ellipsis'] - The style of the terminator.
+ * @param {string} [options.terminator] - Optional override the terminator to use.
+ * @param {string} [options.separator] - Optional override the separator to use between the terminator and the value.
+ * - If no terminator is provided, then separator is ignored.
+ * @returns {string} The formatted string with terminator applied if cutoff occurs.
+ *
+ * @example
+ * formatCutoff('Hello, world!', { locales: 'en-US', maxChars: 8 });
+ * // Returns: 'Hello, w...'
+ *
+ * @example
+ * formatCutoff('Hello, world!', { locales: 'en-US', maxChars: -3 });
+ * // Returns: '...ld!'
+ *
+ * @example
+ * formatCutoff('Very long text that needs cutting', {
+ *   locales: 'en-US',
+ *   maxChars: 15,
+ *   style: 'ellipsis',
+ *   separator: ' '
+ * });
+ * // Returns: 'Very long text ...'
+ */
 export function formatCutoff(
   value: string,
   options?: {
@@ -410,6 +795,22 @@ export function formatCutoff(
   return _formatCutoff({ value, locales: options?.locales, options });
 }
 
+/**
+ * Formats a message according to the specified locales and options.
+ *
+ * @param {string} message - The message to format.
+ * @param {string | string[]} [locales='en'] - The locales to use for formatting.
+ * @param {FormatVariables} [variables={}] - The variables to use for formatting.
+ * @param {StringFormat} [dataFormat='ICU'] - The format of the message. (When STRING, the message is returned as is)
+ * @returns {string} The formatted message.
+ *
+ * @example
+ * formatMessage('Hello {name}', { name: 'John' });
+ * // Returns: "Hello John"
+ *
+ * formatMessage('Hello {name}', { name: 'John' }, { locales: ['fr'] });
+ * // Returns: "Bonjour John"
+ */
 export function formatMessage(
   message: string,
   options?: {
@@ -426,6 +827,14 @@ export function formatMessage(
   }
 }
 
+/**
+ * Formats a number according to the specified locales and options.
+ * @param {Object} params - The parameters for the number formatting.
+ * @param {number} params.value - The number to format.
+ * @param {Intl.NumberFormatOptions} [params.options] - Additional options for number formatting.
+ * @param {string | string[]} [params.options.locales] - The locales to use for formatting.
+ * @returns {string} The formatted number.
+ */
 export function formatNum(
   number: number,
   options: {
@@ -439,6 +848,14 @@ export function formatNum(
   });
 }
 
+/**
+ * Formats a date according to the specified languages and options.
+ * @param {Object} params - The parameters for the date formatting.
+ * @param {Date} params.value - The date to format.
+ * @param {Intl.DateTimeFormatOptions} [params.options] - Additional options for date formatting.
+ * @param {string | string[]} [params.options.locales] - The languages to use for formatting.
+ * @returns {string} The formatted date.
+ */
 export function formatDateTime(
   date: Date,
   options?: {
@@ -452,6 +869,15 @@ export function formatDateTime(
   });
 }
 
+/**
+ * Formats a currency value according to the specified languages, currency, and options.
+ * @param {Object} params - The parameters for the currency formatting.
+ * @param {number} params.value - The currency value to format.
+ * @param {string} params.currency - The currency code (e.g., 'USD').
+ * @param {Intl.NumberFormatOptions} [params.options={}] - Additional options for currency formatting.
+ * @param {string | string[]} [params.options.locales] - The locale codes to use for formatting.
+ * @returns {string} The formatted currency value.
+ */
 export function formatCurrency(
   value: number,
   currency: string,
@@ -467,6 +893,14 @@ export function formatCurrency(
   });
 }
 
+/**
+ * Formats a list of items according to the specified locales and options.
+ * @param {Object} params - The parameters for the list formatting.
+ * @param {Array<string | number>} params.value - The list of items to format.
+ * @param {Intl.ListFormatOptions} [params.options={}] - Additional options for list formatting.
+ * @param {string | string[]} [params.options.locales] - The locales to use for formatting.
+ * @returns {string} The formatted list.
+ */
 export function formatList(
   array: Array<string | number>,
   options: {
@@ -480,6 +914,14 @@ export function formatList(
   });
 }
 
+/**
+ * Formats a list of items according to the specified locales and options.
+ * @param {Array<T>} array - The list of items to format
+ * @param {Object} [options] - Additional options for list formatting
+ * @param {string | string[]} [options.locales] - The locales to use for formatting
+ * @param {Intl.ListFormatOptions} [options] - Additional Intl.ListFormat options
+ * @returns {Array<T | string>} The formatted list parts
+ */
 export function formatListToParts<T>(
   array: Array<T>,
   options?: {
@@ -493,6 +935,15 @@ export function formatListToParts<T>(
   });
 }
 
+/**
+ * Formats a relative time value according to the specified locales and options.
+ * @param {Object} params - The parameters for the relative time formatting.
+ * @param {number} params.value - The relative time value to format.
+ * @param {Intl.RelativeTimeFormatUnit} params.unit - The unit of time (e.g., 'second', 'minute', 'hour', 'day', 'week', 'month', 'year').
+ * @param {Intl.RelativeTimeFormatOptions} [params.options={}] - Additional options for relative time formatting.
+ * @param {string | string[]} [params.options.locales] - The locales to use for formatting.
+ * @returns {string} The formatted relative time string.
+ */
 export function formatRelativeTime(
   value: number,
   unit: Intl.RelativeTimeFormatUnit,
@@ -508,6 +959,14 @@ export function formatRelativeTime(
   });
 }
 
+/**
+ * Formats a relative time string from a Date, automatically selecting the best unit.
+ * @param {Date} date - The date to format relative to now.
+ * @param {Object} options - Formatting options.
+ * @param {string | string[]} options.locales - The locales to use for formatting.
+ * @param {Intl.RelativeTimeFormatOptions} [options] - Additional Intl.RelativeTimeFormat options.
+ * @returns {string} The formatted relative time string (e.g., "2 hours ago", "in 3 days").
+ */
 export function formatRelativeTimeFromDate(
   date: Date,
   options: {
@@ -524,6 +983,16 @@ export function formatRelativeTimeFromDate(
   });
 }
 
+// -------------- Locale Properties -------------- //
+
+/**
+ * Retrieves the display name of locale code using Intl.DisplayNames.
+ *
+ * @param {string} locale - A BCP-47 locale code.
+ * @param {string} [defaultLocale] - The default locale to use for formatting.
+ * @param {CustomMapping} [customMapping] - A custom mapping of locale codes to their names.
+ * @returns {string} The display name corresponding to the code.
+ */
 export function getLocaleName(
   locale: string,
   defaultLocale?: string,
@@ -532,6 +1001,15 @@ export function getLocaleName(
   return _getLocaleName(locale, defaultLocale, customMapping);
 }
 
+/**
+ * Retrieves an emoji based on a given locale code, taking into account region, language, and specific exceptions.
+ *
+ * This function uses the locale's region (if present) to select an emoji or falls back on default emojis for certain languages.
+ *
+ * @param locale - A string representing the locale code (e.g., 'en-US', 'fr-CA').
+ * @param {CustomMapping} [customMapping] - A custom mapping of locale codes to their names.
+ * @returns The emoji representing the locale or its region, or a default emoji if no specific match is found.
+ */
 export function getLocaleEmoji(
   locale: string,
   customMapping?: CustomMapping
@@ -539,6 +1017,40 @@ export function getLocaleEmoji(
   return _getLocaleEmoji(locale, customMapping);
 }
 
+/**
+ * Generates linguistic details for a given locale code.
+ *
+ * This function returns information about the locale,
+ * script, and region of a given language code both in a standard form and in a maximized form (with likely script and region).
+ * The function provides these names in both your default language and native forms, and an associated emoji.
+ *
+ * @param {string} locale - The locale code to get properties for (e.g., "de-AT").
+ * @param {string} [defaultLocale] - The default locale to use for formatting.
+ * @param {CustomMapping} [customMapping] - A custom mapping of locale codes to their names.
+ * @returns {LocaleProperties} - An object containing detailed information about the locale.
+ *
+ * @property {string} code - The full locale code, e.g., "de-AT".
+ * @property {string} name - Language name in the default display language, e.g., "Austrian German".
+ * @property {string} nativeName - Language name in the locale's native language, e.g., "Österreichisches Deutsch".
+ * @property {string} languageCode - The base language code, e.g., "de".
+ * @property {string} languageName - The language name in the default display language, e.g., "German".
+ * @property {string} nativeLanguageName - The language name in the native language, e.g., "Deutsch".
+ * @property {string} nameWithRegionCode - Language name with region in the default language, e.g., "German (AT)".
+ * @property {string} nativeNameWithRegionCode - Language name with region in the native language, e.g., "Deutsch (AT)".
+ * @property {string} regionCode - The region code from maximization, e.g., "AT".
+ * @property {string} regionName - The region name in the default display language, e.g., "Austria".
+ * @property {string} nativeRegionName - The region name in the native language, e.g., "Österreich".
+ * @property {string} scriptCode - The script code from maximization, e.g., "Latn".
+ * @property {string} scriptName - The script name in the default display language, e.g., "Latin".
+ * @property {string} nativeScriptName - The script name in the native language, e.g., "Lateinisch".
+ * @property {string} maximizedCode - The maximized locale code, e.g., "de-Latn-AT".
+ * @property {string} maximizedName - Maximized locale name with likely script in the default language, e.g., "Austrian German (Latin)".
+ * @property {string} nativeMaximizedName - Maximized locale name in the native language, e.g., "Österreichisches Deutsch (Lateinisch)".
+ * @property {string} minimizedCode - Minimized locale code, e.g., "de-AT" (or "de" for "de-DE").
+ * @property {string} minimizedName - Minimized language name in the default language, e.g., "Austrian German".
+ * @property {string} nativeMinimizedName - Minimized language name in the native language, e.g., "Österreichisches Deutsch".
+ * @property {string} emoji - The emoji associated with the locale's region, if applicable.
+ */
 export function getLocaleProperties(
   locale: string,
   defaultLocale?: string,
@@ -547,6 +1059,40 @@ export function getLocaleProperties(
   return _getLocaleProperties(locale, defaultLocale, customMapping);
 }
 
+/**
+ * Retrieves multiple properties for a given region code, including:
+ * - `code`: the original region code
+ * - `name`: the localized display name
+ * - `emoji`: the associated flag or symbol
+ *
+ * Behavior:
+ * - Accepts ISO 3166-1 alpha-2 or UN M.49 region codes (e.g., `"US"`, `"FR"`, `"419"`).
+ * - If `customMapping` contains a `name` or `emoji` for the region, those override the default values.
+ * - Otherwise, uses `Intl.DisplayNames` to get the localized region name in the given `defaultLocale`,
+ *   falling back to `libraryDefaultLocale`.
+ * - Falls back to the region code as `name` if display name resolution fails.
+ * - Falls back to `defaultEmoji` if no emoji mapping is found in `emojis` or `customMapping`.
+ *
+ * @param {string} region - The region code to look up (e.g., `"US"`, `"GB"`, `"DE"`).
+ * @param {string} [defaultLocale=libraryDefaultLocale] - The locale to use when localizing the region name.
+ * @param {CustomRegionMapping} [customMapping] - Optional mapping of region codes to custom names and/or emojis.
+ * @returns {{ code: string, name: string, emoji: string }} An object containing:
+ *  - `code`: the input region code
+ *  - `name`: the localized or custom region name
+ *  - `emoji`: the matching emoji flag or symbol
+ *
+ * @example
+ * getRegionProperties('US', 'en');
+ * // => { code: 'US', name: 'United States', emoji: '🇺🇸' }
+ *
+ * @example
+ * getRegionProperties('US', 'fr');
+ * // => { code: 'US', name: 'États-Unis', emoji: '🇺🇸' }
+ *
+ * @example
+ * getRegionProperties('US', 'en', { US: { name: 'USA', emoji: '🗽' } });
+ * // => { code: 'US', name: 'USA', emoji: '🗽' }
+ */
 export function getRegionProperties(
   region: string,
   defaultLocale?: string,
@@ -555,6 +1101,20 @@ export function getRegionProperties(
   return _getRegionProperties(region, defaultLocale, customMapping);
 }
 
+/**
+ * Determines whether a translation is required based on the source and target locales.
+ *
+ * - If the target locale is not specified, the function returns `false`, as translation is not needed.
+ * - If the source and target locale are the same, returns `false`, indicating that no translation is necessary.
+ * - If the `approvedLocales` array is provided, and the target locale is not within that array, the function also returns `false`.
+ * - Otherwise, it returns `true`, meaning that a translation is required.
+ *
+ * @param {string} sourceLocale - The locale code for the original content (BCP 47 locale code).
+ * @param {string} targetLocale - The locale code of the language to translate the content into (BCP 47 locale code).
+ * @param {string[]} [approvedLocale] - An optional array of approved target locales.
+ *
+ * @returns {boolean} - Returns `true` if translation is required, otherwise `false`.
+ */
 export function requiresTranslation(
   sourceLocale: string,
   targetLocale: string,
@@ -569,6 +1129,12 @@ export function requiresTranslation(
   );
 }
 
+/**
+ * Determines the best matching locale from the provided approved locales list.
+ * @param {string | string[]} locales - A single locale or an array of locales sorted in preference order.
+ * @param {string[]} [approvedLocales=this.locales] - An array of approved locales, also sorted by preference.
+ * @returns {string | undefined} - The best matching locale from the approvedLocales list, or undefined if no match is found.
+ */
 export function determineLocale(
   locales: string | string[],
   approvedLocales: string[] | undefined = [],
@@ -577,10 +1143,22 @@ export function determineLocale(
   return _determineLocale(locales, approvedLocales, customMapping);
 }
 
+/**
+ * Get the text direction for a given locale code using the Intl.Locale API.
+ *
+ * @param {string} locale - A BCP-47 locale code.
+ * @returns {string} - 'rtl' if the locale is right-to-left, otherwise 'ltr'.
+ */
 export function getLocaleDirection(locale: string): 'ltr' | 'rtl' {
   return _getLocaleDirection(locale);
 }
 
+/**
+ * Checks if a given BCP 47 locale code is valid.
+ * @param {string} locale - The BCP 47 locale code to validate.
+ * @param {CustomMapping} [customMapping] - The custom mapping to use for validation.
+ * @returns {boolean} True if the BCP 47 code is valid, false otherwise.
+ */
 export function isValidLocale(
   locale: string,
   customMapping?: CustomMapping
@@ -588,6 +1166,12 @@ export function isValidLocale(
   return _isValidLocale(locale, customMapping);
 }
 
+/**
+ * Resolves the alias locale for a given locale.
+ * @param {string} locale - The locale to resolve the alias locale for
+ * @param {CustomMapping} [customMapping] - The custom mapping to use for resolving the alias locale
+ * @returns {string} The alias locale
+ */
 export function resolveAliasLocale(
   locale: string,
   customMapping?: CustomMapping
@@ -595,6 +1179,12 @@ export function resolveAliasLocale(
   return _resolveAliasLocale(locale, customMapping);
 }
 
+/**
+ * Resolves the canonical locale for a given locale.
+ * @param {string} locale - The locale to resolve the canonical locale for
+ * @param {CustomMapping} [customMapping] - The custom mapping to use for resolving the canonical locale
+ * @returns {string} The canonical locale
+ */
 export function resolveCanonicalLocale(
   locale: string,
   customMapping?: CustomMapping
@@ -602,18 +1192,41 @@ export function resolveCanonicalLocale(
   return _resolveCanonicalLocale(locale, customMapping);
 }
 
+/**
+ * Standardizes a BCP 47 locale code to ensure correct formatting.
+ * @param {string} locale - The BCP 47 locale code to standardize.
+ * @returns {string} The standardized BCP 47 locale code or an empty string if it is an invalid code.
+ */
 export function standardizeLocale(locale: string): string {
   return _standardizeLocale(locale);
 }
 
+/**
+ * Checks if multiple BCP 47 locale codes represent the same dialect.
+ * @param {string[]} locales - The BCP 47 locale codes to compare.
+ * @returns {boolean} True if all BCP 47 codes represent the same dialect, false otherwise.
+ */
 export function isSameDialect(...locales: (string | string[])[]): boolean {
   return _isSameDialect(...locales);
 }
 
+/**
+ * Checks if multiple BCP 47 locale codes represent the same language.
+ * @param {string[]} locales - The BCP 47 locale codes to compare.
+ * @returns {boolean} True if all BCP 47 codes represent the same language, false otherwise.
+ */
 export function isSameLanguage(...locales: (string | string[])[]): boolean {
   return _isSameLanguage(...locales);
 }
 
+/**
+ * Checks if a locale is a superset of another locale.
+ * A subLocale is a subset of superLocale if it is an extension of superLocale or are otherwise identical.
+ *
+ * @param {string} superLocale - The locale to check if it is a superset of the other locale.
+ * @param {string} subLocale - The locale to check if it is a subset of the other locale.
+ * @returns {boolean} True if the first locale is a superset of the second locale, false otherwise.
+ */
 export function isSupersetLocale(
   superLocale: string,
   subLocale: string

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -151,17 +151,12 @@ export class GT extends GTFormatter {
    */
   constructor(params: GTConstructorParams = {}) {
     super(params);
-    // Read environment
+    // Env-var fallbacks (setConfig already ran via super)
     if (typeof process !== 'undefined') {
       this.apiKey ||= process.env?.GT_API_KEY;
       this.devApiKey ||= process.env?.GT_DEV_API_KEY;
       this.projectId ||= process.env?.GT_PROJECT_ID;
     }
-    // Set API-specific properties (super already handled locale config)
-    if (params.apiKey) this.apiKey = params.apiKey;
-    if (params.devApiKey) this.devApiKey = params.devApiKey;
-    if (params.projectId) this.projectId = params.projectId;
-    if (params.baseUrl) this.baseUrl = params.baseUrl;
   }
 
   override setConfig(params: GTConstructorParams) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -93,8 +93,21 @@ export * from './format';
 
 import { GTFormatter } from './format';
 
+// ============================================================ //
+//                        Core Class                            //
+// ============================================================ //
+
 /**
  * Type representing the constructor parameters for the GT class.
+ * @typedef {Object} GTConstructorParams
+ * @property {string} [apiKey] - The API key for accessing the translation service
+ * @property {string} [devApiKey] - The development API key for accessing the translation service
+ * @property {string} [sourceLocale] - The default source locale for translations
+ * @property {string} [targetLocale] - The default target locale for translations
+ * @property {string[]} [locales] - Array of supported locales
+ * @property {string} [projectId] - The project ID for the translation service
+ * @property {string} [baseUrl] - The base URL for the translation service
+ * @property {CustomMapping} [customMapping] - Custom mapping of locale codes to their names
  */
 type GTConstructorParams = {
   apiKey?: string;
@@ -113,6 +126,7 @@ type GTConstructorParams = {
  * It extends GTFormatter with API client methods for server-side use.
  *
  * @class GT
+ * @description A comprehensive toolkit for handling internationalization and localization.
  *
  * @example
  * const gt = new GT({
@@ -150,8 +164,9 @@ export class GT extends GTFormatter {
    * });
    */
   constructor(params: GTConstructorParams = {}) {
+    // Set up config
     super(params);
-    // Env-var fallbacks (setConfig already ran via super)
+    // Read environment
     if (typeof process !== 'undefined') {
       this.apiKey ||= process.env?.GT_API_KEY;
       this.devApiKey ||= process.env?.GT_DEV_API_KEY;
@@ -160,6 +175,8 @@ export class GT extends GTFormatter {
   }
 
   override setConfig(params: GTConstructorParams) {
+    // ----- Environment properties ----- //
+
     // Set API-specific properties
     if (params.apiKey) this.apiKey = params.apiKey;
     if (params.devApiKey) this.devApiKey = params.devApiKey;
@@ -197,16 +214,41 @@ export class GT extends GTFormatter {
 
   // -------------- Branch Methods -------------- //
 
+  /**
+   * Queries branch information from the API.
+   *
+   * @param {BranchQuery} query - Object mapping the current branch and incoming branches
+   * @returns {Promise<BranchDataResult>} The branch information
+   */
   async queryBranchData(query: BranchQuery): Promise<BranchDataResult> {
     this._validateAuth('queryBranchData');
     return await _queryBranchData(query, this._getTranslationConfig());
   }
 
+  /**
+   * Creates a new branch in the API. If the branch already exists, it will be returned.
+   *
+   * @param {CreateBranchQuery} query - Object mapping the branch name and default branch flag
+   * @returns {Promise<CreateBranchResult>} The created branch information
+   */
   async createBranch(query: CreateBranchQuery): Promise<CreateBranchResult> {
     this._validateAuth('createBranch');
     return await _createBranch(query, this._getTranslationConfig());
   }
 
+  /**
+   * Processes file moves by cloning source files and translations with new fileIds.
+   * This is called when files have been moved/renamed and we want to preserve translations.
+   *
+   * @param {MoveMapping[]} moves - Array of move mappings (old fileId to new fileId)
+   * @param {ProcessMovesOptions} options - Options including branchId and timeout
+   * @returns {Promise<ProcessMovesResponse>} The move processing results
+   *
+   * @example
+   * const result = await gt.processFileMoves([
+   *   { oldFileId: 'abc123', newFileId: 'def456', newFileName: 'locales/en.json' }
+   * ], { branchId: 'main' });
+   */
   async processFileMoves(
     moves: MoveMapping[],
     options: ProcessMovesOptions = {}
@@ -219,6 +261,19 @@ export class GT extends GTFormatter {
     );
   }
 
+  /**
+   * Gets orphaned files for a branch - files that exist on the branch
+   * but whose fileIds are not in the provided list.
+   * Used for move detection.
+   *
+   * @param {string} branchId - The branch to check for orphaned files
+   * @param {string[]} fileIds - List of current file IDs (files that are NOT orphaned)
+   * @param {Object} options - Options including timeout
+   * @returns {Promise<GetOrphanedFilesResult>} The orphaned files
+   *
+   * @example
+   * const result = await gt.getOrphanedFiles('branch-id', ['file-1', 'file-2']);
+   */
   async getOrphanedFiles(
     branchId: string,
     fileIds: string[],
@@ -235,6 +290,18 @@ export class GT extends GTFormatter {
 
   // -------------- Translation Methods -------------- //
 
+  /**
+   * Enqueues project setup job using the specified file references
+   *
+   * This method creates setup jobs that will process source file references
+   * and generate a project setup. The files parameter contains references (IDs) to source
+   * files that have already been uploaded via uploadSourceFiles. The setup jobs are queued
+   * for processing and will generate a project setup based on the source files.
+   *
+   * @param {FileReference[]} files - Array of file references containing IDs of previously uploaded source files
+   * @param {SetupProjectOptions} [options] - Optional settings for target locales and timeout
+   * @returns {Promise<SetupProjectResult>} Object containing the jobId and status
+   */
   async setupProject(
     files: FileReference[],
     options?: SetupProjectOptions
@@ -249,6 +316,24 @@ export class GT extends GTFormatter {
     return await _setupProject(files, this._getTranslationConfig(), options);
   }
 
+  /**
+   * Checks the current status of one or more project jobs by their unique identifiers.
+   *
+   * This method polls the API to determine whether one or more jobs are still running,
+   * have completed successfully, or have failed. Jobs are created after calling either enqueueFiles or setupProject.
+   *
+   * @param {string[]} jobIds - The unique identifiers of the jobs to check
+   * @param {number} [timeoutMs] - Optional timeout in milliseconds for the API request
+   * @returns {Promise<CheckJobStatusResult>} Object containing the job status
+   *
+   * @example
+   * const result = await gt.checkJobStatus([
+   *   'job-123',
+   *   'job-456',
+   * ], {
+   *   timeout: 10000,
+   * });
+   */
   async checkJobStatus(
     jobIds: string[],
     timeoutMs?: number
@@ -261,6 +346,13 @@ export class GT extends GTFormatter {
     );
   }
 
+  /**
+   * Polls job statuses until all jobs from enqueueFiles are finished or the timeout is reached.
+   *
+   * @param {EnqueueFilesResult} enqueueResult - The result returned from enqueueFiles
+   * @param {AwaitJobsOptions} [options] - Polling configuration (interval, timeout)
+   * @returns {Promise<AwaitJobsResult>} The final status of all jobs and whether they all completed
+   */
   async awaitJobs(
     enqueueResult: EnqueueFilesResult,
     options?: AwaitJobsOptions
@@ -273,6 +365,19 @@ export class GT extends GTFormatter {
     );
   }
 
+  /**
+   * Enqueues translation jobs for previously uploaded source files.
+   *
+   * This method creates translation jobs that will process existing source files
+   * and generate translations in the specified target languages. The files parameter
+   * contains references (IDs) to source files that have already been uploaded via
+   * uploadSourceFiles. The translation jobs are queued for processing and will
+   * generate translated content based on the source files and target locales provided.
+   *
+   * @param {FileReferenceIds[]} files - Array of file references containing IDs of previously uploaded source files
+   * @param {EnqueueOptions} options - Configuration options including source locale, target locales, and job settings
+   * @returns {Promise<EnqueueFilesResult>} Result containing job IDs, queue status, and processing information
+   */
   async enqueueFiles(
     files: FileReferenceIds[],
     options: EnqueueOptions
@@ -319,20 +424,40 @@ export class GT extends GTFormatter {
     );
   }
 
+  /**
+   * Creates or upserts a file tag, associating a set of source files
+   * with a user-defined tag ID and optional message.
+   *
+   * @param {CreateTagOptions} options - Tag creation options including tagId, sourceFileIds, and optional message
+   * @returns {Promise<CreateTagResult>} The created or updated tag
+   */
   async createTag(options: CreateTagOptions): Promise<CreateTagResult> {
     this._validateAuth('createTag');
     return await _createTag(options, this._getTranslationConfig());
   }
 
+  /**
+   * Publishes or unpublishes files on the CDN.
+   *
+   * @param {PublishFileEntry[]} files - Array of file entries with publish flags
+   * @returns {Promise<PublishFilesResult>} Result containing per-file success/failure
+   */
   async publishFiles(files: PublishFileEntry[]): Promise<PublishFilesResult> {
     this._validateAuth('publishFiles');
     return await _publishFiles(files, this._getTranslationConfig());
   }
 
+  /**
+   * Submits user edit diffs for existing translations so future generations preserve user intent.
+   *
+   * @param {SubmitUserEditDiffsPayload} payload - Project-scoped diff payload.
+   * @returns {Promise<void>} Resolves when submission succeeds.
+   */
   async submitUserEditDiffs(
     payload: SubmitUserEditDiffsPayload
   ): Promise<void> {
     this._validateAuth('submitUserEditDiffs');
+    // Normalize locales to canonical form before submission
     const normalized: SubmitUserEditDiffsPayload = {
       ...payload,
       diffs: (payload.diffs || []).map((d) => ({
@@ -343,6 +468,26 @@ export class GT extends GTFormatter {
     await _submitUserEditDiffs(normalized, this._getTranslationConfig());
   }
 
+  /**
+   * Queries data about one or more source or translation files.
+   *
+   * @param {FileDataQuery} data - Object mapping source and translation file information.
+   * @param {CheckFileTranslationsOptions} options - Options for the API call.
+   * @returns {Promise<FileDataResult>} The source and translation file data information.
+   *
+   * @example
+   * const result = await gt.queryFileData({
+   *   sourceFiles: [
+   *     { fileId: '1234567890', versionId: '1234567890', branchId: '1234567890' },
+   *   ],
+   *   translatedFiles: [
+   *     { fileId: '1234567890', versionId: '1234567890', branchId: '1234567890', locale: 'es-ES' },
+   *   ],
+   * }, {
+   *   timeout: 10000,
+   * });
+   *
+   */
   async queryFileData(
     data: FileDataQuery,
     options: CheckFileTranslationsOptions = {}
@@ -378,6 +523,20 @@ export class GT extends GTFormatter {
     return result;
   }
 
+  /**
+   * Gets source and translation information for a given file ID and version ID.
+   *
+   * @param {FileQuery} data - File query containing file ID and version ID.
+   * @param {CheckFileTranslationsOptions} options - Options for getting source and translation information.
+   * @returns {Promise<FileQueryResult>} The source file and translation information.
+   *
+   * @example
+   * const result = await gt.querySourceFile(
+   *   { fileId: '1234567890', versionId: '1234567890' },
+   *   { timeout: 10000 }
+   * );
+   *
+   */
   async querySourceFile(
     data: FileQuery,
     options: CheckFileTranslationsOptions = {}
@@ -407,6 +566,18 @@ export class GT extends GTFormatter {
     return result;
   }
 
+  /**
+   * Get project data for a given project ID.
+   *
+   * @param {string} projectId - The ID of the project to get the data for.
+   * @returns {Promise<ProjectData>} The project data.
+   *
+   * @example
+   * const result = await gt.getProjectData(
+   *   '1234567890'
+   * );
+   *
+   */
   async getProjectData(
     projectId: string,
     options: { timeout?: number } = {}
@@ -428,6 +599,27 @@ export class GT extends GTFormatter {
     return result;
   }
 
+  /**
+   * Downloads a single file.
+   *
+   * @param file - The file query object.
+   * @param {string} file.fileId - The ID of the file to download.
+   * @param {string} [file.branchId] - The ID of the branch to download the file from. If not provided, the default branch will be used.
+   * @param {string} [file.locale] - The locale to download the file for. If not provided, the source file will be downloaded.
+   * @param {string} [file.versionId] - The version ID to download the file from. If not provided, the latest version will be used.
+   * @param {DownloadFileOptions} options - Options for downloading the file.
+   * @returns {Promise<string>} The downloaded file content.
+   *
+   * @example
+   * const result = await gt.downloadFile({
+   *   fileId: '1234567890',
+   *   branchId: '1234567890',
+   *   locale: 'es-ES',
+   *   versionId: '1234567890',
+   * }, {
+   *   timeout: 10000,
+   * });
+   */
   async downloadFile(
     file: {
       fileId: string;
@@ -459,6 +651,22 @@ export class GT extends GTFormatter {
     return result.data?.[0]?.data ?? '';
   }
 
+  /**
+   * Downloads multiple files in a batch.
+   *
+   * @param {DownloadFileBatchRequest} requests - Array of file query objects to download.
+   * @param {DownloadFileBatchOptions} options - Options for the batch download.
+   * @returns {Promise<DownloadFileBatchResult>} The batch download results.
+   *
+   * @example
+   * const result = await gt.downloadFileBatch([{
+   *   fileId: '1234567890',
+   *   locale: 'es-ES',
+   *   versionId: '1234567890',
+   * }], {
+   *   timeout: 10000,
+   * });
+   */
   async downloadFileBatch(
     requests: DownloadFileBatchRequest,
     options: DownloadFileBatchOptions = {}
@@ -491,6 +699,24 @@ export class GT extends GTFormatter {
     };
   }
 
+  /**
+   * Translates a single source string to the target locale.
+   * Routes through {@link translateMany} under the hood.
+   *
+   * @param {string} source - The source string to translate.
+   * @param {object} options - Translation options including targetLocale and optional entry metadata.
+   * @returns {Promise<TranslationResult | TranslationError>} The translated content.
+   *
+   * @example
+   * const result = await gt.translate('Hello, world!', { targetLocale: 'es' });
+   *
+   * @example
+   * const result = await gt.translate('Hello, world!', {
+   *   targetLocale: 'es',
+   *   dataFormat: 'ICU',
+   *   context: 'A formal greeting',
+   * });
+   */
   async translate(
     source: TranslateManyEntry,
     options: string | TranslateOptions,
@@ -533,6 +759,32 @@ export class GT extends GTFormatter {
     return results[0];
   }
 
+  /**
+   * Translates multiple source strings to the target locale.
+   * Each entry can be a plain string or an object with source and metadata fields.
+   *
+   * @param {TranslateManyEntry[] | Record<string, TranslateManyEntry>} sources - The source entries to translate. Can be an array or a record keyed by hash.
+   * @param {object} options - Translation options including targetLocale.
+   * @returns {Promise<TranslateManyResult | Record<string, TranslationResult>>} The translated contents. An array if sources was an array, a record if sources was a record.
+   *
+   * @example
+   * const result = await gt.translateMany(
+   *   ['Hello, world!', 'Goodbye, world!'],
+   *   { targetLocale: 'es' }
+   * );
+   *
+   * @example
+   * const result = await gt.translateMany(
+   *   [{ source: 'Hello, world!', dataFormat: 'ICU' }],
+   *   { targetLocale: 'es' }
+   * );
+   *
+   * @example
+   * const result = await gt.translateMany(
+   *   { 'my-hash': 'Hello, world!' },
+   *   { targetLocale: 'es' }
+   * );
+   */
   async translateMany(
     sources: TranslateManyEntry[],
     options: string | TranslateOptions,
@@ -584,6 +836,18 @@ export class GT extends GTFormatter {
     );
   }
 
+  /**
+   * Uploads source files to the translation service without any translation content.
+   *
+   * This method creates or replaces source file entries in your project. Each uploaded
+   * file becomes a source that can later be translated into target languages. The files
+   * are processed and stored as base entries that serve as the foundation for generating
+   * translations through the translation workflow.
+   *
+   * @param {Array<{source: FileUpload}>} files - Array of objects containing source file data to upload
+   * @param {UploadFilesOptions} options - Configuration options including source locale and other upload settings
+   * @returns {Promise<UploadFilesResponse>} Upload result containing file IDs, version information, and upload status
+   */
   async uploadSourceFiles(
     files: { source: FileUpload }[],
     options: UploadFilesOptions
@@ -622,10 +886,24 @@ export class GT extends GTFormatter {
     };
   }
 
+  /**
+   * Uploads translation files that correspond to previously uploaded source files.
+   *
+   * This method allows you to provide translated content for existing source files in your project.
+   * Each translation must reference an existing source file and include the translated content
+   * along with the target locale information. This is used when you have pre-existing translations
+   * that you want to upload directly rather than generating them through the translation service.
+   *
+   * @param {Array<{source: FileUpload, translations: FileUpload[]}>} files - Array of file objects where:
+   *   - `source`: Reference to the existing source file (contains IDs but no content)
+   *   - `translations`: Array of translated files, each containing content, locale, and reference IDs
+   * @param {UploadFilesOptions} options - Configuration options including source locale and upload settings
+   * @returns {Promise<UploadFilesResponse>} Upload result containing translation IDs, status, and processing information
+   */
   async uploadTranslations(
     files: {
-      source: FileUpload;
-      translations: FileUpload[];
+      source: FileUpload; // reference only (no content)
+      translations: FileUpload[]; // each has content + ids + locale
     }[],
     options: UploadFilesOptions
   ): Promise<UploadFilesResponse> {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,24 +3,8 @@
 
 // ----- IMPORTS ----- //
 
-import _requiresTranslation from './locales/requiresTranslation';
-import _determineLocale from './locales/determineLocale';
-import {
-  _formatNum,
-  _formatCurrency,
-  _formatList,
-  _formatRelativeTime,
-  _formatRelativeTimeFromDate,
-  _selectRelativeTimeUnit,
-  _formatDateTime,
-  _formatMessageICU,
-  _formatListToParts,
-  _formatCutoff,
-  _formatMessageString,
-} from './formatting/format';
 import {
   CustomMapping,
-  FormatVariables,
   TranslateManyResult,
   TranslationError,
   TranslationRequestConfig,
@@ -32,22 +16,10 @@ import {
   DownloadFileOptions,
   TranslateManyEntry,
 } from './types';
-import _isSameLanguage from './locales/isSameLanguage';
-import _getLocaleProperties, {
-  LocaleProperties,
-} from './locales/getLocaleProperties';
-import _getLocaleEmoji from './locales/getLocaleEmoji';
-import { _isValidLocale, _standardizeLocale } from './locales/isValidLocale';
-import { _getLocaleName } from './locales/getLocaleName';
-import { _getLocaleDirection } from './locales/getLocaleDirection';
 import { libraryDefaultLocale } from './internal';
-import _isSameDialect from './locales/isSameDialect';
-import _isSupersetLocale from './locales/isSupersetLocale';
 import {
   noSourceLocaleProvidedError,
   noTargetLocaleProvidedError,
-  invalidLocaleError,
-  invalidLocalesError,
   noProjectIdProvidedError,
   noApiKeyProvidedError,
 } from './logging/errors';
@@ -70,12 +42,6 @@ import {
 import _submitUserEditDiffs, {
   SubmitUserEditDiffsPayload,
 } from './translate/submitUserEditDiffs';
-import {
-  _getRegionProperties,
-  CustomRegionMapping,
-} from './locales/getRegionProperties';
-import { _resolveAliasLocale } from './locales/resolveAliasLocale';
-import { _resolveCanonicalLocale } from './locales/resolveCanonicalLocale';
 import _uploadSourceFiles from './translate/uploadSourceFiles';
 import _uploadTranslations from './translate/uploadTranslations';
 import {
@@ -119,25 +85,16 @@ import _publishFiles, {
   type PublishFileEntry,
   type PublishFilesResult,
 } from './translate/publishFiles';
-import { CutoffFormatOptions } from './formatting/custom-formats/CutoffFormat/types';
 import { TranslateOptions } from './types-dir/api/entry';
 import { API_VERSION as _API_VERSION } from './translate/api';
-import { StringFormat } from './types-dir/jsx/content';
 
-// ============================================================ //
-//                        Core Class                            //
-// ============================================================ //
+// Re-export everything from format.ts
+export * from './format';
+
+import { GTFormatter } from './format';
+
 /**
  * Type representing the constructor parameters for the GT class.
- * @typedef {Object} GTConstructorParams
- * @property {string} [apiKey] - The API key for accessing the translation service
- * @property {string} [devApiKey] - The development API key for accessing the translation service
- * @property {string} [sourceLocale] - The default source locale for translations
- * @property {string} [targetLocale] - The default target locale for translations
- * @property {string[]} [locales] - Array of supported locales
- * @property {string} [projectId] - The project ID for the translation service
- * @property {string} [baseUrl] - The base URL for the translation service
- * @property {CustomMapping} [customMapping] - Custom mapping of locale codes to their names
  */
 type GTConstructorParams = {
   apiKey?: string;
@@ -153,9 +110,9 @@ type GTConstructorParams = {
 /**
  * GT is the core driver for the General Translation library.
  * This class provides functionality for locale management, formatting, and translation operations.
+ * It extends GTFormatter with API client methods for server-side use.
  *
  * @class GT
- * @description A comprehensive toolkit for handling internationalization and localization.
  *
  * @example
  * const gt = new GT({
@@ -164,7 +121,7 @@ type GTConstructorParams = {
  *   locales: ['en-US', 'es-ES', 'fr-FR']
  * });
  */
-export class GT {
+export class GT extends GTFormatter {
   /** Base URL for the translation service API */
   baseUrl?: string;
 
@@ -176,27 +133,6 @@ export class GT {
 
   /** Development API key for accessing the translation service */
   devApiKey?: string;
-
-  /** Source locale for translations */
-  sourceLocale?: string;
-
-  /** Target locale for translations */
-  targetLocale?: string;
-
-  /** Array of supported locales */
-  locales?: string[];
-
-  /** Array of locales used for rendering variables */
-  _renderingLocales: string[] = [];
-
-  /** Custom mapping for locale codes to their names */
-  customMapping?: CustomMapping;
-
-  /** Lazily derived reverse custom mapping for alias locales */
-  reverseCustomMapping?: Record<string, string>;
-
-  /** Lazily derived custom mapping for regions */
-  customRegionMapping?: CustomRegionMapping;
 
   /**
    * Constructs an instance of the GT class.
@@ -214,83 +150,29 @@ export class GT {
    * });
    */
   constructor(params: GTConstructorParams = {}) {
+    super(params);
     // Read environment
     if (typeof process !== 'undefined') {
       this.apiKey ||= process.env?.GT_API_KEY;
       this.devApiKey ||= process.env?.GT_DEV_API_KEY;
       this.projectId ||= process.env?.GT_PROJECT_ID;
     }
-    // Set up config
-    this.setConfig(params);
+    // Set API-specific properties (super already handled locale config)
+    if (params.apiKey) this.apiKey = params.apiKey;
+    if (params.devApiKey) this.devApiKey = params.devApiKey;
+    if (params.projectId) this.projectId = params.projectId;
+    if (params.baseUrl) this.baseUrl = params.baseUrl;
   }
 
-  setConfig({
-    apiKey,
-    devApiKey,
-    sourceLocale,
-    targetLocale,
-    locales,
-    projectId,
-    customMapping,
-    baseUrl,
-  }: GTConstructorParams) {
-    // ----- Environment properties ----- //
-    if (apiKey) this.apiKey = apiKey;
-    if (devApiKey) this.devApiKey = devApiKey;
-    if (projectId) this.projectId = projectId;
+  override setConfig(params: GTConstructorParams) {
+    // Set API-specific properties
+    if (params.apiKey) this.apiKey = params.apiKey;
+    if (params.devApiKey) this.devApiKey = params.devApiKey;
+    if (params.projectId) this.projectId = params.projectId;
+    if (params.baseUrl) this.baseUrl = params.baseUrl;
 
-    // ----- Standardize locales ----- //
-
-    // source locale
-    if (sourceLocale) {
-      this.sourceLocale = _standardizeLocale(sourceLocale);
-      if (!_isValidLocale(this.sourceLocale, customMapping))
-        throw new Error(invalidLocaleError(this.sourceLocale));
-    }
-
-    // target locale
-    if (targetLocale) {
-      this.targetLocale = _standardizeLocale(targetLocale);
-      if (!_isValidLocale(this.targetLocale, customMapping))
-        throw new Error(invalidLocaleError(this.targetLocale));
-    }
-
-    // rendering locales
-    this._renderingLocales = [];
-    if (this.sourceLocale) this._renderingLocales.push(this.sourceLocale);
-    if (this.targetLocale) this._renderingLocales.push(this.targetLocale);
-    this._renderingLocales.push(libraryDefaultLocale);
-
-    // locales
-    if (locales) {
-      const result: string[] = [];
-      const invalidLocales: string[] = [];
-      locales.forEach((locale) => {
-        const standardizedLocale = _standardizeLocale(locale);
-        if (_isValidLocale(standardizedLocale)) {
-          result.push(standardizedLocale);
-        } else {
-          invalidLocales.push(locale);
-        }
-      });
-      if (invalidLocales.length > 0) {
-        throw new Error(invalidLocalesError(invalidLocales));
-      }
-      this.locales = result;
-    }
-
-    // ----- Other properties ----- //
-    if (baseUrl) this.baseUrl = baseUrl;
-    if (customMapping) {
-      this.customMapping = customMapping;
-      this.reverseCustomMapping = Object.fromEntries(
-        Object.entries(customMapping)
-          .filter(
-            ([, value]) => value && typeof value === 'object' && 'code' in value
-          )
-          .map(([key, value]) => [(value as { code: string }).code, key])
-      );
-    }
+    // Delegate locale/formatting config to parent
+    super.setConfig(params);
   }
 
   // -------------- Private Methods -------------- //
@@ -320,41 +202,16 @@ export class GT {
 
   // -------------- Branch Methods -------------- //
 
-  /**
-   * Queries branch information from the API.
-   *
-   * @param {BranchQuery} query - Object mapping the current branch and incoming branches
-   * @returns {Promise<BranchDataResult>} The branch information
-   */
   async queryBranchData(query: BranchQuery): Promise<BranchDataResult> {
     this._validateAuth('queryBranchData');
     return await _queryBranchData(query, this._getTranslationConfig());
   }
 
-  /**
-   * Creates a new branch in the API. If the branch already exists, it will be returned.
-   *
-   * @param {CreateBranchQuery} query - Object mapping the branch name and default branch flag
-   * @returns {Promise<CreateBranchResult>} The created branch information
-   */
   async createBranch(query: CreateBranchQuery): Promise<CreateBranchResult> {
     this._validateAuth('createBranch');
     return await _createBranch(query, this._getTranslationConfig());
   }
 
-  /**
-   * Processes file moves by cloning source files and translations with new fileIds.
-   * This is called when files have been moved/renamed and we want to preserve translations.
-   *
-   * @param {MoveMapping[]} moves - Array of move mappings (old fileId to new fileId)
-   * @param {ProcessMovesOptions} options - Options including branchId and timeout
-   * @returns {Promise<ProcessMovesResponse>} The move processing results
-   *
-   * @example
-   * const result = await gt.processFileMoves([
-   *   { oldFileId: 'abc123', newFileId: 'def456', newFileName: 'locales/en.json' }
-   * ], { branchId: 'main' });
-   */
   async processFileMoves(
     moves: MoveMapping[],
     options: ProcessMovesOptions = {}
@@ -367,19 +224,6 @@ export class GT {
     );
   }
 
-  /**
-   * Gets orphaned files for a branch - files that exist on the branch
-   * but whose fileIds are not in the provided list.
-   * Used for move detection.
-   *
-   * @param {string} branchId - The branch to check for orphaned files
-   * @param {string[]} fileIds - List of current file IDs (files that are NOT orphaned)
-   * @param {Object} options - Options including timeout
-   * @returns {Promise<GetOrphanedFilesResult>} The orphaned files
-   *
-   * @example
-   * const result = await gt.getOrphanedFiles('branch-id', ['file-1', 'file-2']);
-   */
   async getOrphanedFiles(
     branchId: string,
     fileIds: string[],
@@ -396,18 +240,6 @@ export class GT {
 
   // -------------- Translation Methods -------------- //
 
-  /**
-   * Enqueues project setup job using the specified file references
-   *
-   * This method creates setup jobs that will process source file references
-   * and generate a project setup. The files parameter contains references (IDs) to source
-   * files that have already been uploaded via uploadSourceFiles. The setup jobs are queued
-   * for processing and will generate a project setup based on the source files.
-   *
-   * @param {FileReference[]} files - Array of file references containing IDs of previously uploaded source files
-   * @param {SetupProjectOptions} [options] - Optional settings for target locales and timeout
-   * @returns {Promise<SetupProjectResult>} Object containing the jobId and status
-   */
   async setupProject(
     files: FileReference[],
     options?: SetupProjectOptions
@@ -422,24 +254,6 @@ export class GT {
     return await _setupProject(files, this._getTranslationConfig(), options);
   }
 
-  /**
-   * Checks the current status of one or more project jobs by their unique identifiers.
-   *
-   * This method polls the API to determine whether one or more jobs are still running,
-   * have completed successfully, or have failed. Jobs are created after calling either enqueueFiles or setupProject.
-   *
-   * @param {string[]} jobIds - The unique identifiers of the jobs to check
-   * @param {number} [timeoutMs] - Optional timeout in milliseconds for the API request
-   * @returns {Promise<CheckJobStatusResult>} Object containing the job status
-   *
-   * @example
-   * const result = await gt.checkJobStatus([
-   *   'job-123',
-   *   'job-456',
-   * ], {
-   *   timeout: 10000,
-   * });
-   */
   async checkJobStatus(
     jobIds: string[],
     timeoutMs?: number
@@ -452,13 +266,6 @@ export class GT {
     );
   }
 
-  /**
-   * Polls job statuses until all jobs from enqueueFiles are finished or the timeout is reached.
-   *
-   * @param {EnqueueFilesResult} enqueueResult - The result returned from enqueueFiles
-   * @param {AwaitJobsOptions} [options] - Polling configuration (interval, timeout)
-   * @returns {Promise<AwaitJobsResult>} The final status of all jobs and whether they all completed
-   */
   async awaitJobs(
     enqueueResult: EnqueueFilesResult,
     options?: AwaitJobsOptions
@@ -471,19 +278,6 @@ export class GT {
     );
   }
 
-  /**
-   * Enqueues translation jobs for previously uploaded source files.
-   *
-   * This method creates translation jobs that will process existing source files
-   * and generate translations in the specified target languages. The files parameter
-   * contains references (IDs) to source files that have already been uploaded via
-   * uploadSourceFiles. The translation jobs are queued for processing and will
-   * generate translated content based on the source files and target locales provided.
-   *
-   * @param {FileReferenceIds[]} files - Array of file references containing IDs of previously uploaded source files
-   * @param {EnqueueOptions} options - Configuration options including source locale, target locales, and job settings
-   * @returns {Promise<EnqueueFilesResult>} Result containing job IDs, queue status, and processing information
-   */
   async enqueueFiles(
     files: FileReferenceIds[],
     options: EnqueueOptions
@@ -530,40 +324,20 @@ export class GT {
     );
   }
 
-  /**
-   * Creates or upserts a file tag, associating a set of source files
-   * with a user-defined tag ID and optional message.
-   *
-   * @param {CreateTagOptions} options - Tag creation options including tagId, sourceFileIds, and optional message
-   * @returns {Promise<CreateTagResult>} The created or updated tag
-   */
   async createTag(options: CreateTagOptions): Promise<CreateTagResult> {
     this._validateAuth('createTag');
     return await _createTag(options, this._getTranslationConfig());
   }
 
-  /**
-   * Publishes or unpublishes files on the CDN.
-   *
-   * @param {PublishFileEntry[]} files - Array of file entries with publish flags
-   * @returns {Promise<PublishFilesResult>} Result containing per-file success/failure
-   */
   async publishFiles(files: PublishFileEntry[]): Promise<PublishFilesResult> {
     this._validateAuth('publishFiles');
     return await _publishFiles(files, this._getTranslationConfig());
   }
 
-  /**
-   * Submits user edit diffs for existing translations so future generations preserve user intent.
-   *
-   * @param {SubmitUserEditDiffsPayload} payload - Project-scoped diff payload.
-   * @returns {Promise<void>} Resolves when submission succeeds.
-   */
   async submitUserEditDiffs(
     payload: SubmitUserEditDiffsPayload
   ): Promise<void> {
     this._validateAuth('submitUserEditDiffs');
-    // Normalize locales to canonical form before submission
     const normalized: SubmitUserEditDiffsPayload = {
       ...payload,
       diffs: (payload.diffs || []).map((d) => ({
@@ -574,26 +348,6 @@ export class GT {
     await _submitUserEditDiffs(normalized, this._getTranslationConfig());
   }
 
-  /**
-   * Queries data about one or more source or translation files.
-   *
-   * @param {FileDataQuery} data - Object mapping source and translation file information.
-   * @param {CheckFileTranslationsOptions} options - Options for the API call.
-   * @returns {Promise<FileDataResult>} The source and translation file data information.
-   *
-   * @example
-   * const result = await gt.queryFileData({
-   *   sourceFiles: [
-   *     { fileId: '1234567890', versionId: '1234567890', branchId: '1234567890' },
-   *   ],
-   *   translatedFiles: [
-   *     { fileId: '1234567890', versionId: '1234567890', branchId: '1234567890', locale: 'es-ES' },
-   *   ],
-   * }, {
-   *   timeout: 10000,
-   * });
-   *
-   */
   async queryFileData(
     data: FileDataQuery,
     options: CheckFileTranslationsOptions = {}
@@ -629,20 +383,6 @@ export class GT {
     return result;
   }
 
-  /**
-   * Gets source and translation information for a given file ID and version ID.
-   *
-   * @param {FileQuery} data - File query containing file ID and version ID.
-   * @param {CheckFileTranslationsOptions} options - Options for getting source and translation information.
-   * @returns {Promise<FileQueryResult>} The source file and translation information.
-   *
-   * @example
-   * const result = await gt.querySourceFile(
-   *   { fileId: '1234567890', versionId: '1234567890' },
-   *   { timeout: 10000 }
-   * );
-   *
-   */
   async querySourceFile(
     data: FileQuery,
     options: CheckFileTranslationsOptions = {}
@@ -671,18 +411,7 @@ export class GT {
     }
     return result;
   }
-  /**
-   * Get project data for a given project ID.
-   *
-   * @param {string} projectId - The ID of the project to get the data for.
-   * @returns {Promise<ProjectData>} The project data.
-   *
-   * @example
-   * const result = await gt.getProjectData(
-   *   '1234567890'
-   * );
-   *
-   */
+
   async getProjectData(
     projectId: string,
     options: { timeout?: number } = {}
@@ -704,27 +433,6 @@ export class GT {
     return result;
   }
 
-  /**
-   * Downloads a single file.
-   *
-   * @param file - The file query object.
-   * @param {string} file.fileId - The ID of the file to download.
-   * @param {string} [file.branchId] - The ID of the branch to download the file from. If not provided, the default branch will be used.
-   * @param {string} [file.locale] - The locale to download the file for. If not provided, the source file will be downloaded.
-   * @param {string} [file.versionId] - The version ID to download the file from. If not provided, the latest version will be used.
-   * @param {DownloadFileOptions} options - Options for downloading the file.
-   * @returns {Promise<string>} The downloaded file content.
-   *
-   * @example
-   * const result = await gt.downloadFile({
-   *   fileId: '1234567890',
-   *   branchId: '1234567890',
-   *   locale: 'es-ES',
-   *   versionId: '1234567890',
-   * }, {
-   *   timeout: 10000,
-   * });
-   */
   async downloadFile(
     file: {
       fileId: string;
@@ -756,22 +464,6 @@ export class GT {
     return result.data?.[0]?.data ?? '';
   }
 
-  /**
-   * Downloads multiple files in a batch.
-   *
-   * @param {DownloadFileBatchRequest} requests - Array of file query objects to download.
-   * @param {DownloadFileBatchOptions} options - Options for the batch download.
-   * @returns {Promise<DownloadFileBatchResult>} The batch download results.
-   *
-   * @example
-   * const result = await gt.downloadFileBatch([{
-   *   fileId: '1234567890',
-   *   locale: 'es-ES',
-   *   versionId: '1234567890',
-   * }], {
-   *   timeout: 10000,
-   * });
-   */
   async downloadFileBatch(
     requests: DownloadFileBatchRequest,
     options: DownloadFileBatchOptions = {}
@@ -804,24 +496,6 @@ export class GT {
     };
   }
 
-  /**
-   * Translates a single source string to the target locale.
-   * Routes through {@link translateMany} under the hood.
-   *
-   * @param {string} source - The source string to translate.
-   * @param {object} options - Translation options including targetLocale and optional entry metadata.
-   * @returns {Promise<TranslationResult | TranslationError>} The translated content.
-   *
-   * @example
-   * const result = await gt.translate('Hello, world!', { targetLocale: 'es' });
-   *
-   * @example
-   * const result = await gt.translate('Hello, world!', {
-   *   targetLocale: 'es',
-   *   dataFormat: 'ICU',
-   *   context: 'A formal greeting',
-   * });
-   */
   async translate(
     source: TranslateManyEntry,
     options: string | TranslateOptions,
@@ -864,32 +538,6 @@ export class GT {
     return results[0];
   }
 
-  /**
-   * Translates multiple source strings to the target locale.
-   * Each entry can be a plain string or an object with source and metadata fields.
-   *
-   * @param {TranslateManyEntry[] | Record<string, TranslateManyEntry>} sources - The source entries to translate. Can be an array or a record keyed by hash.
-   * @param {object} options - Translation options including targetLocale.
-   * @returns {Promise<TranslateManyResult | Record<string, TranslationResult>>} The translated contents. An array if sources was an array, a record if sources was a record.
-   *
-   * @example
-   * const result = await gt.translateMany(
-   *   ['Hello, world!', 'Goodbye, world!'],
-   *   { targetLocale: 'es' }
-   * );
-   *
-   * @example
-   * const result = await gt.translateMany(
-   *   [{ source: 'Hello, world!', dataFormat: 'ICU' }],
-   *   { targetLocale: 'es' }
-   * );
-   *
-   * @example
-   * const result = await gt.translateMany(
-   *   { 'my-hash': 'Hello, world!' },
-   *   { targetLocale: 'es' }
-   * );
-   */
   async translateMany(
     sources: TranslateManyEntry[],
     options: string | TranslateOptions,
@@ -941,18 +589,6 @@ export class GT {
     );
   }
 
-  /**
-   * Uploads source files to the translation service without any translation content.
-   *
-   * This method creates or replaces source file entries in your project. Each uploaded
-   * file becomes a source that can later be translated into target languages. The files
-   * are processed and stored as base entries that serve as the foundation for generating
-   * translations through the translation workflow.
-   *
-   * @param {Array<{source: FileUpload}>} files - Array of objects containing source file data to upload
-   * @param {UploadFilesOptions} options - Configuration options including source locale and other upload settings
-   * @returns {Promise<UploadFilesResponse>} Upload result containing file IDs, version information, and upload status
-   */
   async uploadSourceFiles(
     files: { source: FileUpload }[],
     options: UploadFilesOptions
@@ -991,24 +627,10 @@ export class GT {
     };
   }
 
-  /**
-   * Uploads translation files that correspond to previously uploaded source files.
-   *
-   * This method allows you to provide translated content for existing source files in your project.
-   * Each translation must reference an existing source file and include the translated content
-   * along with the target locale information. This is used when you have pre-existing translations
-   * that you want to upload directly rather than generating them through the translation service.
-   *
-   * @param {Array<{source: FileUpload, translations: FileUpload[]}>} files - Array of file objects where:
-   *   - `source`: Reference to the existing source file (contains IDs but no content)
-   *   - `translations`: Array of translated files, each containing content, locale, and reference IDs
-   * @param {UploadFilesOptions} options - Configuration options including source locale and upload settings
-   * @returns {Promise<UploadFilesResponse>} Upload result containing translation IDs, status, and processing information
-   */
   async uploadTranslations(
     files: {
-      source: FileUpload; // reference only (no content)
-      translations: FileUpload[]; // each has content + ids + locale
+      source: FileUpload;
+      translations: FileUpload[];
     }[],
     options: UploadFilesOptions
   ): Promise<UploadFilesResponse> {
@@ -1050,1077 +672,6 @@ export class GT {
       message: `Successfully uploaded ${result.count} files in ${result.batchCount} batch(es)`,
     };
   }
-
-  // -------------- Formatting -------------- //
-
-  /**
-   * Formats a string with cutoff behavior, applying a terminator when the string exceeds the maximum character limit.
-   *
-   * This method uses the GT instance's rendering locales by default for locale-specific terminator selection,
-   * but can be overridden with custom locales in the options.
-   *
-   * @param {string} value - The string value to format with cutoff behavior.
-   * @param {Object} [options] - Configuration options for cutoff formatting.
-   * @param {string | string[]} [options.locales] - The locales to use for terminator selection. Defaults to instance's rendering locales.
-   * @param {number} [options.maxChars] - The maximum number of characters to display.
-   * - Undefined values are treated as no cutoff.
-   * - Negative values follow .slice() behavior and terminator will be added before the value.
-   * - 0 will result in an empty string.
-   * - If cutoff results in an empty string, no terminator is added.
-   * @param {CutoffFormatStyle} [options.style='ellipsis'] - The style of the terminator.
-   * @param {string} [options.terminator] - Optional override the terminator to use.
-   * @param {string} [options.separator] - Optional override the separator to use between the terminator and the value.
-   * - If no terminator is provided, then separator is ignored.
-   * @returns {string} The formatted string with terminator applied if cutoff occurs.
-   *
-   * @example
-   * const gt = new GT({ targetLocale: 'en-US' });
-   * gt.formatCutoff('Hello, world!', { maxChars: 8 });
-   * // Returns: 'Hello, w...'
-   *
-   * @example
-   * gt.formatCutoff('Hello, world!', { maxChars: -3 });
-   * // Returns: '...ld!'
-   */
-  formatCutoff(
-    value: string,
-    options?: {
-      locales?: string | string[];
-    } & CutoffFormatOptions
-  ): string {
-    return formatCutoff(value, {
-      locales: this._renderingLocales,
-      ...options,
-    });
-  }
-
-  /**
-   * Formats a message according to the specified locales and options.
-   *
-   * @param {string} message - The message to format.
-   * @param {string | string[]} [locales='en'] - The locales to use for formatting.
-   * @param {FormatVariables} [variables={}] - The variables to use for formatting.
-   * @param {StringFormat} [dataFormat='ICU'] - The format of the message.
-   * @returns {string} The formatted message.
-   *
-   * @example
-   * gt.formatMessage('Hello {name}', { name: 'John' });
-   * // Returns: "Hello John"
-   *
-   * gt.formatMessage('Hello {name}', { name: 'John' }, { locales: ['fr'] });
-   * // Returns: "Bonjour John"
-   */
-  formatMessage(
-    message: string,
-    options?: {
-      locales?: string | string[];
-      variables?: FormatVariables;
-      dataFormat?: StringFormat;
-    }
-  ): string {
-    return formatMessage(message, {
-      locales: this._renderingLocales,
-      ...options,
-    });
-  }
-  /**
-   * Formats a number according to the specified locales and options.
-   *
-   * @param {number} number - The number to format
-   * @param {Object} [options] - Additional options for number formatting
-   * @param {string | string[]} [options.locales] - The locales to use for formatting
-   * @param {Intl.NumberFormatOptions} [options] - Additional Intl.NumberFormat options
-   * @returns {string} The formatted number
-   *
-   * @example
-   * gt.formatNum(1234.56, { style: 'currency', currency: 'USD' });
-   * // Returns: "$1,234.56"
-   */
-  formatNum(
-    number: number,
-    options?: {
-      locales?: string | string[];
-    } & Intl.NumberFormatOptions
-  ): string {
-    return formatNum(number, {
-      locales: this._renderingLocales,
-      ...options,
-    });
-  }
-
-  /**
-   * Formats a date according to the specified locales and options.
-   *
-   * @param {Date} date - The date to format
-   * @param {Object} [options] - Additional options for date formatting
-   * @param {string | string[]} [options.locales] - The locales to use for formatting
-   * @param {Intl.DateTimeFormatOptions} [options] - Additional Intl.DateTimeFormat options
-   * @returns {string} The formatted date
-   *
-   * @example
-   * gt.formatDateTime(new Date(), { dateStyle: 'full', timeStyle: 'long' });
-   * // Returns: "Thursday, March 14, 2024 at 2:30:45 PM GMT-7"
-   */
-  formatDateTime(
-    date: Date,
-    options?: {
-      locales?: string | string[];
-    } & Intl.DateTimeFormatOptions
-  ): string {
-    return formatDateTime(date, {
-      locales: this._renderingLocales,
-      ...options,
-    });
-  }
-
-  /**
-   * Formats a currency value according to the specified locales and options.
-   *
-   * @param {number} value - The currency value to format
-   * @param {string} currency - The currency code (e.g., 'USD', 'EUR')
-   * @param {Object} [options] - Additional options for currency formatting
-   * @param {string | string[]} [options.locales] - The locales to use for formatting
-   * @param {Intl.NumberFormatOptions} [options] - Additional Intl.NumberFormat options
-   * @returns {string} The formatted currency value
-   *
-   * @example
-   * gt.formatCurrency(1234.56, 'USD', { style: 'currency' });
-   * // Returns: "$1,234.56"
-   */
-  formatCurrency(
-    value: number,
-    currency: string,
-    options?: {
-      locales?: string | string[];
-    } & Intl.NumberFormatOptions
-  ): string {
-    return formatCurrency(value, currency, {
-      locales: this._renderingLocales,
-      ...options,
-    });
-  }
-
-  /**
-   * Formats a list of items according to the specified locales and options.
-   *
-   * @param {Array<string | number>} array - The list of items to format
-   * @param {Object} [options] - Additional options for list formatting
-   * @param {string | string[]} [options.locales] - The locales to use for formatting
-   * @param {Intl.ListFormatOptions} [options] - Additional Intl.ListFormat options
-   * @returns {string} The formatted list
-   *
-   * @example
-   * gt.formatList(['apple', 'banana', 'orange'], { type: 'conjunction' });
-   * // Returns: "apple, banana, and orange"
-   */
-  formatList(
-    array: Array<string | number>,
-    options?: {
-      locales?: string | string[];
-    } & Intl.ListFormatOptions
-  ) {
-    return _formatList({
-      value: array,
-      locales: options?.locales || this._renderingLocales,
-      options: options,
-    });
-  }
-
-  /**
-   * Formats a list of items according to the specified locales and options.
-   * @param {Array<T>} array - The list of items to format
-   * @param {Object} [options] - Additional options for list formatting
-   * @param {string | string[]} [options.locales] - The locales to use for formatting
-   * @param {Intl.ListFormatOptions} [options] - Additional Intl.ListFormat options
-   * @returns {Array<T | string>} The formatted list parts
-   *
-   * @example
-   * gt.formatListToParts(['apple', 42, { foo: 'bar' }], { type: 'conjunction', style: 'short', locales: ['en'] });
-   * // Returns: ['apple', ', ', 42, ' and ', '{ foo: "bar" }']
-   */
-  formatListToParts<T>(
-    array: Array<T>,
-    options?: {
-      locales?: string | string[];
-    } & Intl.ListFormatOptions
-  ): Array<T | string> {
-    return _formatListToParts<T>({
-      value: array,
-      locales: options?.locales || this._renderingLocales,
-      options: options,
-    });
-  }
-
-  /**
-   * Formats a relative time value according to the specified locales and options.
-   *
-   * @param {number} value - The relative time value to format
-   * @param {Intl.RelativeTimeFormatUnit} unit - The unit of time (e.g., 'second', 'minute', 'hour', 'day', 'week', 'month', 'year')
-   * @param {Object} options - Additional options for relative time formatting
-   * @param {string | string[]} [options.locales] - The locales to use for formatting
-   * @param {Intl.RelativeTimeFormatOptions} [options] - Additional Intl.RelativeTimeFormat options
-   * @returns {string} The formatted relative time string
-   *
-   * @example
-   * gt.formatRelativeTime(-1, 'day', { locales: ['en-US'], numeric: 'auto' });
-   * // Returns: "yesterday"
-   */
-  formatRelativeTime(
-    value: number,
-    unit: Intl.RelativeTimeFormatUnit,
-    options?: {
-      locales?: string | string[];
-    } & Omit<Intl.RelativeTimeFormatOptions, 'locales'>
-  ): string {
-    return formatRelativeTime(value, unit, {
-      locales: this._renderingLocales,
-      ...options,
-    });
-  }
-
-  /**
-   * Formats a relative time string from a Date, automatically selecting the best unit.
-   *
-   * @param {Date} date - The date to format relative to now
-   * @param {Object} [options] - Additional options for relative time formatting
-   * @param {string | string[]} [options.locales] - The locales to use for formatting
-   * @returns {string} The formatted relative time string (e.g., "2 hours ago", "in 3 days")
-   *
-   * @example
-   * gt.formatRelativeTimeFromDate(new Date(Date.now() - 3600000));
-   * // Returns: "1 hour ago"
-   */
-  formatRelativeTimeFromDate(
-    date: Date,
-    options?: {
-      locales?: string | string[];
-      baseDate?: Date;
-    } & Omit<Intl.RelativeTimeFormatOptions, 'locales'>
-  ): string {
-    return formatRelativeTimeFromDate(date, {
-      locales: this._renderingLocales,
-      ...options,
-    });
-  }
-
-  // -------------- Locale Properties -------------- //
-
-  /**
-   * Retrieves the display name of a locale code using Intl.DisplayNames, returning an empty string if no name is found.
-   *
-   * @param {string} [locale=this.targetLocale] - A BCP-47 locale code
-   * @returns {string} The display name corresponding to the code
-   * @throws {Error} If no target locale is provided
-   *
-   * @example
-   * gt.getLocaleName('es-ES');
-   * // Returns: "Spanish (Spain)"
-   */
-  getLocaleName(locale = this.targetLocale): string {
-    if (!locale) throw new Error(noTargetLocaleProvidedError('getLocaleName'));
-    return _getLocaleName(locale, this.sourceLocale, this.customMapping);
-  }
-
-  /**
-   * Retrieves an emoji based on a given locale code.
-   * Uses the locale's region (if present) to select an emoji or falls back on default emojis.
-   *
-   * @param {string} [locale=this.targetLocale] - A BCP-47 locale code (e.g., 'en-US', 'fr-CA')
-   * @returns {string} The emoji representing the locale or its region
-   * @throws {Error} If no target locale is provided
-   *
-   * @example
-   * gt.getLocaleEmoji('es-ES');
-   * // Returns: "🇪🇸"
-   */
-  getLocaleEmoji(locale = this.targetLocale): string {
-    if (!locale) throw new Error(noTargetLocaleProvidedError('getLocaleEmoji'));
-    return getLocaleEmoji(locale, this.customMapping);
-  }
-
-  /**
-   * Generates linguistic details for a given locale code.
-   *
-   * This function returns information about the locale,
-   * script, and region of a given language code both in a standard form and in a maximized form (with likely script and region).
-   * The function provides these names in both your default language and native forms, and an associated emoji.
-   *
-   * @param {string} [locale=this.targetLocale] - The locale code to get properties for (e.g., "de-AT").
-   * @returns {LocaleProperties} - An object containing detailed information about the locale.
-   *
-   * @property {string} code - The full locale code, e.g., "de-AT".
-   * @property {string} name - Language name in the default display language, e.g., "Austrian German".
-   * @property {string} nativeName - Language name in the locale's native language, e.g., "Österreichisches Deutsch".
-   * @property {string} languageCode - The base language code, e.g., "de".
-   * @property {string} languageName - The language name in the default display language, e.g., "German".
-   * @property {string} nativeLanguageName - The language name in the native language, e.g., "Deutsch".
-   * @property {string} nameWithRegionCode - Language name with region in the default language, e.g., "German (AT)".
-   * @property {string} nativeNameWithRegionCode - Language name with region in the native language, e.g., "Deutsch (AT)".
-   * @property {string} regionCode - The region code from maximization, e.g., "AT".
-   * @property {string} regionName - The region name in the default display language, e.g., "Austria".
-   * @property {string} nativeRegionName - The region name in the native language, e.g., "Österreich".
-   * @property {string} scriptCode - The script code from maximization, e.g., "Latn".
-   * @property {string} scriptName - The script name in the default display language, e.g., "Latin".
-   * @property {string} nativeScriptName - The script name in the native language, e.g., "Lateinisch".
-   * @property {string} maximizedCode - The maximized locale code, e.g., "de-Latn-AT".
-   * @property {string} maximizedName - Maximized locale name with likely script in the default language, e.g., "Austrian German (Latin)".
-   * @property {string} nativeMaximizedName - Maximized locale name in the native language, e.g., "Österreichisches Deutsch (Lateinisch)".
-   * @property {string} minimizedCode - Minimized locale code, e.g., "de-AT" (or "de" for "de-DE").
-   * @property {string} minimizedName - Minimized language name in the default language, e.g., "Austrian German".
-   * @property {string} nativeMinimizedName - Minimized language name in the native language, e.g., "Österreichisches Deutsch".
-   * @property {string} emoji - The emoji associated with the locale's region, if applicable.
-   */
-  getLocaleProperties(locale = this.targetLocale): LocaleProperties {
-    if (!locale)
-      throw new Error(noTargetLocaleProvidedError('getLocaleProperties'));
-    return getLocaleProperties(locale, this.sourceLocale, this.customMapping);
-  }
-
-  /**
-   * Retrieves multiple properties for a given region code, including:
-   * - `code`: the original region code
-   * - `name`: the localized display name
-   * - `emoji`: the associated flag or symbol
-   *
-   * Behavior:
-   * - Accepts ISO 3166-1 alpha-2 or UN M.49 region codes (e.g., `"US"`, `"FR"`, `"419"`).
-   * - Uses the instance's `targetLocale` to localize the region name for the user.
-   * - If `customMapping` contains a `name` or `emoji` for the region, those override the default values.
-   * - Otherwise, uses `Intl.DisplayNames` to get the localized region name, falling back to `libraryDefaultLocale`.
-   * - Falls back to the region code as `name` if display name resolution fails.
-   * - Falls back to a default emoji if no emoji mapping is found in built-in data or `customMapping`.
-   *
-   * @param {string} [region=this.getLocaleProperties().regionCode] - The region code to look up (e.g., `"US"`, `"GB"`, `"DE"`).
-   * @param {CustomRegionMapping} [customMapping] - Optional mapping of region codes to custom names and/or emojis.
-   * @returns {{ code: string, name: string, emoji: string }} An object containing:
-   *  - `code`: the input region code
-   *  - `name`: the localized or custom region name
-   *  - `emoji`: the matching emoji flag or symbol
-   *
-   * @throws {Error} If no target locale is available to determine region properties.
-   *
-   * @example
-   * const gt = new GT({ targetLocale: 'en-US' });
-   * gt.getRegionProperties('US');
-   * // => { code: 'US', name: 'United States', emoji: '🇺🇸' }
-   *
-   * @example
-   * const gt = new GT({ targetLocale: 'fr-FR' });
-   * gt.getRegionProperties('US');
-   * // => { code: 'US', name: 'États-Unis', emoji: '🇺🇸' }
-   *
-   * @example
-   * gt.getRegionProperties('US', { US: { name: 'USA', emoji: '🗽' } });
-   * // => { code: 'US', name: 'USA', emoji: '🗽' }
-   */
-  getRegionProperties(
-    region = this.getLocaleProperties().regionCode,
-    customMapping?: CustomRegionMapping
-  ): { code: string; name: string; emoji: string } {
-    if (!customMapping) {
-      if (this.customMapping && !this.customRegionMapping) {
-        // Lazy derive custom region mapping from customMapping
-        const customRegionMapping: CustomRegionMapping = {};
-        for (const [locale, lp] of Object.entries(this.customMapping)) {
-          if (
-            lp &&
-            typeof lp === 'object' &&
-            lp.regionCode &&
-            !customRegionMapping[lp.regionCode]
-          ) {
-            const { regionName: name, emoji } = lp;
-            customRegionMapping[lp.regionCode] = {
-              locale,
-              ...(name && { name }),
-              ...(emoji && { emoji }),
-            };
-          }
-        }
-        this.customRegionMapping = customRegionMapping;
-      }
-      customMapping = this.customRegionMapping;
-    }
-    return _getRegionProperties(
-      region,
-      this.targetLocale, // this.targetLocale because we want it in the user's language
-      customMapping
-    );
-  }
-
-  /**
-   * Determines whether a translation is required based on the source and target locales.
-   *
-   * @param {string} [sourceLocale=this.sourceLocale] - The locale code for the original content
-   * @param {string} [targetLocale=this.targetLocale] - The locale code to translate into
-   * @param {string[]} [approvedLocales=this.locales] - Optional array of approved target locales
-   * @returns {boolean} True if translation is required, false otherwise
-   * @throws {Error} If no source locale is provided
-   * @throws {Error} If no target locale is provided
-   *
-   * @example
-   * gt.requiresTranslation('en-US', 'es-ES');
-   * // Returns: true
-   */
-  requiresTranslation(
-    sourceLocale = this.sourceLocale,
-    targetLocale = this.targetLocale,
-    approvedLocales: string[] | undefined = this.locales,
-    customMapping: CustomMapping | undefined = this.customMapping
-  ): boolean {
-    if (!sourceLocale)
-      throw new Error(noSourceLocaleProvidedError('requiresTranslation'));
-    if (!targetLocale)
-      throw new Error(noTargetLocaleProvidedError('requiresTranslation'));
-    return _requiresTranslation(
-      sourceLocale,
-      targetLocale,
-      approvedLocales,
-      customMapping
-    );
-  }
-
-  /**
-   * Determines the best matching locale from the provided approved locales list.
-   *
-   * @param {string | string[]} locales - A single locale or array of locales in preference order
-   * @param {string[]} [approvedLocales=this.locales] - Array of approved locales in preference order
-   * @returns {string | undefined} The best matching locale or undefined if no match is found
-   *
-   * @example
-   * gt.determineLocale(['fr-CA', 'fr-FR'], ['en-US', 'fr-FR', 'es-ES']);
-   * // Returns: "fr-FR"
-   */
-  determineLocale(
-    locales: string | string[],
-    approvedLocales: string[] | undefined = this.locales || [],
-    customMapping: CustomMapping | undefined = this.customMapping
-  ): string | undefined {
-    return _determineLocale(locales, approvedLocales, customMapping);
-  }
-
-  /**
-   * Gets the text direction for a given locale code.
-   *
-   * @param {string} [locale=this.targetLocale] - A BCP-47 locale code
-   * @returns {'ltr' | 'rtl'} 'rtl' if the locale is right-to-left, otherwise 'ltr'
-   * @throws {Error} If no target locale is provided
-   *
-   * @example
-   * gt.getLocaleDirection('ar-SA');
-   * // Returns: "rtl"
-   */
-  getLocaleDirection(locale = this.targetLocale): 'ltr' | 'rtl' {
-    if (!locale)
-      throw new Error(noTargetLocaleProvidedError('getLocaleDirection'));
-    return getLocaleDirection(locale);
-  }
-
-  /**
-   * Checks if a given BCP 47 locale code is valid.
-   *
-   * @param {string} [locale=this.targetLocale] - The BCP 47 locale code to validate
-   * @param {customMapping} [customMapping=this.customMapping] - The custom mapping to use for validation
-   * @returns {boolean} True if the locale code is valid, false otherwise
-   * @throws {Error} If no target locale is provided
-   *
-   * @example
-   * gt.isValidLocale('en-US');
-   * // Returns: true
-   */
-  isValidLocale(
-    locale = this.targetLocale,
-    customMapping: CustomMapping | undefined = this.customMapping
-  ): boolean {
-    if (!locale) throw new Error(noTargetLocaleProvidedError('isValidLocale'));
-    return isValidLocale(locale, customMapping);
-  }
-
-  /**
-   * Resolves the canonical locale for a given locale.
-   * @param locale - The locale to resolve the canonical locale for
-   * @param customMapping - The custom mapping to use for resolving the canonical locale
-   * @returns The canonical locale
-   */
-  resolveCanonicalLocale(
-    locale: string | undefined = this.targetLocale,
-    customMapping: CustomMapping | undefined = this.customMapping
-  ): string {
-    if (!locale)
-      throw new Error(noTargetLocaleProvidedError('resolveCanonicalLocale'));
-    return _resolveCanonicalLocale(locale, customMapping);
-  }
-
-  /**
-   * Resolves the alias locale for a given locale.
-   * @param locale - The locale to resolve the alias locale for
-   * @param customMapping - The custom mapping to use for resolving the alias locale
-   * @returns The alias locale
-   */
-  resolveAliasLocale(
-    locale: string,
-    customMapping: CustomMapping | undefined = this.customMapping
-  ): string {
-    if (!locale)
-      throw new Error(noTargetLocaleProvidedError('resolveAliasLocale'));
-    return _resolveAliasLocale(locale, customMapping);
-  }
-
-  /**
-   * Standardizes a BCP 47 locale code to ensure correct formatting.
-   *
-   * @param {string} [locale=this.targetLocale] - The BCP 47 locale code to standardize
-   * @returns {string} The standardized locale code or empty string if invalid
-   * @throws {Error} If no target locale is provided
-   *
-   * @example
-   * gt.standardizeLocale('en_us');
-   * // Returns: "en-US"
-   */
-  standardizeLocale(locale = this.targetLocale): string {
-    if (!locale)
-      throw new Error(noTargetLocaleProvidedError('standardizeLocale'));
-    return _standardizeLocale(locale);
-  }
-
-  /**
-   * Checks if multiple BCP 47 locale codes represent the same dialect.
-   *
-   * @param {...(string | string[])} locales - The BCP 47 locale codes to compare
-   * @returns {boolean} True if all codes represent the same dialect, false otherwise
-   *
-   * @example
-   * gt.isSameDialect('en-US', 'en-GB');
-   * // Returns: false
-   *
-   * gt.isSameDialect('en', 'en-US');
-   * // Returns: true
-   */
-  isSameDialect(...locales: (string | string[])[]): boolean {
-    return isSameDialect(...locales);
-  }
-
-  /**
-   * Checks if multiple BCP 47 locale codes represent the same language.
-   *
-   * @param {...(string | string[])} locales - The BCP 47 locale codes to compare
-   * @returns {boolean} True if all codes represent the same language, false otherwise
-   *
-   * @example
-   * gt.isSameLanguage('en-US', 'en-GB');
-   * // Returns: true
-   */
-  isSameLanguage(...locales: (string | string[])[]): boolean {
-    return _isSameLanguage(...locales);
-  }
-
-  /**
-   * Checks if a locale is a superset of another locale.
-   *
-   * @param {string} superLocale - The locale to check if it is a superset
-   * @param {string} subLocale - The locale to check if it is a subset
-   * @returns {boolean} True if superLocale is a superset of subLocale, false otherwise
-   *
-   * @example
-   * gt.isSupersetLocale('en', 'en-US');
-   * // Returns: true
-   *
-   * gt.isSupersetLocale('en-US', 'en');
-   * // Returns: false
-   */
-  isSupersetLocale(superLocale: string, subLocale: string): boolean {
-    return isSupersetLocale(superLocale, subLocale);
-  }
-}
-
-// ============================================================ //
-//                    Utility methods                           //
-// ============================================================ //
-
-// -------------- Formatting -------------- //
-
-/**
- * Formats a string with cutoff behavior, applying a terminator when the string exceeds the maximum character limit.
- *
- * This standalone function provides cutoff formatting functionality without requiring a GT instance.
- * The locales parameter is required for proper terminator selection based on the target language.
- *
- * @param {string} value - The string value to format with cutoff behavior.
- * @param {Object} [options] - Configuration options for cutoff formatting.
- * @param {string | string[]} [options.locales] - The locales to use for terminator selection.
- * @param {number} [options.maxChars] - The maximum number of characters to display.
- * - Undefined values are treated as no cutoff.
- * - Negative values follow .slice() behavior and terminator will be added before the value.
- * - 0 will result in an empty string.
- * - If cutoff results in an empty string, no terminator is added.
- * @param {CutoffFormatStyle} [options.style='ellipsis'] - The style of the terminator.
- * @param {string} [options.terminator] - Optional override the terminator to use.
- * @param {string} [options.separator] - Optional override the separator to use between the terminator and the value.
- * - If no terminator is provided, then separator is ignored.
- * @returns {string} The formatted string with terminator applied if cutoff occurs.
- *
- * @example
- * formatCutoff('Hello, world!', { locales: 'en-US', maxChars: 8 });
- * // Returns: 'Hello, w...'
- *
- * @example
- * formatCutoff('Hello, world!', { locales: 'en-US', maxChars: -3 });
- * // Returns: '...ld!'
- *
- * @example
- * formatCutoff('Very long text that needs cutting', {
- *   locales: 'en-US',
- *   maxChars: 15,
- *   style: 'ellipsis',
- *   separator: ' '
- * });
- * // Returns: 'Very long text ...'
- */
-export function formatCutoff(
-  value: string,
-  options?: {
-    locales?: string | string[];
-  } & CutoffFormatOptions
-): string {
-  return _formatCutoff({ value, locales: options?.locales, options });
-}
-
-/**
- * Formats a message according to the specified locales and options.
- *
- * @param {string} message - The message to format.
- * @param {string | string[]} [locales='en'] - The locales to use for formatting.
- * @param {FormatVariables} [variables={}] - The variables to use for formatting.
- * @param {StringFormat} [dataFormat='ICU'] - The format of the message. (When STRING, the message is returned as is)
- * @returns {string} The formatted message.
- *
- * @example
- * formatMessage('Hello {name}', { name: 'John' });
- * // Returns: "Hello John"
- *
- * formatMessage('Hello {name}', { name: 'John' }, { locales: ['fr'] });
- * // Returns: "Bonjour John"
- */
-export function formatMessage(
-  message: string,
-  options?: {
-    locales?: string | string[];
-    variables?: FormatVariables;
-    dataFormat?: StringFormat;
-  }
-): string {
-  switch (options?.dataFormat) {
-    case 'STRING':
-      return _formatMessageString(message);
-    default:
-      return _formatMessageICU(message, options?.locales, options?.variables);
-  }
-}
-
-/**
- * Formats a number according to the specified locales and options.
- * @param {Object} params - The parameters for the number formatting.
- * @param {number} params.value - The number to format.
- * @param {Intl.NumberFormatOptions} [params.options] - Additional options for number formatting.
- * @param {string | string[]} [params.options.locales] - The locales to use for formatting.
- * @returns {string} The formatted number.
- */
-export function formatNum(
-  number: number,
-  options: {
-    locales: string | string[];
-  } & Intl.NumberFormatOptions
-): string {
-  return _formatNum({
-    value: number,
-    locales: options.locales,
-    options,
-  });
-}
-
-/**
- * Formats a date according to the specified languages and options.
- * @param {Object} params - The parameters for the date formatting.
- * @param {Date} params.value - The date to format.
- * @param {Intl.DateTimeFormatOptions} [params.options] - Additional options for date formatting.
- * @param {string | string[]} [params.options.locales] - The languages to use for formatting.
- * @returns {string} The formatted date.
- */
-export function formatDateTime(
-  date: Date,
-  options?: {
-    locales?: string | string[];
-  } & Intl.DateTimeFormatOptions
-): string {
-  return _formatDateTime({
-    value: date,
-    locales: options?.locales,
-    options,
-  });
-}
-
-/**
- * Formats a currency value according to the specified languages, currency, and options.
- * @param {Object} params - The parameters for the currency formatting.
- * @param {number} params.value - The currency value to format.
- * @param {string} params.currency - The currency code (e.g., 'USD').
- * @param {Intl.NumberFormatOptions} [params.options={}] - Additional options for currency formatting.
- * @param {string | string[]} [params.options.locales] - The locale codes to use for formatting.
- * @returns {string} The formatted currency value.
- */
-export function formatCurrency(
-  value: number,
-  currency: string,
-  options: {
-    locales: string | string[];
-  } & Intl.NumberFormatOptions
-): string {
-  return _formatCurrency({
-    value,
-    currency,
-    locales: options.locales,
-    options,
-  });
-}
-
-/**
- * Formats a list of items according to the specified locales and options.
- * @param {Object} params - The parameters for the list formatting.
- * @param {Array<string | number>} params.value - The list of items to format.
- * @param {Intl.ListFormatOptions} [params.options={}] - Additional options for list formatting.
- * @param {string | string[]} [params.options.locales] - The locales to use for formatting.
- * @returns {string} The formatted list.
- */
-export function formatList(
-  array: Array<string | number>,
-  options: {
-    locales: string | string[];
-  } & Intl.ListFormatOptions
-): string {
-  return _formatList({
-    value: array,
-    locales: options.locales,
-    options,
-  });
-}
-
-/**
- * Formats a list of items according to the specified locales and options.
- * @param {Array<T>} array - The list of items to format
- * @param {Object} [options] - Additional options for list formatting
- * @param {string | string[]} [options.locales] - The locales to use for formatting
- * @param {Intl.ListFormatOptions} [options] - Additional Intl.ListFormat options
- * @returns {Array<T | string>} The formatted list parts
- */
-export function formatListToParts<T>(
-  array: Array<T>,
-  options?: {
-    locales?: string | string[];
-  } & Intl.ListFormatOptions
-): Array<T | string> {
-  return _formatListToParts<T>({
-    value: array,
-    locales: options?.locales,
-    options: options,
-  });
-}
-
-/**
- * Formats a relative time value according to the specified locales and options.
- * @param {Object} params - The parameters for the relative time formatting.
- * @param {number} params.value - The relative time value to format.
- * @param {Intl.RelativeTimeFormatUnit} params.unit - The unit of time (e.g., 'second', 'minute', 'hour', 'day', 'week', 'month', 'year').
- * @param {Intl.RelativeTimeFormatOptions} [params.options={}] - Additional options for relative time formatting.
- * @param {string | string[]} [params.options.locales] - The locales to use for formatting.
- * @returns {string} The formatted relative time string.
- */
-export function formatRelativeTime(
-  value: number,
-  unit: Intl.RelativeTimeFormatUnit,
-  options: {
-    locales: string | string[];
-  } & Omit<Intl.RelativeTimeFormatOptions, 'locales'>
-): string {
-  return _formatRelativeTime({
-    value,
-    unit,
-    locales: options.locales,
-    options,
-  });
-}
-
-/**
- * Formats a relative time string from a Date, automatically selecting the best unit.
- * @param {Date} date - The date to format relative to now.
- * @param {Object} options - Formatting options.
- * @param {string | string[]} options.locales - The locales to use for formatting.
- * @param {Intl.RelativeTimeFormatOptions} [options] - Additional Intl.RelativeTimeFormat options.
- * @returns {string} The formatted relative time string (e.g., "2 hours ago", "in 3 days").
- */
-export function formatRelativeTimeFromDate(
-  date: Date,
-  options: {
-    locales: string | string[];
-    baseDate?: Date;
-  } & Omit<Intl.RelativeTimeFormatOptions, 'locales'>
-): string {
-  const { locales, baseDate, ...intlOptions } = options;
-  return _formatRelativeTimeFromDate({
-    date,
-    baseDate: baseDate ?? new Date(),
-    locales,
-    options: intlOptions,
-  });
-}
-
-// -------------- Locale Properties -------------- //
-
-/**
- * Retrieves the display name of locale code using Intl.DisplayNames.
- *
- * @param {string} locale - A BCP-47 locale code.
- * @param {string} [defaultLocale] - The default locale to use for formatting.
- * @param {CustomMapping} [customMapping] - A custom mapping of locale codes to their names.
- * @returns {string} The display name corresponding to the code.
- */
-export function getLocaleName(
-  locale: string,
-  defaultLocale?: string,
-  customMapping?: CustomMapping
-): string {
-  return _getLocaleName(locale, defaultLocale, customMapping);
-}
-
-/**
- * Retrieves an emoji based on a given locale code, taking into account region, language, and specific exceptions.
- *
- * This function uses the locale's region (if present) to select an emoji or falls back on default emojis for certain languages.
- *
- * @param locale - A string representing the locale code (e.g., 'en-US', 'fr-CA').
- * @param {CustomMapping} [customMapping] - A custom mapping of locale codes to their names.
- * @returns The emoji representing the locale or its region, or a default emoji if no specific match is found.
- */
-export function getLocaleEmoji(
-  locale: string,
-  customMapping?: CustomMapping
-): string {
-  return _getLocaleEmoji(locale, customMapping);
-}
-
-/**
- * Generates linguistic details for a given locale code.
- *
- * This function returns information about the locale,
- * script, and region of a given language code both in a standard form and in a maximized form (with likely script and region).
- * The function provides these names in both your default language and native forms, and an associated emoji.
- *
- * @param {string} locale - The locale code to get properties for (e.g., "de-AT").
- * @param {string} [defaultLocale] - The default locale to use for formatting.
- * @param {CustomMapping} [customMapping] - A custom mapping of locale codes to their names.
- * @returns {LocaleProperties} - An object containing detailed information about the locale.
- *
- * @property {string} code - The full locale code, e.g., "de-AT".
- * @property {string} name - Language name in the default display language, e.g., "Austrian German".
- * @property {string} nativeName - Language name in the locale's native language, e.g., "Österreichisches Deutsch".
- * @property {string} languageCode - The base language code, e.g., "de".
- * @property {string} languageName - The language name in the default display language, e.g., "German".
- * @property {string} nativeLanguageName - The language name in the native language, e.g., "Deutsch".
- * @property {string} nameWithRegionCode - Language name with region in the default language, e.g., "German (AT)".
- * @property {string} nativeNameWithRegionCode - Language name with region in the native language, e.g., "Deutsch (AT)".
- * @property {string} regionCode - The region code from maximization, e.g., "AT".
- * @property {string} regionName - The region name in the default display language, e.g., "Austria".
- * @property {string} nativeRegionName - The region name in the native language, e.g., "Österreich".
- * @property {string} scriptCode - The script code from maximization, e.g., "Latn".
- * @property {string} scriptName - The script name in the default display language, e.g., "Latin".
- * @property {string} nativeScriptName - The script name in the native language, e.g., "Lateinisch".
- * @property {string} maximizedCode - The maximized locale code, e.g., "de-Latn-AT".
- * @property {string} maximizedName - Maximized locale name with likely script in the default language, e.g., "Austrian German (Latin)".
- * @property {string} nativeMaximizedName - Maximized locale name in the native language, e.g., "Österreichisches Deutsch (Lateinisch)".
- * @property {string} minimizedCode - Minimized locale code, e.g., "de-AT" (or "de" for "de-DE").
- * @property {string} minimizedName - Minimized language name in the default language, e.g., "Austrian German".
- * @property {string} nativeMinimizedName - Minimized language name in the native language, e.g., "Österreichisches Deutsch".
- * @property {string} emoji - The emoji associated with the locale's region, if applicable.
- */
-export function getLocaleProperties(
-  locale: string,
-  defaultLocale?: string,
-  customMapping?: CustomMapping
-): LocaleProperties {
-  return _getLocaleProperties(locale, defaultLocale, customMapping);
-}
-
-/**
- * Retrieves multiple properties for a given region code, including:
- * - `code`: the original region code
- * - `name`: the localized display name
- * - `emoji`: the associated flag or symbol
- *
- * Behavior:
- * - Accepts ISO 3166-1 alpha-2 or UN M.49 region codes (e.g., `"US"`, `"FR"`, `"419"`).
- * - If `customMapping` contains a `name` or `emoji` for the region, those override the default values.
- * - Otherwise, uses `Intl.DisplayNames` to get the localized region name in the given `defaultLocale`,
- *   falling back to `libraryDefaultLocale`.
- * - Falls back to the region code as `name` if display name resolution fails.
- * - Falls back to `defaultEmoji` if no emoji mapping is found in `emojis` or `customMapping`.
- *
- * @param {string} region - The region code to look up (e.g., `"US"`, `"GB"`, `"DE"`).
- * @param {string} [defaultLocale=libraryDefaultLocale] - The locale to use when localizing the region name.
- * @param {CustomRegionMapping} [customMapping] - Optional mapping of region codes to custom names and/or emojis.
- * @returns {{ code: string, name: string, emoji: string }} An object containing:
- *  - `code`: the input region code
- *  - `name`: the localized or custom region name
- *  - `emoji`: the matching emoji flag or symbol
- *
- * @example
- * getRegionProperties('US', 'en');
- * // => { code: 'US', name: 'United States', emoji: '🇺🇸' }
- *
- * @example
- * getRegionProperties('US', 'fr');
- * // => { code: 'US', name: 'États-Unis', emoji: '🇺🇸' }
- *
- * @example
- * getRegionProperties('US', 'en', { US: { name: 'USA', emoji: '🗽' } });
- * // => { code: 'US', name: 'USA', emoji: '🗽' }
- */
-export function getRegionProperties(
-  region: string,
-  defaultLocale?: string,
-  customMapping?: CustomRegionMapping
-): { code: string; name: string; emoji: string } {
-  return _getRegionProperties(region, defaultLocale, customMapping);
-}
-
-/**
- * Determines whether a translation is required based on the source and target locales.
- *
- * - If the target locale is not specified, the function returns `false`, as translation is not needed.
- * - If the source and target locale are the same, returns `false`, indicating that no translation is necessary.
- * - If the `approvedLocales` array is provided, and the target locale is not within that array, the function also returns `false`.
- * - Otherwise, it returns `true`, meaning that a translation is required.
- *
- * @param {string} sourceLocale - The locale code for the original content (BCP 47 locale code).
- * @param {string} targetLocale - The locale code of the language to translate the content into (BCP 47 locale code).
- * @param {string[]} [approvedLocale] - An optional array of approved target locales.
- *
- * @returns {boolean} - Returns `true` if translation is required, otherwise `false`.
- */
-export function requiresTranslation(
-  sourceLocale: string,
-  targetLocale: string,
-  approvedLocales?: string[],
-  customMapping?: CustomMapping
-): boolean {
-  return _requiresTranslation(
-    sourceLocale,
-    targetLocale,
-    approvedLocales,
-    customMapping
-  );
-}
-
-/**
- * Determines the best matching locale from the provided approved locales list.
- * @param {string | string[]} locales - A single locale or an array of locales sorted in preference order.
- * @param {string[]} [approvedLocales=this.locales] - An array of approved locales, also sorted by preference.
- * @returns {string | undefined} - The best matching locale from the approvedLocales list, or undefined if no match is found.
- */
-export function determineLocale(
-  locales: string | string[],
-  approvedLocales: string[] | undefined = [],
-  customMapping: CustomMapping | undefined = undefined
-): string | undefined {
-  return _determineLocale(locales, approvedLocales, customMapping);
-}
-
-/**
- * Get the text direction for a given locale code using the Intl.Locale API.
- *
- * @param {string} locale - A BCP-47 locale code.
- * @returns {string} - 'rtl' if the locale is right-to-left, otherwise 'ltr'.
- */
-export function getLocaleDirection(locale: string): 'ltr' | 'rtl' {
-  return _getLocaleDirection(locale);
-}
-
-/**
- * Checks if a given BCP 47 locale code is valid.
- * @param {string} locale - The BCP 47 locale code to validate.
- * @param {CustomMapping} [customMapping] - The custom mapping to use for validation.
- * @returns {boolean} True if the BCP 47 code is valid, false otherwise.
- */
-export function isValidLocale(
-  locale: string,
-  customMapping?: CustomMapping
-): boolean {
-  return _isValidLocale(locale, customMapping);
-}
-
-/**
- * Resolves the alias locale for a given locale.
- * @param {string} locale - The locale to resolve the alias locale for
- * @param {CustomMapping} [customMapping] - The custom mapping to use for resolving the alias locale
- * @returns {string} The alias locale
- */
-export function resolveAliasLocale(
-  locale: string,
-  customMapping?: CustomMapping
-): string {
-  return _resolveAliasLocale(locale, customMapping);
-}
-
-/**
- * Resolves the canonical locale for a given locale.
- * @param {string} locale - The locale to resolve the canonical locale for
- * @param {CustomMapping} [customMapping] - The custom mapping to use for resolving the canonical locale
- * @returns {string} The canonical locale
- */
-export function resolveCanonicalLocale(
-  locale: string,
-  customMapping?: CustomMapping
-): string {
-  return _resolveCanonicalLocale(locale, customMapping);
-}
-
-/**
- * Standardizes a BCP 47 locale code to ensure correct formatting.
- * @param {string} locale - The BCP 47 locale code to standardize.
- * @returns {string} The standardized BCP 47 locale code or an empty string if it is an invalid code.
- */
-export function standardizeLocale(locale: string): string {
-  return _standardizeLocale(locale);
-}
-
-/**
- * Checks if multiple BCP 47 locale codes represent the same dialect.
- * @param {string[]} locales - The BCP 47 locale codes to compare.
- * @returns {boolean} True if all BCP 47 codes represent the same dialect, false otherwise.
- */
-export function isSameDialect(...locales: (string | string[])[]): boolean {
-  return _isSameDialect(...locales);
-}
-
-/**
- * Checks if multiple BCP 47 locale codes represent the same language.
- * @param {string[]} locales - The BCP 47 locale codes to compare.
- * @returns {boolean} True if all BCP 47 codes represent the same language, false otherwise.
- */
-export function isSameLanguage(...locales: (string | string[])[]): boolean {
-  return _isSameLanguage(...locales);
-}
-
-/**
- * Checks if a locale is a superset of another locale.
- * A subLocale is a subset of superLocale if it is an extension of superLocale or are otherwise identical.
- *
- * @param {string} superLocale - The locale to check if it is a superset of the other locale.
- * @param {string} subLocale - The locale to check if it is a subset of the other locale.
- * @returns {boolean} True if the first locale is a superset of the second locale, false otherwise.
- */
-export function isSupersetLocale(
-  superLocale: string,
-  subLocale: string
-): boolean {
-  return _isSupersetLocale(superLocale, subLocale);
 }
 
 export const API_VERSION = _API_VERSION;

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -5,6 +5,7 @@ export default defineConfig(
   createTsdownConfig(
     [
       'src/index.ts',
+      'src/format.ts',
       'src/id.ts',
       'src/internal.ts',
       'src/errors.ts',

--- a/packages/next/src/provider/ClientProviderWrapper.tsx
+++ b/packages/next/src/provider/ClientProviderWrapper.tsx
@@ -3,10 +3,10 @@ import { ClientProvider } from 'gt-react/client';
 import { ClientProviderProps } from 'gt-react/internal';
 import { usePathname } from 'next/navigation';
 import { useCallback, useEffect, useMemo } from 'react';
-import { GT, standardizeLocale } from 'generaltranslation';
+import { GTFormatter, standardizeLocale } from 'generaltranslation/format';
 import { useRouter } from 'next/navigation';
 
-function extractLocale(pathname: string, gt: GT): string | null {
+function extractLocale(pathname: string, gt: GTFormatter): string | null {
   const matches = pathname.match(/^\/([^\/]+)(?:\/|$)/);
   return matches ? gt.resolveAliasLocale(matches[1]) : null;
 }
@@ -41,15 +41,12 @@ export default function ClientProviderWrapper(
 
   const gt = useMemo(
     () =>
-      new GT({
-        devApiKey,
+      new GTFormatter({
         sourceLocale: defaultLocale,
         targetLocale: locale,
-        projectId,
-        baseUrl: runtimeUrl || undefined,
         customMapping,
       }),
-    [devApiKey, defaultLocale, locale, projectId, runtimeUrl, customMapping]
+    [defaultLocale, locale, customMapping]
   );
 
   // Trigger page reload when locale changes

--- a/packages/react-core/rollup.base.config.mjs
+++ b/packages/react-core/rollup.base.config.mjs
@@ -30,9 +30,10 @@ export default {
     postcss(), // Process CSS files
     preserveDirectives(), // Preserve directives in the output (i.e., "use client")
   ],
-  external: [
-    'react',
-    'generaltranslation',
-    '@generaltranslation/supported-locales',
-  ],
+  external: (id) =>
+    [
+      'react',
+      'generaltranslation',
+      '@generaltranslation/supported-locales',
+    ].some((ext) => id === ext || id.startsWith(ext + '/')),
 };

--- a/packages/react-core/rollup.base.config.mjs
+++ b/packages/react-core/rollup.base.config.mjs
@@ -30,10 +30,10 @@ export default {
     postcss(), // Process CSS files
     preserveDirectives(), // Preserve directives in the output (i.e., "use client")
   ],
-  external: (id) =>
-    [
-      'react',
-      'generaltranslation',
-      '@generaltranslation/supported-locales',
-    ].some((ext) => id === ext || id.startsWith(ext + '/')),
+  external: [
+    'react',
+    'generaltranslation',
+    'generaltranslation/format',
+    '@generaltranslation/supported-locales',
+  ],
 };

--- a/packages/react-core/src/dictionaries/loadDictionaryHelper.ts
+++ b/packages/react-core/src/dictionaries/loadDictionaryHelper.ts
@@ -1,4 +1,4 @@
-import { getLocaleProperties } from 'generaltranslation';
+import { getLocaleProperties } from 'generaltranslation/format';
 import { dictionaryMissingWarning } from '../errors-dir/createErrors';
 import { CustomLoader, Dictionary } from '../types-dir/types';
 

--- a/packages/react-core/src/errors-dir/createErrors.ts
+++ b/packages/react-core/src/errors-dir/createErrors.ts
@@ -1,4 +1,4 @@
-import { getLocaleProperties } from 'generaltranslation';
+import { getLocaleProperties } from 'generaltranslation/format';
 import { PACKAGE_NAME } from './constants';
 
 // ---- ERRORS ---- //

--- a/packages/react-core/src/hooks/useRegionSelector.ts
+++ b/packages/react-core/src/hooks/useRegionSelector.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import useGTContext from '../provider/GTContext';
-import { getLocaleProperties } from 'generaltranslation'; //
+import { getLocaleProperties } from 'generaltranslation/format';
 
 type RegionData = {
   code: string;

--- a/packages/react-core/src/index.ts
+++ b/packages/react-core/src/index.ts
@@ -31,6 +31,7 @@ import { msg, decodeMsg, decodeOptions } from './messages/messages';
 import useMessages from './translation/hooks/useMessages';
 import { GTContext } from './provider/GTContext';
 import useRuntimeTranslation from './provider/hooks/useRuntimeTranslation';
+import type { TranslateManyFunction } from './provider/hooks/useRuntimeTranslation';
 import useCreateInternalUseGTFunction from './provider/hooks/translation/useCreateInternalUseGTFunction';
 import useCreateInternalUseTranslationsFunction from './provider/hooks/translation/useCreateInternalUseTranslationsFunction';
 import { useCreateInternalUseTranslationsObjFunction } from './provider/hooks/translation/useCreateInternalUseTranslationsObjFunction';
@@ -78,4 +79,5 @@ export {
   useCreateInternalUseGTFunction,
   useCreateInternalUseTranslationsFunction,
   useCreateInternalUseTranslationsObjFunction,
+  TranslateManyFunction,
 };

--- a/packages/react-core/src/provider/GTProvider.tsx
+++ b/packages/react-core/src/provider/GTProvider.tsx
@@ -17,7 +17,7 @@ import {
 import { InternalGTProviderProps } from '../types-dir/config';
 import { useLocaleState } from './hooks/locales/useLocaleState';
 import { useErrorChecks } from './hooks/useErrorChecks';
-import { GT, resolveAliasLocale } from 'generaltranslation';
+import { GTFormatter, resolveAliasLocale } from 'generaltranslation/format';
 import { useLoadDictionary } from './hooks/useLoadDictionary';
 import { useLoadTranslations } from './hooks/useLoadTranslations';
 import { useCreateInternalUseTranslationsObjFunction } from './hooks/translation/useCreateInternalUseTranslationsObjFunction';
@@ -61,6 +61,7 @@ export default function GTProvider({
   readAuthFromEnv = _readAuthFromEnv,
   useDetermineLocale = _useDetermineLocale,
   useRegionState = _useRegionState,
+  translateMany,
   ...metadata
 }: InternalGTProviderProps) {
   // ---------- PROPS ---------- //
@@ -113,19 +114,16 @@ export default function GTProvider({
     regionCookieName: defaultRegionCookieName,
   });
 
-  // Define the GT instance
-  // Used for custom mapping and as a driver for the runtime translation
+  // Define the GTFormatter instance
+  // Used for custom mapping and locale resolution
   const gt = useMemo(
     () =>
-      new GT({
-        devApiKey,
+      new GTFormatter({
         sourceLocale: defaultLocale,
         targetLocale: locale,
-        projectId,
-        baseUrl: runtimeUrl || undefined,
         customMapping,
       }),
-    [devApiKey, defaultLocale, projectId, runtimeUrl, customMapping]
+    [defaultLocale, locale, customMapping]
   );
 
   // Determine the type of translation loading
@@ -188,7 +186,9 @@ export default function GTProvider({
     registerJsxForTranslation,
     developmentApiEnabled,
   } = useRuntimeTranslation({
-    gt,
+    translateMany,
+    projectId,
+    devApiKey,
     locale,
     versionId: _versionId,
     defaultLocale,

--- a/packages/react-core/src/provider/hooks/locales/useLocaleState.ts
+++ b/packages/react-core/src/provider/hooks/locales/useLocaleState.ts
@@ -3,7 +3,7 @@ import {
   requiresTranslation,
   isSameLanguage,
   isValidLocale,
-} from 'generaltranslation';
+} from 'generaltranslation/format';
 import { CustomMapping } from 'generaltranslation/types';
 import {
   invalidCanonicalLocalesError,

--- a/packages/react-core/src/provider/hooks/translation/__tests__/useCreateInternalUseGTFunction.test.ts
+++ b/packages/react-core/src/provider/hooks/translation/__tests__/useCreateInternalUseGTFunction.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { GT } from 'generaltranslation';
+import { GTFormatter } from 'generaltranslation/format';
 import useCreateInternalUseGTFunction from '../useCreateInternalUseGTFunction';
 import { Translations } from '../../../../types-dir/types';
 import { VAR_IDENTIFIER } from 'generaltranslation/internal';
@@ -47,7 +47,7 @@ vi.mock('../../../../messages/messages', () => ({
 }));
 
 describe('useCreateInternalUseGTFunction', () => {
-  let mockGT: GT;
+  let mockGT: GTFormatter;
   let mockRegisterIcuForTranslation: any;
   let consoleWarnSpy: any;
   let consoleErrorSpy: any;

--- a/packages/react-core/src/provider/hooks/translation/useCreateInternalUseGTFunction.ts
+++ b/packages/react-core/src/provider/hooks/translation/useCreateInternalUseGTFunction.ts
@@ -7,7 +7,7 @@ import {
 } from '../../../types-dir/types';
 import { StringFormat } from 'generaltranslation/types';
 import { TranslateIcuCallback } from '../../../types-dir/runtime';
-import { GT } from 'generaltranslation';
+import { GTFormatter } from 'generaltranslation/format';
 import {
   createStringRenderError,
   createStringRenderWarning,
@@ -43,7 +43,7 @@ export default function useCreateInternalUseGTFunction({
   registerIcuForTranslation,
   environment,
 }: {
-  gt: GT;
+  gt: GTFormatter;
   translations: Translations | null;
   locale: string;
   defaultLocale: string;

--- a/packages/react-core/src/provider/hooks/translation/useCreateInternalUseTranslationsFunction.ts
+++ b/packages/react-core/src/provider/hooks/translation/useCreateInternalUseTranslationsFunction.ts
@@ -16,7 +16,7 @@ import {
   createNoEntryFoundWarning,
 } from '../../../errors-dir/createErrors';
 import { hashSource } from 'generaltranslation/id';
-import { GT } from 'generaltranslation';
+import { GTFormatter } from 'generaltranslation/format';
 import { TranslateIcuCallback } from '../../../types-dir/runtime';
 import {
   extractVars,
@@ -27,7 +27,7 @@ import {
 import { StringFormat } from 'generaltranslation/types';
 
 export default function useCreateInternalUseTranslationsFunction(
-  gt: GT,
+  gt: GTFormatter,
   dictionary: Dictionary | undefined,
   dictionaryTranslations: Dictionary | undefined,
   translations: Translations | null,

--- a/packages/react-core/src/provider/hooks/useLoadTranslations.ts
+++ b/packages/react-core/src/provider/hooks/useLoadTranslations.ts
@@ -2,7 +2,7 @@ import { customLoadTranslationsError } from '../../errors-dir/createErrors';
 import fetchTranslations from '../../utils/fetchTranslations';
 import { CustomLoader, Translations } from '../../types-dir/types';
 import { useEffect, useRef, useState } from 'react';
-import { GT } from 'generaltranslation';
+import { GTFormatter } from 'generaltranslation/format';
 import { defaultCacheUrl } from 'generaltranslation/internal';
 
 export function useLoadTranslations({
@@ -24,7 +24,7 @@ export function useLoadTranslations({
   cacheUrl: string | null;
   projectId: string;
   _versionId?: string;
-  gt: GT;
+  gt: GTFormatter;
 }) {
   /** Key for translation tracking:
    * Cache Loading            -> translations = null

--- a/packages/react-core/src/provider/hooks/useRuntimeTranslation.ts
+++ b/packages/react-core/src/provider/hooks/useRuntimeTranslation.ts
@@ -205,8 +205,12 @@ export default function useRuntimeTranslation({
       if (batch.size === 0) return {};
       activeRequestsRef.current += 1;
 
-      const { translateMany: translateManyFn, locale, baseMetadata, timeout } =
-        cfgRef.current;
+      const {
+        translateMany: translateManyFn,
+        locale,
+        baseMetadata,
+        timeout,
+      } = cfgRef.current;
       const requests = Array.from(batch.values());
       const newTranslations: Translations = {};
       const resultsMap = new Map<string, TranslatedChildren | null>();

--- a/packages/react-core/src/provider/hooks/useRuntimeTranslation.ts
+++ b/packages/react-core/src/provider/hooks/useRuntimeTranslation.ts
@@ -20,8 +20,16 @@ import {
   maxBatchSize,
   batchInterval,
 } from '../config/defaultProps';
-import { GT } from 'generaltranslation';
-import type { TranslateManyEntry } from 'generaltranslation/types';
+import type {
+  TranslateManyEntry,
+  TranslationResult,
+} from 'generaltranslation/types';
+
+export type TranslateManyFunction = (
+  sources: Record<string, TranslateManyEntry>,
+  options: Record<string, any>,
+  timeout?: number
+) => Promise<Record<string, TranslationResult>>;
 
 type TranslationRequestMetadata = {
   hash: string;
@@ -47,7 +55,9 @@ type TranslationRequestQueueItem =
     };
 
 export default function useRuntimeTranslation({
-  gt,
+  translateMany,
+  projectId,
+  devApiKey,
   locale,
   versionId, // kept for API compatibility (not used)
   defaultLocale,
@@ -55,9 +65,12 @@ export default function useRuntimeTranslation({
   renderSettings,
   setTranslations,
   environment,
+  developmentApiEnabled: _developmentApiEnabled,
   ...additionalMetadata
 }: {
-  gt: GT;
+  translateMany?: TranslateManyFunction;
+  projectId?: string;
+  devApiKey?: string;
   locale: string;
   versionId?: string;
   defaultLocale?: string;
@@ -68,6 +81,7 @@ export default function useRuntimeTranslation({
   };
   environment: 'development' | 'production' | 'test';
   setTranslations: React.Dispatch<React.SetStateAction<Translations | null>>;
+  developmentApiEnabled?: boolean;
   [key: string]: any;
 }): {
   registerIcuForTranslation: TranslateIcuCallback;
@@ -76,10 +90,11 @@ export default function useRuntimeTranslation({
 } {
   // ------ EARLY RETURN IF DISABLED ----- //
   const developmentApiEnabled =
-    !!gt.projectId &&
-    !!runtimeUrl &&
-    !!gt.devApiKey &&
-    environment === 'development';
+    _developmentApiEnabled ??
+    (!!projectId &&
+      !!runtimeUrl &&
+      !!devApiKey &&
+      environment === 'development');
 
   if (!developmentApiEnabled) {
     const disabledError = (fn: string) =>
@@ -97,20 +112,20 @@ export default function useRuntimeTranslation({
 
   // ---------- CONFIG SNAPSHOT (stable via ref, updated each render) ---------- //
   const cfgRef = useRef({
-    gt,
+    translateMany,
     locale,
     baseMetadata: {
       ...additionalMetadata,
-      projectId: gt.projectId,
+      projectId,
       sourceLocale: defaultLocale,
     },
     timeout: renderSettings.timeout,
   });
-  cfgRef.current.gt = gt;
+  cfgRef.current.translateMany = translateMany;
   cfgRef.current.locale = locale;
   cfgRef.current.baseMetadata = {
     ...additionalMetadata,
-    projectId: gt.projectId,
+    projectId,
     sourceLocale: defaultLocale,
   };
   cfgRef.current.timeout = renderSettings.timeout;
@@ -190,12 +205,17 @@ export default function useRuntimeTranslation({
       if (batch.size === 0) return {};
       activeRequestsRef.current += 1;
 
-      const { gt, locale, baseMetadata, timeout } = cfgRef.current;
+      const { translateMany: translateManyFn, locale, baseMetadata, timeout } =
+        cfgRef.current;
       const requests = Array.from(batch.values());
       const newTranslations: Translations = {};
       const resultsMap = new Map<string, TranslatedChildren | null>();
 
       try {
+        if (!translateManyFn) {
+          throw new Error('translateMany is not available');
+        }
+
         const requestsRecord: Record<string, TranslateManyEntry> = {};
         for (const req of requests) {
           const { source, metadata } = req;
@@ -205,7 +225,7 @@ export default function useRuntimeTranslation({
           };
         }
 
-        const results = await gt.translateMany(
+        const results = await translateManyFn(
           requestsRecord,
           {
             ...baseMetadata,

--- a/packages/react-core/src/types-dir/config.ts
+++ b/packages/react-core/src/types-dir/config.ts
@@ -2,6 +2,7 @@ import React from 'react';
 import { RenderMethod } from './types';
 import { Translations, CustomLoader } from './types';
 import { CustomMapping } from 'generaltranslation/types';
+import type { TranslateManyFunction } from '../provider/hooks/useRuntimeTranslation';
 
 // Special overriden function types
 import { AuthFromEnvParams, AuthFromEnvReturn } from '../utils/types';
@@ -82,5 +83,6 @@ export type InternalGTProviderProps = {
   useRegionState: (params: UseRegionStateParams) => UseRegionStateReturn;
   useEnableI18n?: (params: UseEnableI18nParams) => UseEnableI18nReturn;
   reloadOnLocaleUpdate?: boolean;
+  translateMany?: TranslateManyFunction;
   [key: string]: any;
 };

--- a/packages/react-core/src/types-dir/context.ts
+++ b/packages/react-core/src/types-dir/context.ts
@@ -8,10 +8,10 @@ import {
   DictionaryEntry,
 } from './types';
 import { TranslateIcuCallback, TranslateChildrenCallback } from './runtime';
-import { GT } from 'generaltranslation';
+import { GTFormatter } from 'generaltranslation/format';
 
 export type GTContextType = {
-  gt: GT;
+  gt: GTFormatter;
   registerIcuForTranslation: TranslateIcuCallback;
   registerJsxForTranslation: TranslateChildrenCallback;
   _gtFunction: (

--- a/packages/react-core/src/utils/fetchTranslations.ts
+++ b/packages/react-core/src/utils/fetchTranslations.ts
@@ -1,4 +1,4 @@
-import { GT } from 'generaltranslation';
+import { GTFormatter } from 'generaltranslation/format';
 
 export default async function fetchTranslations({
   cacheUrl,
@@ -11,7 +11,7 @@ export default async function fetchTranslations({
   projectId: string;
   locale: string;
   versionId?: string;
-  gt: GT;
+  gt: GTFormatter;
 }) {
   if (!projectId || !cacheUrl || !locale) return {};
   locale = gt.resolveCanonicalLocale(locale);

--- a/packages/react-core/src/variables/Currency.tsx
+++ b/packages/react-core/src/variables/Currency.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { GT } from 'generaltranslation';
+import { GTFormatter } from 'generaltranslation/format';
 import { GTContext } from '../provider/GTContext';
 
 /**
@@ -33,7 +33,7 @@ function Currency({
 }): React.JSX.Element | null {
   const context = useContext(GTContext);
   if (children == null) return null;
-  const gt = context?.gt || new GT();
+  const gt = context?.gt || new GTFormatter();
   let renderedValue: string | number =
     typeof children === 'string' ? parseFloat(children) : children;
   if (typeof renderedValue === 'number') {

--- a/packages/react-core/src/variables/DateTime.tsx
+++ b/packages/react-core/src/variables/DateTime.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { GT } from 'generaltranslation';
+import { GTFormatter } from 'generaltranslation/format';
 import { GTContext } from '../provider/GTContext';
 
 /**
@@ -31,7 +31,7 @@ function DateTime({
 }): React.JSX.Element | null {
   const context = useContext(GTContext);
   if (children == null) return null;
-  const gt = context?.gt || new GT();
+  const gt = context?.gt || new GTFormatter();
 
   if (!locales) {
     locales = [];

--- a/packages/react-core/src/variables/Num.tsx
+++ b/packages/react-core/src/variables/Num.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { GT } from 'generaltranslation';
+import { GTFormatter } from 'generaltranslation/format';
 import { GTContext } from '../provider/GTContext';
 
 /**
@@ -33,7 +33,7 @@ function Num({
 }): React.JSX.Element | null {
   const context = useContext(GTContext);
   if (children == null) return null;
-  const gt = context?.gt || new GT();
+  const gt = context?.gt || new GTFormatter();
 
   let renderedValue: string | number =
     typeof children === 'string' ? parseFloat(children) : children;

--- a/packages/react-core/src/variables/RelativeTime.tsx
+++ b/packages/react-core/src/variables/RelativeTime.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { GT } from 'generaltranslation';
+import { GTFormatter } from 'generaltranslation/format';
 import { GTContext } from '../provider/GTContext';
 
 /**
@@ -50,7 +50,7 @@ function RelativeTime({
   options?: Intl.RelativeTimeFormatOptions;
 }): React.JSX.Element | null {
   const context = useContext(GTContext);
-  const gt = context?.gt || new GT();
+  const gt = context?.gt || new GTFormatter();
 
   if (!locales) {
     locales = [];

--- a/packages/react/rollup.base.config.mjs
+++ b/packages/react/rollup.base.config.mjs
@@ -30,12 +30,12 @@ export default {
     postcss(), // Process CSS files
     preserveDirectives(), // Preserve directives in the output (i.e., "use client")
   ],
-  external: (id) =>
-    [
-      'react',
-      'react-dom',
-      'generaltranslation',
-      '@generaltranslation/supported-locales',
-      '@generaltranslation/react-core',
-    ].some((ext) => id === ext || id.startsWith(ext + '/')),
+  external: [
+    'react',
+    'react-dom',
+    'generaltranslation',
+    'generaltranslation/format',
+    '@generaltranslation/supported-locales',
+    '@generaltranslation/react-core',
+  ],
 };

--- a/packages/react/rollup.base.config.mjs
+++ b/packages/react/rollup.base.config.mjs
@@ -30,11 +30,12 @@ export default {
     postcss(), // Process CSS files
     preserveDirectives(), // Preserve directives in the output (i.e., "use client")
   ],
-  external: [
-    'react',
-    'react-dom',
-    'generaltranslation',
-    '@generaltranslation/supported-locales',
-    '@generaltranslation/react-core',
-  ],
+  external: (id) =>
+    [
+      'react',
+      'react-dom',
+      'generaltranslation',
+      '@generaltranslation/supported-locales',
+      '@generaltranslation/react-core',
+    ].some((ext) => id === ext || id.startsWith(ext + '/')),
 };

--- a/packages/react/src/react-context/provider/ClientProvider.tsx
+++ b/packages/react/src/react-context/provider/ClientProvider.tsx
@@ -2,7 +2,8 @@
 
 import * as React from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { determineLocale, GT } from 'generaltranslation';
+import { determineLocale, GTFormatter } from 'generaltranslation/format';
+import { useTranslateMany } from './hooks/useTranslateMany';
 import {
   defaultLocaleCookieName,
   defaultRegionCookieName,
@@ -123,20 +124,26 @@ export default function ClientProvider({
 
   // ----- GT SETUP ----- //
 
-  // Define the GT instance
-  // Used for custom mapping and as a driver for the runtime translation
+  // Define the GTFormatter instance
+  // Used for custom mapping and locale resolution
   const gt = useMemo(
     () =>
-      new GT({
-        devApiKey,
+      new GTFormatter({
         sourceLocale: defaultLocale,
         targetLocale: locale,
-        projectId,
-        baseUrl: runtimeUrl || undefined,
         customMapping,
       }),
-    [devApiKey, defaultLocale, locale, projectId, runtimeUrl, customMapping]
+    [defaultLocale, locale, customMapping]
   );
+
+  const translateMany = useTranslateMany({
+    devApiKey,
+    defaultLocale,
+    projectId,
+    runtimeUrl,
+    customMapping,
+    environment,
+  });
 
   // Set the locale via cookies and refresh the page to reload server-side. Make sure the language is supported.
   const setLocale = (newLocale: string): void => {
@@ -159,7 +166,9 @@ export default function ClientProvider({
 
   const { registerIcuForTranslation, registerJsxForTranslation } =
     useRuntimeTranslation({
-      gt,
+      translateMany,
+      projectId,
+      devApiKey,
       locale: locale,
       versionId: _versionId,
       runtimeUrl,

--- a/packages/react/src/react-context/provider/GTProvider.tsx
+++ b/packages/react/src/react-context/provider/GTProvider.tsx
@@ -2,6 +2,7 @@ import { GTProvider as _GTProvider } from '@generaltranslation/react-core';
 import { readAuthFromEnv } from '../utils/readAuthFromEnv';
 import { useRegionState } from './hooks/useRegionState';
 import { useEnableI18n } from './hooks/useEnableI18n';
+import { useTranslateMany } from './hooks/useTranslateMany';
 import { useDetermineLocale } from './hooks/locales/useDetermineLocale';
 import { isSSREnabled } from './helpers/isSSREnabled';
 import { GTProviderProps } from '../types/config';
@@ -32,13 +33,26 @@ import React from 'react';
  * @returns {JSX.Element} The provider component for General Translation context.
  */
 export function GTProvider(props: GTProviderProps): React.JSX.Element {
+  const environment = process.env.NODE_ENV as
+    | 'development'
+    | 'production'
+    | 'test';
+
+  const translateMany = useTranslateMany({
+    devApiKey: props.devApiKey,
+    defaultLocale: props.defaultLocale,
+    projectId: props.projectId,
+    runtimeUrl: props.runtimeUrl,
+    customMapping: props.customMapping,
+    environment,
+  });
+
   return (
     <_GTProvider
       ssr={isSSREnabled()}
-      environment={
-        process.env.NODE_ENV as 'development' | 'production' | 'test'
-      }
+      environment={environment}
       {...props}
+      translateMany={translateMany}
       readAuthFromEnv={readAuthFromEnv}
       useDetermineLocale={useDetermineLocale}
       useRegionState={useRegionState}

--- a/packages/react/src/react-context/provider/hooks/useTranslateMany.ts
+++ b/packages/react/src/react-context/provider/hooks/useTranslateMany.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import type { TranslateManyFunction } from '@generaltranslation/react-core';
+import type { CustomMapping } from 'generaltranslation/types';
 
 export function useTranslateMany({
   devApiKey,
@@ -13,12 +14,12 @@ export function useTranslateMany({
   defaultLocale?: string;
   projectId?: string;
   runtimeUrl?: string | null;
-  customMapping?: Record<string, any>;
+  customMapping?: CustomMapping;
   environment: 'development' | 'production' | 'test';
 }): TranslateManyFunction | undefined {
   return useMemo<TranslateManyFunction | undefined>(() => {
     if (!devApiKey || environment !== 'development') return undefined;
-    let cachedGT: any = null;
+    let cachedGT: ReturnType<typeof Object.create> = null;
     return async (sources, options, timeout) => {
       if (!cachedGT) {
         const mod = await import('generaltranslation');
@@ -32,5 +33,12 @@ export function useTranslateMany({
       }
       return cachedGT.translateMany(sources, options, timeout);
     };
-  }, [devApiKey, defaultLocale, projectId, runtimeUrl, customMapping, environment]);
+  }, [
+    devApiKey,
+    defaultLocale,
+    projectId,
+    runtimeUrl,
+    customMapping,
+    environment,
+  ]);
 }

--- a/packages/react/src/react-context/provider/hooks/useTranslateMany.ts
+++ b/packages/react/src/react-context/provider/hooks/useTranslateMany.ts
@@ -1,0 +1,36 @@
+import { useMemo } from 'react';
+import type { TranslateManyFunction } from '@generaltranslation/react-core';
+
+export function useTranslateMany({
+  devApiKey,
+  defaultLocale,
+  projectId,
+  runtimeUrl,
+  customMapping,
+  environment,
+}: {
+  devApiKey?: string;
+  defaultLocale?: string;
+  projectId?: string;
+  runtimeUrl?: string | null;
+  customMapping?: Record<string, any>;
+  environment: 'development' | 'production' | 'test';
+}): TranslateManyFunction | undefined {
+  return useMemo<TranslateManyFunction | undefined>(() => {
+    if (!devApiKey || environment !== 'development') return undefined;
+    let cachedGT: any = null;
+    return async (sources, options, timeout) => {
+      if (!cachedGT) {
+        const mod = await import('generaltranslation');
+        cachedGT = new mod.GT({
+          devApiKey,
+          sourceLocale: defaultLocale,
+          projectId,
+          baseUrl: runtimeUrl || undefined,
+          customMapping,
+        });
+      }
+      return cachedGT.translateMany(sources, options, timeout);
+    };
+  }, [devApiKey, defaultLocale, projectId, runtimeUrl, customMapping, environment]);
+}


### PR DESCRIPTION
## Summary

- Extracts formatting and locale utilities from `GT` into a new `GTFormatter` class, exposed via a `generaltranslation/format` subpath entry point
- `GT` now extends `GTFormatter`, adding only API client methods — no breaking changes to the public API
- Client-side packages (`react-core`, `react`, `next`) import from `generaltranslation/format` instead of the main entry, keeping the API client out of production bundles
- The client-side dynamic `import('generaltranslation')` for dev-mode runtime translation lives in `gt-react` only (via a shared `useTranslateMany` hook), keeping `react-core` bundler-agnostic and safe for React Native / Metro / edge runtimes
- Production runtime translation in `gt-next` is unaffected — it uses a separate server-side code path (`I18NConfiguration.translateJsx`) that doesn't go through this client-side hook
- Rollup `external` configs updated to treat `generaltranslation/*` subpaths as external

## Test plan

- [x] `pnpm build` — all 20 packages build successfully
- [x] `pnpm test` — all 20 test suites pass
- [x] `turbo lint --filter='...[origin/main]'` — 0 new errors (pre-existing failures in `gt-sanity` unrelated)
- [ ] Verify client bundle size reduction with `size-limit`
- [ ] Smoke test in a React Native app (confirm no Metro bundler errors)
- [ ] Smoke test in a Next.js app (confirm dev-mode and prod runtime translation still work)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts formatting and locale utilities from `GT` into a new `GTFormatter` class exposed via a `generaltranslation/format` subpath entry point. `GT` now extends `GTFormatter`, keeping the public API intact while allowing client-side packages (`react-core`, `react`, `next`) to import only the lightweight formatter — eliminating the API client from production bundles. Dev-mode runtime translation is preserved through a new `useTranslateMany` hook in `gt-react` that lazily `import()`s the full `generaltranslation` module only in development.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — clean extraction with no breaking API changes and all test suites passing.

No P0 or P1 issues found. The GTFormatter extraction is mechanically correct: GT.setConfig override properly delegates to super, polymorphic dispatch during super(params) is intentional and was already reviewed, env-var fallbacks are preserved, and the lazy-import pattern in useTranslateMany correctly gates on devApiKey + development environment. Previously flagged P2 issues (cachedGT typing, lazy-init stale-closure) remain but are minor dev-only concerns.

packages/react/src/react-context/provider/hooks/useTranslateMany.ts — loose typing on cachedGT (already noted in prior reviews, dev-only path)
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/core/src/format.ts | New file — defines GTFormatter class with all formatting/locale methods, and re-exports them as standalone functions; clean extraction with no logic changes. |
| packages/core/src/index.ts | GT now extends GTFormatter; setConfig override correctly sets API properties then delegates to super; env-var fallbacks preserved after super(); all formatting/locale code removed in favor of re-export from format.ts. |
| packages/core/package.json | Adds ./format subpath export (require/import/types) and matching typesVersions entry; consistent with existing subpath conventions. |
| packages/react/src/react-context/provider/hooks/useTranslateMany.ts | New hook — lazily imports generaltranslation in dev-only path, correctly guards with devApiKey + environment checks; cachedGT typed as ReturnType<typeof Object.create> (any) noted in prior review. |
| packages/react-core/src/provider/hooks/useRuntimeTranslation.ts | Replaces gt: GT with translateMany, projectId, devApiKey params; developmentApiEnabled computed locally; guard added before calling translateManyFn; logic preserved. |
| packages/react-core/src/provider/GTProvider.tsx | Uses GTFormatter instead of GT; locale now correctly included in useMemo deps for gt instance (pre-existing omission fixed); translateMany passed through from caller. |
| packages/react/src/react-context/provider/GTProvider.tsx | Wires useTranslateMany result into _GTProvider; environment extracted to a variable and reused correctly. |
| packages/react/src/react-context/provider/ClientProvider.tsx | Switches GT→GTFormatter for the memoized instance; adds useTranslateMany and forwards result to useRuntimeTranslation; runtimeUrl still passed explicitly. |
| packages/next/src/provider/ClientProviderWrapper.tsx | Switches to GTFormatter; removes devApiKey/projectId/runtimeUrl from useMemo deps (correct, formatter doesn't need them); locale still properly captured. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph core["generaltranslation (core)"]
        FMT["GTFormatter\n(format.ts)\n• locale utils\n• formatting methods"]
        GT["GT (index.ts)\n• extends GTFormatter\n• translateMany\n• API client methods"]
        FMT --> GT
    end

    subgraph client["Client Bundles (production)"]
        RC["react-core\nimports generaltranslation/format"]
        RX["gt-react ClientProvider\nimports generaltranslation/format"]
        NX["gt-next ClientProviderWrapper\nimports generaltranslation/format"]
        RC --> FMT
        RX --> FMT
        NX --> FMT
    end

    subgraph devonly["Dev-only (lazy, runtime)"]
        UTM["useTranslateMany hook\n(gt-react only)\nguards: devApiKey + dev env"]
        DYN["dynamic import('generaltranslation')\ncreates GT instance lazily\ncaches in closure"]
        UTM --> DYN
        DYN --> GT
    end

    RX --> UTM
    UTM -- "translateMany fn" --> URT["useRuntimeTranslation\n(react-core)"]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/react/src/react-context/provider/hooks/useTranslateMany.ts`, line 63 ([link](https://github.com/generaltranslation/gt/blob/c16aa1fbdb622448dadfe7b55431d3cd5ea7b51e/packages/react/src/react-context/provider/hooks/useTranslateMany.ts#L63)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Loose typing for `cachedGT`**

   `ReturnType<typeof Object.create>` resolves to `any`, which loses all type safety on `cachedGT`. A cleaner option is `InstanceType<Awaited<typeof import('generaltranslation')>['GT']> | null`, or simply an explicit `any` with a comment. At minimum, initialising as `null` with type `{ translateMany: (...args: any[]) => any } | null` would constrain the interface.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/react/src/react-context/provider/hooks/useTranslateMany.ts
   Line: 63

   Comment:
   **Loose typing for `cachedGT`**

   `ReturnType<typeof Object.create>` resolves to `any`, which loses all type safety on `cachedGT`. A cleaner option is `InstanceType<Awaited<typeof import('generaltranslation')>['GT']> | null`, or simply an explicit `any` with a comment. At minimum, initialising as `null` with type `{ translateMany: (...args: any[]) => any } | null` would constrain the interface.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `packages/react/src/react-context/provider/hooks/useTranslateMany.ts`, line 61-76 ([link](https://github.com/generaltranslation/gt/blob/c16aa1fbdb622448dadfe7b55431d3cd5ea7b51e/packages/react/src/react-context/provider/hooks/useTranslateMany.ts#L61-L76)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`cachedGT` not recreated when `runtimeUrl` or `customMapping` changes**

   `cachedGT` is lazily initialised inside the returned async closure. When any `useMemo` dependency changes, a new closure is created and `cachedGT` resets to `null`. However, because the `GT` instance is built at the point of the *first call*, not at memo creation time, a change to e.g. `runtimeUrl` will reset the cache correctly on the *next render* — but any in-flight request that already captured the old closure will still use the old `baseUrl`. This is inherent to the lazy-init pattern and harmless in practice (dev-only), but worth noting.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/react/src/react-context/provider/hooks/useTranslateMany.ts
   Line: 61-76

   Comment:
   **`cachedGT` not recreated when `runtimeUrl` or `customMapping` changes**

   `cachedGT` is lazily initialised inside the returned async closure. When any `useMemo` dependency changes, a new closure is created and `cachedGT` resets to `null`. However, because the `GT` instance is built at the point of the *first call*, not at memo creation time, a change to e.g. `runtimeUrl` will reset the cache correctly on the *next render* — but any in-flight request that already captured the old closure will still use the old `baseUrl`. This is inherent to the lazy-init pattern and harmless in practice (dev-only), but worth noting.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: remove redundant property assignmen..."](https://github.com/generaltranslation/gt/commit/113e3f856a19d975b8d4aa65c67bd50f2c3a272c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29720947)</sub>

<!-- /greptile_comment -->