### PR TITLE
fix(i18n): preserve locale cache keys

### DIFF
--- a/.changeset/great-locale-cache-keys.md
+++ b/.changeset/great-locale-cache-keys.md
@@ -1,0 +1,5 @@
+---
+'gt-i18n': patch
+---
+
+Fix dialect translation cache keys for fallback and custom alias locales.

--- a/packages/i18n/src/i18n-manager/I18nManager.ts
+++ b/packages/i18n/src/i18n-manager/I18nManager.ts
@@ -217,14 +217,14 @@ class I18nManager<
   ): Promise<Record<Hash, TranslationValue>> {
     try {
       // Validate
-      const resolvedLocale = this.resolveLocale(locale);
-      if (!this.requiresTranslation(resolvedLocale)) {
+      const translationLocale = this.resolveTranslationCacheLocale(locale);
+      if (!translationLocale) {
         return {};
       }
 
       // Get the locale cache
-      let txCache = this.localesCache.get(resolvedLocale);
-      if (!txCache) txCache = await this.localesCache.miss(resolvedLocale);
+      let txCache = this.localesCache.get(translationLocale);
+      if (!txCache) txCache = await this.localesCache.miss(translationLocale);
 
       // Get the translations
       const translations = txCache.getInternalCache();
@@ -245,16 +245,16 @@ class I18nManager<
   ): T | undefined {
     try {
       // Validate
-      const { resolvedLocale, options: lookupOptions } =
+      const { translationLocale, options: lookupOptions } =
         this.resolveLookupParams(locale, options);
 
       // Early return if in default locale
-      if (!this.requiresTranslation(resolvedLocale)) {
+      if (!translationLocale) {
         return message;
       }
 
       // Get the locale cache
-      const txCache = this.localesCache.get(resolvedLocale);
+      const txCache = this.localesCache.get(translationLocale);
       if (!txCache) return undefined;
 
       // Get the translation
@@ -278,17 +278,17 @@ class I18nManager<
   ): Promise<T | undefined> {
     try {
       // Validate
-      const { resolvedLocale, options: lookupOptions } =
+      const { translationLocale, options: lookupOptions } =
         this.resolveLookupParams(locale, options);
 
       // Early return if in default locale
-      if (!this.requiresTranslation(resolvedLocale)) {
+      if (!translationLocale) {
         return message;
       }
 
       // Get the locale cache
-      let txCache = this.localesCache.get(resolvedLocale);
-      if (!txCache) txCache = await this.localesCache.miss(resolvedLocale);
+      let txCache = this.localesCache.get(translationLocale);
+      if (!txCache) txCache = await this.localesCache.miss(translationLocale);
 
       // Get the translation (falling back to runtime translate)
       let translation = txCache.get({ message, options: lookupOptions });
@@ -319,28 +319,30 @@ class I18nManager<
   ): Promise<TranslationResolver<TranslationValue>> {
     try {
       // Validate
-      const resolvedLocale = this.resolveLocale(locale);
+      const translationLocale = this.resolveTranslationCacheLocale(locale);
 
       // Early return if i18n is disabled or default locale
-      if (!this.requiresTranslation(resolvedLocale)) {
+      if (!translationLocale) {
         return (message) => message;
       }
 
       // Invariant: all prefetchEntries must be the same locale
       const resolvedPrefetchEntries = resolvePrefetchEntriesByLocale(
         prefetchEntries,
-        resolvedLocale,
-        (entryLocale) => this.resolveLocale(entryLocale)
+        translationLocale,
+        (entryLocale) =>
+          this.resolveTranslationCacheLocale(entryLocale) ??
+          this.resolveLocale(entryLocale)
       );
       if (resolvedPrefetchEntries.length !== prefetchEntries.length) {
         logger.warn(
-          `I18nManager: getLookupTranslation(): prefetchEntries must all be the same locale, ignoring all entries that are not for ${resolvedLocale}`
+          `I18nManager: getLookupTranslation(): prefetchEntries must all be the same locale, ignoring all entries that are not for ${translationLocale}`
         );
       }
 
       // Get Locale Cache
-      let txCache = this.localesCache.get(resolvedLocale);
-      if (!txCache) txCache = await this.localesCache.miss(resolvedLocale);
+      let txCache = this.localesCache.get(translationLocale);
+      if (!txCache) txCache = await this.localesCache.miss(translationLocale);
       if (!txCache) return () => undefined;
 
       // Prefetch any entries during async block
@@ -468,24 +470,49 @@ class I18nManager<
     return resolvedLocale;
   }
 
-  private resolveLookupParams(locale: string, options: LookupOptions) {
+  /**
+   * Resolve the locale key used to load/read translation caches.
+   * Returns undefined when the requested locale can use source content.
+   */
+  private resolveTranslationCacheLocale(locale: string) {
     const resolvedLocale = this.resolveLocale(locale);
+    if (this.requiresTranslation(resolvedLocale)) {
+      return resolvedLocale;
+    }
+
+    const aliasLocale = this.localeConfig.resolveAliasLocale(
+      standardizeLocale(locale)
+    );
+    if (this.requiresTranslation(aliasLocale)) {
+      return aliasLocale;
+    }
+
+    return undefined;
+  }
+
+  private resolveLookupParams(locale: string, options: LookupOptions) {
+    const translationLocale = this.resolveTranslationCacheLocale(locale);
     return {
-      resolvedLocale,
-      options: this.resolveLookupOptions(options, resolvedLocale),
+      translationLocale,
+      options: translationLocale
+        ? this.resolveLookupOptions(options, translationLocale)
+        : options,
     };
   }
 
   private resolveLookupOptions(
     options: LookupOptions = {} as LookupOptions,
-    resolvedLocale?: string
+    translationLocale?: string
   ) {
     if (!options.$locale) {
       return options;
     }
     return {
       ...options,
-      $locale: resolvedLocale ?? this.resolveLocale(options.$locale),
+      $locale:
+        translationLocale ??
+        this.resolveTranslationCacheLocale(options.$locale) ??
+        this.resolveLocale(options.$locale),
     };
   }
 
@@ -498,7 +525,15 @@ class I18nManager<
     return new GT({
       sourceLocale: this.config.defaultLocale,
       targetLocale: locale,
-      locales: this.config.locales,
+      // GT validates approved locales before constructing its LocaleConfig, so
+      // pass canonical locales here while preserving alias target locales.
+      locales: Array.from(
+        new Set(
+          this.config.locales.map((locale) =>
+            this.localeConfig.resolveCanonicalLocale(locale)
+          )
+        )
+      ),
       customMapping: this.config.customMapping,
       projectId: this.config.projectId,
       baseUrl: this.config.runtimeUrl || undefined,

--- a/packages/i18n/src/i18n-manager/__tests__/I18nManager.test.ts
+++ b/packages/i18n/src/i18n-manager/__tests__/I18nManager.test.ts
@@ -138,6 +138,66 @@ describe('I18nManager', () => {
     expect(loadTranslations).toHaveBeenCalledTimes(testCase.calls);
   });
 
+  it.each([
+    {
+      name: 'requested dialect locale',
+      locale: 'en-GB',
+      translationLocale: 'en-GB',
+      translation: 'Hello there {name}!',
+    },
+    {
+      name: 'custom alias locale',
+      locale: 'brand-british',
+      translationLocale: 'brand-british',
+      translation: 'Hello mate {name}!',
+      customMapping: {
+        'brand-british': {
+          code: 'en-GB',
+          name: 'Brand British',
+        },
+      },
+    },
+    {
+      name: 'canonical locale with custom alias',
+      locale: 'en-GB',
+      translationLocale: 'brand-british',
+      translation: 'Hello mate {name}!',
+      customMapping: {
+        'brand-british': {
+          code: 'en-GB',
+          name: 'Brand British',
+        },
+      },
+    },
+  ])(
+    'uses $name cache key when approved fallback is source-equivalent',
+    async (testCase) => {
+      const loadTranslations = vi
+        .fn()
+        .mockResolvedValue({ [expectedHash]: testCase.translation });
+      const manager = createManager({
+        defaultLocale: 'en-US',
+        locales: ['en-US', 'en'],
+        loadTranslations,
+        ...(testCase.customMapping && {
+          customMapping: testCase.customMapping,
+        }),
+      });
+
+      expect(manager.requiresTranslation('en-GB')).toBe(true);
+      expect(manager.requiresDialectTranslation('en-GB')).toBe(true);
+
+      const translations = await manager.loadTranslations(testCase.locale);
+
+      expect(loadTranslations).toHaveBeenCalledTimes(1);
+      expect(loadTranslations).toHaveBeenCalledWith(testCase.translationLocale);
+      expect(translations[expectedHash]).toBe(testCase.translation);
+      expect(
+        manager.lookupTranslation(testCase.locale, message, lookupOptions)
+      ).toBe(testCase.translation);
+    }
+  );
+
   it('lookupTranslationWithFallback() falls back to runtime translate on cache miss', async () => {
     const unknownMessage = 'Unknown message';
     const unknownOptions: LookupOptions = { $format: 'ICU' };
@@ -195,6 +255,23 @@ describe('I18nManager', () => {
     expect(manager.requiresTranslation('brand-french')).toBe(true);
     expect(manager.requiresDialectTranslation('en-US')).toBe(false);
     expect(() => manager.getGTClass('brand-french')).not.toThrow();
+  });
+
+  it('preserves alias target locale when creating a GT instance', () => {
+    const manager = createManager({
+      locales: ['en', 'brand-french'],
+      customMapping: {
+        'brand-french': {
+          code: 'fr',
+          name: 'Brand French',
+        },
+      },
+    });
+
+    const gt = manager.getGTClass('fr');
+
+    expect(gt.targetLocale).toBe('brand-french');
+    expect(gt.locales).toEqual(['en', 'fr']);
   });
 
   it('normalizes custom aliases before loading and reading locale caches', async () => {


### PR DESCRIPTION
## Summary
- preserve dialect and custom alias locale cache keys when source-language fallback would otherwise skip loading
- keep alias target locales when creating bound GT instances
- add regression coverage for dialect fallback and alias locale cache keys

## Tests
- corepack pnpm --filter gt-i18n test -- src/i18n-manager/__tests__/I18nManager.test.ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR correctly fixes two related locale cache bugs: (1) dialect locales (e.g. `en-GB`) and custom alias locales (e.g. `brand-british`) were having their translation caches skipped when source-language fallback resolution treated them as source-equivalent; (2) `getGTClassClean` was passing raw alias keys in the `locales` array to the GT constructor, which now receives canonical locale forms instead. The new `resolveTranslationCacheLocale` private method centralises both the `resolveLocale` resolution and the alias-based secondary lookup, and the updated callers consistently use it across all translation-loading and lookup paths.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

PR is safe to merge — the logic change is well-scoped, all existing paths are covered, and the new regression tests exercise the fixed scenarios end-to-end.

No P0 or P1 issues found. The new `resolveTranslationCacheLocale` method is a clear, focused refactor with proper fallback semantics. The only previously-open concern (non-canonical `targetLocale` vs canonical `locales` in the GT constructor) was already flagged in a prior review thread.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/great-locale-cache-keys.md | New patch-level changeset entry for the locale cache key fix. |
| packages/i18n/src/i18n-manager/I18nManager.ts | Introduces `resolveTranslationCacheLocale` to handle dialect/alias fallback; replaces `resolveLocale + requiresTranslation` pattern across translation-loading methods; maps configured locales to canonical forms in `getGTClassClean`. |
| packages/i18n/src/i18n-manager/__tests__/I18nManager.test.ts | Adds regression tests for dialect locale cache keys, custom alias locale cache keys, and canonical-locale-with-alias GT instance construction. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["resolveTranslationCacheLocale(locale)"] --> B["resolveLocale(locale)\n→ resolvedLocale"]
    B --> C{requiresTranslation\nresolvedLocale?}
    C -- yes --> D["return resolvedLocale"]
    C -- no --> E["resolveAliasLocale(\n  standardizeLocale(locale)\n) → aliasLocale"]
    E --> F{requiresTranslation\naliasLocale?}
    F -- yes --> G["return aliasLocale\n(dialect / custom alias key)"]
    F -- no --> H["return undefined\n(use source content)"]
    D -->|"cache key"| I["localesCache.get/miss(key)"]
    G -->|"cache key"| I
    H -->|"no translation needed"| J["return {} / message"]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(i18n): preserve locale cache keys"](https://github.com/generaltranslation/gt/commit/46df692ab4f1fbd6b2aea5ab959b7bacbd05f3a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30511229)</sub>

<!-- /greptile_comment -->