### PR TITLE
fix: bun cli python extraction

### DIFF
--- a/.changeset/silly-frogs-clean.md
+++ b/.changeset/silly-frogs-clean.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/python-extractor': patch
+---
+
+fix: bun vs node behavior for python extraction with wasm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,11 +155,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check if CLI changed
+      - name: Check if CLI or Python extractor changed
         id: gt_cli_changed
         shell: bash
         run: |
-          if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q "^packages/cli/"; then
+          if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -qE "^packages/(cli|python-extractor)/"; then
             echo "changed=true" >> $GITHUB_OUTPUT
           else
             echo "changed=false" >> $GITHUB_OUTPUT
@@ -231,11 +231,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check if gtx-cli wrapper changed
+      - name: Check if gtx-cli wrapper or CLI dependency changed
         id: gtx_cli_changed
         shell: bash
         run: |
-          if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -qE "^packages/(cli|gtx-cli)/"; then
+          if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -qE "^packages/(cli|gtx-cli|python-extractor)/"; then
             echo "changed=true" >> $GITHUB_OUTPUT
           else
             echo "changed=false" >> $GITHUB_OUTPUT

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.14.20';
+export const PACKAGE_VERSION = '2.14.22';

--- a/packages/python-extractor/src/__tests__/parserFailure.test.ts
+++ b/packages/python-extractor/src/__tests__/parserFailure.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../parser.js', () => ({
+  getParser: vi.fn(async () => {
+    throw new Error('Unknown WASM specifier for Bun: extra.wasm');
+  }),
+}));
+
+import { extractFromPythonSource } from '../index.js';
+
+describe('parser initialization failures', () => {
+  it('returns a warning instead of throwing', async () => {
+    const result = await extractFromPythonSource(
+      'from gt_flask import t\nt("Hello")',
+      'app.py'
+    );
+
+    expect(result.results).toEqual([]);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain('app.py');
+    expect(result.warnings[0]).toContain('Failed to initialize Python parser');
+    expect(result.warnings[0]).toContain(
+      'Unknown WASM specifier for Bun: extra.wasm'
+    );
+  });
+});

--- a/packages/python-extractor/src/index.ts
+++ b/packages/python-extractor/src/index.ts
@@ -25,7 +25,19 @@ export async function extractFromPythonSource(
   errors: string[];
   warnings: string[];
 }> {
-  const parser = await getParser();
+  let parser: Awaited<ReturnType<typeof getParser>>;
+  try {
+    parser = await getParser();
+  } catch (error) {
+    return {
+      results: [],
+      errors: [],
+      warnings: [
+        `${filePath}: Failed to initialize Python parser; skipping Python extraction. ${formatError(error)}`,
+      ],
+    };
+  }
+
   const tree = parser.parse(sourceCode);
   if (!tree) {
     return {
@@ -70,4 +82,8 @@ export async function extractFromPythonSource(
 
 function prefixErrors(messages: string[], filePath: string): string[] {
   return messages.map((msg) => `${filePath}: ${msg}`);
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/python-extractor/src/parser.ts
+++ b/packages/python-extractor/src/parser.ts
@@ -2,6 +2,8 @@ import { Parser, Language } from 'web-tree-sitter';
 import { createRequire } from 'module';
 
 let parserPromise: Promise<Parser> | null = null;
+const require = createRequire(import.meta.url);
+const isBun = typeof process !== 'undefined' && !!process.versions.bun;
 
 /**
  * Lazily initializes and returns a singleton tree-sitter Parser
@@ -15,17 +17,43 @@ export function getParser(): Promise<Parser> {
 }
 
 async function initParser(): Promise<Parser> {
-  await Parser.init();
+  const parserWasmPath = await resolveWasmPath(
+    'web-tree-sitter/web-tree-sitter.wasm'
+  );
+
+  await Parser.init({
+    locateFile(path: string) {
+      if (path === 'web-tree-sitter.wasm') {
+        return parserWasmPath;
+      }
+      return path;
+    },
+  });
   const parser = new Parser();
 
-  const require = createRequire(import.meta.url);
-  const wasmPath = require.resolve(
+  const wasmPath = await resolveWasmPath(
     'tree-sitter-python/tree-sitter-python.wasm'
   );
   const Python = await Language.load(wasmPath);
   parser.setLanguage(Python);
 
   return parser;
+}
+
+async function resolveWasmPath(specifier: string): Promise<string> {
+  if (!isBun) {
+    return require.resolve(specifier);
+  }
+
+  switch (specifier) {
+    case 'web-tree-sitter/web-tree-sitter.wasm':
+      return (await import('web-tree-sitter/web-tree-sitter.wasm')).default;
+    case 'tree-sitter-python/tree-sitter-python.wasm':
+      return (await import('tree-sitter-python/tree-sitter-python.wasm'))
+        .default;
+    default:
+      return require.resolve(specifier);
+  }
 }
 
 export type { Parser };

--- a/packages/python-extractor/src/parser.ts
+++ b/packages/python-extractor/src/parser.ts
@@ -52,7 +52,7 @@ async function resolveWasmPath(specifier: string): Promise<string> {
       return (await import('tree-sitter-python/tree-sitter-python.wasm'))
         .default;
     default:
-      return require.resolve(specifier);
+      throw new Error(`Unknown WASM specifier for Bun: ${specifier}`);
   }
 }
 

--- a/packages/python-extractor/src/wasm.d.ts
+++ b/packages/python-extractor/src/wasm.d.ts
@@ -1,0 +1,4 @@
+declare module '*.wasm' {
+  const path: string;
+  export default path;
+}


### PR DESCRIPTION
## Summary

Fixes Python extraction in Bun-compiled CLI binaries by ensuring the `web-tree-sitter` and `tree-sitter-python` WASM assets are available at runtime.

## What Changed

- Explicitly resolves `web-tree-sitter.wasm` during `Parser.init()`.
- Uses normal `require.resolve()` in Node so the JS package loads WASM from dependencies.
- Uses Bun-only dynamic `.wasm` imports so standalone binaries embed the WASM assets.
- Adds a `.wasm` module declaration for TypeScript.

## Verification

- Confirmed published `npx gt@bin generate` fails with `/$bunfs/root/web-tree-sitter.wasm`.
- Confirmed published `npx gt@latest generate` works.
- Built local Bun binaries and verified `generate` works on a Flask smoke app.
- Verified generated output contains all expected Python `t(...)` strings.
- Ran Python extractor tests: 129 passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes WASM asset resolution in Bun-compiled standalone CLI binaries for the Python extractor. It splits `resolveWasmPath` into a Node path (`require.resolve`) and a Bun path (dynamic `import()` so the bundler embeds the assets), explicitly passes the resolved WASM path to `Parser.init()` via `locateFile`, and wraps parser initialization in a try/catch so failures produce a warning rather than crashing extraction.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge — the fix is well-scoped, verified end-to-end, and degrades gracefully on init failure.

No P0 or P1 findings. The Bun/Node split is clean, the singleton is handled correctly, the error path is tested, and the CI triggers are correctly extended. The `default` branch issue was flagged in a prior review thread and is already handled by the graceful-degradation wrapper added in `index.ts`.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/python-extractor/src/parser.ts | Core fix: adds `resolveWasmPath` with Bun/Node branch, explicitly passes resolved WASM path to `Parser.init()` via `locateFile`, and throws a clear error for unknown specifiers |
| packages/python-extractor/src/index.ts | Wraps `getParser()` in try/catch so parser init failures degrade gracefully to a warning instead of an uncaught rejection |
| packages/python-extractor/src/__tests__/parserFailure.test.ts | New test covering the parser-init-failure warning path via vi.mock; correctly asserts warning contents and empty results/errors |
| packages/python-extractor/src/wasm.d.ts | New TypeScript ambient module declaration for `*.wasm` imports, required for the Bun dynamic import path to type-check |
| .github/workflows/ci.yml | Extends CI change-detection to include `python-extractor` for both the gt-cli and gtx-cli jobs, ensuring binary builds are triggered when this package changes |
| .changeset/silly-frogs-clean.md | Patch changeset for the `@generaltranslation/python-extractor` package |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getParser called] --> B{parserPromise cached?}
    B -- yes --> C[return cached promise]
    B -- no --> D[initParser]
    D --> E[resolveWasmPath web-tree-sitter.wasm]
    E --> F{isBun?}
    F -- no --> G[require.resolve specifier]
    F -- yes --> H{switch specifier}
    H -- web-tree-sitter --> I[dynamic import web-tree-sitter.wasm]
    H -- tree-sitter-python --> J[dynamic import tree-sitter-python.wasm]
    H -- default --> K[throw Error: Unknown WASM specifier]
    G --> L[Parser.init with locateFile callback]
    I --> L
    J --> M[Language.load wasmPath]
    L --> M
    M --> N[parser.setLanguage Python]
    N --> O[return parser]
    K --> P[extractFromPythonSource catch: return warning]
    O --> Q[extractFromPythonSource parse & extract]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: warning when parser resolution fail..."](https://github.com/generaltranslation/gt/commit/c421ad6d3e6cd25b62ca9ff16c809fb337179bb7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30102586)</sub>

<!-- /greptile_comment -->