### PR TITLE
fix: resolve locale fallback and alias edge cases

### DIFF
--- a/.changeset/friendly-locale-fallbacks.md
+++ b/.changeset/friendly-locale-fallbacks.md
@@ -1,0 +1,7 @@
+---
+'gt-i18n': patch
+'gt-react': patch
+'gt-tanstack-start': patch
+---
+
+Fix source-locale interpolation for missing translations and resolve custom locale aliases consistently in browser and TanStack Start locale detection.

--- a/packages/i18n/src/translation-functions/internal/__tests__/helpers.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/helpers.test.ts
@@ -35,6 +35,8 @@ describe('translation helpers', () => {
       lookupTranslationWithFallback: vi
         .fn()
         .mockResolvedValue('Bonjour {name} !'),
+      getDefaultLocale: vi.fn().mockReturnValue('en'),
+      getLocale: vi.fn().mockReturnValue('fr'),
     };
     vi.mocked(getI18nManager).mockReturnValue(mockManager as any);
 
@@ -44,13 +46,15 @@ describe('translation helpers', () => {
     expect(interpolateMessage).toHaveBeenCalledWith({
       source: 'Hello {name}!',
       target: 'Bonjour {name} !',
-      options: expect.objectContaining({ $format: 'STRING' }),
+      options: expect.objectContaining({ $format: 'STRING', $locale: 'fr' }),
     });
   });
 
   it('resolveStringContentWithFallback interpolates source when no translation found', () => {
     const mockManager = {
       lookupTranslation: vi.fn().mockReturnValue(undefined),
+      getDefaultLocale: vi.fn().mockReturnValue('en'),
+      getLocale: vi.fn().mockReturnValue('fr'),
     };
     vi.mocked(getI18nManager).mockReturnValue(mockManager as any);
 
@@ -60,7 +64,7 @@ describe('translation helpers', () => {
     expect(interpolateMessage).toHaveBeenCalledWith({
       source: 'Hello {name}!',
       target: undefined,
-      options: expect.objectContaining({ $format: 'STRING' }),
+      options: expect.objectContaining({ $format: 'STRING', $locale: 'en' }),
     });
   });
 });

--- a/packages/i18n/src/translation-functions/internal/__tests__/helpers.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/helpers.test.ts
@@ -35,8 +35,6 @@ describe('translation helpers', () => {
       lookupTranslationWithFallback: vi
         .fn()
         .mockResolvedValue('Bonjour {name} !'),
-      getDefaultLocale: vi.fn().mockReturnValue('en'),
-      getLocale: vi.fn().mockReturnValue('fr'),
     };
     vi.mocked(getI18nManager).mockReturnValue(mockManager as any);
 
@@ -46,15 +44,13 @@ describe('translation helpers', () => {
     expect(interpolateMessage).toHaveBeenCalledWith({
       source: 'Hello {name}!',
       target: 'Bonjour {name} !',
-      options: expect.objectContaining({ $format: 'STRING', $locale: 'fr' }),
+      options: expect.objectContaining({ $format: 'STRING' }),
     });
   });
 
   it('resolveStringContentWithFallback interpolates source when no translation found', () => {
     const mockManager = {
       lookupTranslation: vi.fn().mockReturnValue(undefined),
-      getDefaultLocale: vi.fn().mockReturnValue('en'),
-      getLocale: vi.fn().mockReturnValue('fr'),
     };
     vi.mocked(getI18nManager).mockReturnValue(mockManager as any);
 
@@ -64,7 +60,7 @@ describe('translation helpers', () => {
     expect(interpolateMessage).toHaveBeenCalledWith({
       source: 'Hello {name}!',
       target: undefined,
-      options: expect.objectContaining({ $format: 'STRING', $locale: 'en' }),
+      options: expect.objectContaining({ $format: 'STRING' }),
     });
   });
 });

--- a/packages/i18n/src/translation-functions/internal/__tests__/helpers.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/helpers.test.ts
@@ -20,6 +20,7 @@ describe('translation helpers', () => {
 
   it('resolveJsx returns undefined when lookupTranslation returns undefined', () => {
     const mockManager = {
+      getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslation: vi.fn().mockReturnValue(undefined),
     };
     vi.mocked(getI18nManager).mockReturnValue(mockManager as any);
@@ -32,6 +33,7 @@ describe('translation helpers', () => {
 
   it('resolveStringContentWithRuntimeFallback calls lookupTranslationWithFallback and interpolates', async () => {
     const mockManager = {
+      getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslationWithFallback: vi
         .fn()
         .mockResolvedValue('Bonjour {name} !'),
@@ -44,12 +46,13 @@ describe('translation helpers', () => {
     expect(interpolateMessage).toHaveBeenCalledWith({
       source: 'Hello {name}!',
       target: 'Bonjour {name} !',
-      options: expect.objectContaining({ $format: 'STRING' }),
+      options: expect.objectContaining({ $format: 'STRING', $locale: 'fr' }),
     });
   });
 
   it('resolveStringContentWithFallback interpolates source when no translation found', () => {
     const mockManager = {
+      getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslation: vi.fn().mockReturnValue(undefined),
     };
     vi.mocked(getI18nManager).mockReturnValue(mockManager as any);
@@ -60,7 +63,7 @@ describe('translation helpers', () => {
     expect(interpolateMessage).toHaveBeenCalledWith({
       source: 'Hello {name}!',
       target: undefined,
-      options: expect.objectContaining({ $format: 'STRING' }),
+      options: expect.objectContaining({ $format: 'STRING', $locale: 'fr' }),
     });
   });
 });

--- a/packages/i18n/src/translation-functions/internal/__tests__/resolveTranslationSync.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/resolveTranslationSync.test.ts
@@ -15,6 +15,8 @@ describe('resolveTranslationSync', () => {
   it('should call interpolateMessage with source, target, and options when translation found', () => {
     const mockManager = {
       lookupTranslation: vi.fn().mockReturnValue('Bonjour {name} !'),
+      getDefaultLocale: vi.fn().mockReturnValue('en'),
+      getLocale: vi.fn().mockReturnValue('fr'),
     };
     vi.mocked(getI18nManager).mockReturnValue(mockManager as any);
 
@@ -28,6 +30,7 @@ describe('resolveTranslationSync', () => {
       target: 'Bonjour {name} !',
       options: {
         $format: 'ICU',
+        $locale: 'fr',
         name: 'Alice',
       },
     });
@@ -51,6 +54,8 @@ describe('resolveTranslationSync', () => {
   it('should preserve user options when translation found', () => {
     const mockManager = {
       lookupTranslation: vi.fn().mockReturnValue('Translated'),
+      getDefaultLocale: vi.fn().mockReturnValue('en'),
+      getLocale: vi.fn().mockReturnValue('fr'),
     };
     vi.mocked(getI18nManager).mockReturnValue(mockManager as any);
 
@@ -64,6 +69,7 @@ describe('resolveTranslationSync', () => {
       target: 'Translated',
       options: {
         $format: 'ICU',
+        $locale: 'fr',
         name: 'Bob',
         $context: 'greeting',
         $id: 'hello-msg',
@@ -74,6 +80,8 @@ describe('resolveTranslationSync', () => {
   it('should preserve $format in options passed to interpolateMessage', () => {
     const mockManager = {
       lookupTranslation: vi.fn().mockReturnValue('Translated'),
+      getDefaultLocale: vi.fn().mockReturnValue('en'),
+      getLocale: vi.fn().mockReturnValue('fr'),
     };
     vi.mocked(getI18nManager).mockReturnValue(mockManager as any);
 
@@ -87,6 +95,7 @@ describe('resolveTranslationSync', () => {
       target: 'Translated',
       options: {
         $format: 'STRING',
+        $locale: 'fr',
         name: 'Alice',
       },
     });

--- a/packages/i18n/src/translation-functions/internal/__tests__/resolveTranslationSync.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/resolveTranslationSync.test.ts
@@ -15,8 +15,6 @@ describe('resolveTranslationSync', () => {
   it('should call interpolateMessage with source, target, and options when translation found', () => {
     const mockManager = {
       lookupTranslation: vi.fn().mockReturnValue('Bonjour {name} !'),
-      getDefaultLocale: vi.fn().mockReturnValue('en'),
-      getLocale: vi.fn().mockReturnValue('fr'),
     };
     vi.mocked(getI18nManager).mockReturnValue(mockManager as any);
 
@@ -30,7 +28,6 @@ describe('resolveTranslationSync', () => {
       target: 'Bonjour {name} !',
       options: {
         $format: 'ICU',
-        $locale: 'fr',
         name: 'Alice',
       },
     });
@@ -54,8 +51,6 @@ describe('resolveTranslationSync', () => {
   it('should preserve user options when translation found', () => {
     const mockManager = {
       lookupTranslation: vi.fn().mockReturnValue('Translated'),
-      getDefaultLocale: vi.fn().mockReturnValue('en'),
-      getLocale: vi.fn().mockReturnValue('fr'),
     };
     vi.mocked(getI18nManager).mockReturnValue(mockManager as any);
 
@@ -69,7 +64,6 @@ describe('resolveTranslationSync', () => {
       target: 'Translated',
       options: {
         $format: 'ICU',
-        $locale: 'fr',
         name: 'Bob',
         $context: 'greeting',
         $id: 'hello-msg',
@@ -80,8 +74,6 @@ describe('resolveTranslationSync', () => {
   it('should preserve $format in options passed to interpolateMessage', () => {
     const mockManager = {
       lookupTranslation: vi.fn().mockReturnValue('Translated'),
-      getDefaultLocale: vi.fn().mockReturnValue('en'),
-      getLocale: vi.fn().mockReturnValue('fr'),
     };
     vi.mocked(getI18nManager).mockReturnValue(mockManager as any);
 
@@ -95,7 +87,6 @@ describe('resolveTranslationSync', () => {
       target: 'Translated',
       options: {
         $format: 'STRING',
-        $locale: 'fr',
         name: 'Alice',
       },
     });

--- a/packages/i18n/src/translation-functions/internal/__tests__/resolveTranslationSync.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/resolveTranslationSync.test.ts
@@ -14,6 +14,7 @@ describe('resolveTranslationSync', () => {
 
   it('should call interpolateMessage with source, target, and options when translation found', () => {
     const mockManager = {
+      getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslation: vi.fn().mockReturnValue('Bonjour {name} !'),
     };
     vi.mocked(getI18nManager).mockReturnValue(mockManager as any);
@@ -28,6 +29,7 @@ describe('resolveTranslationSync', () => {
       target: 'Bonjour {name} !',
       options: {
         $format: 'ICU',
+        $locale: 'fr',
         name: 'Alice',
       },
     });
@@ -35,6 +37,7 @@ describe('resolveTranslationSync', () => {
 
   it('should return undefined when no translation found', () => {
     const mockManager = {
+      getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslation: vi.fn().mockReturnValue(undefined),
     };
     vi.mocked(getI18nManager).mockReturnValue(mockManager as any);
@@ -50,6 +53,7 @@ describe('resolveTranslationSync', () => {
 
   it('should preserve user options when translation found', () => {
     const mockManager = {
+      getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslation: vi.fn().mockReturnValue('Translated'),
     };
     vi.mocked(getI18nManager).mockReturnValue(mockManager as any);
@@ -64,6 +68,7 @@ describe('resolveTranslationSync', () => {
       target: 'Translated',
       options: {
         $format: 'ICU',
+        $locale: 'fr',
         name: 'Bob',
         $context: 'greeting',
         $id: 'hello-msg',
@@ -73,6 +78,7 @@ describe('resolveTranslationSync', () => {
 
   it('should preserve $format in options passed to interpolateMessage', () => {
     const mockManager = {
+      getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslation: vi.fn().mockReturnValue('Translated'),
     };
     vi.mocked(getI18nManager).mockReturnValue(mockManager as any);
@@ -87,6 +93,7 @@ describe('resolveTranslationSync', () => {
       target: 'Translated',
       options: {
         $format: 'STRING',
+        $locale: 'fr',
         name: 'Alice',
       },
     });

--- a/packages/i18n/src/translation-functions/internal/getGT.ts
+++ b/packages/i18n/src/translation-functions/internal/getGT.ts
@@ -16,8 +16,6 @@ export async function getGT(): Promise<GTFunctionType> {
   // Get the translation resolver
   const i18nManager = getI18nManager();
   const lookupTranslation = await i18nManager.getLookupTranslation();
-  const targetLocale = i18nManager.getLocale();
-  const sourceLocale = i18nManager.getDefaultLocale();
 
   /**
    * Registers a message at build time and resolves its translation at runtime.
@@ -41,7 +39,6 @@ export async function getGT(): Promise<GTFunctionType> {
   ) => {
     const resolutionOptions: LookupOptions = {
       $format: 'ICU',
-      $locale: targetLocale,
       ...options,
     };
 
@@ -52,13 +49,7 @@ export async function getGT(): Promise<GTFunctionType> {
     return interpolateMessage({
       source: message,
       target: translation,
-      options: {
-        ...resolutionOptions,
-        $locale:
-          translation == null
-            ? sourceLocale
-            : (resolutionOptions.$locale ?? targetLocale),
-      },
+      options: resolutionOptions,
     });
   };
 

--- a/packages/i18n/src/translation-functions/internal/getGT.ts
+++ b/packages/i18n/src/translation-functions/internal/getGT.ts
@@ -40,6 +40,7 @@ export async function getGT(): Promise<GTFunctionType> {
     const resolutionOptions: LookupOptions = {
       $format: 'ICU',
       ...options,
+      $locale: options.$locale ?? i18nManager.getLocale(),
     };
 
     // Lookup translation

--- a/packages/i18n/src/translation-functions/internal/getGT.ts
+++ b/packages/i18n/src/translation-functions/internal/getGT.ts
@@ -47,19 +47,18 @@ export async function getGT(): Promise<GTFunctionType> {
 
     // Lookup translation
     const translation = lookupTranslation(message, resolutionOptions);
-    const interpolationOptions =
-      translation == null
-        ? {
-            ...resolutionOptions,
-            $locale: sourceLocale,
-          }
-        : resolutionOptions;
 
     // Format result
     return interpolateMessage({
       source: message,
       target: translation,
-      options: interpolationOptions,
+      options: {
+        ...resolutionOptions,
+        $locale:
+          translation == null
+            ? sourceLocale
+            : (resolutionOptions.$locale ?? targetLocale),
+      },
     });
   };
 

--- a/packages/i18n/src/translation-functions/internal/getGT.ts
+++ b/packages/i18n/src/translation-functions/internal/getGT.ts
@@ -16,6 +16,8 @@ export async function getGT(): Promise<GTFunctionType> {
   // Get the translation resolver
   const i18nManager = getI18nManager();
   const lookupTranslation = await i18nManager.getLookupTranslation();
+  const targetLocale = i18nManager.getLocale();
+  const sourceLocale = i18nManager.getDefaultLocale();
 
   /**
    * Registers a message at build time and resolves its translation at runtime.
@@ -39,17 +41,25 @@ export async function getGT(): Promise<GTFunctionType> {
   ) => {
     const resolutionOptions: LookupOptions = {
       $format: 'ICU',
+      $locale: targetLocale,
       ...options,
     };
 
     // Lookup translation
     const translation = lookupTranslation(message, resolutionOptions);
+    const interpolationOptions =
+      translation == null
+        ? {
+            ...resolutionOptions,
+            $locale: sourceLocale,
+          }
+        : resolutionOptions;
 
     // Format result
     return interpolateMessage({
       source: message,
       target: translation,
-      options: resolutionOptions,
+      options: interpolationOptions,
     });
   };
 

--- a/packages/i18n/src/translation-functions/internal/helpers.ts
+++ b/packages/i18n/src/translation-functions/internal/helpers.ts
@@ -72,7 +72,11 @@ export function resolveStringContent(
   return interpolateMessage({
     source: content,
     target: translation,
-    options: lookupOptions as InterpolationOptions,
+    options: getInterpolationOptions(
+      lookupOptions as InterpolationOptions,
+      i18nManager,
+      translation
+    ),
   });
 }
 
@@ -89,7 +93,11 @@ export function resolveStringContentWithFallback(
   return interpolateMessage({
     source: content,
     target: translation,
-    options: lookupOptions as InterpolationOptions,
+    options: getInterpolationOptions(
+      lookupOptions as InterpolationOptions,
+      i18nManager,
+      translation
+    ),
   });
 }
 
@@ -111,7 +119,11 @@ export async function resolveStringContentWithRuntimeFallback(
   return interpolateMessage({
     source: content,
     target: translation,
-    options: lookupOptions as InterpolationOptions,
+    options: getInterpolationOptions(
+      lookupOptions as InterpolationOptions,
+      i18nManager,
+      translation
+    ),
   });
 }
 // ----- HELPER FUNCTIONS ----- //
@@ -125,6 +137,23 @@ function getLookupOptions<T extends DataFormat>(
 ): LookupOptions {
   return {
     $format: format,
+    ...options,
+  };
+}
+
+function getInterpolationOptions(
+  options: InterpolationOptions,
+  i18nManager: ReturnType<typeof getI18nManager>,
+  translation: StringContent | undefined
+): InterpolationOptions {
+  if (translation == null) {
+    return {
+      ...options,
+      $locale: i18nManager.getDefaultLocale(),
+    };
+  }
+  return {
+    $locale: i18nManager.getLocale(),
     ...options,
   };
 }

--- a/packages/i18n/src/translation-functions/internal/helpers.ts
+++ b/packages/i18n/src/translation-functions/internal/helpers.ts
@@ -126,5 +126,6 @@ function getLookupOptions<T extends DataFormat>(
   return {
     $format: format,
     ...options,
+    $locale: options.$locale ?? getI18nManager().getLocale(),
   };
 }

--- a/packages/i18n/src/translation-functions/internal/helpers.ts
+++ b/packages/i18n/src/translation-functions/internal/helpers.ts
@@ -69,12 +69,11 @@ export function resolveStringContent(
   const i18nManager = getI18nManager();
   const translation = i18nManager.lookupTranslation(content, lookupOptions);
   if (translation == null) return undefined;
-  return interpolateStringResolution(
-    content,
-    translation,
-    lookupOptions as InterpolationOptions,
-    i18nManager
-  );
+  return interpolateMessage({
+    source: content,
+    target: translation,
+    options: lookupOptions as InterpolationOptions,
+  });
 }
 
 /**
@@ -87,12 +86,11 @@ export function resolveStringContentWithFallback(
   const lookupOptions = getLookupOptions(options, 'STRING');
   const i18nManager = getI18nManager();
   const translation = i18nManager.lookupTranslation(content, lookupOptions);
-  return interpolateStringResolution(
-    content,
-    translation,
-    lookupOptions as InterpolationOptions,
-    i18nManager
-  );
+  return interpolateMessage({
+    source: content,
+    target: translation,
+    options: lookupOptions as InterpolationOptions,
+  });
 }
 
 /**
@@ -110,12 +108,11 @@ export async function resolveStringContentWithRuntimeFallback(
     content,
     lookupOptions
   );
-  return interpolateStringResolution(
-    content,
-    translation,
-    lookupOptions as InterpolationOptions,
-    i18nManager
-  );
+  return interpolateMessage({
+    source: content,
+    target: translation,
+    options: lookupOptions as InterpolationOptions,
+  });
 }
 // ----- HELPER FUNCTIONS ----- //
 
@@ -130,23 +127,4 @@ function getLookupOptions<T extends DataFormat>(
     $format: format,
     ...options,
   };
-}
-
-function interpolateStringResolution(
-  content: StringContent,
-  translation: StringContent | undefined,
-  options: InterpolationOptions,
-  i18nManager: ReturnType<typeof getI18nManager>
-): StringContent {
-  return interpolateMessage({
-    source: content,
-    target: translation,
-    options: {
-      ...options,
-      $locale:
-        translation == null
-          ? i18nManager.getDefaultLocale()
-          : options.$locale ?? i18nManager.getLocale(),
-    },
-  });
 }

--- a/packages/i18n/src/translation-functions/internal/helpers.ts
+++ b/packages/i18n/src/translation-functions/internal/helpers.ts
@@ -1,15 +1,20 @@
 import { getI18nManager } from '../../i18n-manager/singleton-operations';
-import { LookupOptions, ResolutionOptions } from '../types/options';
-import {
-  interpolateMessage,
-  InterpolationOptions,
-} from '../utils/interpolation/interpolateMessage';
+import { ResolutionOptions } from '../types/options';
+import { interpolateMessage } from '../utils/interpolation/interpolateMessage';
 import type {
   DataFormat,
   JsxChildren,
   StringContent,
   StringFormat,
 } from 'generaltranslation/types';
+
+type NormalizedLookupOptions<T extends DataFormat> = Omit<
+  ResolutionOptions<T>,
+  '$format' | '$locale'
+> & {
+  $format: T;
+  $locale: string;
+};
 
 // ----- JSX TRANSLATION FUNCTIONS ----- //
 
@@ -72,7 +77,7 @@ export function resolveStringContent(
   return interpolateMessage({
     source: content,
     target: translation,
-    options: lookupOptions as InterpolationOptions,
+    options: lookupOptions,
   });
 }
 
@@ -89,7 +94,7 @@ export function resolveStringContentWithFallback(
   return interpolateMessage({
     source: content,
     target: translation,
-    options: lookupOptions as InterpolationOptions,
+    options: lookupOptions,
   });
 }
 
@@ -111,7 +116,7 @@ export async function resolveStringContentWithRuntimeFallback(
   return interpolateMessage({
     source: content,
     target: translation,
-    options: lookupOptions as InterpolationOptions,
+    options: lookupOptions,
   });
 }
 // ----- HELPER FUNCTIONS ----- //
@@ -122,10 +127,12 @@ export async function resolveStringContentWithRuntimeFallback(
 function getLookupOptions<T extends DataFormat>(
   options: ResolutionOptions<T>,
   format: T
-): LookupOptions {
+): NormalizedLookupOptions<T> {
+  const { $format = format, $locale, ...restOptions } = options;
+
   return {
-    $format: format,
-    ...options,
-    $locale: options.$locale ?? getI18nManager().getLocale(),
+    ...restOptions,
+    $format,
+    $locale: $locale ?? getI18nManager().getLocale(),
   };
 }

--- a/packages/i18n/src/translation-functions/internal/helpers.ts
+++ b/packages/i18n/src/translation-functions/internal/helpers.ts
@@ -69,15 +69,12 @@ export function resolveStringContent(
   const i18nManager = getI18nManager();
   const translation = i18nManager.lookupTranslation(content, lookupOptions);
   if (translation == null) return undefined;
-  return interpolateMessage({
-    source: content,
-    target: translation,
-    options: getInterpolationOptions(
-      lookupOptions as InterpolationOptions,
-      i18nManager,
-      translation
-    ),
-  });
+  return interpolateStringResolution(
+    content,
+    translation,
+    lookupOptions as InterpolationOptions,
+    i18nManager
+  );
 }
 
 /**
@@ -90,15 +87,12 @@ export function resolveStringContentWithFallback(
   const lookupOptions = getLookupOptions(options, 'STRING');
   const i18nManager = getI18nManager();
   const translation = i18nManager.lookupTranslation(content, lookupOptions);
-  return interpolateMessage({
-    source: content,
-    target: translation,
-    options: getInterpolationOptions(
-      lookupOptions as InterpolationOptions,
-      i18nManager,
-      translation
-    ),
-  });
+  return interpolateStringResolution(
+    content,
+    translation,
+    lookupOptions as InterpolationOptions,
+    i18nManager
+  );
 }
 
 /**
@@ -116,15 +110,12 @@ export async function resolveStringContentWithRuntimeFallback(
     content,
     lookupOptions
   );
-  return interpolateMessage({
-    source: content,
-    target: translation,
-    options: getInterpolationOptions(
-      lookupOptions as InterpolationOptions,
-      i18nManager,
-      translation
-    ),
-  });
+  return interpolateStringResolution(
+    content,
+    translation,
+    lookupOptions as InterpolationOptions,
+    i18nManager
+  );
 }
 // ----- HELPER FUNCTIONS ----- //
 
@@ -141,19 +132,21 @@ function getLookupOptions<T extends DataFormat>(
   };
 }
 
-function getInterpolationOptions(
+function interpolateStringResolution(
+  content: StringContent,
+  translation: StringContent | undefined,
   options: InterpolationOptions,
-  i18nManager: ReturnType<typeof getI18nManager>,
-  translation: StringContent | undefined
-): InterpolationOptions {
-  if (translation == null) {
-    return {
+  i18nManager: ReturnType<typeof getI18nManager>
+): StringContent {
+  return interpolateMessage({
+    source: content,
+    target: translation,
+    options: {
       ...options,
-      $locale: i18nManager.getDefaultLocale(),
-    };
-  }
-  return {
-    $locale: i18nManager.getLocale(),
-    ...options,
-  };
+      $locale:
+        translation == null
+          ? i18nManager.getDefaultLocale()
+          : options.$locale ?? i18nManager.getLocale(),
+    },
+  });
 }

--- a/packages/i18n/src/translation-functions/utils/interpolation/__tests__/interpolateMessage.test.ts
+++ b/packages/i18n/src/translation-functions/utils/interpolation/__tests__/interpolateMessage.test.ts
@@ -1,24 +1,15 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { interpolateMessage } from '../interpolateMessage';
-import { getI18nManager } from '../../../../i18n-manager/singleton-operations';
-
-vi.mock('../../../../i18n-manager/singleton-operations', () => ({
-  getI18nManager: vi.fn(),
-}));
 
 describe('interpolateMessage', () => {
-  it('formats missing translation fallback with the source locale', () => {
-    vi.mocked(getI18nManager).mockReturnValue({
-      getDefaultLocale: () => 'en',
-    } as ReturnType<typeof getI18nManager>);
-
+  it('formats missing translation fallback with the provided locale', () => {
     expect(
       interpolateMessage({
         source: 'Value {n, number}',
         target: undefined,
         options: {
           $format: 'ICU',
-          $locale: 'fr',
+          $locale: 'en',
           n: 1234.5,
         },
       })

--- a/packages/i18n/src/translation-functions/utils/interpolation/__tests__/interpolateMessage.test.ts
+++ b/packages/i18n/src/translation-functions/utils/interpolation/__tests__/interpolateMessage.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest';
+import { interpolateMessage } from '../interpolateMessage';
+import { getI18nManager } from '../../../../i18n-manager/singleton-operations';
+
+vi.mock('../../../../i18n-manager/singleton-operations', () => ({
+  getI18nManager: vi.fn(),
+}));
+
+describe('interpolateMessage', () => {
+  it('formats missing translation fallback with the source locale', () => {
+    vi.mocked(getI18nManager).mockReturnValue({
+      getDefaultLocale: () => 'en',
+    } as ReturnType<typeof getI18nManager>);
+
+    expect(
+      interpolateMessage({
+        source: 'Value {n, number}',
+        target: undefined,
+        options: {
+          $format: 'ICU',
+          $locale: 'fr',
+          n: 1234.5,
+        },
+      })
+    ).toBe('Value 1,234.5');
+  });
+});

--- a/packages/i18n/src/translation-functions/utils/interpolation/__tests__/interpolateMessage.test.ts
+++ b/packages/i18n/src/translation-functions/utils/interpolation/__tests__/interpolateMessage.test.ts
@@ -1,15 +1,25 @@
 import { describe, expect, it } from 'vitest';
+import { I18nManager } from '../../../../i18n-manager/I18nManager';
+import { setI18nManager } from '../../../../i18n-manager/singleton-operations';
 import { interpolateMessage } from '../interpolateMessage';
 
 describe('interpolateMessage', () => {
-  it('formats missing translation fallback with the provided locale', () => {
+  it('formats missing translation fallback with the default locale', () => {
+    setI18nManager(
+      new I18nManager({
+        defaultLocale: 'en-US',
+        locales: ['en-US', 'fr'],
+        loadTranslations: async () => ({}),
+      })
+    );
+
     expect(
       interpolateMessage({
         source: 'Value {n, number}',
         target: undefined,
         options: {
           $format: 'ICU',
-          $locale: 'en',
+          $locale: 'fr',
           n: 1234.5,
         },
       })

--- a/packages/i18n/src/translation-functions/utils/interpolation/interpolateMessage.ts
+++ b/packages/i18n/src/translation-functions/utils/interpolation/interpolateMessage.ts
@@ -10,7 +10,8 @@ import type { StringFormat } from 'generaltranslation/types';
  */
 export type InterpolationOptions = {
   $format: StringFormat;
-} & Omit<InlineTranslationOptions, '$format'>;
+  $locale: string;
+} & Omit<InlineTranslationOptions, '$format' | '$locale'>;
 
 /**
  * Interpolation router function for all {@link StringFormat} types

--- a/packages/i18n/src/translation-functions/utils/interpolation/interpolateMessage.ts
+++ b/packages/i18n/src/translation-functions/utils/interpolation/interpolateMessage.ts
@@ -1,4 +1,3 @@
-import { getI18nManager } from '../../../i18n-manager/singleton-operations';
 import { InlineTranslationOptions } from '../../types/options';
 import { interpolateIcuMessage } from './interpolateIcuMessage';
 import { interpolateStringMessage } from './interpolateStringMessage';
@@ -24,22 +23,16 @@ export function interpolateMessage({
   target?: string;
   options: InterpolationOptions;
 }): string {
-  const i18nManager = getI18nManager();
-
   // Format translation
   if (target != null) {
     return routeInterpolation(target, {
-      $locale: i18nManager.getLocale(),
       $_fallback: source,
       ...options,
     });
   }
 
   // Format source
-  return routeInterpolation(source, {
-    ...options,
-    $locale: i18nManager.getDefaultLocale(),
-  });
+  return routeInterpolation(source, options);
 }
 
 // ----- HELPERS ----- //

--- a/packages/i18n/src/translation-functions/utils/interpolation/interpolateMessage.ts
+++ b/packages/i18n/src/translation-functions/utils/interpolation/interpolateMessage.ts
@@ -37,8 +37,8 @@ export function interpolateMessage({
 
   // Format source
   return routeInterpolation(source, {
-    $locale: i18nManager.getDefaultLocale(),
     ...options,
+    $locale: i18nManager.getDefaultLocale(),
   });
 }
 

--- a/packages/i18n/src/translation-functions/utils/interpolation/interpolateMessage.ts
+++ b/packages/i18n/src/translation-functions/utils/interpolation/interpolateMessage.ts
@@ -1,3 +1,4 @@
+import { getI18nManager } from '../../../i18n-manager/singleton-operations';
 import { InlineTranslationOptions } from '../../types/options';
 import { interpolateIcuMessage } from './interpolateIcuMessage';
 import { interpolateStringMessage } from './interpolateStringMessage';
@@ -32,7 +33,10 @@ export function interpolateMessage({
   }
 
   // Format source
-  return routeInterpolation(source, options);
+  return routeInterpolation(source, {
+    ...options,
+    $locale: getI18nManager().getDefaultLocale(),
+  });
 }
 
 // ----- HELPERS ----- //

--- a/packages/react/src/i18n-context/browser-i18n-manager/BrowserI18nManager.ts
+++ b/packages/react/src/i18n-context/browser-i18n-manager/BrowserI18nManager.ts
@@ -5,10 +5,10 @@ import type {
 } from 'gt-i18n/internal/types';
 import type { BrowserStorageAdapter } from './BrowserStorageAdapter';
 import type { HtmlTagOptions } from './utils/types';
-import { determineLocale as gtDetermineLocale } from 'generaltranslation';
 import { Translation } from 'gt-i18n/types';
 import { DEFAULT_HTML_TAG_OPTIONS } from './utils/constants';
 import { LocalStorageTranslationCache } from './LocalStorageTranslationCache';
+import { createInvalidLocaleWarning } from '../../shared/messages';
 
 /**
  * The configuration for the BrowserI18nManager

--- a/packages/react/src/i18n-context/browser-i18n-manager/utils/__tests__/determineLocale.test.ts
+++ b/packages/react/src/i18n-context/browser-i18n-manager/utils/__tests__/determineLocale.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest';
+import { determineLocale } from '../determineLocale';
+
+describe('determineLocale', () => {
+  it('resolves custom locale aliases returned by getLocale', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(
+      determineLocale({
+        defaultLocale: 'en',
+        locales: ['en', 'fr'],
+        customMapping: {
+          'brand-french': {
+            code: 'fr',
+            name: 'Brand French',
+          },
+        },
+        getLocale: () => 'brand-french',
+      })
+    ).toBe('fr');
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+});

--- a/packages/react/src/i18n-context/browser-i18n-manager/utils/determineLocale.ts
+++ b/packages/react/src/i18n-context/browser-i18n-manager/utils/determineLocale.ts
@@ -35,10 +35,7 @@ export function determineLocale({
   // (1) Check custom locale
   if (getLocale) {
     const customLocale = getLocale();
-    const determinedLocale = localeConfig.determineLocale(
-      customLocale,
-      locales
-    );
+    const determinedLocale = localeConfig.determineLocale(customLocale);
     if (!determinedLocale) {
       console.warn(
         createNoLocaleCouldBeDeterminedFromCustomGetLocaleWarning({
@@ -63,5 +60,5 @@ export function determineLocale({
   const navigatorLocales = navigator?.languages || [];
   candidates.push(...navigatorLocales);
 
-  return localeConfig.determineLocale(candidates, locales) || defaultLocale;
+  return localeConfig.determineLocale(candidates) || defaultLocale;
 }

--- a/packages/react/src/i18n-context/browser-i18n-manager/utils/determineLocale.ts
+++ b/packages/react/src/i18n-context/browser-i18n-manager/utils/determineLocale.ts
@@ -1,5 +1,5 @@
 import { CustomMapping } from 'generaltranslation/types';
-import { determineLocale as gtDetermineLocale } from 'generaltranslation';
+import { LocaleConfig } from 'generaltranslation/core';
 import { getCookieValue } from './cookies';
 import { defaultLocaleCookieName } from '@generaltranslation/react-core/internal';
 import { createNoLocaleCouldBeDeterminedFromCustomGetLocaleWarning } from '../../../shared/messages';
@@ -26,13 +26,18 @@ export function determineLocale({
   localeCookieName?: string;
   getLocale?: GetLocale;
 }): string {
+  const localeConfig = new LocaleConfig({
+    defaultLocale,
+    locales,
+    customMapping,
+  });
+
   // (1) Check custom locale
   if (getLocale) {
     const customLocale = getLocale();
-    const determinedLocale = gtDetermineLocale(
+    const determinedLocale = localeConfig.determineLocale(
       customLocale,
-      locales,
-      customMapping
+      locales
     );
     if (!determinedLocale) {
       console.warn(
@@ -58,5 +63,5 @@ export function determineLocale({
   const navigatorLocales = navigator?.languages || [];
   candidates.push(...navigatorLocales);
 
-  return gtDetermineLocale(candidates, locales, customMapping) || defaultLocale;
+  return localeConfig.determineLocale(candidates, locales) || defaultLocale;
 }

--- a/packages/react/src/shared/messages.ts
+++ b/packages/react/src/shared/messages.ts
@@ -20,3 +20,6 @@ export const createNoLocaleCouldBeDeterminedFromCustomGetLocaleWarning = ({
   defaultLocale: string;
 }) =>
   `${PACKAGE_NAME} Warning: Custom getLocale() function returned an unsupported locale: "${customLocale}". Falling back to default locale: "${defaultLocale}".`;
+
+export const createInvalidLocaleWarning = (locale: string) =>
+  `${PACKAGE_NAME} Warning: Invalid locale: "${locale}".`;

--- a/packages/tanstack-start/src/functions/determineLocale.ts
+++ b/packages/tanstack-start/src/functions/determineLocale.ts
@@ -2,7 +2,7 @@ import { defaultLocaleCookieName } from 'gt-react/internal';
 import { createIsomorphicFn } from '@tanstack/react-start';
 import { getRequestHeader, getCookie } from '@tanstack/react-start/server';
 import { CustomMapping } from 'generaltranslation/types';
-import { determineLocale as gtDetermineLocale } from 'generaltranslation';
+import { LocaleConfig } from 'generaltranslation/core';
 
 type DetermineLocaleOptions = {
   defaultLocale: string;
@@ -28,6 +28,11 @@ function determineLocaleServer({
   locales,
   customMapping,
 }: DetermineLocaleOptions) {
+  const localeConfig = new LocaleConfig({
+    defaultLocale,
+    locales,
+    customMapping,
+  });
   const candidates = [];
 
   // (1) Check cookie
@@ -54,7 +59,7 @@ function determineLocaleServer({
   }
 
   // determine locale (falling back to default locale if no match is found)
-  return gtDetermineLocale(candidates, locales, customMapping) || defaultLocale;
+  return localeConfig.determineLocale(candidates, locales) || defaultLocale;
 }
 
 /**
@@ -65,6 +70,11 @@ function determineLocaleClient({
   locales,
   customMapping,
 }: DetermineLocaleOptions) {
+  const localeConfig = new LocaleConfig({
+    defaultLocale,
+    locales,
+    customMapping,
+  });
   const candidates = [];
 
   // (1) Check cookie
@@ -86,5 +96,5 @@ function determineLocaleClient({
   }
 
   // determine locale (falling back to default locale if no match is found)
-  return gtDetermineLocale(candidates, locales, customMapping) || defaultLocale;
+  return localeConfig.determineLocale(candidates, locales) || defaultLocale;
 }

--- a/packages/tanstack-start/src/functions/determineLocale.ts
+++ b/packages/tanstack-start/src/functions/determineLocale.ts
@@ -59,7 +59,7 @@ function determineLocaleServer({
   }
 
   // determine locale (falling back to default locale if no match is found)
-  return localeConfig.determineLocale(candidates, locales) || defaultLocale;
+  return localeConfig.determineLocale(candidates) || defaultLocale;
 }
 
 /**
@@ -96,5 +96,5 @@ function determineLocaleClient({
   }
 
   // determine locale (falling back to default locale if no match is found)
-  return localeConfig.determineLocale(candidates, locales) || defaultLocale;
+  return localeConfig.determineLocale(candidates) || defaultLocale;
 }


### PR DESCRIPTION
## Summary

- format missing-translation source fallbacks with the source/default locale instead of the target locale
- resolve custom locale aliases through `LocaleConfig` in browser and TanStack Start locale detection
- define the missing browser invalid-locale warning helper and remove a stale unused import
- add focused regression tests for source fallback formatting and browser custom `getLocale` aliases

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two independent edge-case bugs: (1) missing-translation source fallbacks were being number/date-formatted with the target locale instead of the default locale, and (2) custom locale aliases defined in `customMapping` were not being resolved when a `getLocale` callback returned an alias code. Both are corrected by moving locale normalisation into `getLookupOptions`/`getGT` and by switching `determineLocale` callers from the standalone `gtDetermineLocale` helper to `LocaleConfig.determineLocale`. The PR also fills a gap where `createInvalidLocaleWarning` was referenced in `BrowserI18nManager` but was never defined.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are targeted bug fixes with focused regression tests and no architectural risk.

No P0 or P1 findings. The logic changes are well-scoped, all existing and new tests cover the fixed paths, and the type-system improvement (NormalizedLookupOptions) removes the previous unsafe casts.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/translation-functions/utils/interpolation/interpolateMessage.ts | Core fix: source-fallback formatting now overrides $locale with getDefaultLocale() while translation path uses caller-supplied $locale; getI18nManager() removed from hot path for the translation branch |
| packages/i18n/src/translation-functions/internal/helpers.ts | getLookupOptions now returns NormalizedLookupOptions<T> with both $format and $locale guaranteed; removes cast to InterpolationOptions throughout |
| packages/react/src/i18n-context/browser-i18n-manager/utils/determineLocale.ts | Switches to LocaleConfig.determineLocale so custom aliases in customMapping are resolved correctly |
| packages/tanstack-start/src/functions/determineLocale.ts | Same LocaleConfig migration as the browser path; both server and client variants updated consistently |
| packages/react/src/i18n-context/browser-i18n-manager/BrowserI18nManager.ts | Removes stale gtDetermineLocale import and adds the previously-missing createInvalidLocaleWarning import that was already used in updateHtmlTag |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[resolveStringContent / resolveStringContentWithFallback] --> B[getLookupOptions]
    B --> |"$locale = options.$locale ?? getLocale()"| C[NormalizedLookupOptions]
    C --> D[lookupTranslation]
    D --> |"translation found"| E[interpolateMessage — target branch]
    D --> |"translation missing"| F[interpolateMessage — source branch]
    E --> |"uses options.$locale (target locale)"| G[routeInterpolation target]
    F --> |"overrides $locale with getDefaultLocale()"| H[routeInterpolation source]
    G --> I[Formatted translation string]
    H --> I
```
</details>

<sub>Reviews (5): Last reviewed commit: ["refactor: require interpolation locale"](https://github.com/generaltranslation/gt/commit/7e2f26dbd4ed69077e4a62ece027682424246ab9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30250431)</sub>

<!-- /greptile_comment -->