### PR TITLE
chore(cli): add pypi distribution

### DIFF
--- a/.changeset/polite-pandas-serve.md
+++ b/.changeset/polite-pandas-serve.md
@@ -1,0 +1,5 @@
+---
+"gt": patch
+---
+
+Add PyPI distribution support for the GT CLI.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,6 +169,23 @@ jobs:
           source-dir: packages/cli/binaries
           destination-dir: cli/latest
 
+      # PyPI: gtx-cli (Python launcher with bundled gt binaries)
+      - name: Setup Python
+        if: steps.check-gt.outputs.should_release_bin == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Publish gtx-cli to PyPI
+        if: steps.check-gt.outputs.should_release_bin == 'true'
+        working-directory: packages/cli/pypi
+        run: |
+          python -m pip install --upgrade build twine
+          python scripts/build_platform_wheels.py --version "${{ steps.gt-version.outputs.version }}" --source ../binaries --check --upload --skip-existing
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+
       - name: Release gt binary to npm
         if: steps.check-gt.outputs.should_release_bin == 'true'
         run: pnpm --filter gt run bin:prep && pnpm --filter gt publish --tag bin --no-git-checks && pnpm --filter gt run bin:restore && pnpm --filter gt run build:clean

--- a/packages/cli/pypi/.gitignore
+++ b/packages/cli/pypi/.gitignore
@@ -1,0 +1,4 @@
+dist/
+*.egg-info/
+__pycache__/
+gtx_cli/bin/*

--- a/packages/cli/pypi/LICENSE.md
+++ b/packages/cli/pypi/LICENSE.md
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, ALv2 Future License
+
+## Abbreviation
+
+FSL-1.1-ALv2
+
+## Notice
+
+Copyright 2025 General Translation, Inc.
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/packages/cli/pypi/README.md
+++ b/packages/cli/pypi/README.md
@@ -1,0 +1,57 @@
+# gtx-cli
+
+`gtx-cli` is the PyPI distribution for the General Translation CLI. It installs
+small Python entry points that run the bundled standalone `gt` binary for your
+platform.
+
+## Installation
+
+```bash
+pip install gtx-cli
+```
+
+## Usage
+
+```bash
+gt init
+gt translate
+gt upload
+```
+
+The package installs `gt`, `gtx`, and `gtx-cli` command aliases.
+
+## How it works
+
+PyPI hosts one wheel per supported platform. Each wheel contains the
+Bun-compiled CLI binary for that platform. At runtime, the Python launcher execs
+the bundled binary directly.
+
+## Documentation
+
+Full CLI documentation is available at
+[generaltranslation.com/docs/cli](https://generaltranslation.com/docs/cli).
+
+## Release
+
+Build the Bun executables first from `packages/cli`, then build and publish the
+platform wheels:
+
+```bash
+pnpm --filter gt run build:bin:clean
+cd packages/cli/pypi
+python -m pip install --upgrade build twine
+python scripts/build_platform_wheels.py \
+  --version 2.14.22 \
+  --source ../binaries \
+  --check \
+  --upload \
+  --skip-existing \
+  --token-file ~/Documents/dev/secrets/pypi-api-token.txt
+```
+
+The script restores `gtx_cli.__version__` and removes copied binaries from the
+source tree after building.
+
+## License
+
+FSL-1.1-ALv2. See `LICENSE.md`.

--- a/packages/cli/pypi/README.md
+++ b/packages/cli/pypi/README.md
@@ -1,8 +1,7 @@
 # gtx-cli
 
 `gtx-cli` is the PyPI distribution for the General Translation CLI. It installs
-small Python entry points that run the bundled standalone `gt` binary for your
-platform.
+a `gt` command that runs the bundled standalone binary for your platform.
 
 ## Installation
 
@@ -17,8 +16,6 @@ gt init
 gt translate
 gt upload
 ```
-
-The package installs `gt`, `gtx`, and `gtx-cli` command aliases.
 
 ## How it works
 

--- a/packages/cli/pypi/gtx_cli/__init__.py
+++ b/packages/cli/pypi/gtx_cli/__init__.py
@@ -1,0 +1,10 @@
+"""Python launcher for the General Translation CLI."""
+
+__version__ = "0.0.0"
+
+
+def main() -> None:
+    """Run the General Translation CLI."""
+    from gtx_cli.cli import main as _main
+
+    _main()

--- a/packages/cli/pypi/gtx_cli/cli.py
+++ b/packages/cli/pypi/gtx_cli/cli.py
@@ -1,0 +1,50 @@
+"""Run the bundled General Translation CLI binary for this platform."""
+
+from __future__ import annotations
+
+import os
+import platform
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _ensure_executable(path: Path) -> None:
+    """Ensure a bundled Unix binary has executable mode bits."""
+    if sys.platform == "win32":
+        return
+
+    current_mode = path.stat().st_mode
+    executable_bits = stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+    if current_mode & executable_bits != executable_bits:
+        path.chmod(current_mode | executable_bits)
+
+
+def _bundled_binary() -> Path:
+    """Return the bundled CLI binary path for this platform-specific wheel."""
+    binary_name = "gt.exe" if sys.platform == "win32" else "gt"
+    binary_path = Path(__file__).resolve().parent / "bin" / binary_name
+
+    if not binary_path.is_file():
+        raise RuntimeError(
+            f"bundled CLI binary not found for {platform.system()}-{platform.machine()}: {binary_path}"
+        )
+    _ensure_executable(binary_path)
+    return binary_path
+
+
+def main() -> None:
+    """Run the bundled CLI binary with the current process arguments."""
+    try:
+        binary = _bundled_binary()
+    except Exception as exc:
+        print(f"gtx-cli: failed to locate bundled CLI binary: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+
+    argv = [str(binary), *sys.argv[1:]]
+    if sys.platform == "win32":
+        result = subprocess.run(argv)
+        raise SystemExit(result.returncode)
+
+    os.execv(str(binary), argv)

--- a/packages/cli/pypi/pyproject.toml
+++ b/packages/cli/pypi/pyproject.toml
@@ -1,0 +1,54 @@
+[build-system]
+requires = ["hatchling>=1.26"]
+build-backend = "hatchling.build"
+
+[project]
+name = "gtx-cli"
+dynamic = ["version"]
+description = "Self-contained Python launcher for the General Translation CLI"
+readme = "README.md"
+requires-python = ">=3.8"
+license = "FSL-1.1-ALv2"
+license-files = ["LICENSE.md"]
+authors = [
+    { name = "General Translation, Inc.", email = "support@generaltranslation.com" },
+]
+keywords = ["i18n", "internationalization", "translation", "localization", "cli"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Topic :: Software Development :: Internationalization",
+]
+
+[project.urls]
+Homepage = "https://generaltranslation.com"
+Documentation = "https://generaltranslation.com/docs/cli"
+Repository = "https://github.com/generaltranslation/gt"
+Issues = "https://github.com/generaltranslation/gt/issues"
+
+[project.scripts]
+gt = "gtx_cli:main"
+
+[tool.hatch.version]
+path = "gtx_cli/__init__.py"
+
+[tool.hatch.build.targets.wheel]
+packages = ["gtx_cli"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"gtx_cli/bin" = "gtx_cli/bin"
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "gtx_cli/",
+    "scripts/",
+    "LICENSE.md",
+    "README.md",
+    "pyproject.toml",
+]

--- a/packages/cli/pypi/scripts/build_platform_wheels.py
+++ b/packages/cli/pypi/scripts/build_platform_wheels.py
@@ -28,6 +28,8 @@ class PlatformWheel:
 
 
 PLATFORM_WHEELS = (
+    # Keep macOS wheel tags aligned with the bundled Bun executables' minos.
+    # Current outputs report minos 13.0 via `otool -l`.
     PlatformWheel("macos-arm64", "gt-darwin-arm64", "gt", "py3-none-macosx_13_0_arm64"),
     PlatformWheel("macos-x64", "gt-darwin-x64", "gt", "py3-none-macosx_13_0_x86_64"),
     PlatformWheel("linux-arm64", "gt-linux-arm64", "gt", "py3-none-manylinux_2_17_aarch64"),
@@ -182,6 +184,9 @@ def selected_platforms(names: list[str] | None) -> list[PlatformWheel]:
 
 
 def run_twine(args: argparse.Namespace, wheels: list[Path]) -> None:
+    if not wheels:
+        return
+
     if args.check:
         subprocess.run([sys.executable, "-m", "twine", "check", *(str(wheel) for wheel in wheels)], check=True)
 

--- a/packages/cli/pypi/scripts/build_platform_wheels.py
+++ b/packages/cli/pypi/scripts/build_platform_wheels.py
@@ -32,8 +32,10 @@ PLATFORM_WHEELS = (
     # Current outputs report minos 13.0 via `otool -l`.
     PlatformWheel("macos-arm64", "gt-darwin-arm64", "gt", "py3-none-macosx_13_0_arm64"),
     PlatformWheel("macos-x64", "gt-darwin-x64", "gt", "py3-none-macosx_13_0_x86_64"),
-    PlatformWheel("linux-arm64", "gt-linux-arm64", "gt", "py3-none-manylinux_2_17_aarch64"),
-    PlatformWheel("linux-x64", "gt-linux-x64", "gt", "py3-none-manylinux_2_17_x86_64"),
+    # Keep Linux wheel tags aligned with the bundled Bun executables' GLIBC symbols.
+    # Current outputs reference GLIBC_2.25 via `objdump -p`.
+    PlatformWheel("linux-arm64", "gt-linux-arm64", "gt", "py3-none-manylinux_2_25_aarch64"),
+    PlatformWheel("linux-x64", "gt-linux-x64", "gt", "py3-none-manylinux_2_25_x86_64"),
     PlatformWheel("windows-x64", "gt-win32-x64.exe", "gt.exe", "py3-none-win_amd64"),
 )
 

--- a/packages/cli/pypi/scripts/build_platform_wheels.py
+++ b/packages/cli/pypi/scripts/build_platform_wheels.py
@@ -164,6 +164,7 @@ def retag_wheel(source_wheel: Path, output_dir: Path, wheel_tag: str) -> Path:
             records[info.filename] = data
 
         if not record_path:
+            output_wheel.unlink(missing_ok=True)
             raise SystemExit(f"Could not find RECORD in {source_wheel}")
 
         record_buffer = io.StringIO()
@@ -209,9 +210,10 @@ def main() -> None:
     output_dir = args.out_dir.resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    original_init = set_version(args.version)
+    original_init: str | None = None
     built_wheels: list[Path] = []
     try:
+        original_init = set_version(args.version)
         for platform_wheel in selected_platforms(args.platform):
             print(f"Building {platform_wheel.name} wheel...", flush=True)
             prepare_binary(source, platform_wheel)
@@ -219,7 +221,8 @@ def main() -> None:
                 pure_wheel = run_build(Path(temp_dir))
                 built_wheels.append(retag_wheel(pure_wheel, output_dir, platform_wheel.wheel_tag))
     finally:
-        INIT_PATH.write_text(original_init, encoding="utf-8")
+        if original_init is not None:
+            INIT_PATH.write_text(original_init, encoding="utf-8")
         clean_bin_dir()
 
     for wheel in built_wheels:

--- a/packages/cli/pypi/scripts/build_platform_wheels.py
+++ b/packages/cli/pypi/scripts/build_platform_wheels.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Build platform-specific PyPI wheels that each bundle one gt executable."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import csv
+import hashlib
+import io
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class PlatformWheel:
+    name: str
+    source_binary: str
+    bundled_binary: str
+    wheel_tag: str
+
+
+PLATFORM_WHEELS = (
+    PlatformWheel("macos-arm64", "gt-darwin-arm64", "gt", "py3-none-macosx_13_0_arm64"),
+    PlatformWheel("macos-x64", "gt-darwin-x64", "gt", "py3-none-macosx_13_0_x86_64"),
+    PlatformWheel("linux-arm64", "gt-linux-arm64", "gt", "py3-none-manylinux_2_17_aarch64"),
+    PlatformWheel("linux-x64", "gt-linux-x64", "gt", "py3-none-manylinux_2_17_x86_64"),
+    PlatformWheel("windows-x64", "gt-win32-x64.exe", "gt.exe", "py3-none-win_amd64"),
+)
+
+PYPI_DIR = Path(__file__).resolve().parents[1]
+BIN_DIR = PYPI_DIR / "gtx_cli" / "bin"
+INIT_PATH = PYPI_DIR / "gtx_cli" / "__init__.py"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version", required=True, help="Version to embed in the wheel metadata")
+    parser.add_argument(
+        "--source",
+        type=Path,
+        default=PYPI_DIR.parent / "binaries",
+        help="Directory containing binaries from packages/cli/scripts/build-exe.sh",
+    )
+    parser.add_argument("--out-dir", type=Path, default=PYPI_DIR / "dist")
+    parser.add_argument(
+        "--platform",
+        action="append",
+        choices=[platform.name for platform in PLATFORM_WHEELS],
+        help="Platform to build. May be passed more than once. Defaults to all platforms.",
+    )
+    parser.add_argument("--check", action="store_true", help="Run twine check on the built wheels")
+    parser.add_argument("--upload", action="store_true", help="Upload the built wheels with twine")
+    parser.add_argument("--skip-existing", action="store_true", help="Pass --skip-existing to twine upload")
+    parser.add_argument(
+        "--token-file",
+        type=Path,
+        help="File containing a PyPI API token. Used only when --upload is passed.",
+    )
+    return parser.parse_args()
+
+
+def set_version(version: str) -> str:
+    original = INIT_PATH.read_text(encoding="utf-8")
+    updated = original
+    marker = '__version__ = "'
+    start = updated.find(marker)
+    if start == -1:
+        raise SystemExit(f"Could not find __version__ assignment in {INIT_PATH}")
+    start += len(marker)
+    end = updated.find('"', start)
+    if end == -1:
+        raise SystemExit(f"Could not parse __version__ assignment in {INIT_PATH}")
+    updated = updated[:start] + version + updated[end:]
+    INIT_PATH.write_text(updated, encoding="utf-8")
+    return original
+
+
+def clean_bin_dir() -> None:
+    if BIN_DIR.exists():
+        shutil.rmtree(BIN_DIR)
+    BIN_DIR.mkdir(parents=True)
+
+
+def prepare_binary(source: Path, platform_wheel: PlatformWheel) -> None:
+    clean_bin_dir()
+    source_binary = source / platform_wheel.source_binary
+    if not source_binary.is_file():
+        raise SystemExit(f"Missing expected CLI binary: {source_binary}")
+
+    target = BIN_DIR / platform_wheel.bundled_binary
+    shutil.copy2(source_binary, target)
+    if platform_wheel.bundled_binary != "gt.exe":
+        target.chmod(target.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def run_build(temp_out_dir: Path) -> Path:
+    subprocess.run(
+        [sys.executable, "-m", "build", "--wheel", "--outdir", str(temp_out_dir)],
+        cwd=PYPI_DIR,
+        check=True,
+    )
+    wheels = list(temp_out_dir.glob("*.whl"))
+    if len(wheels) != 1:
+        raise SystemExit(f"Expected exactly one wheel in {temp_out_dir}, found {len(wheels)}")
+    return wheels[0]
+
+
+def wheel_record_hash(data: bytes) -> str:
+    digest = hashlib.sha256(data).digest()
+    encoded = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return f"sha256={encoded}"
+
+
+def rewrite_wheel_metadata(metadata: bytes, wheel_tag: str) -> bytes:
+    text = metadata.decode("utf-8")
+    lines = []
+    saw_tag = False
+    for line in text.splitlines():
+        if line.startswith("Root-Is-Purelib:"):
+            lines.append("Root-Is-Purelib: false")
+        elif line.startswith("Tag:"):
+            if not saw_tag:
+                lines.append(f"Tag: {wheel_tag}")
+                saw_tag = True
+        else:
+            lines.append(line)
+
+    if not saw_tag:
+        lines.append(f"Tag: {wheel_tag}")
+
+    return ("\n".join(lines) + "\n").encode("utf-8")
+
+
+def retag_wheel(source_wheel: Path, output_dir: Path, wheel_tag: str) -> Path:
+    wheel_name = source_wheel.name
+    name_parts = wheel_name[:-4].rsplit("-", 3)
+    if len(name_parts) != 4:
+        raise SystemExit(f"Unexpected wheel filename: {wheel_name}")
+
+    output_wheel = output_dir / f"{name_parts[0]}-{wheel_tag}.whl"
+    records: dict[str, bytes] = {}
+    record_path = ""
+
+    with zipfile.ZipFile(source_wheel, "r") as src, zipfile.ZipFile(output_wheel, "w", zipfile.ZIP_DEFLATED) as dst:
+        for info in src.infolist():
+            data = src.read(info.filename)
+            if info.filename.endswith(".dist-info/RECORD"):
+                record_path = info.filename
+                continue
+            if info.filename.endswith(".dist-info/WHEEL"):
+                data = rewrite_wheel_metadata(data, wheel_tag)
+
+            dst.writestr(info, data)
+            records[info.filename] = data
+
+        if not record_path:
+            raise SystemExit(f"Could not find RECORD in {source_wheel}")
+
+        record_buffer = io.StringIO()
+        writer = csv.writer(record_buffer, lineterminator="\n")
+        for filename, data in records.items():
+            writer.writerow([filename, wheel_record_hash(data), str(len(data))])
+        writer.writerow([record_path, "", ""])
+        dst.writestr(record_path, record_buffer.getvalue().encode("utf-8"))
+
+    return output_wheel
+
+
+def selected_platforms(names: list[str] | None) -> list[PlatformWheel]:
+    if not names:
+        return list(PLATFORM_WHEELS)
+    requested = set(names)
+    return [platform for platform in PLATFORM_WHEELS if platform.name in requested]
+
+
+def run_twine(args: argparse.Namespace, wheels: list[Path]) -> None:
+    if args.check:
+        subprocess.run([sys.executable, "-m", "twine", "check", *(str(wheel) for wheel in wheels)], check=True)
+
+    if args.upload:
+        env = os.environ.copy()
+        if args.token_file:
+            env["TWINE_USERNAME"] = "__token__"
+            env["TWINE_PASSWORD"] = args.token_file.expanduser().read_text(encoding="utf-8").strip()
+
+        command = [sys.executable, "-m", "twine", "upload"]
+        if args.skip_existing:
+            command.append("--skip-existing")
+        command.extend(str(wheel) for wheel in wheels)
+        subprocess.run(command, check=True, env=env)
+
+
+def main() -> None:
+    args = parse_args()
+    source = args.source.resolve()
+    output_dir = args.out_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    original_init = set_version(args.version)
+    built_wheels: list[Path] = []
+    try:
+        for platform_wheel in selected_platforms(args.platform):
+            print(f"Building {platform_wheel.name} wheel...", flush=True)
+            prepare_binary(source, platform_wheel)
+            with tempfile.TemporaryDirectory(prefix=f"gtx-cli-{platform_wheel.name}-") as temp_dir:
+                pure_wheel = run_build(Path(temp_dir))
+                built_wheels.append(retag_wheel(pure_wheel, output_dir, platform_wheel.wheel_tag))
+    finally:
+        INIT_PATH.write_text(original_init, encoding="utf-8")
+        clean_bin_dir()
+
+    for wheel in built_wheels:
+        print(wheel)
+    run_twine(args, built_wheels)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/cli/pypi/scripts/set_version.py
+++ b/packages/cli/pypi/scripts/set_version.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Set gtx_cli.__version__ from the released npm package version."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <version>", file=sys.stderr)
+        raise SystemExit(2)
+
+    version = sys.argv[1]
+    init_path = Path(__file__).resolve().parents[1] / "gtx_cli" / "__init__.py"
+    text = init_path.read_text(encoding="utf-8")
+    updated = re.sub(r'__version__\s*=\s*"[^"]*"', f'__version__ = "{version}"', text)
+
+    if updated == text:
+        print(f"Could not find __version__ assignment in {init_path}", file=sys.stderr)
+        raise SystemExit(1)
+
+    init_path.write_text(updated, encoding="utf-8")
+    print(f"Set gtx-cli version to {version}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.14.20';
+export const PACKAGE_VERSION = '2.14.22';


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a PyPI distribution (`gtx-cli`) for the General Translation CLI, packaging platform-specific Bun-compiled binaries into per-platform wheels and publishing them via a new CI step in `release.yml`. The implementation manually retagges a pure-Python wheel into platform wheels by rewriting `WHEEL` metadata, regenerating the `RECORD` file with correct SHA-256 hashes, and staging each binary before invoking `python -m build`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; no blocking issues found.

Only a single P2 finding: `unlink` on an open file inside a `with zipfile` block which would fail on Windows, but the code path is unreachable with standard hatchling-built wheels and CI runs on Linux.

No files require special attention beyond the minor cleanup issue in `build_platform_wheels.py`.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/pypi/scripts/build_platform_wheels.py | Main wheel-building script; correctly handles version patching, binary staging, wheel retagging, RECORD regeneration, and twine publish. One minor issue: `unlink` on still-open zip file on Windows in an unreachable error path. |
| packages/cli/pypi/gtx_cli/cli.py | Python launcher that locates and execs the bundled binary; uses `os.execv` on Unix and `subprocess.run` on Windows correctly. |
| packages/cli/pypi/pyproject.toml | Hatchling-based wheel config; registers only `gt` console script entry point (see prior review thread about `gtx`/`gtx-cli` aliases). |
| .github/workflows/release.yml | Adds PyPI publish step gated on the same `should_release_bin` condition; correctly injects `TWINE_USERNAME`/`TWINE_PASSWORD` via env and passes `--skip-existing` for idempotency. |
| packages/cli/pypi/scripts/set_version.py | Standalone version-setter using regex; clean and straightforward. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CI: release.yml\nshould_release_bin == true] --> B[Setup Python 3.x]
    B --> C[pip install build twine]
    C --> D[build_platform_wheels.py\n--version --source --check --upload --skip-existing]
    D --> E[set_version: patch __init__.py\nwith release version]
    E --> F{For each platform wheel\nmacos-arm64/x64, linux-arm64/x64, win-x64}
    F --> G[prepare_binary:\ncopy gt binary to gtx_cli/bin/]
    G --> H[python -m build --wheel\npure-Python wheel in tmp dir]
    H --> I[retag_wheel:\nrewrite WHEEL metadata\nregenerate RECORD hashes\nrename to platform tag]
    I --> F
    F -->|all platforms done| J[finally: restore __init__.py\nclean bin dir]
    J --> K[twine check wheels]
    K --> L[twine upload --skip-existing\nto PyPI via TWINE_PASSWORD]
    L --> M[gtx-cli wheel per platform\navailable on PyPI]
    M --> N[pip install gtx-cli\ngets platform-native gt binary]
    N --> O[gt / gtx_cli.cli.main\nos.execv bundled binary]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/cli/pypi/scripts/build_platform_wheels.py
Line: 166-168

Comment:
**`unlink` on an open file fails on Windows**

`output_wheel` is still open via the `dst` `ZipFile` context manager when `unlink` is called on line 167. On Windows, deleting an open file raises `PermissionError`, so this cleanup path would itself raise an exception instead of falling through to the `SystemExit`. On Linux/macOS this is harmless. Since this branch requires a wheel built by hatchling to have no RECORD (essentially impossible in practice), the impact is negligible, but the fix is straightforward — close `dst` before unlinking by restructuring the error check after the outer `with` block, or set a flag inside and raise after the block.

```suggestion
        if not record_path:
            raise SystemExit(f"Could not find RECORD in {source_wheel}")
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: greptile"](https://github.com/generaltranslation/gt/commit/0b741145c94065bb5763fc9948cc0468e158a74e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30058410)</sub>

<!-- /greptile_comment -->