### PR TITLE
Refactor variable formatting helpers

### DIFF
--- a/packages/next/src/variables/Currency.tsx
+++ b/packages/next/src/variables/Currency.tsx
@@ -1,5 +1,6 @@
 import getI18NConfig from '../config-dir/getI18NConfig';
 import { useLocale } from '../request/getLocale';
+import { formatCurrency } from 'generaltranslation';
 import React from 'react';
 
 /**
@@ -35,8 +36,6 @@ function Currency({
     locales = [useLocale(), getI18NConfig().getDefaultLocale()];
   }
 
-  const gt = getI18NConfig().getGTClass();
-
   // Determine the value to be formatted
   const renderedValue =
     typeof children === 'string' ? parseFloat(children) : children;
@@ -44,7 +43,7 @@ function Currency({
   // Format the number as currency according to the locale
   const formattedValue =
     typeof renderedValue === 'number'
-      ? gt.formatCurrency(renderedValue, currency, { locales, ...options })
+      ? formatCurrency(renderedValue, currency, { locales, ...options })
       : renderedValue;
 
   return <>{formattedValue}</>;

--- a/packages/next/src/variables/DateTime.tsx
+++ b/packages/next/src/variables/DateTime.tsx
@@ -1,5 +1,6 @@
 import getI18NConfig from '../config-dir/getI18NConfig';
 import { useLocale } from '../request/getLocale';
+import { formatDateTime } from 'generaltranslation';
 import React from 'react';
 
 /**
@@ -33,11 +34,10 @@ function DateTime({
     locales = [useLocale(), getI18NConfig().getDefaultLocale()];
   }
 
-  const gt = getI18NConfig().getGTClass();
-
-  const result = gt
-    .formatDateTime(children, { locales, ...options })
-    .replace(/[\u200F\u202B\u202E]/g, '');
+  const result = formatDateTime(children, { locales, ...options }).replace(
+    /[\u200F\u202B\u202E]/g,
+    ''
+  );
   // Note: This component may cause hydration errors when the output differs
   // between server and client (e.g., different timezones or locales).
   // We cannot use suppressHydrationWarning because this is a purely logical

--- a/packages/next/src/variables/Num.tsx
+++ b/packages/next/src/variables/Num.tsx
@@ -1,5 +1,6 @@
 import getI18NConfig from '../config-dir/getI18NConfig';
 import { useLocale } from '../request/getLocale';
+import { formatNum } from 'generaltranslation';
 import React from 'react';
 
 /**
@@ -34,7 +35,6 @@ function Num({
   if (!locales) {
     locales = [useLocale(), getI18NConfig().getDefaultLocale()];
   }
-  const gt = getI18NConfig().getGTClass();
 
   // Determine the value to be used
   const renderedValue =
@@ -43,7 +43,7 @@ function Num({
   // Format the number according to the locale
   const formattedValue =
     typeof renderedValue === 'number'
-      ? gt.formatNum(renderedValue, { locales, ...options })
+      ? formatNum(renderedValue, { locales, ...options })
       : renderedValue;
 
   return <>{formattedValue}</>;

--- a/packages/next/src/variables/RelativeTime.tsx
+++ b/packages/next/src/variables/RelativeTime.tsx
@@ -1,5 +1,9 @@
 import getI18NConfig from '../config-dir/getI18NConfig';
 import { useLocale } from '../request/getLocale';
+import {
+  formatRelativeTime,
+  formatRelativeTimeFromDate,
+} from 'generaltranslation';
 import React from 'react';
 
 /**
@@ -50,8 +54,6 @@ function RelativeTime({
     locales = [useLocale(), getI18NConfig().getDefaultLocale()];
   }
 
-  const gt = getI18NConfig().getGTClass();
-
   // Resolve the date from either `date` prop or `children` (for backwards compat)
   const resolvedDate = date ?? children;
 
@@ -65,14 +67,14 @@ function RelativeTime({
   let result: string;
 
   if (value !== undefined && unit) {
-    result = gt.formatRelativeTime(value, unit, {
+    result = formatRelativeTime(value, unit, {
       locales,
       numeric: options.numeric,
       style: options.style,
       localeMatcher: options.localeMatcher,
     });
   } else if (resolvedDate != null) {
-    result = gt.formatRelativeTimeFromDate(resolvedDate, {
+    result = formatRelativeTimeFromDate(resolvedDate, {
       locales,
       baseDate: baseDate ?? new Date(),
       numeric: options.numeric,

--- a/packages/react-core/src/variables/Currency.tsx
+++ b/packages/react-core/src/variables/Currency.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { GT } from 'generaltranslation';
+import { formatCurrency } from 'generaltranslation';
 import { GTContext } from '../provider/GTContext';
 
 /**
@@ -33,7 +33,6 @@ function Currency({
 }): React.JSX.Element | null {
   const context = useContext(GTContext);
   if (children == null) return null;
-  const gt = context?.gt || new GT();
   let renderedValue: string | number =
     typeof children === 'string' ? parseFloat(children) : children;
   if (typeof renderedValue === 'number') {
@@ -43,7 +42,7 @@ function Currency({
       if (context?.defaultLocale) locales.push(context.defaultLocale);
     }
     // Format the value using Intl.NumberFormat
-    renderedValue = gt.formatCurrency(renderedValue, currency, {
+    renderedValue = formatCurrency(renderedValue, currency, {
       locales,
       ...options,
     });

--- a/packages/react-core/src/variables/DateTime.tsx
+++ b/packages/react-core/src/variables/DateTime.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { GT } from 'generaltranslation';
+import { formatDateTime } from 'generaltranslation';
 import { GTContext } from '../provider/GTContext';
 
 /**
@@ -31,16 +31,16 @@ function DateTime({
 }): React.JSX.Element | null {
   const context = useContext(GTContext);
   if (children == null) return null;
-  const gt = context?.gt || new GT();
 
   if (!locales) {
     locales = [];
     if (context?.locale) locales.push(context.locale);
     if (context?.defaultLocale) locales.push(context.defaultLocale);
   }
-  const result = gt
-    .formatDateTime(children, { locales, ...options })
-    .replace(/[\u200F\u202B\u202E]/g, '');
+  const result = formatDateTime(children, { locales, ...options }).replace(
+    /[\u200F\u202B\u202E]/g,
+    ''
+  );
 
   // Note: This component may cause hydration errors when the output differs
   // between server and client (e.g., different timezones or locales).

--- a/packages/react-core/src/variables/Num.tsx
+++ b/packages/react-core/src/variables/Num.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { GT } from 'generaltranslation';
+import { formatNum } from 'generaltranslation';
 import { GTContext } from '../provider/GTContext';
 
 /**
@@ -33,7 +33,6 @@ function Num({
 }): React.JSX.Element | null {
   const context = useContext(GTContext);
   if (children == null) return null;
-  const gt = context?.gt || new GT();
 
   let renderedValue: string | number =
     typeof children === 'string' ? parseFloat(children) : children;
@@ -44,7 +43,7 @@ function Num({
       if (context?.defaultLocale) locales.push(context.defaultLocale);
     }
     // Using Intl.NumberFormat for consistent number formatting
-    renderedValue = gt.formatNum(renderedValue, { locales, ...options });
+    renderedValue = formatNum(renderedValue, { locales, ...options });
   }
   return <>{renderedValue}</>;
 }

--- a/packages/react-core/src/variables/RelativeTime.tsx
+++ b/packages/react-core/src/variables/RelativeTime.tsx
@@ -1,5 +1,8 @@
 import React, { useContext } from 'react';
-import { GT } from 'generaltranslation';
+import {
+  formatRelativeTime,
+  formatRelativeTimeFromDate,
+} from 'generaltranslation';
 import { GTContext } from '../provider/GTContext';
 
 /**
@@ -50,7 +53,6 @@ function RelativeTime({
   options?: Intl.RelativeTimeFormatOptions;
 }): React.JSX.Element | null {
   const context = useContext(GTContext);
-  const gt = context?.gt || new GT();
 
   if (!locales) {
     locales = [];
@@ -72,7 +74,7 @@ function RelativeTime({
 
   if (value !== undefined && unit) {
     // Explicit value + unit mode
-    result = gt.formatRelativeTime(value, unit, {
+    result = formatRelativeTime(value, unit, {
       locales,
       numeric: options.numeric,
       style: options.style,
@@ -80,7 +82,7 @@ function RelativeTime({
     });
   } else if (resolvedDate != null) {
     // Auto-select unit from Date
-    result = gt.formatRelativeTimeFromDate(resolvedDate, {
+    result = formatRelativeTimeFromDate(resolvedDate, {
       locales,
       baseDate: baseDate ?? new Date(),
       numeric: options.numeric,

--- a/packages/react/src/i18n-context/functions/variables/GtInternalCurrency.tsx
+++ b/packages/react/src/i18n-context/functions/variables/GtInternalCurrency.tsx
@@ -1,4 +1,4 @@
-import { getBrowserI18nManager } from '../../browser-i18n-manager/singleton-operations';
+import { formatCurrency } from 'generaltranslation';
 import { getDefaultLocale, getLocale } from '../locale-operations';
 
 /**
@@ -23,9 +23,7 @@ function GtInternalCurrency({
   const locales = [...localesProp, getLocale(), getDefaultLocale()];
 
   // Apply formatting
-  const i18nManager = getBrowserI18nManager();
-  const gt = i18nManager.getGTClass();
-  const formattedCurrency = gt.formatCurrency(parsedNumber, currency, {
+  const formattedCurrency = formatCurrency(parsedNumber, currency, {
     locales,
     ...options,
   });

--- a/packages/react/src/i18n-context/functions/variables/GtInternalDateTime.tsx
+++ b/packages/react/src/i18n-context/functions/variables/GtInternalDateTime.tsx
@@ -1,4 +1,4 @@
-import { getBrowserI18nManager } from '../../browser-i18n-manager/singleton-operations';
+import { formatDateTime } from 'generaltranslation';
 import { getDefaultLocale, getLocale } from '../locale-operations';
 
 /**
@@ -19,11 +19,10 @@ function GtInternalDateTime({
   const locales = [...localesProp, getLocale(), getDefaultLocale()];
 
   // Apply formatting
-  const i18nManager = getBrowserI18nManager();
-  const gt = i18nManager.getGTClass();
-  const result = gt
-    .formatDateTime(children, { locales, ...options })
-    .replace(/[\u200F\u202B\u202E]/g, '');
+  const result = formatDateTime(children, { locales, ...options }).replace(
+    /[\u200F\u202B\u202E]/g,
+    ''
+  );
 
   // Return formatted date
   return result;

--- a/packages/react/src/i18n-context/functions/variables/GtInternalNum.tsx
+++ b/packages/react/src/i18n-context/functions/variables/GtInternalNum.tsx
@@ -1,4 +1,4 @@
-import { getBrowserI18nManager } from '../../browser-i18n-manager/singleton-operations';
+import { formatNum } from 'generaltranslation';
 import { getDefaultLocale, getLocale } from '../locale-operations';
 
 /**
@@ -21,9 +21,7 @@ function GtInternalNum({
   const locales = [...localesProp, getLocale(), getDefaultLocale()];
 
   // Apply formatting
-  const i18nManager = getBrowserI18nManager();
-  const gt = i18nManager.getGTClass();
-  const formattedNumber = gt.formatNum(parsedNumber, { locales, ...options });
+  const formattedNumber = formatNum(parsedNumber, { locales, ...options });
 
   // Return formatted number
   return formattedNumber;

--- a/packages/react/src/i18n-context/functions/variables/GtInternalRelativeTime.tsx
+++ b/packages/react/src/i18n-context/functions/variables/GtInternalRelativeTime.tsx
@@ -1,4 +1,7 @@
-import { getBrowserI18nManager } from '../../browser-i18n-manager/singleton-operations';
+import {
+  formatRelativeTime,
+  formatRelativeTimeFromDate,
+} from 'generaltranslation';
 import { getDefaultLocale, getLocale } from '../locale-operations';
 
 /**
@@ -24,8 +27,6 @@ function GtInternalRelativeTime({
   locales?: string[];
   options?: Intl.RelativeTimeFormatOptions;
 }): string | null {
-  const i18nManager = getBrowserI18nManager();
-  const gt = i18nManager.getGTClass();
   const locales = [...localesProp, getLocale(), getDefaultLocale()];
 
   // Resolve the date from either `date` prop or `children` (for backwards compat)
@@ -42,7 +43,7 @@ function GtInternalRelativeTime({
 
   if (value !== undefined && unit) {
     // Explicit value + unit mode
-    result = gt.formatRelativeTime(value, unit, {
+    result = formatRelativeTime(value, unit, {
       locales,
       numeric: options.numeric,
       style: options.style,
@@ -50,7 +51,7 @@ function GtInternalRelativeTime({
     });
   } else if (resolvedDate != null) {
     // Auto-select unit from Date
-    result = gt.formatRelativeTimeFromDate(resolvedDate, {
+    result = formatRelativeTimeFromDate(resolvedDate, {
       locales,
       baseDate: baseDate ?? new Date(),
       numeric: options.numeric,


### PR DESCRIPTION
## Summary
- Replace browser variable component usage of `BrowserI18nManager#getGTClass` with standalone `generaltranslation` format helpers.
- Replace `@generaltranslation/react-core` variable component usage of `GT` formatting methods with the same standalone helpers.
- Replace `gt-next` variable component usage of `getI18NConfig().getGTClass()` for number/date/currency/relative-time formatting with standalone helpers.
- Preserve the existing locale fallback order and formatting behavior.

## Verification
- `pnpm --filter gt-react test`
- `pnpm --filter gt-react exec eslint src/i18n-context/functions/variables/GtInternalNum.tsx src/i18n-context/functions/variables/GtInternalDateTime.tsx src/i18n-context/functions/variables/GtInternalCurrency.tsx src/i18n-context/functions/variables/GtInternalRelativeTime.tsx`
- `pnpm --filter @generaltranslation/react-core exec prettier --write src/variables/Num.tsx src/variables/DateTime.tsx src/variables/Currency.tsx src/variables/RelativeTime.tsx`
- `pnpm --filter @generaltranslation/react-core exec eslint src/variables/Num.tsx src/variables/DateTime.tsx src/variables/Currency.tsx src/variables/RelativeTime.tsx`
- `pnpm --filter @generaltranslation/react-core test`
- `pnpm --filter @generaltranslation/react-core exec tsc --noEmit`
- `pnpm --filter gt-next exec prettier --write src/variables/Num.tsx src/variables/DateTime.tsx src/variables/Currency.tsx src/variables/RelativeTime.tsx`
- `pnpm --filter gt-next exec eslint src/variables/Num.tsx src/variables/DateTime.tsx src/variables/Currency.tsx src/variables/RelativeTime.tsx`
- `pnpm --filter gt-next exec tsc --noEmit`
- `pnpm --filter gt-next run test:js`

## Note
- `pnpm --filter gt-react exec tsc --noEmit` is currently blocked by an unrelated existing missing `createInvalidLocaleWarning` reference in `BrowserI18nManager.ts`.
