### PR TITLE
Decouple locale helpers from GT class access

### DIFF
--- a/packages/i18n/src/helpers/locale.ts
+++ b/packages/i18n/src/helpers/locale.ts
@@ -52,6 +52,5 @@ export function getDefaultLocale() {
  */
 export function getLocaleProperties(locale?: string) {
   const i18nManager = getI18nManager();
-  const gtInstance = i18nManager.getGTClass();
-  return gtInstance.getLocaleProperties(locale);
+  return i18nManager.getLocaleProperties(locale);
 }

--- a/packages/i18n/src/i18n-manager/I18nManager.ts
+++ b/packages/i18n/src/i18n-manager/I18nManager.ts
@@ -6,8 +6,19 @@ import { validateConfig } from './validation/validateConfig';
 import { Translation } from './translations-manager/utils/types/translation-data';
 import { StorageAdapter } from './storage-adapter/StorageAdapter';
 import { libraryDefaultLocale } from 'generaltranslation/internal';
-import { GT, standardizeLocale } from 'generaltranslation';
-import { CustomMapping } from 'generaltranslation/types';
+import {
+  determineLocale as gtDetermineLocale,
+  getLocaleDirection as gtGetLocaleDirection,
+  getLocaleProperties as gtGetLocaleProperties,
+  GT,
+  isSameLanguage as gtIsSameLanguage,
+  isValidLocale as gtIsValidLocale,
+  requiresTranslation as gtRequiresTranslation,
+  resolveAliasLocale as gtResolveAliasLocale,
+  resolveCanonicalLocale as gtResolveCanonicalLocale,
+  standardizeLocale,
+} from 'generaltranslation';
+import { CustomMapping, LocaleProperties } from 'generaltranslation/types';
 import { LookupOptions } from '../translation-functions/types/options';
 import { FallbackStorageAdapter } from './storage-adapter/FallbackStorageAdapter';
 import { getGTServicesEnabled } from './utils/getGTServicesEnabled';
@@ -174,8 +185,7 @@ class I18nManager<
   setLocale(locale: string): void {
     try {
       this.validateLocale(locale);
-      const gtInstance = this.getGTClassClean();
-      const newLocale = gtInstance.determineLocale(locale)!;
+      const newLocale = this.determineLocale(locale)!;
       const previousLocale = this.getLocale();
       this.storeAdapter.setItem('locale', newLocale);
       this.emit('locale-update', {
@@ -199,6 +209,56 @@ class I18nManager<
    */
   getLocales(): string[] {
     return this.config.locales;
+  }
+
+  /**
+   * Determine the best supported locale from a preferred locale list
+   */
+  determineLocale(locales: string | string[]): string | undefined {
+    return gtDetermineLocale(
+      locales,
+      this.config.locales,
+      this.config.customMapping
+    );
+  }
+
+  /**
+   * Resolve a locale alias using the configured custom mapping
+   */
+  resolveAliasLocale(locale: string): string {
+    return gtResolveAliasLocale(locale, this.config.customMapping);
+  }
+
+  /**
+   * Resolve a locale to its canonical code using the configured custom mapping
+   */
+  resolveCanonicalLocale(locale: string): string {
+    return gtResolveCanonicalLocale(locale, this.config.customMapping);
+  }
+
+  /**
+   * Return true when a locale is valid for the configured custom mapping
+   */
+  isValidLocale(locale: string): boolean {
+    return gtIsValidLocale(locale, this.config.customMapping);
+  }
+
+  /**
+   * Get locale display metadata
+   */
+  getLocaleProperties(locale: string = this.getLocale()): LocaleProperties {
+    return gtGetLocaleProperties(
+      locale,
+      this.config.defaultLocale,
+      this.config.customMapping
+    );
+  }
+
+  /**
+   * Get text direction for a locale
+   */
+  getLocaleDirection(locale: string = this.getLocale()): 'ltr' | 'rtl' {
+    return gtGetLocaleDirection(locale);
   }
 
   /**
@@ -446,11 +506,15 @@ class I18nManager<
    */
   requiresTranslation(locale: string = this.getLocale()): boolean {
     const defaultLocale = this.getDefaultLocale();
-    const gtInstance = this.getGTClass();
     const locales = this.getLocales();
     return (
       this.isTranslationEnabled() &&
-      gtInstance.requiresTranslation(defaultLocale, locale, locales)
+      gtRequiresTranslation(
+        defaultLocale,
+        locale,
+        locales,
+        this.config.customMapping
+      )
     );
   }
 
@@ -461,10 +525,9 @@ class I18nManager<
    */
   requiresDialectTranslation(locale: string = this.getLocale()): boolean {
     const defaultLocale = this.getDefaultLocale();
-    const gt = this.getGTClass();
     return (
       this.requiresTranslation(locale) &&
-      gt.isSameLanguage(defaultLocale, locale)
+      gtIsSameLanguage(defaultLocale, locale)
     );
   }
 
@@ -487,11 +550,7 @@ class I18nManager<
    * Validate locale
    */
   private validateLocale(locale: string): void {
-    const gtInstance = this.getGTClass();
-    if (
-      !gtInstance.isValidLocale(locale) ||
-      !gtInstance.determineLocale(locale)
-    ) {
+    if (!this.isValidLocale(locale) || !this.determineLocale(locale)) {
       throw new Error(
         `I18nManager: validateLocale(): locale ${locale} is not valid`
       );

--- a/packages/next/src/config-dir/I18NConfiguration.ts
+++ b/packages/next/src/config-dir/I18NConfiguration.ts
@@ -1,4 +1,13 @@
-import { GT, isSameLanguage } from 'generaltranslation';
+import {
+  determineLocale as gtDetermineLocale,
+  getLocaleDirection as gtGetLocaleDirection,
+  getLocaleProperties as gtGetLocaleProperties,
+  GT,
+  isSameLanguage,
+  isValidLocale as gtIsValidLocale,
+  resolveAliasLocale as gtResolveAliasLocale,
+  resolveCanonicalLocale as gtResolveCanonicalLocale,
+} from 'generaltranslation';
 import translationManager, { TranslationManager } from './TranslationManager';
 import {
   RenderMethod,
@@ -19,7 +28,7 @@ import {
   defaultResetLocaleCookieName,
 } from '../utils/cookies';
 import { defaultLocaleHeaderName } from '../utils/headers';
-import { CustomMapping } from 'generaltranslation/types';
+import { CustomMapping, LocaleProperties } from 'generaltranslation/types';
 import { GTTranslationError } from '../utils/errors';
 import type { TranslateManyEntry } from 'generaltranslation/types';
 
@@ -322,6 +331,37 @@ export default class I18NConfiguration {
    */
   getLocales(): string[] {
     return this.locales;
+  }
+
+  determineLocale(
+    locales: string | string[],
+    approvedLocales: string[] | undefined = this.locales
+  ): string | undefined {
+    return gtDetermineLocale(locales, approvedLocales, this.customMapping);
+  }
+
+  resolveAliasLocale(locale: string): string {
+    return gtResolveAliasLocale(locale, this.customMapping);
+  }
+
+  resolveCanonicalLocale(locale: string): string {
+    return gtResolveCanonicalLocale(locale, this.customMapping);
+  }
+
+  isValidLocale(locale: string): boolean {
+    return gtIsValidLocale(locale, this.customMapping);
+  }
+
+  getLocaleProperties(locale: string): LocaleProperties {
+    return gtGetLocaleProperties(
+      locale,
+      this.defaultLocale,
+      this.customMapping
+    );
+  }
+
+  getLocaleDirection(locale: string): 'ltr' | 'rtl' {
+    return gtGetLocaleDirection(locale);
   }
 
   /**

--- a/packages/next/src/config-dir/loadTranslation.ts
+++ b/packages/next/src/config-dir/loadTranslation.ts
@@ -56,8 +56,9 @@ export default async function loadTranslations(
       _props: RemoteLoadTranslationsInput
     ): Promise<any> => {
       try {
-        const gt = getI18NConfig().getGTClass();
-        const targetLocale = gt.resolveCanonicalLocale(_props.targetLocale);
+        const targetLocale = getI18NConfig().resolveCanonicalLocale(
+          _props.targetLocale
+        );
         const response = await fetch(
           `${_props.cacheUrl}/${_props.projectId}/${targetLocale}${
             _props._versionId ? `/${_props._versionId}` : ''

--- a/packages/next/src/index.server.ts
+++ b/packages/next/src/index.server.ts
@@ -32,7 +32,6 @@ import {
   InlineTranslationOptions,
   RuntimeTranslationOptions,
 } from 'gt-react';
-import { GT } from 'generaltranslation';
 import {
   useMessages,
   useGT,
@@ -45,7 +44,7 @@ export function useGTClass() {
 }
 
 export function useLocaleProperties(locale: string): LocaleProperties {
-  return (useGTClass() as GT).getLocaleProperties(locale);
+  return getI18NConfig().getLocaleProperties(locale);
 }
 
 export function useLocales() {

--- a/packages/next/src/middleware-dir/__tests__/localeResolution.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/localeResolution.edge.test.ts
@@ -1,7 +1,6 @@
 // @vitest-environment edge-runtime
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { NextRequest } from 'next/server';
-import { GT } from 'generaltranslation';
 import { getLocaleFromRequest } from '../utils';
 
 // Mock gt-react/internal — only provides a constant, avoids deep react-core build chain
@@ -53,7 +52,6 @@ function callGetLocaleFromRequest(
     defaultLocalePaths?: string[];
   } = {}
 ) {
-  const gt = new GT();
   return getLocaleFromRequest(
     req,
     overrides.defaultLocale ?? DEFAULT_LOCALE,
@@ -64,8 +62,7 @@ function callGetLocaleFromRequest(
     overrides.defaultLocalePaths ?? [],
     REFERRER_COOKIE,
     LOCALE_COOKIE,
-    RESET_COOKIE,
-    gt
+    RESET_COOKIE
   );
 }
 

--- a/packages/next/src/middleware-dir/createNextMiddleware.ts
+++ b/packages/next/src/middleware-dir/createNextMiddleware.ts
@@ -1,5 +1,8 @@
-import { isSameDialect, standardizeLocale } from 'generaltranslation';
-import { GT } from 'generaltranslation';
+import {
+  isSameDialect,
+  isValidLocale,
+  standardizeLocale,
+} from 'generaltranslation';
 import { libraryDefaultLocale } from 'generaltranslation/internal';
 import { createUnsupportedLocalesWarning } from '../errors/createErrors';
 import { NextRequest, NextResponse } from 'next/server';
@@ -60,10 +63,7 @@ export default function createNextMiddleware({
     }
   }
 
-  // gt instance
-  const gt = new GT({
-    customMapping: envParams?.customMapping,
-  });
+  const customMapping = envParams?.customMapping;
 
   // using gt services
   const gtServicesEnabled =
@@ -97,12 +97,14 @@ export default function createNextMiddleware({
   const localeHeaderName =
     headersAndCookies?.localeHeaderName || defaultLocaleHeaderName;
 
-  if (!gt.isValidLocale(defaultLocale))
+  if (!isValidLocale(defaultLocale, customMapping))
     throw new Error(
       `gt-next middleware: defaultLocale "${defaultLocale}" is not a valid locale.`
     );
 
-  const warningLocales = locales.filter((locale) => !gt.isValidLocale(locale));
+  const warningLocales = locales.filter(
+    (locale) => !isValidLocale(locale, customMapping)
+  );
   if (warningLocales.length)
     console.warn(createUnsupportedLocalesWarning(warningLocales));
 
@@ -174,7 +176,7 @@ export default function createNextMiddleware({
       referrerLocaleCookieName,
       localeCookieName,
       resetLocaleCookieName,
-      gt
+      customMapping
     );
 
     const headerList = new Headers(req.headers);

--- a/packages/next/src/middleware-dir/utils.ts
+++ b/packages/next/src/middleware-dir/utils.ts
@@ -1,5 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { GT, standardizeLocale } from 'generaltranslation';
+import {
+  determineLocale,
+  isValidLocale,
+  resolveAliasLocale,
+  standardizeLocale,
+} from 'generaltranslation';
+import { CustomMapping } from 'generaltranslation/types';
 import { NextURL } from 'next/dist/server/web/next-url';
 
 export type PathConfig = {
@@ -268,7 +274,7 @@ export function getLocaleFromRequest(
   referrerLocaleCookieName: string,
   localeCookieName: string,
   resetLocaleCookieName: string,
-  gt: GT
+  customMapping?: CustomMapping
 ): {
   userLocale: string;
   pathnameLocale: string | undefined;
@@ -290,15 +296,16 @@ export function getLocaleFromRequest(
 
     if (
       extractedLocale &&
-      gt.isValidLocale(extractedLocale) &&
-      gt.determineLocale([extractedLocale], approvedLocales)
+      isValidLocale(extractedLocale, customMapping) &&
+      determineLocale([extractedLocale], approvedLocales, customMapping)
     ) {
-      const determinedLocale = gt.determineLocale(
+      const determinedLocale = determineLocale(
         [extractedLocale],
-        approvedLocales
+        approvedLocales,
+        customMapping
       );
       if (determinedLocale) {
-        pathnameLocale = gt.resolveAliasLocale(determinedLocale);
+        pathnameLocale = resolveAliasLocale(determinedLocale, customMapping);
         candidates.push(pathnameLocale);
       }
     }
@@ -316,7 +323,10 @@ export function getLocaleFromRequest(
 
   // Check cookie locale
   const cookieLocale = req.cookies.get(localeCookieName);
-  if (cookieLocale?.value && gt.isValidLocale(cookieLocale?.value)) {
+  if (
+    cookieLocale?.value &&
+    isValidLocale(cookieLocale?.value, customMapping)
+  ) {
     const resetCookie = req.cookies.get(resetLocaleCookieName);
     if (resetCookie?.value) {
       // Add this back in when we support custom getLocale
@@ -334,11 +344,11 @@ export function getLocaleFromRequest(
   const referrerLocaleCookie = req.cookies.get(referrerLocaleCookieName);
   if (
     referrerLocaleCookie?.value &&
-    gt.isValidLocale(referrerLocaleCookie.value) &&
+    isValidLocale(referrerLocaleCookie.value, customMapping) &&
     !clearResetCookie
   ) {
     const referrerLocale = referrerLocaleCookie.value;
-    if (gt.determineLocale([referrerLocale], approvedLocales)) {
+    if (determineLocale([referrerLocale], approvedLocales, customMapping)) {
       candidates.push(referrerLocale);
     }
   }
@@ -358,9 +368,10 @@ export function getLocaleFromRequest(
 
   // determine userLocale
   const unstandardizedUserLocale =
-    gt.determineLocale(
-      candidates.filter((locale) => gt.isValidLocale(locale)),
-      approvedLocales
+    determineLocale(
+      candidates.filter((locale) => isValidLocale(locale, customMapping)),
+      approvedLocales,
+      customMapping
     ) || defaultLocale;
   const userLocale = gtServicesEnabled
     ? standardizeLocale(unstandardizedUserLocale)

--- a/packages/next/src/provider/ClientProviderWrapper.tsx
+++ b/packages/next/src/provider/ClientProviderWrapper.tsx
@@ -2,13 +2,21 @@
 import { ClientProvider } from 'gt-react/client';
 import { ClientProviderProps } from 'gt-react/internal';
 import { usePathname } from 'next/navigation';
-import { useCallback, useEffect, useMemo } from 'react';
-import { GT, standardizeLocale } from 'generaltranslation';
+import { useCallback, useEffect } from 'react';
+import {
+  determineLocale,
+  resolveAliasLocale,
+  standardizeLocale,
+} from 'generaltranslation';
+import { CustomMapping } from 'generaltranslation/types';
 import { useRouter } from 'next/navigation';
 
-function extractLocale(pathname: string, gt: GT): string | null {
+function extractLocale(
+  pathname: string,
+  customMapping?: CustomMapping
+): string | null {
   const matches = pathname.match(/^\/([^\/]+)(?:\/|$)/);
-  return matches ? gt.resolveAliasLocale(matches[1]) : null;
+  return matches ? resolveAliasLocale(matches[1], customMapping) : null;
 }
 
 export default function ClientProviderWrapper(
@@ -25,9 +33,6 @@ export default function ClientProviderWrapper(
     gtServicesEnabled,
     referrerLocaleCookieName,
     localeRoutingEnabledCookieName,
-    devApiKey,
-    projectId,
-    runtimeUrl,
     customMapping,
   } = props;
 
@@ -39,26 +44,13 @@ export default function ClientProviderWrapper(
     router.refresh();
   }, [router]);
 
-  const gt = useMemo(
-    () =>
-      new GT({
-        devApiKey,
-        sourceLocale: defaultLocale,
-        targetLocale: locale,
-        projectId,
-        baseUrl: runtimeUrl || undefined,
-        customMapping,
-      }),
-    [devApiKey, defaultLocale, locale, projectId, runtimeUrl, customMapping]
-  );
-
   // Trigger page reload when locale changes
   // When nav to same route but in diff locale, client components were cached and not re-rendered
   const pathname = usePathname();
   useEffect(() => {
     // ----- Referrer Locale ----- //
     if (locale) {
-      document.cookie = `${referrerLocaleCookieName}=${gt.resolveAliasLocale(locale)};path=/`;
+      document.cookie = `${referrerLocaleCookieName}=${resolveAliasLocale(locale, customMapping)};path=/`;
     }
 
     // ----- Middleware ----- //
@@ -71,18 +63,20 @@ export default function ClientProviderWrapper(
         ?.split('=')[1] === 'true';
     if (middlewareEnabled) {
       // Extract locale from pathname
-      const extractedLocale = extractLocale(pathname, gt) || defaultLocale;
-      let pathLocale = gt.determineLocale(
+      const extractedLocale =
+        extractLocale(pathname, customMapping) || defaultLocale;
+      let pathLocale = determineLocale(
         [
           gtServicesEnabled
             ? standardizeLocale(extractedLocale)
             : extractedLocale,
           defaultLocale,
         ],
-        locales
+        locales,
+        customMapping
       );
       if (pathLocale) {
-        pathLocale = gt.resolveAliasLocale(pathLocale);
+        pathLocale = resolveAliasLocale(pathLocale, customMapping);
       }
 
       if (pathLocale && locales.includes(pathLocale) && pathLocale !== locale) {
@@ -102,6 +96,7 @@ export default function ClientProviderWrapper(
     referrerLocaleCookieName,
     localeRoutingEnabledCookieName,
     reloadServer,
+    customMapping,
   ]);
 
   return <ClientProvider {...props} reloadServer={reloadServer} />;

--- a/packages/next/src/request/getLocale.ts
+++ b/packages/next/src/request/getLocale.ts
@@ -23,20 +23,19 @@ export async function getLocale(): Promise<string> {
   // Use the request function to get the locale
   if (getLocaleFunction) return await getLocaleFunction();
   const I18NConfig = getI18NConfig();
-  const gt = I18NConfig.getGTClass();
 
   if (process.env._GENERALTRANSLATION_ENABLE_SSG === 'false') {
     const requestFunction = getRequestFunction('getLocale');
     // Support new behavior
     getLocaleFunction = async () => {
       const requestLocale = await requestFunction();
-      return gt.resolveAliasLocale(
+      return I18NConfig.resolveAliasLocale(
         requestLocale || I18NConfig.getDefaultLocale()
       );
     };
   } else {
     // Support legacy behavior
-    getLocaleFunction = legacyGetLocaleFunction(I18NConfig, gt);
+    getLocaleFunction = legacyGetLocaleFunction(I18NConfig);
   }
 
   return getLocaleFunction();

--- a/packages/next/src/request/getLocaleDirection.ts
+++ b/packages/next/src/request/getLocaleDirection.ts
@@ -18,14 +18,14 @@ export function getLocaleDirection(locale: string): 'ltr' | 'rtl';
 export function getLocaleDirection(): Promise<'ltr' | 'rtl'>;
 // Implementation
 export function getLocaleDirection(locale?: string) {
-  const gt = getI18NConfig().getGTClass();
+  const I18NConfig = getI18NConfig();
   if (typeof locale === 'string') {
     // Synchronous result when locale is given
-    return gt.getLocaleDirection(locale) as 'ltr' | 'rtl';
+    return I18NConfig.getLocaleDirection(locale) as 'ltr' | 'rtl';
   }
   // Asynchronous result when locale is not given
   return getLocale().then((resolvedLocale) =>
-    gt.getLocaleDirection(resolvedLocale)
+    I18NConfig.getLocaleDirection(resolvedLocale)
   ) as Promise<'ltr' | 'rtl'>;
 }
 
@@ -43,6 +43,5 @@ export function getLocaleDirection(locale?: string) {
  */
 export function useLocaleDirection(locale?: string): 'ltr' | 'rtl' {
   locale = locale || useLocale();
-  const gt = getI18NConfig().getGTClass();
-  return gt.getLocaleDirection(locale);
+  return getI18NConfig().getLocaleDirection(locale);
 }

--- a/packages/next/src/request/headers/getNextLocale.ts
+++ b/packages/next/src/request/headers/getNextLocale.ts
@@ -52,6 +52,5 @@ export async function getNextLocale(): Promise<RequestFunctionReturnType> {
   // add defaultLocale just in case there are no matches
   preferredLocales.push(defaultLocale);
 
-  const gt = getI18NConfig().getGTClass();
-  return gt.determineLocale(preferredLocales, locales);
+  return I18NConfig.determineLocale(preferredLocales, locales);
 }

--- a/packages/next/src/request/registerLocale.ts
+++ b/packages/next/src/request/registerLocale.ts
@@ -9,6 +9,5 @@ import { localeStore } from './localeStore';
  * @param locale - A BCP-47 locale tag (e.g., 'en-US', 'de', 'fr')
  */
 export function registerLocale(locale: string): void {
-  const gt = getI18NConfig().getGTClass();
-  localeStore.enterWith(gt.resolveAliasLocale(locale));
+  localeStore.enterWith(getI18NConfig().resolveAliasLocale(locale));
 }

--- a/packages/next/src/request/utils/getRequestFunction.ts
+++ b/packages/next/src/request/utils/getRequestFunction.ts
@@ -63,8 +63,7 @@ function handleExperimentalLocaleResolution(
             defaultExperimentalLocaleResolutionParam
         );
         const I18NConfig = getI18NConfig();
-        const gt = I18NConfig.getGTClass();
-        return unverifiedLocale && gt.isValidLocale(unverifiedLocale)
+        return unverifiedLocale && I18NConfig.isValidLocale(unverifiedLocale)
           ? unverifiedLocale
           : undefined;
       } catch (error) {

--- a/packages/next/src/request/utils/legacyGetLocaleFunction.ts
+++ b/packages/next/src/request/utils/legacyGetLocaleFunction.ts
@@ -1,4 +1,3 @@
-import { GT } from 'generaltranslation';
 import { RequestFunctionReturnType } from '../types';
 import { legacyGetRequestFunction } from './legacyGetRequestFunction';
 import isSSR from './isSSR';
@@ -11,8 +10,7 @@ let getStaticLocaleFunction: () => Promise<RequestFunctionReturnType>;
  * @deprecated
  */
 export function legacyGetLocaleFunction(
-  I18NConfig: I18NConfiguration,
-  gt: GT
+  I18NConfig: I18NConfiguration
 ): () => Promise<string> {
   // Construct getLocale function
   getLocaleFunction = legacyGetRequestFunction('getLocale', true);
@@ -24,6 +22,8 @@ export function legacyGetLocaleFunction(
     const locale = isSSR()
       ? await getLocaleFunction()
       : await getStaticLocaleFunction();
-    return gt.resolveAliasLocale(locale || I18NConfig.getDefaultLocale());
+    return I18NConfig.resolveAliasLocale(
+      locale || I18NConfig.getDefaultLocale()
+    );
   };
 }

--- a/packages/next/src/server-dir/buildtime/__tests__/getTranslations.test.ts
+++ b/packages/next/src/server-dir/buildtime/__tests__/getTranslations.test.ts
@@ -95,6 +95,10 @@ vi.mock('generaltranslation', () => ({
   determineLocale: vi.fn(
     (preferred, available) => preferred[0] || available[0]
   ),
+  resolveAliasLocale: vi.fn((locale) => locale),
+  resolveCanonicalLocale: vi.fn((locale) => locale),
+  isValidLocale: vi.fn(() => true),
+  getLocaleDirection: vi.fn(() => 'ltr'),
 }));
 vi.mock('generaltranslation/id', () => ({
   hashSource: mockHashSource,

--- a/packages/next/src/server.ts
+++ b/packages/next/src/server.ts
@@ -25,7 +25,7 @@ export function getGTClass() {
 }
 
 export function getLocaleProperties(locale: string): LocaleProperties {
-  return getGTClass().getLocaleProperties(locale);
+  return getI18NConfig().getLocaleProperties(locale);
 }
 
 export function getLocales(): string[] {

--- a/packages/react/src/i18n-context/browser-i18n-manager/BrowserI18nManager.ts
+++ b/packages/react/src/i18n-context/browser-i18n-manager/BrowserI18nManager.ts
@@ -5,7 +5,11 @@ import type {
 } from 'gt-i18n/internal/types';
 import type { BrowserStorageAdapter } from './BrowserStorageAdapter';
 import type { HtmlTagOptions } from './utils/types';
-import { determineLocale as gtDetermineLocale } from 'generaltranslation';
+import {
+  getLocaleDirection,
+  isValidLocale,
+  resolveCanonicalLocale,
+} from 'generaltranslation';
 import { Translation } from 'gt-i18n/types';
 import { DEFAULT_HTML_TAG_OPTIONS } from './utils/constants';
 import { LocalStorageTranslationCache } from './LocalStorageTranslationCache';
@@ -141,13 +145,14 @@ export class BrowserI18nManager extends I18nManager<
   ): void {
     // Get parameters
     const locale = htmlTagOptions?.lang || this.getLocale();
-    const gtInstance = this.getGTClass();
-    const canonicalLocale = gtInstance.resolveCanonicalLocale(locale);
-    const localeDirection =
-      htmlTagOptions?.dir || gtInstance.getLocaleDirection(locale);
+    const canonicalLocale = resolveCanonicalLocale(
+      locale,
+      this.config.customMapping
+    );
+    const localeDirection = htmlTagOptions?.dir || getLocaleDirection(locale);
 
     // Validate parameters
-    if (!gtInstance.isValidLocale(canonicalLocale)) {
+    if (!isValidLocale(canonicalLocale, this.config.customMapping)) {
       console.warn(createInvalidLocaleWarning(locale));
       return;
     }
@@ -169,6 +174,10 @@ export class BrowserI18nManager extends I18nManager<
 }
 
 // ===== Helper Functions ===== //
+
+function createInvalidLocaleWarning(locale: string): string {
+  return `gt-react: Invalid locale: ${locale}.`;
+}
 
 /**
  * Creates the dev hot reload config


### PR DESCRIPTION
## Summary
- Add locale helper methods to `gt-i18n`'s `I18nManager` so locale resolution and metadata no longer need a GT instance internally.
- Add matching locale helper methods to `gt-next`'s `I18NConfiguration` and route request/middleware/server locale utilities through them.
- Replace browser HTML tag locale metadata access with standalone `generaltranslation` locale helpers and restore `gt-react` typecheck by defining the invalid-locale warning helper.

## Verification
- `pnpm --filter gt-i18n exec eslint src/helpers/locale.ts src/i18n-manager/I18nManager.ts`
- `pnpm --filter gt-i18n exec tsc --noEmit`
- `pnpm --filter gt-i18n test`
- `pnpm --filter gt-react exec eslint src/i18n-context/browser-i18n-manager/BrowserI18nManager.ts src/i18n-context/ui/LocaleSelector.tsx`
- `pnpm --filter gt-react exec tsc --noEmit`
- `pnpm --filter gt-react test`
- `pnpm --filter gt-next exec eslint src/config-dir/I18NConfiguration.ts src/config-dir/loadTranslation.ts src/index.server.ts src/middleware-dir/__tests__/localeResolution.edge.test.ts src/middleware-dir/createNextMiddleware.ts src/middleware-dir/utils.ts src/provider/ClientProviderWrapper.tsx src/request/getLocale.ts src/request/getLocaleDirection.ts src/request/headers/getNextLocale.ts src/request/registerLocale.ts src/request/utils/getRequestFunction.ts src/request/utils/legacyGetLocaleFunction.ts src/server.ts src/server-dir/buildtime/__tests__/getTranslations.test.ts`
- `pnpm --filter gt-next exec tsc --noEmit`
- `pnpm --filter gt-next run test:js`

## Note
- `pnpm --filter gt-node exec tsc --noEmit` is still blocked by existing generic incompatibilities in `src/setup/initializeGT.ts` and `src/setup/withGT.ts`; no `gt-node` files are changed in this PR.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR decouples locale resolution helpers from the `GT` class by adding delegate methods (`determineLocale`, `resolveAliasLocale`, `resolveCanonicalLocale`, `isValidLocale`, `getLocaleProperties`, `getLocaleDirection`) to both `I18nManager` and `I18NConfiguration`, each forwarding to the corresponding standalone `generaltranslation` function. All call sites across `gt-next` and `gt-react` are updated to go through these delegates instead of instantiating or casting to a `GT` instance. As a side effect, `ClientProviderWrapper` drops a `useMemo`-created `GT` instance that was never in the `useEffect` dependency array (latent stale-closure), replacing it with direct standalone calls and correctly adding `customMapping` to the effect deps.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — purely mechanical refactor with no behavioural changes and a latent bug fix in ClientProviderWrapper.

All changes are direct substitutions of GT instance method calls with equivalent standalone generaltranslation functions passing the same customMapping. The ClientProviderWrapper change is a strict improvement (removes stale-closure risk). No new logic, no missing customMapping threads, and the test mock additions cover the newly-direct function calls.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/i18n-manager/I18nManager.ts | Adds delegate methods (determineLocale, resolveAliasLocale, resolveCanonicalLocale, isValidLocale, getLocaleProperties, getLocaleDirection) that forward directly to standalone generaltranslation functions, and updates internal callers to use them instead of instantiating GT. |
| packages/next/src/config-dir/I18NConfiguration.ts | Adds the same set of locale helper delegate methods mirroring I18nManager, while keeping the existing GT instance for runtime translation. isSameLanguage remains used (unaliased) inside requiresTranslation — import is valid and intentional. |
| packages/next/src/middleware-dir/utils.ts | Replaces GT instance parameter with optional CustomMapping, and switches all isValidLocale / determineLocale / resolveAliasLocale calls to standalone generaltranslation imports. No behavioural change. |
| packages/next/src/provider/ClientProviderWrapper.tsx | Removes useMemo GT instance (which was not in useEffect deps, causing a latent stale-closure), replaces with direct standalone calls, and correctly adds customMapping to the effect dependency array. Improvement over previous code. |
| packages/react/src/i18n-context/browser-i18n-manager/BrowserI18nManager.ts | Replaces getGTClass() calls with imported standalone helpers (resolveCanonicalLocale, getLocaleDirection, isValidLocale) and defines the previously-missing createInvalidLocaleWarning helper, restoring the typecheck. |
| packages/next/src/server-dir/buildtime/__tests__/getTranslations.test.ts | Expands generaltranslation mock with resolveAliasLocale, resolveCanonicalLocale, isValidLocale, and getLocaleDirection — but getLocaleProperties is not mocked; acceptable if no getTranslations code path exercises it. |
| packages/next/src/request/headers/getNextLocale.ts | Removes gt instance, routes determineLocale through I18NConfig.determineLocale — semantically equivalent call with same locales argument. |
| packages/next/src/index.server.ts | Drops the (useGTClass() as GT) cast and calls getI18NConfig().getLocaleProperties() directly, removing the need for the GT import entirely. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Call site\n(middleware / request / provider)"] -->|before| B["new GT({ customMapping })\n.determineLocale / .isValidLocale\n.resolveAliasLocale etc."]
    A -->|after| C["I18NConfiguration\nor I18nManager\ndelegate method"]
    C --> D["standalone generaltranslation\nfunction\n(determineLocale, isValidLocale,\nresolveAliasLocale, …)"]
    B --> D
    style B stroke:#f66,stroke-dasharray:5
    style C stroke:#090
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Decouple locale helpers from GT class ac..."](https://github.com/generaltranslation/gt/commit/27016a4629599db4d03e72d552de70c5eada4970) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29917775)</sub>

<!-- /greptile_comment -->