### PR TITLE
Add client-safe locale config helper

### DIFF
--- a/packages/core/src/LocaleConfig.ts
+++ b/packages/core/src/LocaleConfig.ts
@@ -1,0 +1,310 @@
+import {
+  _formatCurrency,
+  _formatCutoff,
+  _formatDateTime,
+  _formatList,
+  _formatListToParts,
+  _formatMessageICU,
+  _formatMessageString,
+  _formatNum,
+  _formatRelativeTime,
+  _formatRelativeTimeFromDate,
+} from './formatting/format';
+import _requiresTranslation from './locales/requiresTranslation';
+import _determineLocale from './locales/determineLocale';
+import _isSameLanguage from './locales/isSameLanguage';
+import _getLocaleProperties from './locales/getLocaleProperties';
+import _getLocaleEmoji from './locales/getLocaleEmoji';
+import { _isValidLocale, _standardizeLocale } from './locales/isValidLocale';
+import { _getLocaleName } from './locales/getLocaleName';
+import { _getLocaleDirection } from './locales/getLocaleDirection';
+import { libraryDefaultLocale } from './settings/settings';
+import _isSameDialect from './locales/isSameDialect';
+import _isSupersetLocale from './locales/isSupersetLocale';
+import { CustomMapping, FormatVariables } from './types';
+import { _resolveAliasLocale } from './locales/resolveAliasLocale';
+import { _resolveCanonicalLocale } from './locales/resolveCanonicalLocale';
+import { CutoffFormatOptions } from './formatting/custom-formats/CutoffFormat/types';
+import { StringFormat } from './types-dir/jsx/content';
+
+export type LocaleConfigConstructorParams = {
+  defaultLocale?: string;
+  locales?: string[];
+  customMapping?: CustomMapping;
+};
+
+type LocalesOption = {
+  locales?: string | string[];
+};
+
+type WithLocales<T = object> = T & LocalesOption;
+
+/**
+ * LocaleConfig is a client-safe locale and formatting helper.
+ *
+ * It intentionally does not store project IDs, API keys, runtime URLs, or any
+ * translation credentials. It only stores locale metadata needed to resolve
+ * aliases, choose formatting fallbacks, and format values with Intl.
+ */
+export class LocaleConfig {
+  readonly defaultLocale: string;
+  readonly locales: string[];
+  readonly customMapping?: CustomMapping;
+
+  constructor({
+    defaultLocale = libraryDefaultLocale,
+    locales = [],
+    customMapping,
+  }: LocaleConfigConstructorParams = {}) {
+    this.defaultLocale = defaultLocale;
+    this.locales = locales;
+    this.customMapping = customMapping;
+  }
+
+  private get translationLocales() {
+    return this.locales.length ? this.locales : undefined;
+  }
+
+  private resolveCanonicalLocaleList(locales: string[]) {
+    return locales.map((locale) => this.resolveCanonicalLocale(locale));
+  }
+
+  private resolveCanonicalLocaleArgs(locales: (string | string[])[]) {
+    return locales.map((locale) =>
+      Array.isArray(locale)
+        ? this.resolveCanonicalLocaleList(locale)
+        : this.resolveCanonicalLocale(locale)
+    );
+  }
+
+  private toLocaleList(locales: string | string[]) {
+    return Array.isArray(locales) ? locales : [locales];
+  }
+
+  private getFormattingLocales(
+    targetLocale?: string,
+    locales?: string | string[]
+  ) {
+    const localeList =
+      locales !== undefined
+        ? this.toLocaleList(locales)
+        : [targetLocale, this.defaultLocale, libraryDefaultLocale];
+
+    return localeList
+      .filter((locale): locale is string => !!locale)
+      .map((locale) => this.resolveCanonicalLocale(locale));
+  }
+
+  formatNum(
+    value: number,
+    targetLocale?: string,
+    options: WithLocales<Intl.NumberFormatOptions> = {}
+  ) {
+    const { locales, ...intlOptions } = options;
+    return _formatNum({
+      value,
+      locales: this.getFormattingLocales(targetLocale, locales),
+      options: intlOptions,
+    });
+  }
+
+  formatDateTime(
+    value: Date,
+    targetLocale?: string,
+    options: WithLocales<Intl.DateTimeFormatOptions> = {}
+  ) {
+    const { locales, ...intlOptions } = options;
+    return _formatDateTime({
+      value,
+      locales: this.getFormattingLocales(targetLocale, locales),
+      options: intlOptions,
+    });
+  }
+
+  formatCurrency(
+    value: number,
+    currency: string,
+    targetLocale?: string,
+    options: WithLocales<Intl.NumberFormatOptions> = {}
+  ) {
+    const { locales, ...intlOptions } = options;
+    return _formatCurrency({
+      value,
+      currency,
+      locales: this.getFormattingLocales(targetLocale, locales),
+      options: intlOptions,
+    });
+  }
+
+  formatRelativeTime(
+    value: number,
+    unit: Intl.RelativeTimeFormatUnit,
+    targetLocale?: string,
+    options: WithLocales<Intl.RelativeTimeFormatOptions> = {}
+  ) {
+    const { locales, ...intlOptions } = options;
+    return _formatRelativeTime({
+      value,
+      unit,
+      locales: this.getFormattingLocales(targetLocale, locales),
+      options: intlOptions,
+    });
+  }
+
+  formatRelativeTimeFromDate(
+    date: Date,
+    targetLocale?: string,
+    options: WithLocales<
+      Intl.RelativeTimeFormatOptions & { baseDate?: Date }
+    > = {}
+  ) {
+    const { locales, baseDate, ...intlOptions } = options;
+    return _formatRelativeTimeFromDate({
+      date,
+      baseDate: baseDate ?? new Date(),
+      locales: this.getFormattingLocales(targetLocale, locales),
+      options: intlOptions,
+    });
+  }
+
+  formatCutoff(
+    value: string,
+    targetLocale?: string,
+    options: WithLocales<CutoffFormatOptions> = {}
+  ) {
+    const { locales, ...formatOptions } = options;
+    return _formatCutoff({
+      value,
+      locales: this.getFormattingLocales(targetLocale, locales),
+      options: formatOptions,
+    });
+  }
+
+  formatMessage(
+    message: string,
+    targetLocale?: string,
+    options: WithLocales<{
+      variables?: FormatVariables;
+      dataFormat?: StringFormat;
+    }> = {}
+  ) {
+    const { locales, variables, dataFormat } = options;
+    if (dataFormat === 'STRING') return _formatMessageString(message);
+    return _formatMessageICU(
+      message,
+      this.getFormattingLocales(targetLocale, locales),
+      variables
+    );
+  }
+
+  formatList(
+    array: Array<string | number>,
+    targetLocale?: string,
+    options: WithLocales<Intl.ListFormatOptions> = {}
+  ) {
+    const { locales, ...intlOptions } = options;
+    return _formatList({
+      value: array,
+      locales: this.getFormattingLocales(targetLocale, locales),
+      options: intlOptions,
+    });
+  }
+
+  formatListToParts<T>(
+    array: Array<T>,
+    targetLocale?: string,
+    options: WithLocales<Intl.ListFormatOptions> = {}
+  ) {
+    const { locales, ...intlOptions } = options;
+    return _formatListToParts<T>({
+      value: array,
+      locales: this.getFormattingLocales(targetLocale, locales),
+      options: intlOptions,
+    });
+  }
+
+  getLocaleName(locale: string) {
+    return _getLocaleName(locale, this.defaultLocale, this.customMapping);
+  }
+
+  getLocaleEmoji(locale: string) {
+    return _getLocaleEmoji(locale, this.customMapping);
+  }
+
+  getLocaleProperties(locale: string) {
+    return _getLocaleProperties(locale, this.defaultLocale, this.customMapping);
+  }
+
+  requiresTranslation(
+    targetLocale: string,
+    sourceLocale: string = this.defaultLocale,
+    approvedLocales: string[] | undefined = this.translationLocales
+  ) {
+    return _requiresTranslation(
+      this.resolveCanonicalLocale(sourceLocale),
+      this.resolveCanonicalLocale(targetLocale),
+      approvedLocales
+        ? this.resolveCanonicalLocaleList(approvedLocales)
+        : undefined,
+      this.customMapping
+    );
+  }
+
+  determineLocale(
+    locales: string | string[],
+    approvedLocales: string[] = this.locales
+  ) {
+    const approvedLocalePairs = approvedLocales.map((locale) => ({
+      locale,
+      canonicalLocale: this.resolveCanonicalLocale(locale),
+    }));
+    const resolvedLocale = _determineLocale(
+      Array.isArray(locales)
+        ? this.resolveCanonicalLocaleList(locales)
+        : this.resolveCanonicalLocale(locales),
+      approvedLocalePairs.map(({ canonicalLocale }) => canonicalLocale),
+      this.customMapping
+    );
+    if (!resolvedLocale) return undefined;
+    return (
+      approvedLocalePairs.find(
+        ({ canonicalLocale }) => canonicalLocale === resolvedLocale
+      )?.locale || this.resolveAliasLocale(resolvedLocale)
+    );
+  }
+
+  getLocaleDirection(locale: string) {
+    return _getLocaleDirection(this.resolveCanonicalLocale(locale));
+  }
+
+  isValidLocale(locale: string) {
+    return _isValidLocale(locale, this.customMapping);
+  }
+
+  resolveCanonicalLocale(locale: string) {
+    return _resolveCanonicalLocale(locale, this.customMapping);
+  }
+
+  resolveAliasLocale(locale: string) {
+    return _resolveAliasLocale(locale, this.customMapping);
+  }
+
+  standardizeLocale(locale: string) {
+    return _standardizeLocale(locale);
+  }
+
+  isSameDialect(...locales: (string | string[])[]) {
+    return _isSameDialect(...this.resolveCanonicalLocaleArgs(locales));
+  }
+
+  isSameLanguage(...locales: (string | string[])[]) {
+    return _isSameLanguage(...this.resolveCanonicalLocaleArgs(locales));
+  }
+
+  isSupersetLocale(superLocale: string, subLocale: string) {
+    return _isSupersetLocale(
+      this.resolveCanonicalLocale(superLocale),
+      this.resolveCanonicalLocale(subLocale)
+    );
+  }
+}

--- a/packages/core/src/__tests__/index.test.ts
+++ b/packages/core/src/__tests__/index.test.ts
@@ -15,8 +15,6 @@ vi.mock('../translate/translateMany', () => ({
 }));
 
 const numberValue = 1234.56;
-const dateValue = new Date('2024-01-02T00:00:00Z');
-const listValue = ['red', 'blue'];
 
 const brandFrenchMapping = {
   'brand-french': {
@@ -25,33 +23,12 @@ const brandFrenchMapping = {
   },
 };
 
-const formatNumWithIntl = (locale: string) =>
-  new Intl.NumberFormat(locale, {
-    numberingSystem: 'latn',
-  }).format(numberValue);
-
 const formatCurrencyWithIntl = (locale: string, currency = 'EUR') =>
   new Intl.NumberFormat(locale, {
     style: 'currency',
     currency,
     numberingSystem: 'latn',
   }).format(numberValue);
-
-const formatDateWithIntl = (locale: string) =>
-  new Intl.DateTimeFormat(locale, {
-    calendar: 'gregory',
-    numberingSystem: 'latn',
-    dateStyle: 'full',
-    timeZone: 'UTC',
-  }).format(dateValue);
-
-const formatListWithIntl = (
-  locale: string,
-  options: Intl.ListFormatOptions = {
-    type: 'conjunction',
-    style: 'long',
-  }
-) => new Intl.ListFormat(locale, options).format(listValue);
 
 describe.sequential('GT Translation Methods', () => {
   beforeEach(() => {
@@ -647,15 +624,7 @@ describe.sequential('GT Translation Methods', () => {
 });
 
 describe('LocaleConfig', () => {
-  it('initializes locale state without optional fields', () => {
-    const localeConfig = new LocaleConfig();
-
-    expect(localeConfig.defaultLocale).toBe('en');
-    expect(localeConfig.locales).toEqual([]);
-    expect(localeConfig.requiresTranslation('es', 'en')).toBe(true);
-  });
-
-  it('formats currency with a custom alias by resolving to the canonical locale', () => {
+  it('formats with a custom alias by resolving to the canonical locale', () => {
     const localeConfig = new LocaleConfig({
       defaultLocale: 'en-US',
       customMapping: {
@@ -670,86 +639,9 @@ describe('LocaleConfig', () => {
 
     expect(result).toBe(formatCurrencyWithIntl('fr-FR'));
   });
-
-  it('resolves explicit locales before formatting', () => {
-    const localeConfig = new LocaleConfig({
-      defaultLocale: 'en-US',
-      customMapping: {
-        'brand-de': {
-          code: 'de-DE',
-          name: 'Brand German',
-        },
-      },
-    });
-
-    const result = localeConfig.formatNum(numberValue, undefined, {
-      locales: ['brand-de', 'en-US'],
-    });
-
-    expect(result).toBe(formatNumWithIntl('de-DE'));
-  });
-
-  it('formats lists with a custom alias by resolving to the canonical locale', () => {
-    const localeConfig = new LocaleConfig({
-      defaultLocale: 'en-US',
-      customMapping: {
-        'brand-es': {
-          code: 'es-ES',
-          name: 'Brand Spanish',
-        },
-      },
-    });
-
-    const result = localeConfig.formatList(listValue, 'brand-es', {
-      type: 'disjunction',
-    });
-
-    expect(result).toBe(
-      formatListWithIntl('es-ES', {
-        type: 'disjunction',
-        style: 'long',
-      })
-    );
-  });
-
-  it('resolves custom aliases before locale matching', () => {
-    const localeConfig = new LocaleConfig({
-      defaultLocale: 'en',
-      locales: ['fr'],
-      customMapping: {
-        'brand-fr': {
-          code: 'fr-FR',
-          name: 'Brand French',
-        },
-      },
-    });
-
-    expect(localeConfig.requiresTranslation('brand-fr')).toBe(true);
-    expect(localeConfig.determineLocale('brand-fr')).toBe('fr');
-    expect(localeConfig.isSameLanguage('brand-fr', 'fr-CA')).toBe(true);
-  });
 });
 
 describe('GT LocaleConfig delegation', () => {
-  it('uses the target locale before the source locale for default formatting', () => {
-    const gt = new GT({
-      sourceLocale: 'en-US',
-      targetLocale: 'fr-FR',
-    });
-
-    expect(gt.formatNum(numberValue)).toBe(formatNumWithIntl('fr-FR'));
-    expect(gt.formatCurrency(numberValue, 'EUR')).toBe(
-      formatCurrencyWithIntl('fr-FR')
-    );
-    expect(
-      gt.formatDateTime(dateValue, {
-        dateStyle: 'full',
-        timeZone: 'UTC',
-      })
-    ).toBe(formatDateWithIntl('fr-FR'));
-    expect(gt.formatList(listValue)).toBe(formatListWithIntl('fr-FR'));
-  });
-
   it('formats with a custom target locale alias through LocaleConfig', () => {
     const gt = new GT({
       sourceLocale: 'en-US',
@@ -762,7 +654,7 @@ describe('GT LocaleConfig delegation', () => {
     expect(result).toBe(formatCurrencyWithIntl('fr-FR'));
   });
 
-  it('exposes a client-safe localeConfig without credentials', () => {
+  it('exposes client-safe localeConfig and refreshes it from setConfig', () => {
     const gt = new GT({
       apiKey: 'test-api-key',
       devApiKey: 'test-dev-key',
@@ -770,19 +662,12 @@ describe('GT LocaleConfig delegation', () => {
       sourceLocale: 'en-US',
       targetLocale: 'es-ES',
     });
+    const initialLocaleConfig = gt.localeConfig;
 
     expect(gt.localeConfig).toBeInstanceOf(LocaleConfig);
     expect('apiKey' in gt.localeConfig).toBe(false);
     expect('devApiKey' in gt.localeConfig).toBe(false);
     expect('projectId' in gt.localeConfig).toBe(false);
-  });
-
-  it('keeps localeConfig stable until setConfig refreshes it', () => {
-    const gt = new GT({
-      sourceLocale: 'en-US',
-      targetLocale: 'es-ES',
-    });
-    const initialLocaleConfig = gt.localeConfig;
 
     gt.setConfig({
       targetLocale: 'brand-french',

--- a/packages/core/src/__tests__/index.test.ts
+++ b/packages/core/src/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { GT } from '../index';
+import { GT, LocaleConfig } from '../index';
 import _translateMany from '../translate/translateMany';
 import {
   TranslationResult,
@@ -14,7 +14,46 @@ vi.mock('../translate/translateMany', () => ({
   default: vi.fn(),
 }));
 
-describe('GT Translation Methods', () => {
+const numberValue = 1234.56;
+const dateValue = new Date('2024-01-02T00:00:00Z');
+const listValue = ['red', 'blue'];
+
+const brandFrenchMapping = {
+  'brand-french': {
+    code: 'fr-FR',
+    name: 'Brand French',
+  },
+};
+
+const formatNumWithIntl = (locale: string) =>
+  new Intl.NumberFormat(locale, {
+    numberingSystem: 'latn',
+  }).format(numberValue);
+
+const formatCurrencyWithIntl = (locale: string, currency = 'EUR') =>
+  new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency,
+    numberingSystem: 'latn',
+  }).format(numberValue);
+
+const formatDateWithIntl = (locale: string) =>
+  new Intl.DateTimeFormat(locale, {
+    calendar: 'gregory',
+    numberingSystem: 'latn',
+    dateStyle: 'full',
+    timeZone: 'UTC',
+  }).format(dateValue);
+
+const formatListWithIntl = (
+  locale: string,
+  options: Intl.ListFormatOptions = {
+    type: 'conjunction',
+    style: 'long',
+  }
+) => new Intl.ListFormat(locale, options).format(listValue);
+
+describe.sequential('GT Translation Methods', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -604,5 +643,156 @@ describe('GT Translation Methods', () => {
       const result = gt.resolveAliasLocale('zh-CN');
       expect(result).toBe('zh-CN');
     });
+  });
+});
+
+describe('LocaleConfig', () => {
+  it('initializes locale state without optional fields', () => {
+    const localeConfig = new LocaleConfig();
+
+    expect(localeConfig.defaultLocale).toBe('en');
+    expect(localeConfig.locales).toEqual([]);
+    expect(localeConfig.requiresTranslation('es', 'en')).toBe(true);
+  });
+
+  it('formats currency with a custom alias by resolving to the canonical locale', () => {
+    const localeConfig = new LocaleConfig({
+      defaultLocale: 'en-US',
+      customMapping: {
+        'brand-fr': {
+          code: 'fr-FR',
+          name: 'Brand French',
+        },
+      },
+    });
+
+    const result = localeConfig.formatCurrency(numberValue, 'EUR', 'brand-fr');
+
+    expect(result).toBe(formatCurrencyWithIntl('fr-FR'));
+  });
+
+  it('resolves explicit locales before formatting', () => {
+    const localeConfig = new LocaleConfig({
+      defaultLocale: 'en-US',
+      customMapping: {
+        'brand-de': {
+          code: 'de-DE',
+          name: 'Brand German',
+        },
+      },
+    });
+
+    const result = localeConfig.formatNum(numberValue, undefined, {
+      locales: ['brand-de', 'en-US'],
+    });
+
+    expect(result).toBe(formatNumWithIntl('de-DE'));
+  });
+
+  it('formats lists with a custom alias by resolving to the canonical locale', () => {
+    const localeConfig = new LocaleConfig({
+      defaultLocale: 'en-US',
+      customMapping: {
+        'brand-es': {
+          code: 'es-ES',
+          name: 'Brand Spanish',
+        },
+      },
+    });
+
+    const result = localeConfig.formatList(listValue, 'brand-es', {
+      type: 'disjunction',
+    });
+
+    expect(result).toBe(
+      formatListWithIntl('es-ES', {
+        type: 'disjunction',
+        style: 'long',
+      })
+    );
+  });
+
+  it('resolves custom aliases before locale matching', () => {
+    const localeConfig = new LocaleConfig({
+      defaultLocale: 'en',
+      locales: ['fr'],
+      customMapping: {
+        'brand-fr': {
+          code: 'fr-FR',
+          name: 'Brand French',
+        },
+      },
+    });
+
+    expect(localeConfig.requiresTranslation('brand-fr')).toBe(true);
+    expect(localeConfig.determineLocale('brand-fr')).toBe('fr');
+    expect(localeConfig.isSameLanguage('brand-fr', 'fr-CA')).toBe(true);
+  });
+});
+
+describe('GT LocaleConfig delegation', () => {
+  it('uses the target locale before the source locale for default formatting', () => {
+    const gt = new GT({
+      sourceLocale: 'en-US',
+      targetLocale: 'fr-FR',
+    });
+
+    expect(gt.formatNum(numberValue)).toBe(formatNumWithIntl('fr-FR'));
+    expect(gt.formatCurrency(numberValue, 'EUR')).toBe(
+      formatCurrencyWithIntl('fr-FR')
+    );
+    expect(
+      gt.formatDateTime(dateValue, {
+        dateStyle: 'full',
+        timeZone: 'UTC',
+      })
+    ).toBe(formatDateWithIntl('fr-FR'));
+    expect(gt.formatList(listValue)).toBe(formatListWithIntl('fr-FR'));
+  });
+
+  it('formats with a custom target locale alias through LocaleConfig', () => {
+    const gt = new GT({
+      sourceLocale: 'en-US',
+      targetLocale: 'brand-french',
+      customMapping: brandFrenchMapping,
+    });
+
+    const result = gt.formatCurrency(numberValue, 'EUR');
+
+    expect(result).toBe(formatCurrencyWithIntl('fr-FR'));
+  });
+
+  it('exposes a client-safe localeConfig without credentials', () => {
+    const gt = new GT({
+      apiKey: 'test-api-key',
+      devApiKey: 'test-dev-key',
+      projectId: 'test-project',
+      sourceLocale: 'en-US',
+      targetLocale: 'es-ES',
+    });
+
+    expect(gt.localeConfig).toBeInstanceOf(LocaleConfig);
+    expect('apiKey' in gt.localeConfig).toBe(false);
+    expect('devApiKey' in gt.localeConfig).toBe(false);
+    expect('projectId' in gt.localeConfig).toBe(false);
+  });
+
+  it('keeps localeConfig stable until setConfig refreshes it', () => {
+    const gt = new GT({
+      sourceLocale: 'en-US',
+      targetLocale: 'es-ES',
+    });
+    const initialLocaleConfig = gt.localeConfig;
+
+    gt.setConfig({
+      targetLocale: 'brand-french',
+      customMapping: brandFrenchMapping,
+    });
+
+    expect(gt.localeConfig).not.toBe(initialLocaleConfig);
+    expect(gt.resolveCanonicalLocale('brand-french')).toBe('fr-FR');
+    expect(gt.formatCurrency(numberValue, 'EUR')).toBe(
+      formatCurrencyWithIntl('fr-FR')
+    );
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -123,6 +123,12 @@ import { CutoffFormatOptions } from './formatting/custom-formats/CutoffFormat/ty
 import { TranslateOptions } from './types-dir/api/entry';
 import { API_VERSION as _API_VERSION } from './translate/api';
 import { StringFormat } from './types-dir/jsx/content';
+import { LocaleConfig } from './LocaleConfig';
+
+export {
+  LocaleConfig,
+  type LocaleConfigConstructorParams,
+} from './LocaleConfig';
 
 // ============================================================ //
 //                        Core Class                            //
@@ -186,9 +192,6 @@ export class GT {
   /** Array of supported locales */
   locales?: string[];
 
-  /** Array of locales used for rendering variables */
-  _renderingLocales: string[] = [];
-
   /** Custom mapping for locale codes to their names */
   customMapping?: CustomMapping;
 
@@ -197,6 +200,14 @@ export class GT {
 
   /** Lazily derived custom mapping for regions */
   customRegionMapping?: CustomRegionMapping;
+
+  /** Client-safe locale and formatting helpers (backing field) */
+  private _localeConfig = new LocaleConfig();
+
+  /** Client-safe locale and formatting helpers */
+  get localeConfig(): LocaleConfig {
+    return this._localeConfig;
+  }
 
   /**
    * Constructs an instance of the GT class.
@@ -255,12 +266,6 @@ export class GT {
         throw new Error(invalidLocaleError(this.targetLocale));
     }
 
-    // rendering locales
-    this._renderingLocales = [];
-    if (this.sourceLocale) this._renderingLocales.push(this.sourceLocale);
-    if (this.targetLocale) this._renderingLocales.push(this.targetLocale);
-    this._renderingLocales.push(libraryDefaultLocale);
-
     // locales
     if (locales) {
       const result: string[] = [];
@@ -291,6 +296,11 @@ export class GT {
           .map(([key, value]) => [(value as { code: string }).code, key])
       );
     }
+    this._localeConfig = new LocaleConfig({
+      defaultLocale: this.sourceLocale,
+      locales: this.locales ?? [],
+      customMapping: this.customMapping,
+    });
   }
 
   // -------------- Private Methods -------------- //
@@ -1088,10 +1098,7 @@ export class GT {
       locales?: string | string[];
     } & CutoffFormatOptions
   ): string {
-    return formatCutoff(value, {
-      locales: this._renderingLocales,
-      ...options,
-    });
+    return this.localeConfig.formatCutoff(value, this.targetLocale, options);
   }
 
   /**
@@ -1118,10 +1125,7 @@ export class GT {
       dataFormat?: StringFormat;
     }
   ): string {
-    return formatMessage(message, {
-      locales: this._renderingLocales,
-      ...options,
-    });
+    return this.localeConfig.formatMessage(message, this.targetLocale, options);
   }
   /**
    * Formats a number according to the specified locales and options.
@@ -1142,10 +1146,7 @@ export class GT {
       locales?: string | string[];
     } & Intl.NumberFormatOptions
   ): string {
-    return formatNum(number, {
-      locales: this._renderingLocales,
-      ...options,
-    });
+    return this.localeConfig.formatNum(number, this.targetLocale, options);
   }
 
   /**
@@ -1167,10 +1168,7 @@ export class GT {
       locales?: string | string[];
     } & Intl.DateTimeFormatOptions
   ): string {
-    return formatDateTime(date, {
-      locales: this._renderingLocales,
-      ...options,
-    });
+    return this.localeConfig.formatDateTime(date, this.targetLocale, options);
   }
 
   /**
@@ -1194,10 +1192,12 @@ export class GT {
       locales?: string | string[];
     } & Intl.NumberFormatOptions
   ): string {
-    return formatCurrency(value, currency, {
-      locales: this._renderingLocales,
-      ...options,
-    });
+    return this.localeConfig.formatCurrency(
+      value,
+      currency,
+      this.targetLocale,
+      options
+    );
   }
 
   /**
@@ -1219,11 +1219,7 @@ export class GT {
       locales?: string | string[];
     } & Intl.ListFormatOptions
   ) {
-    return _formatList({
-      value: array,
-      locales: options?.locales || this._renderingLocales,
-      options: options,
-    });
+    return this.localeConfig.formatList(array, this.targetLocale, options);
   }
 
   /**
@@ -1244,11 +1240,11 @@ export class GT {
       locales?: string | string[];
     } & Intl.ListFormatOptions
   ): Array<T | string> {
-    return _formatListToParts<T>({
-      value: array,
-      locales: options?.locales || this._renderingLocales,
-      options: options,
-    });
+    return this.localeConfig.formatListToParts<T>(
+      array,
+      this.targetLocale,
+      options
+    );
   }
 
   /**
@@ -1272,10 +1268,12 @@ export class GT {
       locales?: string | string[];
     } & Omit<Intl.RelativeTimeFormatOptions, 'locales'>
   ): string {
-    return formatRelativeTime(value, unit, {
-      locales: this._renderingLocales,
-      ...options,
-    });
+    return this.localeConfig.formatRelativeTime(
+      value,
+      unit,
+      this.targetLocale,
+      options
+    );
   }
 
   /**
@@ -1297,10 +1295,11 @@ export class GT {
       baseDate?: Date;
     } & Omit<Intl.RelativeTimeFormatOptions, 'locales'>
   ): string {
-    return formatRelativeTimeFromDate(date, {
-      locales: this._renderingLocales,
-      ...options,
-    });
+    return this.localeConfig.formatRelativeTimeFromDate(
+      date,
+      this.targetLocale,
+      options
+    );
   }
 
   // -------------- Locale Properties -------------- //
@@ -1318,7 +1317,7 @@ export class GT {
    */
   getLocaleName(locale = this.targetLocale): string {
     if (!locale) throw new Error(noTargetLocaleProvidedError('getLocaleName'));
-    return _getLocaleName(locale, this.sourceLocale, this.customMapping);
+    return this.localeConfig.getLocaleName(locale);
   }
 
   /**
@@ -1335,7 +1334,7 @@ export class GT {
    */
   getLocaleEmoji(locale = this.targetLocale): string {
     if (!locale) throw new Error(noTargetLocaleProvidedError('getLocaleEmoji'));
-    return getLocaleEmoji(locale, this.customMapping);
+    return this.localeConfig.getLocaleEmoji(locale);
   }
 
   /**
@@ -1373,7 +1372,7 @@ export class GT {
   getLocaleProperties(locale = this.targetLocale): LocaleProperties {
     if (!locale)
       throw new Error(noTargetLocaleProvidedError('getLocaleProperties'));
-    return getLocaleProperties(locale, this.sourceLocale, this.customMapping);
+    return this.localeConfig.getLocaleProperties(locale);
   }
 
   /**
@@ -1471,6 +1470,13 @@ export class GT {
       throw new Error(noSourceLocaleProvidedError('requiresTranslation'));
     if (!targetLocale)
       throw new Error(noTargetLocaleProvidedError('requiresTranslation'));
+    if (customMapping === this.customMapping) {
+      return this.localeConfig.requiresTranslation(
+        targetLocale,
+        sourceLocale,
+        approvedLocales
+      );
+    }
     return _requiresTranslation(
       sourceLocale,
       targetLocale,
@@ -1495,6 +1501,9 @@ export class GT {
     approvedLocales: string[] | undefined = this.locales || [],
     customMapping: CustomMapping | undefined = this.customMapping
   ): string | undefined {
+    if (customMapping === this.customMapping) {
+      return this.localeConfig.determineLocale(locales, approvedLocales ?? []);
+    }
     return _determineLocale(locales, approvedLocales, customMapping);
   }
 
@@ -1512,7 +1521,7 @@ export class GT {
   getLocaleDirection(locale = this.targetLocale): 'ltr' | 'rtl' {
     if (!locale)
       throw new Error(noTargetLocaleProvidedError('getLocaleDirection'));
-    return getLocaleDirection(locale);
+    return this.localeConfig.getLocaleDirection(locale);
   }
 
   /**
@@ -1532,7 +1541,10 @@ export class GT {
     customMapping: CustomMapping | undefined = this.customMapping
   ): boolean {
     if (!locale) throw new Error(noTargetLocaleProvidedError('isValidLocale'));
-    return isValidLocale(locale, customMapping);
+    if (customMapping === this.customMapping) {
+      return this.localeConfig.isValidLocale(locale);
+    }
+    return _isValidLocale(locale, customMapping);
   }
 
   /**
@@ -1547,6 +1559,9 @@ export class GT {
   ): string {
     if (!locale)
       throw new Error(noTargetLocaleProvidedError('resolveCanonicalLocale'));
+    if (customMapping === this.customMapping) {
+      return this.localeConfig.resolveCanonicalLocale(locale);
+    }
     return _resolveCanonicalLocale(locale, customMapping);
   }
 
@@ -1562,6 +1577,9 @@ export class GT {
   ): string {
     if (!locale)
       throw new Error(noTargetLocaleProvidedError('resolveAliasLocale'));
+    if (customMapping === this.customMapping) {
+      return this.localeConfig.resolveAliasLocale(locale);
+    }
     return _resolveAliasLocale(locale, customMapping);
   }
 
@@ -1579,7 +1597,7 @@ export class GT {
   standardizeLocale(locale = this.targetLocale): string {
     if (!locale)
       throw new Error(noTargetLocaleProvidedError('standardizeLocale'));
-    return _standardizeLocale(locale);
+    return this.localeConfig.standardizeLocale(locale);
   }
 
   /**
@@ -1596,7 +1614,7 @@ export class GT {
    * // Returns: true
    */
   isSameDialect(...locales: (string | string[])[]): boolean {
-    return isSameDialect(...locales);
+    return this.localeConfig.isSameDialect(...locales);
   }
 
   /**
@@ -1610,7 +1628,7 @@ export class GT {
    * // Returns: true
    */
   isSameLanguage(...locales: (string | string[])[]): boolean {
-    return _isSameLanguage(...locales);
+    return this.localeConfig.isSameLanguage(...locales);
   }
 
   /**
@@ -1628,7 +1646,7 @@ export class GT {
    * // Returns: false
    */
   isSupersetLocale(superLocale: string, subLocale: string): boolean {
-    return isSupersetLocale(superLocale, subLocale);
+    return this.localeConfig.isSupersetLocale(superLocale, subLocale);
   }
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -205,7 +205,7 @@ export class GT {
   private _localeConfig = new LocaleConfig();
 
   /** Client-safe locale and formatting helpers */
-  get localeConfig(): LocaleConfig {
+  get localeConfig() {
     return this._localeConfig;
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -202,7 +202,7 @@ export class GT {
   customRegionMapping?: CustomRegionMapping;
 
   /** Client-safe locale and formatting helpers (backing field) */
-  private _localeConfig = new LocaleConfig();
+  private _localeConfig!: LocaleConfig;
 
   /** Client-safe locale and formatting helpers */
   get localeConfig() {

--- a/packages/i18n/src/i18n-manager/I18nManager.ts
+++ b/packages/i18n/src/i18n-manager/I18nManager.ts
@@ -41,7 +41,7 @@ type TranslationResolver<U extends Translation = Translation> = <
   T extends U = U,
 >(
   message: T,
-  options: LookupOptions
+  options?: LookupOptions
 ) => T | undefined;
 
 /**
@@ -277,7 +277,7 @@ class I18nManager<
    */
   lookupTranslation<T extends TranslationValue = TranslationValue>(
     message: T,
-    options: LookupOptions
+    options: LookupOptions = {} as LookupOptions
   ): T | undefined {
     try {
       // Validate
@@ -307,7 +307,10 @@ class I18nManager<
    */
   async lookupTranslationWithFallback<
     T extends TranslationValue = TranslationValue,
-  >(message: T, options: LookupOptions): Promise<T | undefined> {
+  >(
+    message: T,
+    options: LookupOptions = {} as LookupOptions
+  ): Promise<T | undefined> {
     try {
       // Validate
       const { locale, options: lookupOptions } =
@@ -387,7 +390,7 @@ class I18nManager<
       );
 
       // Create translation resolver
-      return (message, options: LookupOptions) => {
+      return (message, options: LookupOptions = {} as LookupOptions) => {
         // Calculate hash
         return txCache.get({
           message,
@@ -413,7 +416,7 @@ class I18nManager<
     T extends TranslationValue = TranslationValue,
   >(
     message: T,
-    options: LookupOptions
+    options: LookupOptions = {} as LookupOptions
   ) => {
     return this.lookupTranslation(message, options);
   };
@@ -505,7 +508,7 @@ class I18nManager<
     return resolvedLocale;
   }
 
-  private resolveLookupParams(options: LookupOptions): {
+  private resolveLookupParams(options: LookupOptions = {} as LookupOptions): {
     locale: string;
     options: LookupOptions;
   } {
@@ -517,7 +520,7 @@ class I18nManager<
   }
 
   private resolveLookupOptions(
-    options: LookupOptions,
+    options: LookupOptions = {} as LookupOptions,
     resolvedLocale?: string
   ): LookupOptions {
     if (!options.$locale) {

--- a/packages/i18n/src/i18n-manager/I18nManager.ts
+++ b/packages/i18n/src/i18n-manager/I18nManager.ts
@@ -362,12 +362,12 @@ class I18nManager<
       }
 
       // Invariant: all prefetchEntries must be the same locale
-      const filteredPrefetchEntries = filterPrefetchEntriesByLocale(
+      const resolvedPrefetchEntries = resolvePrefetchEntriesByLocale(
         prefetchEntries,
         resolvedLocale,
         (entryLocale) => this.resolveLocale(entryLocale)
       );
-      if (filteredPrefetchEntries.length !== prefetchEntries.length) {
+      if (resolvedPrefetchEntries.length !== prefetchEntries.length) {
         logger.warn(
           `I18nManager: getLookupTranslation(): prefetchEntries must all be the same locale, ignoring all entries that are not for ${resolvedLocale}`
         );
@@ -379,10 +379,6 @@ class I18nManager<
       if (!txCache) return () => undefined;
 
       // Prefetch any entries during async block
-      const resolvedPrefetchEntries = filteredPrefetchEntries.map((entry) => ({
-        message: entry.message,
-        options: this.resolveLookupOptions(entry.options),
-      }));
       await Promise.all(
         resolvedPrefetchEntries
           .filter((entry) => txCache.get(entry) == null)
@@ -653,23 +649,35 @@ function standardizeLocales(config: {
 }
 
 /**
- * Filter prefetch entries by locale
+ * Resolve prefetch entry locales and keep entries matching the active locale.
  * @template TranslationType - The type of the translation
  * @param {PrefetchEntry<TranslationType>[]} prefetchEntries - The prefetch entries to filter
  * @param {string} locale - The locale to filter by
  * @returns {PrefetchEntry<TranslationType>[]} The filtered prefetch entries
  */
-function filterPrefetchEntriesByLocale<TranslationType extends Translation>(
+function resolvePrefetchEntriesByLocale<TranslationType extends Translation>(
   prefetchEntries: PrefetchEntry<TranslationType>[],
   locale: string,
   resolveLocale: (locale: string) => string
 ) {
-  return prefetchEntries.filter((entry) => {
-    if (entry.options.$locale == null) return true;
+  return prefetchEntries.flatMap((entry) => {
+    const entryLocale = entry.options.$locale;
+    if (entryLocale == null) return [entry];
+
     try {
-      return resolveLocale(entry.options.$locale) === locale;
+      const resolvedLocale = resolveLocale(entryLocale);
+      if (resolvedLocale !== locale) return [];
+      return [
+        {
+          message: entry.message,
+          options: {
+            ...entry.options,
+            $locale: resolvedLocale,
+          },
+        },
+      ];
     } catch {
-      return false;
+      return [];
     }
   });
 }

--- a/packages/i18n/src/i18n-manager/I18nManager.ts
+++ b/packages/i18n/src/i18n-manager/I18nManager.ts
@@ -487,7 +487,7 @@ class I18nManager<
    * Handle errors
    * Soft error in production, throw in development
    */
-  private handleError(error: unknown): void {
+  private handleError(error: unknown) {
     switch (this.config.environment) {
       case 'development':
         throw error;
@@ -508,10 +508,7 @@ class I18nManager<
     return resolvedLocale;
   }
 
-  private resolveLookupParams(options: LookupOptions = {} as LookupOptions): {
-    locale: string;
-    options: LookupOptions;
-  } {
+  private resolveLookupParams(options: LookupOptions = {} as LookupOptions) {
     const locale = this.resolveLocale(options.$locale ?? this.getLocale());
     return {
       locale,
@@ -522,7 +519,7 @@ class I18nManager<
   private resolveLookupOptions(
     options: LookupOptions = {} as LookupOptions,
     resolvedLocale?: string
-  ): LookupOptions {
+  ) {
     if (!options.$locale) {
       return options;
     }
@@ -537,7 +534,7 @@ class I18nManager<
    * This is helpful for when our getLocale function is bound to a
    * specifica context
    */
-  private getGTClassClean(locale?: string): GT {
+  private getGTClassClean(locale?: string) {
     return new GT({
       sourceLocale: this.config.defaultLocale,
       targetLocale: locale,
@@ -666,8 +663,8 @@ function filterPrefetchEntriesByLocale<TranslationType extends Translation>(
   prefetchEntries: PrefetchEntry<TranslationType>[],
   locale: string,
   resolveLocale: (locale: string) => string
-): PrefetchEntry<TranslationType>[] {
-  const filteredEntries = prefetchEntries.filter((entry) => {
+) {
+  return prefetchEntries.filter((entry) => {
     if (entry.options.$locale == null) return true;
     try {
       return resolveLocale(entry.options.$locale) === locale;
@@ -675,7 +672,6 @@ function filterPrefetchEntriesByLocale<TranslationType extends Translation>(
       return false;
     }
   });
-  return filteredEntries;
 }
 
 /**

--- a/packages/i18n/src/i18n-manager/I18nManager.ts
+++ b/packages/i18n/src/i18n-manager/I18nManager.ts
@@ -6,7 +6,7 @@ import { validateConfig } from './validation/validateConfig';
 import { Translation } from './translations-manager/utils/types/translation-data';
 import { StorageAdapter } from './storage-adapter/StorageAdapter';
 import { libraryDefaultLocale } from 'generaltranslation/internal';
-import { GT, standardizeLocale } from 'generaltranslation';
+import { GT, LocaleConfig, standardizeLocale } from 'generaltranslation';
 import { CustomMapping } from 'generaltranslation/types';
 import { LookupOptions } from '../translation-functions/types/options';
 import { FallbackStorageAdapter } from './storage-adapter/FallbackStorageAdapter';
@@ -78,6 +78,11 @@ class I18nManager<
   private localesCache: LocalesCache<TranslationValue>;
 
   /**
+   * Client-safe locale and formatting helpers
+   */
+  private localeConfig: LocaleConfig;
+
+  /**
    * Creates an instance of I18nManager.
    * TODO: resolve gtConfig from just file path
    * @param params - The parameters for the I18nManager constructor
@@ -94,6 +99,11 @@ class I18nManager<
 
     // Setup
     this.config = standardizeConfig(params);
+    this.localeConfig = new LocaleConfig({
+      defaultLocale: this.config.defaultLocale,
+      locales: this.config.locales,
+      customMapping: this.config.customMapping,
+    });
     this.storeAdapter =
       (params.storeAdapter as StorageAdapterInstanceType) ??
       new FallbackStorageAdapter();
@@ -173,9 +183,7 @@ class I18nManager<
    */
   setLocale(locale: string): void {
     try {
-      this.validateLocale(locale);
-      const gtInstance = this.getGTClassClean();
-      const newLocale = gtInstance.determineLocale(locale)!;
+      const newLocale = this.resolveLocale(locale);
       const previousLocale = this.getLocale();
       this.storeAdapter.setItem('locale', newLocale);
       this.emit('locale-update', {
@@ -246,14 +254,14 @@ class I18nManager<
   ): Promise<Record<Hash, TranslationValue>> {
     try {
       // Validate
-      this.validateLocale(locale);
-      if (!this.requiresTranslation(locale)) {
+      const resolvedLocale = this.resolveLocale(locale);
+      if (!this.requiresTranslation(resolvedLocale)) {
         return {};
       }
 
       // Get the locale cache
-      let txCache = this.localesCache.get(locale);
-      if (!txCache) txCache = await this.localesCache.miss(locale);
+      let txCache = this.localesCache.get(resolvedLocale);
+      if (!txCache) txCache = await this.localesCache.miss(resolvedLocale);
 
       // Get the translations
       const translations = txCache.getInternalCache();
@@ -273,8 +281,8 @@ class I18nManager<
   ): T | undefined {
     try {
       // Validate
-      const locale = options.$locale ?? this.getLocale();
-      this.validateLocale(locale);
+      const { locale, options: lookupOptions } =
+        this.resolveLookupParams(options);
 
       // Early return if in default locale
       if (!this.requiresTranslation(locale)) {
@@ -286,7 +294,7 @@ class I18nManager<
       if (!txCache) return undefined;
 
       // Get the translation
-      return txCache.get({ message, options });
+      return txCache.get({ message, options: lookupOptions });
     } catch (error) {
       this.handleError(error);
       return undefined;
@@ -302,8 +310,8 @@ class I18nManager<
   >(message: T, options: LookupOptions): Promise<T | undefined> {
     try {
       // Validate
-      const locale = options.$locale ?? this.getLocale();
-      this.validateLocale(locale);
+      const { locale, options: lookupOptions } =
+        this.resolveLookupParams(options);
 
       // Early return if in default locale
       if (!this.requiresTranslation(locale)) {
@@ -315,9 +323,9 @@ class I18nManager<
       if (!txCache) txCache = await this.localesCache.miss(locale);
 
       // Get the translation (falling back to runtime translate)
-      let translation = txCache.get({ message, options });
+      let translation = txCache.get({ message, options: lookupOptions });
       if (translation == null)
-        translation = await txCache.miss({ message, options });
+        translation = await txCache.miss({ message, options: lookupOptions });
       return translation;
     } catch (error) {
       this.handleError(error);
@@ -343,32 +351,37 @@ class I18nManager<
   ): Promise<TranslationResolver<TranslationValue>> {
     try {
       // Validate
-      this.validateLocale(locale);
+      const resolvedLocale = this.resolveLocale(locale);
 
       // Early return if i18n is disabled or default locale
-      if (!this.requiresTranslation(locale)) {
+      if (!this.requiresTranslation(resolvedLocale)) {
         return (message) => message;
       }
 
       // Invariant: all prefetchEntries must be the same locale
       const filteredPrefetchEntries = filterPrefetchEntriesByLocale(
         prefetchEntries,
-        locale
+        resolvedLocale,
+        (entryLocale) => this.resolveLocale(entryLocale)
       );
       if (filteredPrefetchEntries.length !== prefetchEntries.length) {
         logger.warn(
-          `I18nManager: getLookupTranslation(): prefetchEntries must all be the same locale, ignoring all entries that are not for ${locale}`
+          `I18nManager: getLookupTranslation(): prefetchEntries must all be the same locale, ignoring all entries that are not for ${resolvedLocale}`
         );
       }
 
       // Get Locale Cache
-      let txCache = this.localesCache.get(locale);
-      if (!txCache) txCache = await this.localesCache.miss(locale);
+      let txCache = this.localesCache.get(resolvedLocale);
+      if (!txCache) txCache = await this.localesCache.miss(resolvedLocale);
       if (!txCache) return () => undefined;
 
       // Prefetch any entries during async block
+      const resolvedPrefetchEntries = filteredPrefetchEntries.map((entry) => ({
+        message: entry.message,
+        options: this.resolveLookupOptions(entry.options),
+      }));
       await Promise.all(
-        filteredPrefetchEntries
+        resolvedPrefetchEntries
           .filter((entry) => txCache.get(entry) == null)
           .map((entry) => txCache.miss(entry))
       );
@@ -376,7 +389,10 @@ class I18nManager<
       // Create translation resolver
       return (message, options: LookupOptions) => {
         // Calculate hash
-        return txCache.get({ message, options });
+        return txCache.get({
+          message,
+          options: this.resolveLookupOptions(options),
+        });
       };
     } catch (error) {
       this.handleError(error);
@@ -412,8 +428,6 @@ class I18nManager<
     locale: string = this.getLocale()
   ): Promise<Record<Hash, TranslationValue>> {
     try {
-      // Validate
-      this.validateLocale(locale);
       return this.loadTranslations(locale);
     } catch (error) {
       this.handleError(error);
@@ -446,11 +460,10 @@ class I18nManager<
    */
   requiresTranslation(locale: string = this.getLocale()): boolean {
     const defaultLocale = this.getDefaultLocale();
-    const gtInstance = this.getGTClass();
     const locales = this.getLocales();
     return (
       this.isTranslationEnabled() &&
-      gtInstance.requiresTranslation(defaultLocale, locale, locales)
+      this.localeConfig.requiresTranslation(locale, defaultLocale, locales)
     );
   }
 
@@ -461,10 +474,9 @@ class I18nManager<
    */
   requiresDialectTranslation(locale: string = this.getLocale()): boolean {
     const defaultLocale = this.getDefaultLocale();
-    const gt = this.getGTClass();
     return (
       this.requiresTranslation(locale) &&
-      gt.isSameLanguage(defaultLocale, locale)
+      this.localeConfig.isSameLanguage(defaultLocale, locale)
     );
   }
 
@@ -483,19 +495,38 @@ class I18nManager<
     }
   }
 
-  /**
-   * Validate locale
-   */
-  private validateLocale(locale: string): void {
-    const gtInstance = this.getGTClass();
-    if (
-      !gtInstance.isValidLocale(locale) ||
-      !gtInstance.determineLocale(locale)
-    ) {
+  private resolveLocale(locale: string) {
+    const resolvedLocale = this.localeConfig.determineLocale(locale);
+    if (!this.localeConfig.isValidLocale(locale) || !resolvedLocale) {
       throw new Error(
         `I18nManager: validateLocale(): locale ${locale} is not valid`
       );
     }
+    return resolvedLocale;
+  }
+
+  private resolveLookupParams(options: LookupOptions): {
+    locale: string;
+    options: LookupOptions;
+  } {
+    const locale = this.resolveLocale(options.$locale ?? this.getLocale());
+    return {
+      locale,
+      options: this.resolveLookupOptions(options, locale),
+    };
+  }
+
+  private resolveLookupOptions(
+    options: LookupOptions,
+    resolvedLocale?: string
+  ): LookupOptions {
+    if (!options.$locale) {
+      return options;
+    }
+    return {
+      ...options,
+      $locale: resolvedLocale ?? this.resolveLocale(options.$locale),
+    };
   }
 
   /**
@@ -630,11 +661,17 @@ function standardizeLocales(config: {
  */
 function filterPrefetchEntriesByLocale<TranslationType extends Translation>(
   prefetchEntries: PrefetchEntry<TranslationType>[],
-  locale: string
+  locale: string,
+  resolveLocale: (locale: string) => string
 ): PrefetchEntry<TranslationType>[] {
-  const filteredEntries = prefetchEntries.filter(
-    (entry) => entry.options.$locale == null || entry.options.$locale === locale
-  );
+  const filteredEntries = prefetchEntries.filter((entry) => {
+    if (entry.options.$locale == null) return true;
+    try {
+      return resolveLocale(entry.options.$locale) === locale;
+    } catch {
+      return false;
+    }
+  });
   return filteredEntries;
 }
 

--- a/packages/i18n/src/i18n-manager/__tests__/I18nManager.test.ts
+++ b/packages/i18n/src/i18n-manager/__tests__/I18nManager.test.ts
@@ -117,4 +117,48 @@ describe('I18nManager', () => {
     expect(result).toBe('Message inconnu');
     expect(mockTranslateMany).toHaveBeenCalled();
   });
+
+  it('resolves custom aliases for locale metadata operations', () => {
+    const manager = createManager({
+      customMapping: {
+        'brand-french': {
+          code: 'fr',
+          name: 'Brand French',
+        },
+      },
+    });
+
+    manager.setLocale('brand-french');
+
+    expect(manager.getLocale()).toBe('fr');
+    expect(manager.requiresTranslation('brand-french')).toBe(true);
+    expect(manager.requiresDialectTranslation('en-US')).toBe(false);
+  });
+
+  it('normalizes custom aliases before loading and reading locale caches', async () => {
+    const loadTranslations = vi
+      .fn()
+      .mockResolvedValue({ [expectedHash]: translatedString });
+    const manager = createManager({
+      loadTranslations,
+      customMapping: {
+        'brand-french': {
+          code: 'fr',
+          name: 'Brand French',
+        },
+      },
+    });
+
+    await manager.loadTranslations('brand-french');
+
+    expect(loadTranslations).toHaveBeenCalledTimes(1);
+    expect(loadTranslations).toHaveBeenCalledWith('fr');
+    expect(
+      manager.lookupTranslation(message, {
+        ...lookupOptions,
+        $locale: 'brand-french',
+      })
+    ).toBe(translatedString);
+    expect(loadTranslations).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/i18n/src/i18n-manager/__tests__/resolveTranslationSync.test.ts
+++ b/packages/i18n/src/i18n-manager/__tests__/resolveTranslationSync.test.ts
@@ -20,6 +20,19 @@ describe('I18nManager.resolveTranslationSync', () => {
     expect(result).toBeUndefined();
   });
 
+  it('does not throw without options in development', () => {
+    const manager = new I18nManager({
+      defaultLocale: 'en',
+      locales: ['en', 'fr'],
+      loadTranslations: vi.fn(),
+      environment: 'development',
+    });
+    manager.setLocale('fr');
+
+    expect(() => manager.resolveTranslationSync('Hello')).not.toThrow();
+    expect(manager.resolveTranslationSync('Hello')).toBeUndefined();
+  });
+
   it('should return the correct translation via hash lookup after async getTranslations populates resolvedCache', async () => {
     const message = 'Hello {name}!';
     const options = { $context: 'greeting' };


### PR DESCRIPTION
## Summary
- add a client-safe LocaleConfig helper for locale metadata, alias resolution, and Intl formatting
- delegate GT locale formatting and metadata helpers through LocaleConfig
- normalize custom locale aliases in I18nManager before cache/load operations

## Tests
- pnpm --filter generaltranslation test
- pnpm --filter gt-i18n test
- pnpm --filter generaltranslation build
- pnpm --filter gt-i18n build
- pnpm --filter generaltranslation lint
- pnpm --filter gt-i18n lint
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `LocaleConfig`, a credential-free helper class that encapsulates locale metadata, alias resolution, and `Intl` formatting. All formatting methods in `GT` are delegated through it, and `I18nManager` replaces the old `validateLocale`+`determineLocale` pattern with a unified `resolveLocale` that normalises custom aliases before cache/load operations.

Note that the formatting locale priority order has changed from **source-first** (`[sourceLocale, targetLocale, 'en']`) to **target-first** (`[targetLocale, sourceLocale, 'en']`), which is intentional and tested but is a behavioural break for existing callers that relied on the old ordering.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — no correctness bugs found; only minor style issues remain.

All findings are P2 (style/efficiency). The logic is correct, alias resolution is consistent across both packages, and the intentional locale-priority change is well-covered by tests. The redundant field initializer and double `resolveLocale` call in the prefetch path are trivial issues that don't affect runtime behaviour.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/core/src/LocaleConfig.ts | New client-safe `LocaleConfig` class wrapping all locale helpers and Intl formatters; aliases resolved via `resolveCanonicalLocaleArgs` before every comparison — logic looks correct and well-tested. |
| packages/core/src/index.ts | GT delegates all formatting/locale helpers to the new `LocaleConfig`; ordering is now target-locale-first (previously source-locale-first), which is intentional but a behavioural break; minor redundant field initializer. |
| packages/i18n/src/i18n-manager/I18nManager.ts | Replaces `validateLocale`+`determineLocale` pattern with `resolveLocale`; normalises custom aliases before cache/load; minor double-resolution in prefetch entry mapping. |
| packages/core/src/__tests__/index.test.ts | Adds thorough `LocaleConfig` and `GT LocaleConfig delegation` test suites covering alias resolution, credential exclusion, and `setConfig` refresh. |
| packages/i18n/src/i18n-manager/__tests__/I18nManager.test.ts | Two new tests covering alias normalisation in `setLocale` and locale-cache reads — clear and correctly exercise the changed paths. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/core/src/index.ts`, line 563 ([link](https://github.com/generaltranslation/gt/blob/70a208f99ad60cb8cae45d16e3f5da95f125376e/packages/core/src/index.ts#L563)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Redundant field initializer allocation**

   `private _localeConfig = new LocaleConfig()` creates a default (empty) `LocaleConfig` instance that is immediately discarded when the constructor calls `setConfig`, which overwrites `_localeConfig` with a properly-configured instance. The throwaway allocation is harmless but unnecessary — consider initializing to `null!` or using a `declare` field and assigning only in `setConfig`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/core/src/index.ts
   Line: 563

   Comment:
   **Redundant field initializer allocation**

   `private _localeConfig = new LocaleConfig()` creates a default (empty) `LocaleConfig` instance that is immediately discarded when the constructor calls `setConfig`, which overwrites `_localeConfig` with a properly-configured instance. The throwaway allocation is harmless but unnecessary — consider initializing to `null!` or using a `declare` field and assigning only in `setConfig`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `packages/i18n/src/i18n-manager/I18nManager.ts`, line 999-1002 ([link](https://github.com/generaltranslation/gt/blob/70a208f99ad60cb8cae45d16e3f5da95f125376e/packages/i18n/src/i18n-manager/I18nManager.ts#L999-L1002)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Double `resolveLocale` call in prefetch path**

   `resolveLookupOptions(entry.options)` is called here without a pre-resolved locale, so when `entry.options.$locale` is set the method falls through to `this.resolveLocale(options.$locale)` — a second resolution after `filterPrefetchEntriesByLocale` already called `resolveLocale` on the same value during filtering. Pass the already-resolved locale to avoid the redundant work:

   ```typescript
   const resolvedPrefetchEntries = filteredPrefetchEntries.map((entry) => {
     const entryLocale = entry.options.$locale
       ? this.resolveLocale(entry.options.$locale)
       : undefined;
     return {
       message: entry.message,
       options: this.resolveLookupOptions(entry.options, entryLocale),
     };
   });
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/i18n/src/i18n-manager/I18nManager.ts
   Line: 999-1002

   Comment:
   **Double `resolveLocale` call in prefetch path**

   `resolveLookupOptions(entry.options)` is called here without a pre-resolved locale, so when `entry.options.$locale` is set the method falls through to `this.resolveLocale(options.$locale)` — a second resolution after `filterPrefetchEntriesByLocale` already called `resolveLocale` on the same value during filtering. Pass the already-resolved locale to avoid the redundant work:

   ```typescript
   const resolvedPrefetchEntries = filteredPrefetchEntries.map((entry) => {
     const entryLocale = entry.options.$locale
       ? this.resolveLocale(entry.options.$locale)
       : undefined;
     return {
       message: entry.message,
       options: this.resolveLookupOptions(entry.options, entryLocale),
     };
   });
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/core/src/index.ts
Line: 563

Comment:
**Redundant field initializer allocation**

`private _localeConfig = new LocaleConfig()` creates a default (empty) `LocaleConfig` instance that is immediately discarded when the constructor calls `setConfig`, which overwrites `_localeConfig` with a properly-configured instance. The throwaway allocation is harmless but unnecessary — consider initializing to `null!` or using a `declare` field and assigning only in `setConfig`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/i18n/src/i18n-manager/I18nManager.ts
Line: 999-1002

Comment:
**Double `resolveLocale` call in prefetch path**

`resolveLookupOptions(entry.options)` is called here without a pre-resolved locale, so when `entry.options.$locale` is set the method falls through to `this.resolveLocale(options.$locale)` — a second resolution after `filterPrefetchEntriesByLocale` already called `resolveLocale` on the same value during filtering. Pass the already-resolved locale to avoid the redundant work:

```typescript
const resolvedPrefetchEntries = filteredPrefetchEntries.map((entry) => {
  const entryLocale = entry.options.$locale
    ? this.resolveLocale(entry.options.$locale)
    : undefined;
  return {
    message: entry.message,
    options: this.resolveLookupOptions(entry.options, entryLocale),
  };
});
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(i18n): default lookup options"](https://github.com/generaltranslation/gt/commit/70a208f99ad60cb8cae45d16e3f5da95f125376e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29934359)</sub>

<!-- /greptile_comment -->