### PR TITLE
fix: release versioning issue for pypi

### DIFF
--- a/.changeset/sharp-nights-tease.md
+++ b/.changeset/sharp-nights-tease.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+fix: release versioning

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,7 +193,7 @@ jobs:
         if: steps.check-gtx-cli.outputs.should_release_bin == 'true'
         run: |
           published_packages='${{ steps.changesets.outputs.publishedPackages }}'
-          version=$(echo "$published_packages" | jq -r '.[] | select(.name == "gtx-cli") | .version')
+          version=$(echo "$published_packages" | grep -A1 '"name": *"gtx-cli"' | grep '"version"' | sed 's/.*"version": *"\([^"]*\)".*/\1/')
           echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Build gtx-cli binaries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
         if: steps.check-gt.outputs.should_release_bin == 'true'
         run: |
           published_packages='${{ steps.changesets.outputs.publishedPackages }}'
-          version=$(echo "$published_packages" | grep -A1 '"name": *"gt"' | grep '"version"' | sed 's/.*"version": *"\([^"]*\)".*/\1/')
+          version=$(echo "$published_packages" | jq -r '.[] | select(.name == "gt") | .version')
           echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Build gt binaries
@@ -193,7 +193,7 @@ jobs:
         if: steps.check-gtx-cli.outputs.should_release_bin == 'true'
         run: |
           published_packages='${{ steps.changesets.outputs.publishedPackages }}'
-          version=$(echo "$published_packages" | grep -A1 '"name": *"gtx-cli"' | grep '"version"' | sed 's/.*"version": *"\([^"]*\)".*/\1/')
+          version=$(echo "$published_packages" | jq -r '.[] | select(.name == "gtx-cli") | .version')
           echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Build gtx-cli binaries

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.14.20';
+export const PACKAGE_VERSION = '2.14.22';


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the PyPI release versioning issue by replacing the fragile `grep -A1 | grep | sed` version extraction for the `gt` package with a `jq`-based approach in `release.yml`, and bumps the auto-generated `version.ts` to `2.14.22`.

- The parallel `gtx-cli` version extraction (line 196) still uses the old `grep/sed` chain and needs the same `jq` fix.
- The `grep`-based name checks on lines 132 and 185 (substring matches) remain unfixed — `grep -q '\"name\": *\"gt\"'` will match `gtx-cli`, potentially triggering the wrong binary release path.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge for the immediate PyPI fix, but the `gtx-cli` version extraction and both `grep` name-checks remain broken.

Two pre-existing P1s (lines 132 and 185, already flagged in prior review) remain unresolved, and a newly identified P1 on line 196 shows the fix was applied inconsistently — `gtx-cli` version extraction still uses the fragile pattern. Multiple P1s pull the score below the P1 ceiling of 4.

.github/workflows/release.yml — lines 132, 185 (grep name checks) and line 196 (gtx-cli version extraction) all need the same jq treatment applied to line 143.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Fixes `gt` version extraction to use `jq`, but `gtx-cli` version extraction (line 196) and both `grep`-based name checks (lines 132, 185) retain the old fragile patterns. |
| .changeset/sharp-nights-tease.md | Patch changeset for the `gt` package documenting the release versioning fix — no issues. |
| packages/cli/src/generated/version.ts | Auto-generated version bump from `2.14.20` to `2.14.22` — no issues. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Changesets publishes packages] --> B{gt published?}
    B -- "grep substring check line 132\n⚠️ matches gtx-cli too" --> C[Extract gt version\n✅ jq fixed in this PR]
    C --> D[Build & upload gt binaries]
    A --> E{gtx-cli published?}
    E -- "grep substring check line 185\n⚠️ not fixed" --> F[Extract gtx-cli version\n⚠️ grep/sed not fixed line 196]
    F --> G[Build & upload gtx-cli binaries]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `.github/workflows/release.yml`, line 132-135 ([link](https://github.com/generaltranslation/gt/blob/a9499306b6c76400a73940a9f81b01f89b07bb12/.github/workflows/release.yml#L132-L135)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Grep name-check can false-match sibling packages**

   `grep -q '"name": *"gt"'` treats the pattern as a substring search, so `"name": "gtx-cli"` satisfies it (the text `"name": "gt` appears inside `"name": "gtx-cli"`). If `gtx-cli` is the only package published in a given release run, the `gt` binary-release steps will still fire with an empty `${{ steps.gt-version.outputs.version }}`, likely uploading whatever stale binaries happen to exist to the wrong R2 path. The same symmetrical issue exists in the `check-gtx-cli` step.

   Switch both checks to `jq` to match the now-consistent version-extraction approach:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/release.yml
   Line: 132-135

   Comment:
   **Grep name-check can false-match sibling packages**

   `grep -q '"name": *"gt"'` treats the pattern as a substring search, so `"name": "gtx-cli"` satisfies it (the text `"name": "gt` appears inside `"name": "gtx-cli"`). If `gtx-cli` is the only package published in a given release run, the `gt` binary-release steps will still fire with an empty `${{ steps.gt-version.outputs.version }}`, likely uploading whatever stale binaries happen to exist to the wrong R2 path. The same symmetrical issue exists in the `check-gtx-cli` step.

   Switch both checks to `jq` to match the now-consistent version-extraction approach:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `.github/workflows/release.yml`, line 185-188 ([link](https://github.com/generaltranslation/gt/blob/a9499306b6c76400a73940a9f81b01f89b07bb12/.github/workflows/release.yml#L185-L188)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Same false-match risk for gtx-cli check**

   `grep -q '"name": *"gtx-cli"'` is also a substring search. Consistent fix:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/release.yml
   Line: 185-188

   Comment:
   **Same false-match risk for gtx-cli check**

   `grep -q '"name": *"gtx-cli"'` is also a substring search. Consistent fix:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

3. `.github/workflows/release.yml`, line 196 ([link](https://github.com/generaltranslation/gt/blob/393ef8f4b46d2f3747115f125cfe75f143b0ed13/.github/workflows/release.yml#L196)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`gtx-cli` version extraction still uses old `grep/sed` pattern**

   The `gt` version extraction was upgraded to `jq` in this PR, but the parallel `gtx-cli` extraction on line 196 still uses the same fragile `grep -A1 | grep | sed` chain that this fix was specifically addressing. If the JSON is compact or reordered (as apparently happened for `gt`), the version will be extracted incorrectly or return empty, causing the binary upload to write to a bad R2 path.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/release.yml
   Line: 196

   Comment:
   **`gtx-cli` version extraction still uses old `grep/sed` pattern**

   The `gt` version extraction was upgraded to `jq` in this PR, but the parallel `gtx-cli` extraction on line 196 still uses the same fragile `grep -A1 | grep | sed` chain that this fix was specifically addressing. If the JSON is compact or reordered (as apparently happened for `gt`), the version will be extracted incorrectly or return empty, causing the binary upload to write to a bad R2 path.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/release.yml
Line: 196

Comment:
**`gtx-cli` version extraction still uses old `grep/sed` pattern**

The `gt` version extraction was upgraded to `jq` in this PR, but the parallel `gtx-cli` extraction on line 196 still uses the same fragile `grep -A1 | grep | sed` chain that this fix was specifically addressing. If the JSON is compact or reordered (as apparently happened for `gt`), the version will be extracted incorrectly or return empty, causing the binary upload to write to a bad R2 path.

```suggestion
          version=$(echo "$published_packages" | jq -r '.[] | select(.name == "gtx-cli") | .version')
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["revert unecessary change"](https://github.com/generaltranslation/gt/commit/393ef8f4b46d2f3747115f125cfe75f143b0ed13) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30073470)</sub>

<!-- /greptile_comment -->