### PR TITLE
fix(cli): sort JSON keys when outputting translation files

### DIFF
--- a/.changeset/sort-json-keys.md
+++ b/.changeset/sort-json-keys.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Sort JSON keys when outputting translation files for deterministic output

--- a/packages/cli/src/api/__tests__/downloadFileBatch.test.ts
+++ b/packages/cli/src/api/__tests__/downloadFileBatch.test.ts
@@ -181,6 +181,43 @@ describe('downloadFileBatch', () => {
     expect(result.failed).toHaveLength(0);
   });
 
+  it('should sort JSON keys when writing JSON output files', async () => {
+    const mockResponseData = createMockResponseData({
+      files: [
+        {
+          id: 'translation-1',
+          branchId: 'branch-1',
+          fileId: 'file-1',
+          versionId: 'version-1',
+          locale: 'en',
+          fileFormat: 'JSON' as FileFormat,
+          data: '{"z":1,"a":{"c":3,"b":2}}',
+          fileName: 'file1.json',
+          metadata: {},
+        },
+      ],
+      count: 1,
+    });
+    const files = createBatchedFiles(1);
+    const fileTracker = createMockFileTracker(files);
+
+    vi.mocked(gt.downloadFileBatch).mockResolvedValue(mockResponseData);
+    setupFileSystemMocks();
+
+    const result = await downloadFileBatch(
+      fileTracker,
+      files,
+      createMockSettings()
+    );
+
+    expect(fs.promises.writeFile).toHaveBeenCalledWith(
+      '/output/file1.json',
+      JSON.stringify({ a: { b: 2, c: 3 }, z: 1 }, null, 2)
+    );
+    expect(result.successful).toHaveLength(1);
+    expect(result.failed).toHaveLength(0);
+  });
+
   it('should create directories if they do not exist', async () => {
     const mockResponseData = createMockResponseData({
       files: [

--- a/packages/cli/src/api/downloadFileBatch.ts
+++ b/packages/cli/src/api/downloadFileBatch.ts
@@ -257,8 +257,19 @@ export async function downloadFileBatch(
                 inputPath,
                 options
               );
-              if (remerged !== existingContent) {
-                await fs.promises.writeFile(outputPath, remerged);
+              let remergedData = remerged;
+              if (outputPath.endsWith('.json')) {
+                try {
+                  const jsonData = JSON.parse(remergedData);
+                  const sortedData = stringify(jsonData);
+                  const sortedJsonData = JSON.parse(sortedData);
+                  remergedData = JSON.stringify(sortedJsonData, null, 2);
+                } catch {
+                  // Fall through with unsorted content
+                }
+              }
+              if (remergedData !== existingContent) {
+                await fs.promises.writeFile(outputPath, remergedData);
               }
               // Track for postprocessing (e.g. openapi path localization)
               // even when the API download was skipped
@@ -272,15 +283,18 @@ export async function downloadFileBatch(
         }
         let data = mergeWithSource(file.data, locale, inputPath, options);
 
-        // If the file is a GTJSON file, stable sort the order and format the data
-        if (file.fileFormat === 'GTJSON') {
+        // Stable sort JSON keys for deterministic output
+        if (
+          file.fileFormat === 'GTJSON' ||
+          outputPath.endsWith('.json')
+        ) {
           try {
             const jsonData = JSON.parse(data);
             const sortedData = stringify(jsonData); // stably sort with fast-json-stable-stringify
             const sortedJsonData = JSON.parse(sortedData);
             data = JSON.stringify(sortedJsonData, null, 2); // format the data
           } catch (error) {
-            logger.warn(`Failed to sort GTJson file: ${file.id}: ` + error);
+            logger.warn(`Failed to sort JSON file: ${file.id}: ` + error);
           }
         }
 

--- a/packages/cli/src/api/downloadFileBatch.ts
+++ b/packages/cli/src/api/downloadFileBatch.ts
@@ -286,10 +286,7 @@ export async function downloadFileBatch(
         let data = mergeWithSource(file.data, locale, inputPath, options);
 
         // Stable sort JSON keys for deterministic output
-        if (
-          file.fileFormat === 'GTJSON' ||
-          outputPath.endsWith('.json')
-        ) {
+        if (file.fileFormat === 'GTJSON' || outputPath.endsWith('.json')) {
           try {
             data = sortJsonString(data);
           } catch (error) {

--- a/packages/cli/src/api/downloadFileBatch.ts
+++ b/packages/cli/src/api/downloadFileBatch.ts
@@ -26,6 +26,11 @@ import { SUPPORTED_FILE_EXTENSIONS } from '../formats/files/supportedFiles.js';
 import { hasNonIdentityFileFormatTransformForType } from '../formats/files/transformFormat.js';
 import { getRelative } from '../fs/findFilepath.js';
 
+function sortJsonString(data: string): string {
+  const sortedData = stringify(JSON.parse(data));
+  return JSON.stringify(JSON.parse(sortedData), null, 2);
+}
+
 /**
  * Merges translated content with the current source file for schema-based formats.
  */
@@ -260,10 +265,7 @@ export async function downloadFileBatch(
               let remergedData = remerged;
               if (outputPath.endsWith('.json')) {
                 try {
-                  const jsonData = JSON.parse(remergedData);
-                  const sortedData = stringify(jsonData);
-                  const sortedJsonData = JSON.parse(sortedData);
-                  remergedData = JSON.stringify(sortedJsonData, null, 2);
+                  remergedData = sortJsonString(remergedData);
                 } catch {
                   // Fall through with unsorted content
                 }
@@ -289,10 +291,7 @@ export async function downloadFileBatch(
           outputPath.endsWith('.json')
         ) {
           try {
-            const jsonData = JSON.parse(data);
-            const sortedData = stringify(jsonData); // stably sort with fast-json-stable-stringify
-            const sortedJsonData = JSON.parse(sortedData);
-            data = JSON.stringify(sortedJsonData, null, 2); // format the data
+            data = sortJsonString(data);
           } catch (error) {
             logger.warn(`Failed to sort JSON file: ${file.id}: ` + error);
           }

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.14.27';
+export const PACKAGE_VERSION = '2.14.29';

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.14.29';
+export const PACKAGE_VERSION = '2.14.27';


### PR DESCRIPTION
Extends the existing GTJSON key sorting to all JSON output files (`.json`), ensuring deterministic key ordering in translation files.

## Changes

- **`downloadFileBatch.ts`**: Broadened the stable-sort block to apply to any `.json` output file, not just `GTJSON` format files.
- Also sorts keys during the re-merge path (when existing translations are re-merged with updated source files).

Uses the existing `fast-json-stable-stringify` dependency — no new deps.

Requested by @nebrelbug.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the existing `fast-json-stable-stringify` key-sorting behaviour from `GTJSON`-format files to all `.json` output files, ensuring deterministic key ordering across all translation file types. The `sortJsonString` helper is cleanly extracted and applied to both the main download path and the re-merge path, with appropriate error handling in each branch.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrowly scoped, well-guarded, and backed by a new test.

Only a P2 test-coverage gap was found; no logic bugs or breaking changes are present.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/api/downloadFileBatch.ts | Extracts `sortJsonString` helper and broadens sorting to all `.json` output files; logic is correct and well-guarded. |
| packages/cli/src/api/__tests__/downloadFileBatch.test.ts | Adds a test for JSON key sorting on the main download path; re-merge path sorting is not covered. |
| .changeset/sort-json-keys.md | Patch changeset correctly targets the `gt` CLI package with an accurate description. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[downloadFileBatch called] --> B{File already up to date?}
    B -- Yes, re-merge path --> C[mergeWithSource]
    C --> D{outputPath ends with .json?}
    D -- Yes --> E[sortJsonString]
    E --> F{Sort succeeded?}
    F -- Yes --> G[remergedData = sorted JSON]
    F -- No / invalid JSON --> H[fall through with unsorted]
    G --> I{remergedData !== existingContent?}
    H --> I
    I -- Yes --> J[writeFile]
    I -- No --> K[skip write]
    B -- No, main download path --> L[mergeWithSource]
    L --> M{fileFormat===GTJSON OR outputPath ends .json?}
    M -- Yes --> N[sortJsonString]
    N --> O{Sort succeeded?}
    O -- Yes --> P[data = sorted JSON]
    O -- No --> Q[logger.warn, data unchanged]
    P --> R[writeFile]
    Q --> R
    M -- No --> R
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/cli/src/api/__tests__/downloadFileBatch.test.ts:184-219
**Re-merge path sorting not covered by tests**

The new test covers the main download path, but the PR also adds sorting in the re-merge path (lines 265–272 of `downloadFileBatch.ts`) that runs when existing translations are re-merged with updated source files. There is currently no test verifying that a `.json` file going through the re-merge branch is also sorted. Since the two paths have different error-handling (re-merge silently falls through; main path logs a warning), a test for the re-merge case would give confidence that the behaviour is correct and that the silent swallow is intentional.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["style(cli): format JSON sorting conditio..."](https://github.com/generaltranslation/gt/commit/8fdbf133f96c8290ffae6f201375048c05384ebe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30259243)</sub>

<!-- /greptile_comment -->