### PR TITLE
fix(cli): remove --publish flag from gt translate

### DIFF
--- a/packages/cli/src/cli/flags.ts
+++ b/packages/cli/src/cli/flags.ts
@@ -52,7 +52,6 @@ export function attachTranslateFlags(command: Command) {
       'Detect and save local edits before enqueuing translations',
       false
     )
-    .option('--publish', 'Publish translations to the CDN', false)
     .option(
       '--experimental-localize-static-urls',
       'Triggering this will run a script after the cli tool that localizes all urls in content files. Currently only supported for md and mdx files.',

--- a/packages/cli/src/config/generateSettings.ts
+++ b/packages/cli/src/config/generateSettings.ts
@@ -188,12 +188,10 @@ export async function generateSettings(
   // For human review, always stage the project
   mergedOptions.stageTranslations = mergedOptions.stageTranslations ?? false;
 
-  // Add publish — only set if explicitly configured or passed via flag.
-  // When neither is set, leave undefined so the publish step knows
+  // Add publish — only set if explicitly configured in gt.config.json.
+  // When not set, leave undefined so the publish step knows
   // there is no global publish intent.
-  if (flags.publish) {
-    mergedOptions.publish = true;
-  } else if (gtConfig.publish !== undefined) {
+  if (gtConfig.publish !== undefined) {
     mergedOptions.publish = gtConfig.publish;
   } else {
     mergedOptions.publish = undefined;

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -69,7 +69,6 @@ export type TranslateFlags = SharedFlags & {
   saveLocal?: boolean;
   stageTranslations?: boolean;
   setupProject?: boolean; // if true, skip enqueue step
-  publish?: boolean;
   force?: boolean;
   forceDownload?: boolean;
   tag?: string;


### PR DESCRIPTION
Removes the `--publish` CLI flag from `gt translate`.

## What changed

- Removed `--publish` option from `attachTranslateFlags()` in `flags.ts`
- Removed `publish` from `TranslateFlags` type
- Updated `generateSettings` to no longer check `flags.publish` (config-only now)

## What still works

- `publish: true` in `gt.config.json` still works as before
- Per-file `publish` flags in include patterns still work
- `save-local --publish` retains its own flag (separate registration in `base.ts`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the `--publish` CLI flag from `gt translate`, restricting publish control to `gt.config.json` and per-file include-pattern flags. The three-file change is clean and self-consistent, though the `if/else` block in `generateSettings.ts` that used to handle `flags.publish` is now a no-op and can be simplified.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the only remaining feedback is a minor style cleanup.

All findings are P2. The removal is correctly applied across flags, types, and settings generation with no broken paths or missing handling.

packages/cli/src/config/generateSettings.ts — the now-redundant `if/else` block around lines 194-198 is worth cleaning up.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/cli/flags.ts | Removes the `--publish` option from `attachTranslateFlags()`; no other flags are affected. |
| packages/cli/src/config/generateSettings.ts | Drops `flags.publish` branch; the remaining `if/else` block is now a no-op because `mergedOptions` is already seeded with `gtConfig.publish` via the earlier spread. |
| packages/cli/src/types/index.ts | Removes `publish?: boolean` from `TranslateFlags`; `Settings` still retains `publish?: boolean`, which is correct. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[gt translate CLI invoked] --> B{--publish flag?}
    B -- "before PR: yes" --> C[flags.publish = true\noverrides config]
    B -- "after PR: removed" --> D[flag no longer exists]
    D --> E{gt.config.json\npublish field?}
    E -- set --> F[mergedOptions.publish = gtConfig.publish]
    E -- not set --> G[mergedOptions.publish = undefined\nno global publish intent]
    F --> H[Publish step proceeds]
    G --> I[No global publish\nper-file flags still apply]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/cli/src/config/generateSettings.ts`, line 194-198 ([link](https://github.com/generaltranslation/gt/blob/38d6e6d08bc12dc92652e268fceb9c9c9c9d8a32/packages/cli/src/config/generateSettings.ts#L194-L198)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Redundant `if/else` block after flag removal**

   With `flags.publish` gone, `mergedOptions` is already seeded with `gtConfig.publish` (or `undefined`) by the `{ ...gtConfig, ...flags }` spread on line 147. The explicit `if/else` now only reassigns the same value that is already there, so it can be simplified to a comment or removed entirely.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/cli/src/config/generateSettings.ts
   Line: 194-198

   Comment:
   **Redundant `if/else` block after flag removal**

   With `flags.publish` gone, `mergedOptions` is already seeded with `gtConfig.publish` (or `undefined`) by the `{ ...gtConfig, ...flags }` spread on line 147. The explicit `if/else` now only reassigns the same value that is already there, so it can be simplified to a comment or removed entirely.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/cli/src/config/generateSettings.ts
Line: 194-198

Comment:
**Redundant `if/else` block after flag removal**

With `flags.publish` gone, `mergedOptions` is already seeded with `gtConfig.publish` (or `undefined`) by the `{ ...gtConfig, ...flags }` spread on line 147. The explicit `if/else` now only reassigns the same value that is already there, so it can be simplified to a comment or removed entirely.

```suggestion
  // publish is read from gt.config.json via the spread above;
  // leave undefined when not explicitly configured so the publish step
  // knows there is no global publish intent.
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): remove --publish flag from gt ..."](https://github.com/generaltranslation/gt/commit/38d6e6d08bc12dc92652e268fceb9c9c9c9d8a32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30061333)</sub>

<!-- /greptile_comment -->