### PR TITLE
feat(cli): Distribute gt CLI on PyPI as gtx-cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,3 +227,16 @@ jobs:
         run: pnpm --filter gtx-cli run bin:prep && pnpm --filter gtx-cli publish --tag bin --no-git-checks && pnpm --filter gtx-cli run bin:restore && pnpm --filter gtx-cli run build:clean
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # PyPI: gtx-cli (Python wrapper that downloads the gt binary)
+      - name: Publish gtx-cli to PyPI
+        if: steps.check-gt.outputs.should_release_bin == 'true'
+        working-directory: packages/cli/pypi
+        run: |
+          pip install hatch
+          python scripts/set_version.py "${{ steps.gt-version.outputs.version }}"
+          hatch build
+          hatch publish
+        env:
+          HATCH_INDEX_USER: __token__
+          HATCH_INDEX_AUTH: ${{ secrets.PYPI_TOKEN }}

--- a/packages/cli/pypi/README.md
+++ b/packages/cli/pypi/README.md
@@ -1,0 +1,38 @@
+# gtx-cli
+
+CLI tool for AI-powered i18n — [General Translation](https://generaltranslation.com).
+
+This is a Python wrapper that downloads and runs the `gt` CLI binary. It provides the same functionality as `npx gt` but installable via `pip`.
+
+## Installation
+
+```bash
+pip install gtx-cli
+```
+
+## Usage
+
+```bash
+# Initialize your project
+gt init
+
+# Translate your project
+gt translate
+
+# Upload translation keys
+gt upload
+```
+
+Both `gt` and `gtx` commands are available after installation.
+
+## Documentation
+
+Visit [generaltranslation.com/docs/cli](https://generaltranslation.com/docs/cli) for full documentation.
+
+## How It Works
+
+On first run, the CLI binary is downloaded for your platform (macOS, Linux, or Windows) and cached locally. Subsequent runs use the cached binary directly.
+
+## License
+
+FSL-1.1-ALv2 — see [LICENSE](https://github.com/generaltranslation/gt/blob/main/packages/cli/LICENSE.md).

--- a/packages/cli/pypi/gtx_cli/__init__.py
+++ b/packages/cli/pypi/gtx_cli/__init__.py
@@ -1,0 +1,10 @@
+"""gtx-cli: CLI tool for AI-powered i18n — General Translation."""
+
+__version__ = "0.0.0"  # Replaced at publish time by the workflow
+
+
+def main() -> None:
+    """Entry point."""
+    from gtx_cli.cli import main as _main
+
+    _main()

--- a/packages/cli/pypi/gtx_cli/cli.py
+++ b/packages/cli/pypi/gtx_cli/cli.py
@@ -1,0 +1,114 @@
+"""
+Download (if needed) and run the gt CLI binary.
+
+The binary is a Bun-compiled standalone executable hosted on Cloudflare R2.
+We cache it in a platform-appropriate directory so subsequent runs are instant.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import stat
+import subprocess
+import sys
+import tempfile
+import urllib.request
+
+# R2 CDN base URL for CLI binaries
+_R2_BASE = "https://cdn.generaltranslation.com/cli"
+
+
+def _cache_dir() -> str:
+    """Return platform-appropriate cache directory."""
+    if sys.platform == "darwin":
+        base = os.path.join(os.path.expanduser("~"), "Library", "Caches")
+    elif sys.platform == "win32":
+        base = os.environ.get("LOCALAPPDATA", os.path.expanduser("~"))
+    else:
+        base = os.environ.get("XDG_CACHE_HOME", os.path.join(os.path.expanduser("~"), ".cache"))
+    return os.path.join(base, "gtx-cli")
+
+
+def _detect_binary_name() -> str:
+    """Map current platform/arch to the binary filename."""
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+
+    arch_map = {
+        "x86_64": "x64",
+        "amd64": "x64",
+        "aarch64": "arm64",
+        "arm64": "arm64",
+    }
+    arch = arch_map.get(machine)
+    if not arch:
+        raise RuntimeError(f"Unsupported architecture: {machine}")
+
+    if system == "darwin":
+        return f"gt-darwin-{arch}"
+    elif system == "linux":
+        return f"gt-linux-{arch}"
+    elif system == "windows":
+        if arch != "x64":
+            raise RuntimeError(f"Unsupported Windows architecture: {machine}")
+        return "gt-win32-x64.exe"
+    else:
+        raise RuntimeError(f"Unsupported platform: {system}")
+
+
+def _download(url: str, dest: str) -> None:
+    """Download a URL to a destination path with a temp-file swap."""
+    os.makedirs(os.path.dirname(dest), exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(dest))
+    try:
+        with urllib.request.urlopen(url) as resp, os.fdopen(fd, "wb") as out:
+            while True:
+                chunk = resp.read(1 << 16)
+                if not chunk:
+                    break
+                out.write(chunk)
+        os.replace(tmp, dest)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _ensure_binary(version: str) -> str:
+    """Return path to the gt binary, downloading if necessary."""
+    binary_name = _detect_binary_name()
+    cache = _cache_dir()
+    binary_path = os.path.join(cache, version, binary_name)
+
+    if not os.path.isfile(binary_path):
+        url = f"{_R2_BASE}/v{version}/{binary_name}"
+        print(f"Downloading gt CLI v{version}...", file=sys.stderr)
+        _download(url, binary_path)
+
+        # Make executable on Unix
+        if not binary_name.endswith(".exe"):
+            st = os.stat(binary_path)
+            os.chmod(binary_path, st.st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+    return binary_path
+
+
+def main() -> None:
+    """Entry point: download (if needed) and exec the gt binary."""
+    from gtx_cli import __version__ as version
+
+    try:
+        binary = _ensure_binary(version)
+    except Exception as exc:
+        print(f"gtx-cli: failed to get binary: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    # On Unix, exec replaces the process; on Windows, use subprocess
+    if sys.platform == "win32":
+        result = subprocess.run([binary, *sys.argv[1:]])
+        sys.exit(result.returncode)
+    else:
+        os.execv(binary, [binary, *sys.argv[1:]])

--- a/packages/cli/pypi/pyproject.toml
+++ b/packages/cli/pypi/pyproject.toml
@@ -1,0 +1,40 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "gtx-cli"
+dynamic = ["version"]
+description = "CLI tool for AI-powered i18n — General Translation"
+readme = "README.md"
+license = "FSL-1.1-ALv2"
+requires-python = ">=3.8"
+authors = [{ name = "General Translation, Inc.", email = "support@generaltranslation.com" }]
+keywords = ["i18n", "internationalization", "translation", "localization", "cli"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Internationalization",
+    "Topic :: Software Development :: Localization",
+    "Programming Language :: Python :: 3",
+]
+
+[project.urls]
+Homepage = "https://generaltranslation.com"
+Documentation = "https://generaltranslation.com/docs/cli"
+Repository = "https://github.com/generaltranslation/gt"
+Issues = "https://github.com/generaltranslation/gt/issues"
+
+[project.scripts]
+gtx = "gtx_cli:main"
+gt = "gtx_cli:main"
+
+[tool.hatch.version]
+path = "gtx_cli/__init__.py"
+
+[tool.hatch.build.targets.wheel]
+packages = ["gtx_cli"]
+
+[tool.hatch.build.targets.sdist]
+include = ["gtx_cli/", "README.md", "pyproject.toml"]

--- a/packages/cli/pypi/scripts/set_version.py
+++ b/packages/cli/pypi/scripts/set_version.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Set __version__ in gtx_cli/__init__.py from an argument."""
+import re
+import sys
+from pathlib import Path
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <version>", file=sys.stderr)
+        sys.exit(1)
+
+    version = sys.argv[1]
+    init_path = Path(__file__).resolve().parent.parent / "gtx_cli" / "__init__.py"
+    text = init_path.read_text()
+    text = re.sub(r'__version__\s*=\s*"[^"]*"', f'__version__ = "{version}"', text)
+    init_path.write_text(text)
+    print(f"Set gtx_cli version to {version}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a Python wrapper package so the GT CLI can be installed via pip:

```bash
pip install gtx-cli
gt init
gt translate
```

## How it works

- **`packages/cli/pypi/`** — A lightweight Python package that, on first run, downloads the correct platform binary from R2 (same binaries already uploaded by the release workflow) and caches it locally.
- Both `gt` and `gtx` commands are registered as entry points.
- The release workflow is updated to build and publish to PyPI whenever `gt` is published to npm, keeping versions in sync.

## What's needed

- A `PYPI_TOKEN` secret needs to be added to the `release` environment (API token from pypi.org for the `gtx-cli` project).

## Files

| File | Purpose |
|------|---------|
| `packages/cli/pypi/pyproject.toml` | Package metadata (hatchling build) |
| `packages/cli/pypi/gtx_cli/__init__.py` | Version + entry point |
| `packages/cli/pypi/gtx_cli/cli.py` | Binary download, cache, and exec logic |
| `packages/cli/pypi/scripts/set_version.py` | Sets version at publish time |
| `packages/cli/pypi/README.md` | PyPI readme |
| `.github/workflows/release.yml` | Added PyPI publish step |

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a Python wrapper package (`gtx-cli`) that lets users install and run the `gt` CLI binary via `pip`. On first invocation it downloads the platform-specific binary from Cloudflare R2 and caches it locally; subsequent runs exec the cached binary directly.

- **P1 – no download timeout**: `urllib.request.urlopen` in `_download` has no `timeout`, so a slow or unreachable CDN causes the process to hang silently forever.
- **P1 (security) – no binary integrity check**: the downloaded binary is executed without verifying a checksum; a compromised CDN or supply-chain attack would silently serve and cache a malicious executable.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Not safe to merge without addressing the missing download timeout and the lack of binary integrity verification before exec.

Two P1 findings on the critical path: the missing timeout means users can be silently blocked forever on first install, and the absence of a checksum check before executing a downloaded binary is a meaningful supply-chain risk. Neither is theoretical — both affect every first-time user on every platform.

packages/cli/pypi/gtx_cli/cli.py — both P1 findings live here
</details>

<details open><summary><h3>Security Review</h3></summary>

- **Unverified binary execution** (`packages/cli/pypi/gtx_cli/cli.py`): The binary downloaded from `cdn.generaltranslation.com` is written to disk, made executable, and `exec`'d without any SHA-256 or other integrity check. HTTPS protects the transport, but a compromised R2 bucket or a supply-chain substitution would result in an arbitrary binary being silently cached and run as the user. Publishing per-version `checksums.txt` to R2 and verifying before `os.replace` is the standard mitigation.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/pypi/gtx_cli/cli.py | Core binary-download-and-exec logic; missing download timeout (can hang forever) and integrity check on downloaded binary (security risk) |
| .github/workflows/release.yml | Adds PyPI publish step gated on gt npm release; unpinned hatch version is the only concern |
| packages/cli/pypi/gtx_cli/__init__.py | Minimal init; placeholder version replaced at publish time by the workflow script |
| packages/cli/pypi/pyproject.toml | Package metadata looks correct; gt entry point may conflict with system commands on some Linux distros |
| packages/cli/pypi/scripts/set_version.py | Simple regex-based version injector; straightforward and correct |
| packages/cli/pypi/README.md | Clear PyPI readme; no issues |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant gtx_cli as gtx_cli (Python)
    participant Cache as Local Cache
    participant R2 as Cloudflare R2

    User->>gtx_cli: gt / gtx command
    gtx_cli->>Cache: check binary_path exists?
    alt binary cached
        Cache-->>gtx_cli: yes
        gtx_cli->>User: os.execv(binary, args)
    else not cached
        gtx_cli->>R2: GET /cli/v{version}/{binary_name}
        Note over gtx_cli,R2: No timeout — can hang indefinitely<br/>No checksum verification
        R2-->>gtx_cli: binary bytes
        gtx_cli->>Cache: atomic temp-file swap + chmod
        gtx_cli->>User: os.execv(binary, args)
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/cli/pypi/gtx_cli/cli.py
Line: 65

Comment:
**No download timeout — CLI can hang indefinitely**

`urllib.request.urlopen(url)` is called with no `timeout` argument, so if the CDN is unreachable, rate-limiting, or simply slow, this call blocks forever with no error or progress indicator. Users will see the "Downloading gt CLI…" message and then nothing, with no way to distinguish a hang from a large download.

```suggestion
        with urllib.request.urlopen(url, timeout=60) as resp, os.fdopen(fd, "wb") as out:
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/cli/pypi/gtx_cli/cli.py
Line: 86-94

Comment:
**No integrity check on downloaded binary**

The binary is downloaded and then made executable and `exec`'d without verifying its contents against a known-good checksum. HTTPS protects the transport layer, but if the R2 bucket or CDN is compromised, or if the origin URL is swapped in a supply-chain attack, a malicious binary would be silently cached and executed. The existing npm binary release workflow already produces binaries; publishing their SHA-256 digests alongside them (e.g. a `checksums.txt` uploaded to the same R2 path) and verifying here with `hashlib` before `os.replace` would close this gap.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/cli/pypi/gtx_cli/cli.py
Line: 86

Comment:
**Race condition between existence check and download**

Two concurrent `gt` invocations (e.g. in a parallel CI matrix) will both pass `os.path.isfile(binary_path)` returning `False`, both call `_download`, and both call `os.chmod`. The atomic `os.replace` means neither write corrupts the file, but the double `chmod` is harmless noise. The real risk is that a user who runs two commands simultaneously gets two download attempts printing "Downloading…" to stderr. A simple file-lock (e.g. `fcntl.flock` on Unix) around the check+download block would prevent this.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/release.yml
Line: 236

Comment:
**Unpinned `hatch` version in CI**

`pip install hatch` pulls whatever is latest at run time. A breaking hatch release could silently fail future PyPI publishes. Pin to a specific version for reproducibility:

```suggestion
          pip install "hatch==1.14.1"
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/cli/pypi/pyproject.toml
Line: 32-33

Comment:
**`gt` entry point will conflict with system-installed `gt`**

Registering `gt` as a pip entry point installs a `gt` executable on `PATH` globally. `gt` is also the conventional abbreviation for GNU `groff`'s `gt` tool on some Linux distributions, and any other package that provides a `gt` command will silently lose to (or be lost to) this one. Consider dropping the `gt` entry point from the PyPI package and keeping only `gtx` / `gtx-cli`, since users who want the `gt` shorthand can add an alias themselves or install via npm where the naming is less ambiguous.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(cli): add PyPI distribution as gtx-..."](https://github.com/generaltranslation/gt/commit/aa4f8d67838b6e700fcf89aa23963150466e8cdd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30032745)</sub>

> Greptile also left **5 inline comments** on this PR.

<!-- /greptile_comment -->