### PR TITLE
fix: release version detection

### DIFF
--- a/.changeset/four-rings-boil.md
+++ b/.changeset/four-rings-boil.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+chore: fix release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,7 @@ jobs:
         run: |
           published_packages='${{ steps.changesets.outputs.publishedPackages }}'
 
-          if echo "$published_packages" | grep -q '"name": *"gt"'; then
+          if echo "$published_packages" | jq -e 'any(.[]; .name == "gt")' > /dev/null; then
             echo "should_release_bin=true" >> $GITHUB_OUTPUT
           else
             echo "should_release_bin=false" >> $GITHUB_OUTPUT
@@ -140,7 +140,7 @@ jobs:
         if: steps.check-gt.outputs.should_release_bin == 'true'
         run: |
           published_packages='${{ steps.changesets.outputs.publishedPackages }}'
-          version=$(echo "$published_packages" | jq -r '.[] | select(.name == "gt") | .version')
+          version=$(echo "$published_packages" | jq -er '.[] | select(.name == "gt") | .version')
           echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Build gt binaries
@@ -199,7 +199,7 @@ jobs:
         run: |
           published_packages='${{ steps.changesets.outputs.publishedPackages }}'
 
-          if echo "$published_packages" | grep -q '"name": *"gtx-cli"'; then
+          if echo "$published_packages" | jq -e 'any(.[]; .name == "gtx-cli")' > /dev/null; then
             echo "should_release_bin=true" >> $GITHUB_OUTPUT
           else
             echo "should_release_bin=false" >> $GITHUB_OUTPUT
@@ -210,7 +210,7 @@ jobs:
         if: steps.check-gtx-cli.outputs.should_release_bin == 'true'
         run: |
           published_packages='${{ steps.changesets.outputs.publishedPackages }}'
-          version=$(echo "$published_packages" | grep -A1 '"name": *"gtx-cli"' | grep '"version"' | sed 's/.*"version": *"\([^"]*\)".*/\1/')
+          version=$(echo "$published_packages" | jq -er '.[] | select(.name == "gtx-cli") | .version')
           echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Build gtx-cli binaries

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.14.22';
+export const PACKAGE_VERSION = '2.14.24';


### PR DESCRIPTION
## Why

The release workflow still used string matching and line-oriented parsing for parts of the CLI binary release path. That made the package checks vulnerable to false matches between `gt` and `gtx-cli`, and the `gtx-cli` version extraction could fail if the published package JSON was compacted or fields were reordered.

This was not causing issues for consumers because the published package artifacts were still available at the expected versions, but it left the release automation fragile and able to upload binaries to incorrect or empty version paths in edge cases.

## What

- Use `jq` exact package-name checks for both `gt` and `gtx-cli`.
- Use `jq` version extraction for `gtx-cli`, matching the existing `gt` workflow.
- Make version extraction fail when a matching package does not provide a usable version, avoiding uploads to invalid release paths.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two reliability issues in the binary release workflow: `grep`-based package detection that could match `gtx-cli` when checking for `gt`, and a `grep`/`sed` version extraction for `gtx-cli` that could silently fail on compact or reordered JSON. Both are replaced with exact `jq` queries, and the `-e` flag is added so that a missing/null version now causes the step to fail loudly rather than uploading to a broken path. The `version.ts` bump is auto-generated and expected.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are targeted hardening of the CI release workflow with no production code impact.

Changes are confined to the CI release workflow and an auto-generated version file. The jq replacements are strictly more correct than the prior grep/sed approach, and the -e flag addition improves failure visibility. No logic regressions or new risk introduced.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Replaces fragile grep/sed-based package detection and version extraction with exact jq queries, preventing false matches between `gt` and `gtx-cli` and making missing-version failures explicit. |
| .changeset/four-rings-boil.md | Standard changeset file marking a patch release for the `gt` package. |
| packages/cli/src/generated/version.ts | Auto-generated version bump from 2.14.22 to 2.14.24; minor version skip is expected if a prior release was attempted between the two. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Changesets publish step] --> B{published == true?}
    B -- No --> Z[Skip binary releases]
    B -- Yes --> C{jq exact match\nname == gt}
    C -- no match --> D[skip gt release]
    C -- match --> E[Extract gt version via jq -er]
    E -- null or missing --> G[Step fails loudly]
    E -- version string --> H[Build and upload gt binaries to R2]
    H --> I[Publish gtx-cli to PyPI]
    H --> J[Release gt binary to npm]
    B -- Yes --> K{jq exact match\nname == gtx-cli}
    K -- no match --> L[skip gtx-cli release]
    K -- match --> N[Extract gtx-cli version via jq -er]
    N -- null or missing --> O[Step fails loudly]
    N -- version string --> P[Build and upload gtx-cli binaries to R2]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: release version detection"](https://github.com/generaltranslation/gt/commit/47a3e62847c64fcf48e6382d353d3383e793fa61) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30085552)</sub>

<!-- /greptile_comment -->