### PR TITLE
fix(cli): warn when translated files fail to download

### DIFF
--- a/.changeset/better-oranges-dance.md
+++ b/.changeset/better-oranges-dance.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+fix: silent error on download file failure

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.14.20';
+export const PACKAGE_VERSION = '2.14.22';

--- a/packages/cli/src/workflows/steps/DownloadStep.ts
+++ b/packages/cli/src/workflows/steps/DownloadStep.ts
@@ -98,6 +98,13 @@ export class DownloadTranslationsStep extends WorkflowStep<
         logger.warn(
           `Failed to download ${missing.length} file(s):\n${missing.map((f) => `- ${f.fileName} (${f.locale})`).join('\n')}`
         );
+        for (const f of missing) {
+          recordWarning(
+            'failed_download',
+            f.fileName,
+            `Failed to download for locale ${f.locale}`
+          );
+        }
       }
 
       // Prepare batch download data

--- a/packages/cli/src/workflows/steps/DownloadStep.ts
+++ b/packages/cli/src/workflows/steps/DownloadStep.ts
@@ -83,6 +83,23 @@ export class DownloadTranslationsStep extends WorkflowStep<
         (file) => file.completedAt !== null
       );
 
+      if (readyTranslations.length < currentQueryData.length) {
+        const readyKeys = new Set(
+          readyTranslations.map(
+            (t) => `${t.branchId}:${t.fileId}:${t.versionId}:${t.locale}`
+          )
+        );
+        const missing = currentQueryData.filter(
+          (item) =>
+            !readyKeys.has(
+              `${item.branchId}:${item.fileId}:${item.versionId}:${item.locale}`
+            )
+        );
+        logger.warn(
+          `Failed to download ${missing.length} file(s):\n${missing.map((f) => `- ${f.fileName} (${f.locale})`).join('\n')}`
+        );
+      }
+
       // Prepare batch download data
       const batchFiles: BatchedFiles = readyTranslations
         .map((translation) => {


### PR DESCRIPTION
### Description

When a translation job completes but the server has no translated file record, the CLI silently reports "No files to download" with a green checkmark. This adds a warning that lists the specific files and locales that failed, so the issue is visible instead of silent.

### Test plan
- Run `pnpm gt translate` with a POT file config using `transformationFormat: "PO"`
- Verify the warning lists the missing files instead of silently succeeding

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR surfaces a previously silent failure: when `queryFileData` returns no record for a completed translation job, the CLI now emits a `logger.warn` and records each missing file via `recordWarning` instead of quietly showing a green "No files to download". The key-based diff between `readyTranslations` and `currentQueryData` is consistent with the existing composite key format used elsewhere in the file.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the fix correctly surfaces silent download failures, with one minor UX inconsistency around the success spinner.

Only P2 findings — the warning logic is correct and consistent with existing patterns, but the spinner still shows green success when all files fail to download, which partially undercuts the new warning.

packages/cli/src/workflows/steps/DownloadStep.ts — the return value and spinner path when all files are missing.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/workflows/steps/DownloadStep.ts | Adds a warning block that identifies `currentQueryData` items absent from `readyTranslations` and calls `recordWarning` for each; returns `true` regardless, so the spinner still shows success even when all files are missing. |
| .changeset/better-oranges-dance.md | Standard changeset entry for a patch-level fix; correctly targets the `gt` package. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[downloadFiles called] --> B{currentQueryData empty?}
    B -- yes --> C[return true]
    B -- no --> D[queryFileData API call]
    D --> E[filter readyTranslations where completedAt != null]
    E --> F{readyTranslations.length < currentQueryData.length?}
    F -- yes --> G[compute missing items via readyKeys set]
    G --> H[logger.warn with missing file list]
    H --> I[recordWarning for each missing file]
    I --> J[build batchFiles from readyTranslations]
    F -- no --> J
    J --> K{batchFiles empty?}
    K -- yes --> L[spinner: 'No files to download']
    K -- no --> M[downloadFilesWithRetry]
    M --> N{failed.length > 0?}
    N -- yes --> O[logger.warn + recordWarning for failed]
    N -- no --> P[spinner: success]
    O --> P
    L --> Q[return true]
    P --> Q
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/cli/src/workflows/steps/DownloadStep.ts
Line: 86-108

Comment:
**Misleading spinner when all files are missing**

When every file in `currentQueryData` is missing from `readyTranslations` (the scenario described in the PR), `batchFiles` is empty so the code falls into the `else` branch at line 165 and stops the spinner with `chalk.green('No files to download')`. Because `downloadFiles` still returns `true`, `run()` then calls `this.spinner.stop(chalk.green('Downloaded files successfully'))`. The user sees a green success message right after the `logger.warn` output, which partially undercuts the new warning.

Consider returning `false` (or a distinct status) when `missing.length > 0` so the spinner in `run()` shows the red "Failed to download files" path instead.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;e/cli/fix-no-files-to-down..."](https://github.com/generaltranslation/gt/commit/1c658d460e2632b3d3b29b35b4e6b5bd9e30a145) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30200246)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->