### PR TITLE
refactor(i18n): add shared translation cache controls

### DIFF
--- a/.changeset/quiet-cache-bridges.md
+++ b/.changeset/quiet-cache-bridges.md
@@ -1,0 +1,5 @@
+---
+'gt-i18n': patch
+---
+
+Add shared cache expiry, batching, and runtime translation configuration to I18nManager.

--- a/.changeset/quiet-cache-bridges.md
+++ b/.changeset/quiet-cache-bridges.md
@@ -1,4 +1,5 @@
 ---
+'generaltranslation': patch
 'gt-i18n': patch
 ---
 

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -4,6 +4,7 @@ export {
   defaultRuntimeApiUrl,
 } from './settings/settingsUrls';
 export { libraryDefaultLocale } from './settings/settings';
+export type { RuntimeTranslateManyOptions } from './types-dir/api/entry';
 export { pluralForms, isAcceptedPluralForm } from './settings/plurals';
 import _getPluralForm from './locales/getPluralForm';
 import { defaultTimeout } from './settings/settings';

--- a/packages/core/src/types-dir/api/entry.ts
+++ b/packages/core/src/types-dir/api/entry.ts
@@ -24,10 +24,14 @@ export type EntryMetadata = {
   actionType?: ActionType;
 };
 
-export type TranslateOptions = {
-  targetLocale: string;
+export type RuntimeTranslateManyOptions = {
   sourceLocale?: string;
   modelProvider?: string;
+  [key: string]: unknown;
+};
+
+export type TranslateOptions = RuntimeTranslateManyOptions & {
+  targetLocale: string;
 };
 
 /**

--- a/packages/i18n/src/i18n-manager/I18nManager.ts
+++ b/packages/i18n/src/i18n-manager/I18nManager.ts
@@ -95,9 +95,14 @@ class I18nManager<
     });
     // Create cache miss handlers
     const loadTranslations = createTranslationLoader<TranslationValue>(params);
+    const runtimeTranslationTimeout =
+      this.config.runtimeTranslation?.timeout ?? DEFAULT_TRANSLATION_TIMEOUT;
+    const runtimeTranslationMetadata =
+      this.config.runtimeTranslation?.metadata ?? {};
     const createTranslateMany = createTranslateManyFactory(
       this.getGTClassClean(),
-      DEFAULT_TRANSLATION_TIMEOUT
+      runtimeTranslationTimeout,
+      runtimeTranslationMetadata
     );
 
     // Subscribe lifecycle callbacks
@@ -109,6 +114,8 @@ class I18nManager<
     this.localesCache = new LocalesCache<TranslationValue>({
       loadTranslations,
       createTranslateMany,
+      ttl: this.config.cacheExpiryTime,
+      batchConfig: this.config.batchConfig,
       lifecycle: createLifecycleCallbacks((...args) => this.emit(...args)),
     });
   }
@@ -528,6 +535,9 @@ function standardizeConfig<TranslationValue extends Translation>(
     devApiKey: config.devApiKey,
     apiKey: config.apiKey,
     runtimeUrl: config.runtimeUrl,
+    cacheExpiryTime: config.cacheExpiryTime,
+    batchConfig: config.batchConfig,
+    runtimeTranslation: config.runtimeTranslation,
     _versionId: config._versionId,
     ...(gtServicesEnabled
       ? standardizeLocales(dedupedLocales)

--- a/packages/i18n/src/i18n-manager/__tests__/I18nManager.test.ts
+++ b/packages/i18n/src/i18n-manager/__tests__/I18nManager.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { I18nManager } from '../I18nManager';
+import { createTranslateManyFactory } from '../translations-manager/utils/createTranslateMany';
 import { hashMessage } from '../../utils/hashMessage';
 import { LookupOptions } from '../../translation-functions/types/options';
 
@@ -33,6 +34,10 @@ describe('I18nManager', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockTranslateMany.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   // ===== REGRESSION TESTS ===== //
@@ -89,13 +94,66 @@ describe('I18nManager', () => {
     expect(after).toBe(translatedString);
   });
 
+  it.each([
+    {
+      name: 'expires',
+      cacheExpiryTime: 100,
+      advanceBy: 101,
+      lookupAfter: undefined,
+      reloaded: 'Salut {name} !',
+      calls: 2,
+    },
+    {
+      name: 'keeps',
+      cacheExpiryTime: null,
+      advanceBy: 60_001,
+      lookupAfter: translatedString,
+      reloaded: translatedString,
+      calls: 1,
+    },
+  ])('$name locale caches according to cacheExpiryTime', async (testCase) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    const loadTranslations = vi
+      .fn()
+      .mockResolvedValueOnce({ [expectedHash]: translatedString })
+      .mockResolvedValueOnce({ [expectedHash]: 'Salut {name} !' });
+    const manager = createManager({
+      cacheExpiryTime: testCase.cacheExpiryTime,
+      loadTranslations,
+    });
+
+    await manager.loadTranslations('fr');
+    expect(manager.lookupTranslation('fr', message, lookupOptions)).toBe(
+      translatedString
+    );
+
+    vi.advanceTimersByTime(testCase.advanceBy);
+    expect(manager.lookupTranslation('fr', message, lookupOptions)).toBe(
+      testCase.lookupAfter
+    );
+
+    const translations = await manager.loadTranslations('fr');
+    expect(translations[expectedHash]).toBe(testCase.reloaded);
+    expect(loadTranslations).toHaveBeenCalledTimes(testCase.calls);
+  });
+
   it('lookupTranslationWithFallback() falls back to runtime translate on cache miss', async () => {
     const unknownMessage = 'Unknown message';
     const unknownOptions: LookupOptions = { $format: 'ICU' };
     const unknownHash = hashMessage(unknownMessage, unknownOptions);
 
     // loadTranslations returns translations that do NOT include unknownMessage
-    const manager = createManager();
+    const manager = createManager({
+      runtimeTranslation: {
+        timeout: 4321,
+        metadata: {
+          sourceLocale: 'en',
+          projectId: 'project-id',
+          publish: true,
+        },
+      },
+    });
 
     // Mock translateMany to return a translation for the unknown message
     mockTranslateMany.mockResolvedValue({
@@ -113,6 +171,15 @@ describe('I18nManager', () => {
 
     expect(result).toBe('Message inconnu');
     expect(mockTranslateMany).toHaveBeenCalled();
+    expect(createTranslateManyFactory).toHaveBeenCalledWith(
+      expect.any(Object),
+      4321,
+      {
+        sourceLocale: 'en',
+        projectId: 'project-id',
+        publish: true,
+      }
+    );
   });
 
   it('resolves custom aliases for locale metadata operations', () => {

--- a/packages/i18n/src/i18n-manager/translations-manager/LocalesCache.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/LocalesCache.ts
@@ -1,5 +1,6 @@
 import { Cache } from './Cache';
 import { Hash, TranslationKey, TranslationsCache } from './TranslationsCache';
+import type { TranslationBatchConfig } from './TranslationsCache';
 import { Translation } from './utils/types/translation-data';
 import { DEFAULT_CACHE_EXPIRY_TIME } from './utils/constants';
 import { CreateTranslateMany } from './utils/createTranslateMany';
@@ -58,6 +59,8 @@ export class LocalesCache<TranslationValue extends Translation> extends Cache<
    */
   private ttl: number = DEFAULT_CACHE_EXPIRY_TIME;
 
+  private _batchConfig?: TranslationBatchConfig;
+
   /**
    * Translations cache lifecycle callbacks (locale embedded)
    */
@@ -75,6 +78,7 @@ export class LocalesCache<TranslationValue extends Translation> extends Cache<
   constructor({
     init = {},
     ttl,
+    batchConfig,
     loadTranslations,
     createTranslateMany,
     lifecycle: {
@@ -86,6 +90,7 @@ export class LocalesCache<TranslationValue extends Translation> extends Cache<
   }: {
     init?: Record<string, CacheEntry<TranslationValue>>;
     ttl?: number | null;
+    batchConfig?: TranslationBatchConfig;
     createTranslateMany: CreateTranslateMany;
     loadTranslations: SafeTranslationsLoader<TranslationValue>;
     lifecycle: LocalesCacheLifecycleCallbacks<TranslationValue>;
@@ -97,6 +102,7 @@ export class LocalesCache<TranslationValue extends Translation> extends Cache<
 
     this._translationLoader = loadTranslations;
     this._createTranslateMany = createTranslateMany;
+    this._batchConfig = batchConfig;
     this._onTranslationsCacheHit = onTranslationsCacheHit;
     this._onTranslationsCacheMiss = onTranslationsCacheMiss;
   }
@@ -184,6 +190,7 @@ export class LocalesCache<TranslationValue extends Translation> extends Cache<
       init: await translationsPromise,
       lifecycle: this._createTranslationsCacheLifecycle(locale),
       translateMany: this._createTranslateMany(locale),
+      batchConfig: this._batchConfig,
     });
 
     return { translationsCache, expiresAt };

--- a/packages/i18n/src/i18n-manager/translations-manager/TranslationsCache.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/TranslationsCache.ts
@@ -28,11 +28,14 @@ const DEFAULT_BATCH_CONFIG: Required<TranslationBatchConfig> = {
 };
 
 function getPositiveValue(value: number | undefined, defaultValue: number) {
-  return Number.isFinite(value) && value > 0 ? value : defaultValue;
+  if (value === undefined || !Number.isFinite(value) || value <= 0) {
+    return defaultValue;
+  }
+  return value;
 }
 
 function getPositiveInteger(value: number | undefined, defaultValue: number) {
-  if (!Number.isFinite(value)) return defaultValue;
+  if (value === undefined || !Number.isFinite(value)) return defaultValue;
   const integer = Math.trunc(value);
   return integer > 0 ? integer : defaultValue;
 }

--- a/packages/i18n/src/i18n-manager/translations-manager/TranslationsCache.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/TranslationsCache.ts
@@ -15,6 +15,47 @@ const MAX_BATCH_SIZE = 25;
 const MAX_CONCURRENT_REQUESTS = 100;
 const BATCH_INTERVAL = 50;
 
+export type TranslationBatchConfig = {
+  maxConcurrentRequests?: number;
+  maxBatchSize?: number;
+  batchInterval?: number;
+};
+
+const DEFAULT_BATCH_CONFIG: Required<TranslationBatchConfig> = {
+  maxConcurrentRequests: MAX_CONCURRENT_REQUESTS,
+  maxBatchSize: MAX_BATCH_SIZE,
+  batchInterval: BATCH_INTERVAL,
+};
+
+function getPositiveValue(value: number | undefined, defaultValue: number) {
+  return Number.isFinite(value) && value > 0 ? value : defaultValue;
+}
+
+function getPositiveInteger(value: number | undefined, defaultValue: number) {
+  if (!Number.isFinite(value)) return defaultValue;
+  const integer = Math.trunc(value);
+  return integer > 0 ? integer : defaultValue;
+}
+
+function normalizeBatchConfig(
+  batchConfig?: TranslationBatchConfig
+): Required<TranslationBatchConfig> {
+  return {
+    maxConcurrentRequests: getPositiveInteger(
+      batchConfig?.maxConcurrentRequests,
+      DEFAULT_BATCH_CONFIG.maxConcurrentRequests
+    ),
+    maxBatchSize: getPositiveInteger(
+      batchConfig?.maxBatchSize,
+      DEFAULT_BATCH_CONFIG.maxBatchSize
+    ),
+    batchInterval: getPositiveValue(
+      batchConfig?.batchInterval,
+      DEFAULT_BATCH_CONFIG.batchInterval
+    ),
+  };
+}
+
 /**
  * InputKey type for lookups
  * @typedef {Object} TranslationKey
@@ -81,6 +122,8 @@ export class TranslationsCache<
    */
   private _activeRequests = 0;
 
+  private _batchConfig: Required<TranslationBatchConfig>;
+
   /**
    * Translate many function
    */
@@ -96,9 +139,11 @@ export class TranslationsCache<
     init,
     translateMany,
     lifecycle,
+    batchConfig,
   }: {
     init: Record<Hash, TranslationValue>;
     translateMany: TranslateMany;
+    batchConfig?: TranslationBatchConfig;
     lifecycle: LifecycleParam<
       TranslationKey<TranslationValue>,
       Hash,
@@ -108,6 +153,7 @@ export class TranslationsCache<
   }) {
     super(init, lifecycle);
     this._translateMany = translateMany;
+    this._batchConfig = normalizeBatchConfig(batchConfig);
   }
 
   /**
@@ -171,7 +217,7 @@ export class TranslationsCache<
     const translationPromise = this._enqueueTranslation(key);
 
     // If batch is full, flush now
-    if (this._queue.length >= MAX_BATCH_SIZE) {
+    if (this._queue.length >= this._batchConfig.maxBatchSize) {
       this._flushNow();
     } else {
       this._scheduleBatch();
@@ -205,7 +251,7 @@ export class TranslationsCache<
     this._batchTimer = setTimeout(() => {
       this._batchTimer = null;
       this._drainQueue();
-    }, BATCH_INTERVAL);
+    }, this._batchConfig.batchInterval);
   }
 
   /**
@@ -214,9 +260,9 @@ export class TranslationsCache<
   private _drainQueue(): void {
     while (
       this._queue.length > 0 &&
-      this._activeRequests < MAX_CONCURRENT_REQUESTS
+      this._activeRequests < this._batchConfig.maxConcurrentRequests
     ) {
-      const batch = this._queue.splice(0, MAX_BATCH_SIZE);
+      const batch = this._queue.splice(0, this._batchConfig.maxBatchSize);
       this._sendBatchRequest(batch);
     }
     // If items remain (hit concurrency limit), schedule again

--- a/packages/i18n/src/i18n-manager/translations-manager/__tests__/TranslationsCache.test.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/__tests__/TranslationsCache.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { TranslationsCache, TranslateMany } from '../TranslationsCache';
+import { TranslationsCache } from '../TranslationsCache';
 import { hashMessage } from '../../../utils/hashMessage';
 import { LookupOptions } from '../../../translation-functions/types/options';
 
@@ -158,6 +158,107 @@ describe('TranslationsCache', () => {
     const results = await Promise.all(promises);
     expect(results[0]).toBe('translated-msg-0');
     expect(results[24]).toBe('translated-msg-24');
+  });
+
+  it('miss() honors custom batching config', async () => {
+    const intervalKey = makeKey('Waiting');
+    mockTranslateMany.mockResolvedValueOnce(
+      mockTranslateManyResponse([
+        { hash: intervalKey.hash, translation: 'En attente' },
+      ])
+    );
+    const intervalCache = new TranslationsCache({
+      init: {},
+      translateMany: mockTranslateMany,
+      batchConfig: { batchInterval: 10 },
+    });
+    const intervalPromise = intervalCache.miss({
+      message: intervalKey.message,
+      options: intervalKey.options,
+    });
+
+    vi.advanceTimersByTime(9);
+    expect(mockTranslateMany).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    await expect(intervalPromise).resolves.toBe('En attente');
+    expect(mockTranslateMany).toHaveBeenCalledTimes(1);
+
+    const k1 = makeKey('Hello');
+    const k2 = makeKey('Goodbye');
+    mockTranslateMany.mockResolvedValueOnce(
+      mockTranslateManyResponse([
+        { hash: k1.hash, translation: 'Bonjour' },
+        { hash: k2.hash, translation: 'Au revoir' },
+      ])
+    );
+    const sizeCache = new TranslationsCache({
+      init: {},
+      translateMany: mockTranslateMany,
+      batchConfig: { maxBatchSize: 2 },
+    });
+
+    const p1 = sizeCache.miss({
+      message: k1.message,
+      options: k1.options,
+    });
+    const p2 = sizeCache.miss({
+      message: k2.message,
+      options: k2.options,
+    });
+
+    expect(mockTranslateMany).toHaveBeenCalledTimes(2);
+    await expect(Promise.all([p1, p2])).resolves.toEqual([
+      'Bonjour',
+      'Au revoir',
+    ]);
+  });
+
+  it('miss() falls back to default batching values for invalid config', async () => {
+    const intervalKey = makeKey('Invalid interval');
+    mockTranslateMany.mockResolvedValueOnce(
+      mockTranslateManyResponse([
+        { hash: intervalKey.hash, translation: 'Intervalle invalide' },
+      ])
+    );
+
+    const intervalCache = new TranslationsCache({
+      init: {},
+      translateMany: mockTranslateMany,
+      batchConfig: { batchInterval: 0 },
+    });
+    const intervalPromise = intervalCache.miss({
+      message: intervalKey.message,
+      options: intervalKey.options,
+    });
+
+    vi.advanceTimersByTime(49);
+    expect(mockTranslateMany).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    await expect(intervalPromise).resolves.toBe('Intervalle invalide');
+    expect(mockTranslateMany).toHaveBeenCalledTimes(1);
+
+    const sizeKey = makeKey('Invalid size');
+    mockTranslateMany.mockResolvedValueOnce(
+      mockTranslateManyResponse([
+        { hash: sizeKey.hash, translation: 'Taille invalide' },
+      ])
+    );
+
+    const sizeCache = new TranslationsCache({
+      init: {},
+      translateMany: mockTranslateMany,
+      batchConfig: { maxBatchSize: 0.5, maxConcurrentRequests: 0.5 },
+    });
+    const sizePromise = sizeCache.miss({
+      message: sizeKey.message,
+      options: sizeKey.options,
+    });
+
+    vi.advanceTimersByTime(50);
+    await expect(sizePromise).resolves.toBe('Taille invalide');
+    expect(mockTranslateMany).toHaveBeenCalledTimes(2);
   });
 
   it('miss() rejects promise when translateMany throws', async () => {

--- a/packages/i18n/src/i18n-manager/translations-manager/utils/createTranslateMany.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/utils/createTranslateMany.ts
@@ -1,10 +1,11 @@
 import type { Locale } from '../LocalesCache';
 import type { TranslateMany } from '../TranslationsCache';
+import type { RuntimeTranslateManyOptions } from '../../types';
 
 type TranslateManyClient = {
   translateMany(
     sources: Parameters<TranslateMany>[0],
-    options: { targetLocale: string },
+    options: { targetLocale: string } & RuntimeTranslateManyOptions,
     timeout?: number
   ): ReturnType<TranslateMany>;
 };
@@ -21,8 +22,13 @@ export type CreateTranslateMany = (locale: Locale) => TranslateMany;
  */
 export function createTranslateManyFactory(
   gtInstance: TranslateManyClient,
-  timeout?: number
+  timeout?: number,
+  metadata: RuntimeTranslateManyOptions = {}
 ): CreateTranslateMany {
   return (locale) => (sources) =>
-    gtInstance.translateMany(sources, { targetLocale: locale }, timeout);
+    gtInstance.translateMany(
+      sources,
+      { ...metadata, targetLocale: locale },
+      timeout
+    );
 }

--- a/packages/i18n/src/i18n-manager/translations-manager/utils/createTranslateMany.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/utils/createTranslateMany.ts
@@ -1,6 +1,6 @@
+import type { RuntimeTranslateManyOptions } from 'generaltranslation/internal';
 import type { Locale } from '../LocalesCache';
 import type { TranslateMany } from '../TranslationsCache';
-import type { RuntimeTranslateManyOptions } from '../../types';
 
 type TranslateManyClient = {
   translateMany(

--- a/packages/i18n/src/i18n-manager/types.ts
+++ b/packages/i18n/src/i18n-manager/types.ts
@@ -1,3 +1,4 @@
+import type { RuntimeTranslateManyOptions } from 'generaltranslation/internal';
 import type { CustomMapping } from 'generaltranslation/types';
 import { GTConfig } from '../config/types';
 import { TranslationsLoader } from './translations-manager/translations-loaders/types';
@@ -5,13 +6,7 @@ import { Translation } from './translations-manager/utils/types/translation-data
 import type { LifecycleCallbacks } from './lifecycle-hooks/types';
 import type { TranslationBatchConfig } from './translations-manager/TranslationsCache';
 
-export type RuntimeTranslateManyOptions = {
-  sourceLocale?: string;
-  modelProvider?: string;
-  [key: string]: unknown;
-};
-
-export type RuntimeTranslationConfig = {
+type RuntimeTranslationConfig = {
   timeout?: number;
   metadata?: RuntimeTranslateManyOptions;
 };

--- a/packages/i18n/src/i18n-manager/types.ts
+++ b/packages/i18n/src/i18n-manager/types.ts
@@ -3,15 +3,34 @@ import { GTConfig } from '../config/types';
 import { TranslationsLoader } from './translations-manager/translations-loaders/types';
 import { Translation } from './translations-manager/utils/types/translation-data';
 import type { LifecycleCallbacks } from './lifecycle-hooks/types';
+import type { TranslationBatchConfig } from './translations-manager/TranslationsCache';
+
+export type RuntimeTranslateManyOptions = {
+  sourceLocale?: string;
+  modelProvider?: string;
+  [key: string]: unknown;
+};
+
+export type RuntimeTranslationConfig = {
+  timeout?: number;
+  metadata?: RuntimeTranslateManyOptions;
+};
 
 /**
  * Parameters for the I18nManager constructor
  */
 export type I18nManagerConstructorParams<
   TranslationValue extends Translation = Translation,
-> = GTConfig & {
+> = Omit<GTConfig, 'cacheExpiryTime'> & {
+  /**
+   * Locale cache TTL in milliseconds. Undefined uses the default TTL, null
+   * disables expiry, and a number sets an explicit TTL.
+   */
+  cacheExpiryTime?: number | null;
   loadTranslations?: TranslationsLoader;
   environment?: 'development' | 'production';
+  batchConfig?: TranslationBatchConfig;
+  runtimeTranslation?: RuntimeTranslationConfig;
   // Cache lifecycle hooks
   /** @deprecated - move to subscription api instead */
   lifecycle?: LifecycleCallbacks<TranslationValue>;
@@ -30,6 +49,13 @@ export type I18nManagerConfig = {
   devApiKey?: string;
   apiKey?: string;
   runtimeUrl?: string | null;
+  /**
+   * Locale cache TTL in milliseconds. Undefined uses the default TTL, null
+   * disables expiry, and a number sets an explicit TTL.
+   */
+  cacheExpiryTime?: number | null;
+  batchConfig?: TranslationBatchConfig;
+  runtimeTranslation?: RuntimeTranslationConfig;
   _versionId?: string;
 };
 

--- a/packages/i18n/src/internal-types.ts
+++ b/packages/i18n/src/internal-types.ts
@@ -4,8 +4,6 @@ export type {
   TranslationsLoader,
   I18nManagerConfig,
   LifecycleCallbacks,
-  RuntimeTranslateManyOptions,
-  RuntimeTranslationConfig,
   ConditionStoreConfig,
   ConditionStore,
   WritableConditionStore,

--- a/packages/i18n/src/internal-types.ts
+++ b/packages/i18n/src/internal-types.ts
@@ -4,6 +4,8 @@ export type {
   TranslationsLoader,
   I18nManagerConfig,
   LifecycleCallbacks,
+  RuntimeTranslateManyOptions,
+  RuntimeTranslationConfig,
   ConditionStoreConfig,
   ConditionStore,
   WritableConditionStore,


### PR DESCRIPTION
## Summary
- add I18nManager config for locale cache expiry, batching, and runtime translation timeout/metadata
- pass those controls through LocalesCache and TranslationsCache
- normalize invalid batch values and add focused gt-i18n coverage

## Tests
- pnpm --filter gt-i18n test -- --run src/i18n-manager/__tests__/I18nManager.test.ts src/i18n-manager/translations-manager/__tests__/TranslationsCache.test.ts src/i18n-manager/translations-manager/__tests__/LocalesCache.test.ts
- pnpm --filter gt-i18n build

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds three new `I18nManager` config knobs — `cacheExpiryTime` (locale cache TTL), `batchConfig` (runtime translation batching), and `runtimeTranslation` (timeout + metadata) — and threads them through `LocalesCache` and `TranslationsCache`. Batch config values are normalized against zero/non-finite inputs, but `cacheExpiryTime: 0` is not guarded and would produce an immediately-expiring cache (every lookup re-fetches). New focused tests cover TTL expiry, TTL disable, custom batch intervals/sizes, and invalid batch values.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; only a P2 style inconsistency between cacheExpiryTime and batchConfig normalization.

All findings are P2. The change is additive, well-tested, and the zero-TTL issue is a mis-use edge case rather than a present breakage.

packages/i18n/src/i18n-manager/translations-manager/LocalesCache.ts — cacheExpiryTime: 0 normalization gap
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/i18n-manager/translations-manager/TranslationsCache.ts | Adds `TranslationBatchConfig` type and `normalizeBatchConfig` helper; wires `_batchConfig` into batch-flush and drain-queue logic. Normalization correctly rejects zero/non-finite values for all three fields. |
| packages/i18n/src/i18n-manager/translations-manager/LocalesCache.ts | Threads `batchConfig` through to each `TranslationsCache` on miss; `cacheExpiryTime: 0` is not normalized and creates an immediately-expiring cache (unlike batchConfig fields which reject zero). |
| packages/i18n/src/i18n-manager/I18nManager.ts | Extracts `runtimeTranslation` timeout/metadata from config and passes to `createTranslateManyFactory`; forwards `cacheExpiryTime` and `batchConfig` to `LocalesCache`. Clean pass-through. |
| packages/i18n/src/i18n-manager/translations-manager/utils/createTranslateMany.ts | Adds `metadata` parameter to factory; spread order `{ ...metadata, targetLocale: locale }` correctly ensures `targetLocale` is never overridden by caller-supplied metadata. |
| packages/i18n/src/i18n-manager/types.ts | Adds `RuntimeTranslateManyOptions`, `RuntimeTranslationConfig` types and extends `I18nManagerConstructorParams`/`I18nManagerConfig` with `cacheExpiryTime`, `batchConfig`, `runtimeTranslation`. Type definitions are clean. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[I18nManager constructor] -->|standardizeConfig| B[I18nManagerConfig]
    B -->|cacheExpiryTime, batchConfig| C[LocalesCache]
    B -->|runtimeTranslation.timeout\nruntimeTranslation.metadata| D[createTranslateManyFactory]
    D --> E[CreateTranslateMany closure]
    C -->|on miss| F[TranslationsCache per locale]
    F -->|normalizeBatchConfig| G[_batchConfig\nmaxBatchSize / batchInterval / maxConcurrentRequests]
    E -->|translateMany call| H[gtInstance.translateMany\nsources, metadata + targetLocale, timeout]
    C -->|ttl=null → -1\nttl=0 → 0 ⚠️\nttl=N → N| I[expiresAt computation]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/i18n/src/i18n-manager/translations-manager/LocalesCache.ts:101
**`cacheExpiryTime: 0` silently creates a zero-TTL cache**

When a caller passes `cacheExpiryTime: 0`, `this.ttl` is set to `0`, and `fallback()` computes `expiresAt = Date.now() + 0`. Every subsequent `get()` call will see `entry.expiresAt < Date.now()` as true, so every locale lookup misses the cache and re-fetches, defeating the purpose of caching entirely.

The batch config helpers (`getPositiveInteger`, `getPositiveValue`) already reject zero and fall back to defaults — but `cacheExpiryTime` has no equivalent guard. Consider adding a normalization step similar to:

```ts
this.ttl = ttl === null ? -1 : ((ttl != null && ttl > 0) ? ttl : DEFAULT_CACHE_EXPIRY_TIME);
```

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["refactor(i18n): move translation cache c..."](https://github.com/generaltranslation/gt/commit/da05a1c6760e1082258663836bb162bda7a4b706) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30413415)</sub>

<!-- /greptile_comment -->