### PR TITLE
F/tagged template meta

### DIFF
--- a/.changeset/spicy-flies-peel.md
+++ b/.changeset/spicy-flies-peel.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Pass metadata to for tagged templates

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.14.24';
+export const PACKAGE_VERSION = '2.14.27';

--- a/packages/cli/src/react/jsx/utils/stringParsing/processTaggedTemplateCall/__tests__/processTaggedTemplateCall.test.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/processTaggedTemplateCall/__tests__/processTaggedTemplateCall.test.ts
@@ -1,7 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect } from 'vitest';
 import { parse } from '@babel/parser';
 import traverseModule, { NodePath } from '@babel/traverse';
 import * as t from '@babel/types';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { processTaggedTemplateCall } from '../index.js';
 import { ParsingConfig, ParsingOutput } from '../../types.js';
 import { Updates } from '../../../../../../types/index.js';
@@ -10,6 +13,28 @@ import { Updates } from '../../../../../../types/index.js';
 const traverse = (traverseModule as any).default || traverseModule;
 
 const FILE_PATH = 'test.tsx';
+const tempFiles: string[] = [];
+
+function writeTempFile(content: string): string {
+  const filePath = path.join(
+    os.tmpdir(),
+    `gt-tagged-template-test-${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2)}.tsx`
+  );
+  fs.writeFileSync(filePath, content, 'utf8');
+  tempFiles.push(filePath);
+  return filePath;
+}
+
+afterEach(() => {
+  for (const filePath of tempFiles) {
+    try {
+      fs.unlinkSync(filePath);
+    } catch {}
+  }
+  tempFiles.length = 0;
+});
 
 function createConfig(overrides?: Partial<ParsingConfig>): ParsingConfig {
   return {
@@ -121,11 +146,17 @@ describe('processTaggedTemplateCall', () => {
   it('should preserve source file metadata for derive variants', () => {
     const output = runProcessTaggedTemplateCall(
       `
-        function getSubject(gender: string) {
-          return gender === "male" ? "boy" : "girl";
+        import { derive } from 'gt-react';
+
+        function getSubject() {
+          if (gender === "male") {
+            return "boy";
+          } else {
+            return "girl";
+          }
         }
 
-        t\`The \${derive(getSubject(gender))} is playing in the park.\`
+        t\`The \${derive(getSubject())} is playing in the park.\`
       `
     );
 
@@ -138,6 +169,45 @@ describe('processTaggedTemplateCall', () => {
     expect(
       output.updates.every((u) => u.metadata.filePaths?.[0] === FILE_PATH)
     ).toBe(true);
+  });
+
+  it('should preserve source code metadata for derive variants', () => {
+    const code = [
+      "import { derive } from 'gt-react';",
+      '',
+      'function getSubject() {',
+      '  if (gender === "male") {',
+      '    return "boy";',
+      '  } else {',
+      '    return "girl";',
+      '  }',
+      '}',
+      '',
+      'const sentence = t`The ${derive(getSubject())} is playing in the park.`;',
+    ].join('\n');
+    const filePath = writeTempFile(code);
+    const relativeFilePath = path.relative(process.cwd(), filePath);
+
+    const output = runProcessTaggedTemplateCall(code, 't', {
+      file: filePath,
+      includeSourceCodeContext: true,
+    });
+
+    expect(output.updates).toHaveLength(2);
+    expect(output.updates.map((u) => u.source).sort()).toEqual([
+      'The boy is playing in the park.',
+      'The girl is playing in the park.',
+    ]);
+
+    for (const update of output.updates) {
+      expect(update.metadata.filePaths).toEqual([relativeFilePath]);
+      expect(update.metadata.sourceCode?.[relativeFilePath]).toHaveLength(1);
+      const entry = update.metadata.sourceCode?.[relativeFilePath]?.[0];
+      expect(entry?.target).toContain(
+        't`The ${derive(getSubject())} is playing in the park.`'
+      );
+      expect(entry?.before).toContain('return "girl"');
+    }
   });
 
   it('should still extract when ignoreTaggedTemplates is true (gating is done by caller)', () => {

--- a/packages/cli/src/react/jsx/utils/stringParsing/processTaggedTemplateCall/__tests__/processTaggedTemplateCall.test.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/processTaggedTemplateCall/__tests__/processTaggedTemplateCall.test.ts
@@ -118,6 +118,27 @@ describe('processTaggedTemplateCall', () => {
     });
   });
 
+  it('should preserve source file metadata for derive variants', () => {
+    const output = runProcessTaggedTemplateCall(
+      `
+        function getSubject(gender: string) {
+          return gender === "male" ? "boy" : "girl";
+        }
+
+        t\`The \${derive(getSubject(gender))} is playing in the park.\`
+      `
+    );
+
+    expect(output.updates).toHaveLength(2);
+    expect(output.updates.map((u) => u.source).sort()).toEqual([
+      'The boy is playing in the park.',
+      'The girl is playing in the park.',
+    ]);
+    expect(output.updates.every((u) => u.metadata.staticId)).toBe(true);
+    expect(output.updates.every((u) => u.metadata.filePaths?.[0] === FILE_PATH))
+      .toBe(true);
+  });
+
   it('should still extract when ignoreTaggedTemplates is true (gating is done by caller)', () => {
     const output = runProcessTaggedTemplateCall('t`hello ${name}`', 't', {
       ignoreTaggedTemplates: true,

--- a/packages/cli/src/react/jsx/utils/stringParsing/processTaggedTemplateCall/__tests__/processTaggedTemplateCall.test.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/processTaggedTemplateCall/__tests__/processTaggedTemplateCall.test.ts
@@ -135,8 +135,9 @@ describe('processTaggedTemplateCall', () => {
       'The girl is playing in the park.',
     ]);
     expect(output.updates.every((u) => u.metadata.staticId)).toBe(true);
-    expect(output.updates.every((u) => u.metadata.filePaths?.[0] === FILE_PATH))
-      .toBe(true);
+    expect(
+      output.updates.every((u) => u.metadata.filePaths?.[0] === FILE_PATH)
+    ).toBe(true);
   });
 
   it('should still extract when ignoreTaggedTemplates is true (gating is done by caller)', () => {

--- a/packages/cli/src/react/jsx/utils/stringParsing/processTaggedTemplateCall/index.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/processTaggedTemplateCall/index.ts
@@ -2,12 +2,15 @@ import { NodePath } from '@babel/traverse';
 import * as t from '@babel/types';
 import { ParsingConfig, ParsingOutput } from '../types.js';
 import { handleTaggedTemplateTranslationCall } from './handleTaggedTemplateTranslationCall.js';
+import { extractStringEntryMetadata } from '../processTranslationCall/extractStringEntryMetadata.js';
+import { SURROUNDING_LINE_COUNT } from '../../../../../utils/constants.js';
 
 /**
  * Processes a tagged template expression (e.g., t`hello ${name}`).
  * Extracts the translatable string with numeric placeholders for expressions.
  *
- * Tagged templates don't support an options argument, so metadata is empty.
+ * Tagged templates don't support an options argument, but still carry
+ * source metadata for dashboard grouping and source context.
  *
  * @param tPath - The path to the tag identifier
  * @param config - Parsing configuration
@@ -25,10 +28,17 @@ export function processTaggedTemplateCall(
     return;
   }
 
+  const metadata = extractStringEntryMetadata({
+    output,
+    config,
+    nodeLoc: tPath.parent.loc,
+    surroundingLineCount: SURROUNDING_LINE_COUNT,
+  });
+
   handleTaggedTemplateTranslationCall({
     tPath,
     quasi: tPath.parent.quasi,
-    metadata: {},
+    metadata,
     config,
     output,
   });


### PR DESCRIPTION
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds source file metadata (file paths and optional source code context) to tagged template translation calls (`t\`...\``), bringing them in line with regular `t()` call expressions. The implementation reuses `extractStringEntryMetadata` from `processTranslationCall` and is backed by two new test cases covering both `filePaths` and `sourceCode` metadata paths.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge — the change is a targeted, well-tested enrichment of metadata for tagged template calls with no correctness issues.

No P0 or P1 issues found. The implementation correctly reuses `extractStringEntryMetadata` (no `options` argument, which is intentional for tagged templates), passes the right node location, and both new test cases cover the `filePaths` and `sourceCode` metadata paths end-to-end.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/react/jsx/utils/stringParsing/processTaggedTemplateCall/index.ts | Calls `extractStringEntryMetadata` before passing metadata to the handler, replacing the previous empty `{}` metadata. The `nodeLoc` is correctly sourced from `tPath.parent.loc` (the full `TaggedTemplateExpression` node). |
| packages/cli/src/react/jsx/utils/stringParsing/processTaggedTemplateCall/__tests__/processTaggedTemplateCall.test.ts | Adds two new test cases: one for `filePaths` metadata on `derive` variants using the existing `FILE_PATH` constant, and one for `sourceCode` metadata using a real temp file with `includeSourceCodeContext: true`. Proper temp-file cleanup via `afterEach` is included. |
| packages/cli/src/generated/version.ts | Auto-generated version bump from 2.14.24 to 2.14.27. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[processTaggedTemplateCall] --> B{isTaggedTemplateExpression?}
    B -- No --> C[return early]
    B -- Yes --> D[extractStringEntryMetadata\nfilePaths + optional sourceCode]
    D --> E[handleTaggedTemplateTranslationCall\nmetadata]
    E --> F[deriveExpression]
    F --> G{derive calls present?}
    G -- Yes --> H[expand variants\neach gets spread metadata]
    G -- No --> I[single update\nwith metadata]
    H --> J[output.updates push\nfilePaths + sourceCode per variant]
    I --> J
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: add tests"](https://github.com/generaltranslation/gt/commit/970d03bef21aa7da22423827ce32c516dc6e45c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30110013)</sub>

<!-- /greptile_comment -->