### PR TITLE
fix: avoid mutating locale selector locales

### DIFF
--- a/.changeset/sort-locale-selector-copy.md
+++ b/.changeset/sort-locale-selector-copy.md
@@ -1,0 +1,5 @@
+---
+"@generaltranslation/react-core": patch
+---
+
+Fix locale selector sorting so it does not mutate provider locale state.

--- a/packages/react-core/src/hooks/useLocaleSelector.ts
+++ b/packages/react-core/src/hooks/useLocaleSelector.ts
@@ -6,7 +6,6 @@ import useGTContext from '../provider/GTContext';
  * Gets the list of properties for using a locale selector.
  * Provides locale management utilities for the application.
  * @param locales an optional list of locales to use for the drop down. These locales must be a subset of the locales provided by the `<GTProvider>` context. When not provided, the list of locales from the `<GTProvider>` context is used.
- * Provides locale management utilities for the application.
  *
  * @returns {Object} An object containing locale-related utilities:
  * @returns {string} return.locale - The currently selected locale.
@@ -23,14 +22,14 @@ export default function useLocaleSelector(locales?: string[]) {
     if (!contextLocales || contextLocales.length === 0) {
       return [];
     }
-    const res = contextLocales.sort((a, b) =>
-      new Intl.Collator().compare(
+    const collator = new Intl.Collator();
+    return [...contextLocales].sort((a, b) =>
+      collator.compare(
         gt.getLocaleProperties(a).nativeNameWithRegionCode,
         gt.getLocaleProperties(b).nativeNameWithRegionCode
       )
     );
-    return res;
-  }, [contextLocales]);
+  }, [contextLocales, gt]);
 
   // create getLocaleProperties callback
   const getLocalePropertiesCallback = useCallback(


### PR DESCRIPTION
## Summary
- Sort a copied locale array in `useLocaleSelector` instead of mutating provider locale state.
- Include `gt` in the memo dependency list.
- Add a patch changeset for `@generaltranslation/react-core`.

## Testing
- `PATH=/Users/bgub/.local/state/fnm_multishells/99733_1777516129942/bin:$PATH pnpm --filter @generaltranslation/react-core lint` (passes with existing warnings)
- `PATH=/Users/bgub/.local/state/fnm_multishells/99733_1777516129942/bin:$PATH pnpm --filter @generaltranslation/react-core transpile`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug in `useLocaleSelector` where calling `.sort()` directly on `contextLocales` was mutating the provider's locale state array in place. The fix spreads the array into a copy before sorting (`[...contextLocales].sort(...)`), and also extracts a single `Intl.Collator` instance outside the comparator (avoiding recreating it on every comparison). `gt` is added to the `useMemo` dependency array for correctness.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge — the fix is minimal, correct, and addresses a clear mutation bug.

The change correctly prevents in-place mutation of provider state by spreading the array before sorting. Adding `gt` to the `useMemo` dependency array is consistent with its existing usage in `useCallback`. The `Intl.Collator` extraction is a minor perf improvement. No regressions or new issues introduced.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/hooks/useLocaleSelector.ts | Fixes in-place mutation of provider locale array by sorting a shallow copy; extracts Intl.Collator for efficiency; adds `gt` to useMemo deps. |
| .changeset/sort-locale-selector-copy.md | Adds a patch changeset entry for `@generaltranslation/react-core` describing the locale sort mutation fix. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Component
    participant ULS as useLocaleSelector
    participant CTX as GTContext (Provider)

    C->>ULS: useLocaleSelector(locales?)
    ULS->>CTX: useGTContext()
    CTX-->>ULS: { contextLocales, locale, setLocale, gt }

    Note over ULS: useMemo([contextLocales, gt])
    ULS->>ULS: [...contextLocales] (shallow copy)
    ULS->>ULS: copy.sort(collator.compare(nativeNameWithRegionCode))
    Note over CTX: contextLocales array is NOT mutated

    ULS-->>C: { locale, locales: sortedLocales, setLocale, getLocaleProperties }
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: avoid mutating locale selector loca..."](https://github.com/generaltranslation/gt/commit/cc079091093bdb5b598c3bad6dec5daa234d83d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30519514)</sub>

<!-- /greptile_comment -->