### PR TITLE
fix(cli): clarify missing download status

### DIFF
--- a/.changeset/quiet-download-missing-files.md
+++ b/.changeset/quiet-download-missing-files.md
@@ -1,0 +1,5 @@
+---
+"gt": patch
+---
+
+Show a warning download status when completed files are missing from the download response.

--- a/packages/cli/src/workflows/steps/DownloadStep.ts
+++ b/packages/cli/src/workflows/steps/DownloadStep.ts
@@ -38,19 +38,7 @@ export class DownloadTranslationsStep extends WorkflowStep<
     this.spinner = logger.createProgressBar(fileTracker.completed.size);
     this.spinner.start('Downloading files...');
 
-    // Download ready files
-    const success = await this.downloadFiles(
-      fileTracker,
-      resolveOutputPath,
-      forceDownload
-    );
-    if (success) {
-      this.spinner.stop(chalk.green('Downloaded files successfully'));
-    } else {
-      this.spinner.stop(chalk.red('Failed to download files'));
-    }
-
-    return success;
+    return this.downloadFiles(fileTracker, resolveOutputPath, forceDownload);
   }
 
   private async downloadFiles(
@@ -64,6 +52,7 @@ export class DownloadTranslationsStep extends WorkflowStep<
 
       // If no files to download, we're done
       if (currentQueryData.length === 0) {
+        this.spinner?.stop(chalk.green('No files to download'));
         return true;
       }
 
@@ -82,6 +71,7 @@ export class DownloadTranslationsStep extends WorkflowStep<
       const readyTranslations = translatedFiles.filter(
         (file) => file.completedAt !== null
       );
+      let missingCount = 0;
 
       if (readyTranslations.length < currentQueryData.length) {
         const readyKeys = new Set(
@@ -95,6 +85,7 @@ export class DownloadTranslationsStep extends WorkflowStep<
               `${item.branchId}:${item.fileId}:${item.versionId}:${item.locale}`
             )
         );
+        missingCount = missing.length;
         logger.warn(
           `Failed to download ${missing.length} file(s):\n${missing.map((f) => `- ${f.fileName} (${f.locale})`).join('\n')}`
         );
@@ -161,6 +152,10 @@ export class DownloadTranslationsStep extends WorkflowStep<
             );
           }
         }
+      } else if (missingCount > 0) {
+        this.spinner?.stop(
+          chalk.yellow('No files downloaded - see warnings above')
+        );
       } else {
         this.spinner?.stop(chalk.green('No files to download'));
       }

--- a/packages/cli/src/workflows/steps/__tests__/DownloadStep.test.ts
+++ b/packages/cli/src/workflows/steps/__tests__/DownloadStep.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GT } from 'generaltranslation';
+import type { Settings } from '../../../types/index.js';
+import { downloadFileBatch } from '../../../api/downloadFileBatch.js';
+import { logger } from '../../../console/logger.js';
+import {
+  clearWarnings,
+  getWarnings,
+} from '../../../state/translateWarnings.js';
+import { DownloadTranslationsStep } from '../DownloadStep.js';
+
+vi.mock('../../../console/logger.js', () => ({
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+    createProgressBar: vi.fn(() => ({
+      start: vi.fn(),
+      stop: vi.fn(),
+      advance: vi.fn(),
+    })),
+  },
+}));
+
+vi.mock('../../../api/downloadFileBatch.js', () => ({
+  downloadFileBatch: vi.fn(),
+}));
+
+describe('DownloadTranslationsStep', () => {
+  const mockGt = {
+    queryFileData: vi.fn(),
+  };
+
+  const mockSettings = {};
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearWarnings();
+  });
+
+  it('shows a warning stop message when every completed file is missing', async () => {
+    mockGt.queryFileData.mockResolvedValue({
+      translatedFiles: [],
+    });
+
+    const fileTracker = {
+      completed: new Map([
+        [
+          'branch-1:file-1:version-1:fr',
+          {
+            branchId: 'branch-1',
+            fileId: 'file-1',
+            versionId: 'version-1',
+            locale: 'fr',
+            fileName: 'messages.json',
+          },
+        ],
+      ]),
+      inProgress: new Map(),
+      failed: new Map(),
+      skipped: new Map(),
+    };
+
+    const step = new DownloadTranslationsStep(
+      mockGt as unknown as GT,
+      mockSettings as Settings
+    );
+    const success = await step.run({
+      fileTracker,
+      resolveOutputPath: () => 'out/messages.fr.json',
+    });
+
+    expect(success).toBe(true);
+    expect(downloadFileBatch).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to download 1 file(s)')
+    );
+
+    const progressBar = vi.mocked(logger.createProgressBar).mock.results[0]
+      ?.value;
+
+    expect(progressBar?.stop).toHaveBeenCalledTimes(1);
+    expect(progressBar?.stop).toHaveBeenCalledWith(
+      expect.stringContaining('No files downloaded')
+    );
+    expect(getWarnings()).toEqual([
+      {
+        category: 'failed_download',
+        fileName: 'messages.json',
+        reason: 'Failed to download for locale fr',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Let `DownloadTranslationsStep` stop the progress bar from the detailed download paths instead of always reporting generic success.
- Show a warning status when all completed files are missing from the download response.
- Add regression coverage for the missing completed-file case.

## Context
This is related to PR #1300 but is a separate local follow-up from the recovered worktree.

## Testing
- `PATH=/Users/bgub/.local/state/fnm_multishells/99733_1777516129942/bin:$PATH pnpm --filter gt exec vitest run src/workflows/steps/__tests__/DownloadStep.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves spinner lifecycle management from `run()` into `downloadFiles()`, adds a `missingCount` variable to track files absent from the API response, and surfaces a yellow "No files downloaded - see warnings above" status when every queried file is missing. A new regression test covers this path end-to-end.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all spinner stop paths are covered, the new warning branch is logically correct, and the regression test validates the targeted case.

No P0 or P1 issues found. All code paths call spinner.stop exactly once, the missingCount variable is correctly scoped and checked, and the test accurately reflects the new behavior.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/workflows/steps/DownloadStep.ts | Moves spinner lifecycle management into downloadFiles(), adds missingCount tracking, and adds a yellow warning stop when all queried files are absent from the API response. |
| packages/cli/src/workflows/steps/__tests__/DownloadStep.test.ts | New regression test that exercises the all-files-missing path, validating the warning spinner message, warn log, and recorded warning state. |
| .changeset/quiet-download-missing-files.md | Patch-level changeset entry describing the new warning behavior for missing download files. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[run] --> B[createProgressBar / start]
    B --> C[downloadFiles]
    C --> D{currentQueryData.length == 0?}
    D -- Yes --> E[stop: green 'No files to download'\nreturn true]
    D -- No --> F[queryFileData]
    F --> G{readyTranslations < currentQueryData?}
    G -- Yes --> H[log warn + recordWarning\nmissingCount = missing.length]
    G -- No --> I[missingCount stays 0]
    H --> J[build batchFiles]
    I --> J
    J --> K{batchFiles.length > 0?}
    K -- Yes --> L[downloadFilesWithRetry]
    L --> M[stop: green 'Downloaded X files'\nreturn true]
    K -- No --> N{missingCount > 0?}
    N -- Yes --> O[stop: yellow 'No files downloaded - see warnings above'\nreturn true]
    N -- No --> P[stop: green 'No files to download'\nreturn true]
    C -- exception --> Q[stop: red error\nreturn false]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): clarify missing download statu..."](https://github.com/generaltranslation/gt/commit/292d4aaccf72ad48e066379f2e5e9229bf6059e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30538254)</sub>

<!-- /greptile_comment -->