### PR TITLE
docs: add agent guidance entrypoints

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -58,7 +58,25 @@ Turbo tasks: `build`, `test`, `lint`, `lint:fix`, `transpile`, `build:clean`, `b
 - ESLint: `@typescript-eslint` rules, unused vars prefixed with `_`, no explicit `any` (warn).
 - Prefer `const` over `let`. Never `var`.
 - Test files: `*.test.ts` / `*.spec.ts` using Vitest.
-- Build outputs go to `dist/`. Never edit `dist/` directly.
+- Build outputs go to `dist/`. Change source files and rebuild instead of editing `dist/` directly.
+- Do not use default exports.
+- Avoid `useEffect` in React code. Prefer derived state, event handlers, refs, or framework data-loading patterns; only use `useEffect` when synchronizing with an external system.
+
+## Git and PR Conventions
+
+- Commit messages should follow Conventional Commits style (for example, `feat: add locale fallback` or `fix: preserve formatter options`).
+- PR titles should also follow Conventional Commits style.
+
+## Focused References
+
+Load only the relevant file for the area being changed:
+
+- React, Next.js, React Native, or TanStack Start packages: `.claude/rules/react-packages.md`
+- Core i18n packages: `.claude/rules/core.md`
+- Compiler or build plugin code: `.claude/rules/compiler.md` and `packages/compiler/AGENTS.md`
+- CLI packages: `.claude/rules/cli.md`
+- ESLint plugin packages: `.claude/rules/linter-plugins.md`
+- Tests: `.claude/rules/testing.md`
 
 ## Important Patterns
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+.claude/CLAUDE.md

--- a/packages/compiler/AGENTS.md
+++ b/packages/compiler/AGENTS.md
@@ -1,0 +1,1 @@
+.claude/CLAUDE.md


### PR DESCRIPTION
## Summary
- Add root AGENTS.md symlink to the existing Claude instructions
- Add compiler package AGENTS.md symlink for nested agent discovery
- Update shared agent guidance with Conventional Commit/PR title rules, useEffect/default export guidance, and focused reference pointers

## Tests
- Not run; docs/symlink-only change

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds root and compiler-package `AGENTS.md` symlinks for agent discovery, and enriches `.claude/CLAUDE.md` with guidance on Conventional Commits, avoiding `useEffect`, banning default exports, and focused rule-file references. Both symlinks use the same relative path (`.claude/CLAUDE.md`) but correctly resolve to different targets — the root CLAUDE.md and `packages/compiler/.claude/CLAUDE.md` respectively — since relative symlink paths are resolved from the directory containing the symlink.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Docs/symlink-only change; no runtime code is modified and both symlinks resolve to existing files.

All three changed files are documentation or symlinks. The symlink targets are verified to exist in the repo, and the new CLAUDE.md additions are clear, consistent guidelines. No logic, build artifacts, or runtime behaviour is affected.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .claude/CLAUDE.md | Adds new guidance: no default exports, avoid useEffect, Conventional Commits conventions, and focused reference pointers to package-specific rule files. |
| AGENTS.md | New symlink to .claude/CLAUDE.md; resolves correctly to the root-level agent instructions file. |
| packages/compiler/AGENTS.md | New symlink to .claude/CLAUDE.md; resolves relative to packages/compiler/, correctly landing on packages/compiler/.claude/CLAUDE.md (the compiler-specific instructions). |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Agent starts in repo root"] --> B["Discovers AGENTS.md (root)"]
    B --> C["Symlink → .claude/CLAUDE.md (root)"]
    C --> D["General monorepo conventions\nConventional Commits, no default exports,\navoid useEffect, focused references"]

    E["Agent starts in packages/compiler"] --> F["Discovers packages/compiler/AGENTS.md"]
    F --> G["Symlink → packages/compiler/.claude/CLAUDE.md"]
    G --> H["Compiler-specific instructions\n4-pass Babel pipeline, JSX rules,\ntesting, invariants"]

    D --> I["Focused References section\npoints agent to per-area rule files"]
    I --> J[".claude/rules/react-packages.md"]
    I --> K[".claude/rules/compiler.md"]
    I --> L[".claude/rules/cli.md"]
    I --> M["packages/compiler/AGENTS.md"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add agent guidance entrypoints"](https://github.com/generaltranslation/gt/commit/b0593bb2ad22a74839e54556641479953a7d709e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30063247)</sub>

<!-- /greptile_comment -->