### PR TITLE
Remove unused renderVariable internal export

### DIFF
--- a/packages/react-core/src/internal.ts
+++ b/packages/react-core/src/internal.ts
@@ -35,7 +35,6 @@ import { injectAndMerge } from './dictionaries/injectAndMerge';
 import { collectUntranslatedEntries } from './dictionaries/collectUntranslatedEntries';
 import { msg, decodeMsg, decodeOptions } from './messages/messages';
 import { Static, Derive } from './variables/Derive';
-import renderVariable from './rendering/renderVariable';
 
 export * from 'gt-i18n/fallbacks';
 export { declareStatic, derive, declareVar, decodeVars } from 'gt-i18n';
@@ -76,5 +75,4 @@ export {
   decodeOptions,
   Static,
   Derive,
-  renderVariable,
 };


### PR DESCRIPTION
## Summary
- remove the unused renderVariable named export from @generaltranslation/react-core/internal
- keep the renderVariable implementation in place for direct runtime rendering usage

## Testing
- git diff --check
- pnpm --filter @generaltranslation/react-core transpile *(fails: node_modules missing, tsc not found locally)*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the `renderVariable` named export from the `@generaltranslation/react-core/internal` barrel file while keeping the implementation intact. No other package imports `renderVariable` through this barrel, making the change safe.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — one-line removal of an unused export with no downstream consumers.

The only change is deleting an unused named export from a barrel file. A codebase-wide search confirms no package imports `renderVariable` from `@generaltranslation/react-core/internal`; the sole usage in `GtInternalTranslateJsx.tsx` imports it from a local relative path instead.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/internal.ts | Removes unused `renderVariable` import and re-export; no consumers of this barrel rely on the removed export. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["packages/react-core/src/rendering/renderVariable.tsx\n(implementation, unchanged)"]
    B["packages/react-core/src/internal.ts\n(barrel export)"]
    C["External consumers via\n@generaltranslation/react-core/internal"]
    D["packages/react/src/i18n-context/functions/\nvariables/utils/renderVariable.tsx\n(local copy, unaffected)"]

    A -->|"was re-exported (removed)"| B
    B -->|"❌ renderVariable no longer exported"| C
    A -.->|"still used internally by\nrenderDefaultChildren / renderTranslatedChildren"| E["renderDefaultChildren.tsx\nrenderTranslatedChildren.tsx"]
    D -->|"imported locally (unchanged)"| F["GtInternalTranslateJsx.tsx"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Remove unused renderVariable internal ex..."](https://github.com/generaltranslation/gt/commit/e43eb9a0d10fc0708cda62b215d5e40ab7be8223) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30373619)</sub>

<!-- /greptile_comment -->