### PR TITLE
chore: no silent fail for missed downloads

### DIFF
--- a/.changeset/better-oranges-dance.md
+++ b/.changeset/better-oranges-dance.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+fix: silent error on download file failure

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.14.20';
+export const PACKAGE_VERSION = '2.14.22';

--- a/packages/cli/src/workflows/steps/DownloadStep.ts
+++ b/packages/cli/src/workflows/steps/DownloadStep.ts
@@ -98,6 +98,13 @@ export class DownloadTranslationsStep extends WorkflowStep<
         logger.warn(
           `Failed to download ${missing.length} file(s):\n${missing.map((f) => `- ${f.fileName} (${f.locale})`).join('\n')}`
         );
+        for (const f of missing) {
+          recordWarning(
+            'failed_download',
+            f.fileName,
+            `Failed to download for locale ${f.locale}`
+          );
+        }
       }
 
       // Prepare batch download data

--- a/packages/cli/src/workflows/steps/DownloadStep.ts
+++ b/packages/cli/src/workflows/steps/DownloadStep.ts
@@ -83,6 +83,23 @@ export class DownloadTranslationsStep extends WorkflowStep<
         (file) => file.completedAt !== null
       );
 
+      if (readyTranslations.length < currentQueryData.length) {
+        const readyKeys = new Set(
+          readyTranslations.map(
+            (t) => `${t.branchId}:${t.fileId}:${t.versionId}:${t.locale}`
+          )
+        );
+        const missing = currentQueryData.filter(
+          (item) =>
+            !readyKeys.has(
+              `${item.branchId}:${item.fileId}:${item.versionId}:${item.locale}`
+            )
+        );
+        logger.warn(
+          `Failed to download ${missing.length} file(s):\n${missing.map((f) => `- ${f.fileName} (${f.locale})`).join('\n')}`
+        );
+      }
+
       // Prepare batch download data
       const batchFiles: BatchedFiles = readyTranslations
         .map((translation) => {


### PR DESCRIPTION
## fix(cli): warn when translated files fail to download

When a translation job completes but the server has no translated file record, the CLI silently reports "No files to download" with a green checkmark. This adds a warning that lists the specific files and locales that failed, so the issue is visible instead of silent.

### Test plan
- Run `pnpm gt translate` with a POT file config using `transformationFormat: "PO"`
- Verify the warning lists the missing files instead of silently succeeding

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses the silent-fail scenario in `DownloadStep.ts` where jobs reported as complete by the polling step had no corresponding translated file record on the server. The fix computes which files are missing from the server's `readyTranslations` response and emits both a `logger.warn` and a `recordWarning` entry for each, so failures are visible in the terminal and in the downstream warning summary.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the core logic is correct and the only finding is a minor UX inconsistency in spinner colouring

All findings are P2. The missing-file detection logic (Set-based key diff) is correct, recordWarning is now called as expected, and the changeset is properly scoped. The spinner colour inconsistency is a non-blocking cosmetic issue.

packages/cli/src/workflows/steps/DownloadStep.ts — spinner stop colour when all files are missing
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/workflows/steps/DownloadStep.ts | Adds server-side missing-file detection with warn + recordWarning; minor UX inconsistency when all files are missing causes spinner to still display green "No files to download" |
| .changeset/better-oranges-dance.md | Standard patch changeset entry for the silent-download-failure fix |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[fileTracker.completed entries] -->|queryFileData| B[Server: translatedFiles]
    B --> C{Filter completedAt != null}
    C --> D[readyTranslations]
    D --> E{readyTranslations.length < currentQueryData.length?}
    E -->|Yes - NEW| F[Compute missing keys via Set diff]
    F --> G[logger.warn + recordWarning per missing file]
    G --> H[Build batchFiles from readyTranslations]
    E -->|No| H
    H --> I{batchFiles.length > 0?}
    I -->|Yes| J[downloadFilesWithRetry]
    J --> K{Any failed?}
    K -->|Yes| L[logger.warn + recordWarning per failed file]
    K -->|No| M[Spinner: Downloaded N files]
    L --> M
    I -->|No| N[Spinner: No files to download - still green even if missing > 0]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/cli/src/workflows/steps/DownloadStep.ts
Line: 164-166

Comment:
**Green spinner contradicts the missing-file warning**

When every file in `currentQueryData` is missing (i.e. `readyTranslations` is empty), `batchFiles` will also be empty. The code then falls into the `else` branch (line 165) and the spinner stops with `chalk.green('No files to download')` — a success-coloured message that directly contradicts the `logger.warn` that was just emitted. A user watching the terminal output could easily interpret the green spinner as "all good" and overlook the warning above it.

Consider stopping the spinner with a warning colour when `missing.length > 0`:

```typescript
if (batchFiles.length > 0) {
  // ... existing download logic
} else if (missing.length > 0) {
  this.spinner?.stop(chalk.yellow('No files downloaded — see warnings above'));
} else {
  this.spinner?.stop(chalk.green('No files to download'));
}
```

(You'd need to hoist `missing` out of the `if` block, or track it as a variable before the spinner stop.)

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;e/cli/fix-no-files-to-down..."](https://github.com/generaltranslation/gt/commit/1c658d460e2632b3d3b29b35b4e6b5bd9e30a145) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30065496)</sub>

<!-- /greptile_comment -->