### PR TITLE
fix: disable browser auth

### DIFF
--- a/.changeset/quiet-browsers-bow.md
+++ b/.changeset/quiet-browsers-bow.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Temporarily disable browser-based CLI auth and direct users to manual credentials instead.

--- a/packages/cli/src/cli/__tests__/base.test.ts
+++ b/packages/cli/src/cli/__tests__/base.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { BaseCLI } from '../base.js';
+import { logger } from '../../console/logger.js';
+import { logErrorAndExit } from '../../console/logging.js';
+import { createOrUpdateConfig } from '../../fs/config/setupConfig.js';
+
+vi.mock('../../console/logger.js', () => ({
+  logger: {
+    endCommand: vi.fn(),
+    info: vi.fn(),
+    message: vi.fn(),
+    startCommand: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    createSpinner: () => ({
+      start: vi.fn(),
+      stop: vi.fn(),
+      message: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock('../../console/logging.js', () => ({
+  displayHeader: vi.fn(),
+  logErrorAndExit: vi.fn((message: string) => {
+    throw new Error(message);
+  }),
+  promptConfirm: vi.fn(),
+  promptMultiSelect: vi.fn().mockResolvedValue([]),
+  promptSelect: vi.fn(),
+  promptText: vi.fn(),
+}));
+
+vi.mock('../../setup/userInput.js', () => ({
+  getDesiredLocales: vi.fn().mockResolvedValue({
+    defaultLocale: 'en',
+    locales: ['es'],
+  }),
+}));
+
+vi.mock('../../utils/packageJson.js', () => ({
+  isPackageInstalled: vi.fn(),
+  searchForPackageJson: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('../../fs/config/setupConfig.js', () => ({
+  createOrUpdateConfig: vi.fn().mockResolvedValue(undefined),
+}));
+
+class TestCLI extends BaseCLI {
+  public runHandleInitCommand() {
+    return this.handleInitCommand(false, false, false);
+  }
+}
+
+describe('BaseCLI setup wizard credentials', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.GT_PROJECT_ID;
+    delete process.env.GT_API_KEY;
+    delete process.env.GT_DEV_API_KEY;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('continues silently when automatic auth is unavailable', async () => {
+    const cli = Object.create(TestCLI.prototype) as TestCLI;
+
+    await expect(cli.runHandleInitCommand()).resolves.toBeUndefined();
+
+    expect(createOrUpdateConfig).toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logErrorAndExit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -36,8 +36,10 @@ import {
 import { getDesiredLocales } from '../setup/userInput.js';
 import { installPackage } from '../utils/installPackage.js';
 import { getPackageManager } from '../utils/packageManager.js';
-import { retrieveCredentials, setCredentials } from '../utils/credentials.js';
-import { areCredentialsSet } from '../utils/credentials.js';
+import {
+  areCredentialsSet,
+  logBrowserAuthUnavailableAndExit,
+} from '../utils/credentials.js';
 import { upload } from './commands/upload.js';
 import { attachSharedFlags, attachTranslateFlags } from './flags.js';
 import { handleStage } from './commands/stage.js';
@@ -337,7 +339,9 @@ export class BaseCLI {
   protected setupLoginCommand(): void {
     this.program
       .command('auth')
-      .description('Generate General Translation API keys and project ID')
+      .description(
+        'Browser-based API key generation is temporarily unavailable'
+      )
       .option(
         '-c, --config <path>',
         'Filepath to config file, by default gt.config.json',
@@ -345,37 +349,11 @@ export class BaseCLI {
       )
       .option(
         '-t, --key-type <type>',
-        'Type of key to generate, production | development | all'
+        'Deprecated while browser-based API key generation is unavailable'
       )
       .action(async (options: LoginOptions) => {
         displayHeader('Authenticating with General Translation...');
-        if (!options.keyType) {
-          options.keyType = await promptSelect<
-            'development' | 'production' | 'all'
-          >({
-            message: 'What type of API key would you like to generate?',
-            options: [
-              { value: 'development', label: 'Development' },
-              { value: 'production', label: 'Production' },
-              { value: 'all', label: 'Both' },
-            ],
-            defaultValue: 'all',
-          });
-        } else {
-          if (
-            options.keyType !== 'development' &&
-            options.keyType !== 'production' &&
-            options.keyType !== 'all'
-          ) {
-            logErrorAndExit(
-              'Invalid key type, must be development, production, or all'
-            );
-          }
-        }
         await this.handleLoginCommand(options);
-        logger.endCommand(
-          `Done! ${options.keyType} keys have been generated and saved to your .env.local file.`
-        );
       });
   }
 
@@ -692,35 +670,21 @@ See https://generaltranslation.com/en/docs/next/guides/local-tx`
 
     // Set credentials
     if (!areCredentialsSet()) {
-      const loginQuestion = useDefaults
-        ? true
-        : await promptConfirm({
-            message:
-              'Would you like the wizard to automatically generate API keys and a project ID for you?',
-            defaultValue: true,
-          });
-      if (loginQuestion) {
-        const settings = await generateSettings({});
-        const keyType = useDefaults
-          ? 'all'
-          : await promptSelect<'development' | 'production' | 'all'>({
-              message: 'What type of API key would you like to generate?',
-              options: [
-                { value: 'development', label: 'Development' },
-                { value: 'production', label: 'Production' },
-                { value: 'all', label: 'Both' },
-              ],
-              defaultValue: 'all',
-            });
-        const credentials = await retrieveCredentials(settings, keyType);
-        await setCredentials(credentials, settings.framework);
-      }
+      // behavior is temporarily disabled, so we return early
+      return;
     }
   }
   protected async handleLoginCommand(options: LoginOptions): Promise<void> {
-    const settings = await generateSettings({ config: options.config });
-    const keyType = options.keyType || 'all';
-    const credentials = await retrieveCredentials(settings, keyType);
-    await setCredentials(credentials, settings.framework);
+    if (
+      options.keyType &&
+      options.keyType !== 'development' &&
+      options.keyType !== 'production' &&
+      options.keyType !== 'all'
+    ) {
+      logErrorAndExit(
+        'Invalid key type, must be development, production, or all'
+      );
+    }
+    logBrowserAuthUnavailableAndExit();
   }
 }

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.14.24';
+export const PACKAGE_VERSION = '2.14.27';

--- a/packages/cli/src/utils/__tests__/credentials.test.ts
+++ b/packages/cli/src/utils/__tests__/credentials.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  BROWSER_AUTH_UNAVAILABLE_MESSAGE,
+  retrieveCredentials,
+} from '../credentials.js';
+import { logErrorAndExit } from '../../console/logging.js';
+import type { Settings } from '../../types/index.js';
+
+vi.mock('../../console/logging.js', () => ({
+  logErrorAndExit: vi.fn((message: string) => {
+    throw new Error(message);
+  }),
+}));
+
+describe('retrieveCredentials', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('fails with manual credential instructions before making auth requests', async () => {
+    await expect(retrieveCredentials({} as Settings, 'all')).rejects.toThrow(
+      BROWSER_AUTH_UNAVAILABLE_MESSAGE
+    );
+
+    expect(logErrorAndExit).toHaveBeenCalledWith(
+      BROWSER_AUTH_UNAVAILABLE_MESSAGE
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/utils/credentials.ts
+++ b/packages/cli/src/utils/credentials.ts
@@ -1,10 +1,11 @@
 import { logErrorAndExit } from '../console/logging.js';
-import { logger } from '../console/logger.js';
 import path from 'node:path';
 import fs from 'node:fs';
 import { Settings, SupportedFrameworks } from '../types/index.js';
-import chalk from 'chalk';
-import apiRequest from './fetch.js';
+
+export const BROWSER_AUTH_UNAVAILABLE_MESSAGE =
+  'Automatic browser-based CLI login is temporarily unavailable. Create an API key in the General Translation dashboard, then provide credentials manually: set GT_PROJECT_ID and GT_API_KEY (or GT_DEV_API_KEY) environment variables, add projectId to gt.config.json, or pass --project-id and --api-key to commands that support them.';
+
 // Type for credentials returned from the dashboard
 type Credentials = {
   apiKeys: ApiKey[];
@@ -16,84 +17,16 @@ type ApiKey = {
   type: 'development' | 'production';
 };
 
-// Fetches project ID and API key by opening the dashboard in the browser
+// Browser credential retrieval is temporarily unavailable.
 export async function retrieveCredentials(
-  settings: Settings,
-  keyType: 'development' | 'production' | 'all'
+  _settings: Settings,
+  _keyType: 'development' | 'production' | 'all'
 ): Promise<Credentials> {
-  // Generate a session ID
-  const { sessionId } = await generateCredentialsSession(
-    settings.baseUrl,
-    keyType
-  );
-
-  const urlToOpen = `${settings.dashboardUrl}/cli/wizard/${sessionId}`;
-  await import('open').then((open) =>
-    open.default(urlToOpen, {
-      wait: false,
-    })
-  );
-
-  logger.message(
-    `${chalk.dim(
-      `If the browser window didn't open automatically, please open the following link:`
-    )}\n\n${chalk.cyan(urlToOpen)}`
-  );
-
-  const spinner = logger.createSpinner('dots');
-  spinner.start('Waiting for response from dashboard...');
-
-  const credentials = await new Promise<Credentials>(
-    async (resolve, reject) => {
-      const interval = setInterval(async () => {
-        // Ping the dashboard to see if the credentials are set
-        try {
-          const res = await apiRequest(
-            settings.baseUrl,
-            `/cli/wizard/${sessionId}`,
-            { method: 'GET' }
-          );
-          if (res.status === 200) {
-            const data = await res.json();
-            resolve(data as Credentials);
-            clearInterval(interval);
-            clearTimeout(timeout);
-            apiRequest(settings.baseUrl, `/cli/wizard/${sessionId}`, {
-              method: 'DELETE',
-            });
-          }
-        } catch (err) {
-          console.error(err);
-        }
-      }, 2000);
-      // timeout after 1 hour
-      const timeout = setTimeout(
-        () => {
-          spinner.stop('Timed out');
-          clearInterval(interval);
-          logErrorAndExit('Timed out waiting for response from dashboard');
-        },
-        1000 * 60 * 60
-      );
-    }
-  );
-  spinner.stop('Received credentials');
-  return credentials;
+  return logBrowserAuthUnavailableAndExit();
 }
 
-export async function generateCredentialsSession(
-  url: string,
-  keyType: 'development' | 'production' | 'all'
-): Promise<{
-  sessionId: string;
-}> {
-  const res = await apiRequest(url, '/cli/wizard/session', {
-    body: { keyType },
-  });
-  if (!res.ok) {
-    logErrorAndExit('Failed to generate credentials session');
-  }
-  return await res.json();
+export function logBrowserAuthUnavailableAndExit(): never {
+  return logErrorAndExit(BROWSER_AUTH_UNAVAILABLE_MESSAGE);
 }
 
 // Checks if the credentials are set in the environment variables


### PR DESCRIPTION
browser auth no longer supported on API. will be brought back in future. disable for now

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR temporarily disables browser-based CLI authentication across the `gt auth` command and the `gt init` wizard by replacing the browser-polling flow with immediate `logBrowserAuthUnavailableAndExit()` calls and adding a unit-tested early return when credentials are absent. The core mechanics are sound, but `setCredentials` is now an exported function with no remaining callers, and the init-wizard credential step exits silently without directing the user to set credentials manually.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for the temporary disable; user-facing UX gap (silent return in init wizard) is worth addressing before this lands in production.

All findings are P2 style issues or already discussed in prior threads. No runtime errors, data loss, or security issues introduced. Score held at 4 rather than 5 because of the silent credential skip already flagged in prior review threads.

packages/cli/src/cli/base.ts (silent return at credential step) and packages/cli/src/utils/credentials.ts (dead setCredentials export)
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/utils/credentials.ts | Browser-auth logic gutted; `retrieveCredentials` now immediately calls `logBrowserAuthUnavailableAndExit`, but `setCredentials` is retained as unreferenced dead code. |
| packages/cli/src/cli/base.ts | `auth` command and init-wizard credential step disabled; `auth` command now always calls `logBrowserAuthUnavailableAndExit`, while init-wizard silently returns early when credentials are absent. |
| packages/cli/src/cli/__tests__/base.test.ts | New test covering init-wizard credential skip; verifies `createOrUpdateConfig` is still called and no error/warn is surfaced — locks in silent-skip behavior. |
| packages/cli/src/utils/__tests__/credentials.test.ts | New test confirming `retrieveCredentials` throws immediately with `BROWSER_AUTH_UNAVAILABLE_MESSAGE` and never calls `fetch`. |
| .changeset/quiet-browsers-bow.md | Patch-level changeset entry documenting the temporary disable of browser-based CLI auth. |
| packages/cli/src/generated/version.ts | Auto-generated version bump from 2.14.24 to 2.14.27. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User runs `gt auth`] --> B[handleLoginCommand]
    B --> C{keyType passed\nand invalid?}
    C -- Yes --> D[logErrorAndExit\n'Invalid key type...']
    C -- No --> E[logBrowserAuthUnavailableAndExit\nPrint BROWSER_AUTH_UNAVAILABLE_MESSAGE]

    F[User runs `gt init`] --> G[handleInitCommand wizard]
    G --> H[createOrUpdateConfig written]
    H --> I{areCredentialsSet?}
    I -- Yes --> J[Continue wizard\n- install gt pkg\n- set credentials]
    I -- No --> K[return early silently\nno message shown]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/cli/src/utils/credentials.ts
Line: 41-102

Comment:
**`setCredentials` is now unreachable dead code**

`setCredentials` is no longer imported anywhere in the codebase — `grep` confirms the only file that referenced it (`base.ts`) dropped the import in this PR. The function body still writes to `.env.local` and mutates `.gitignore`, so leaving it exported could cause confusion when the feature is re-enabled and callers are wired back up with a stale implementation. If preserving it for the planned revival is intentional, a comment explaining that would help; otherwise it can be removed for now alongside the other deleted browser-auth code.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: disable browser auth"](https://github.com/generaltranslation/gt/commit/ca62dadd3fe9d0eb9f085c1ad94c302bb39fc794) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30113736)</sub>

<!-- /greptile_comment -->