### PR TITLE
fix(compiler): preserve typed static expression errors

### DIFF
--- a/.changeset/four-flies-reply.md
+++ b/.changeset/four-flies-reply.md
@@ -1,0 +1,5 @@
+---
+"@generaltranslation/compiler": patch
+---
+
+Preserve invalid template escape errors in `msg()` and `t()` validation even when string autoderive is enabled.

--- a/packages/compiler/src/transform/macro-expansion/transformTemplateLiteral.ts
+++ b/packages/compiler/src/transform/macro-expansion/transformTemplateLiteral.ts
@@ -20,7 +20,7 @@ export function transformTemplateLiteral(path: NodePath<t.TemplateLiteral>): {
 } {
   const { parts, errors } = flattenExpressionToParts(path);
   if (errors.length > 0) {
-    return { errors, content: [] };
+    return { errors: errors.map(({ message }) => message), content: [] };
   }
   const variants = multiply(parts);
 

--- a/packages/compiler/src/transform/validation/__tests__/validateTranslationFunctionCallback.test.ts
+++ b/packages/compiler/src/transform/validation/__tests__/validateTranslationFunctionCallback.test.ts
@@ -668,13 +668,16 @@ describe('validateTranslationFunctionCallback', () => {
         expect(result.context).toBe('greeting');
       });
 
-      it('should return error when $context is not a static expression', () => {
+      it('should report invalid template escapes in $context', () => {
         const callExpr = t.callExpression(t.identifier('useGT_callback'), [
           t.stringLiteral('Hello'),
           t.objectExpression([
             t.objectProperty(
               t.identifier('$context'),
-              t.identifier('contextVar')
+              t.templateLiteral(
+                [t.templateElement({ raw: '\\xg', cooked: undefined })],
+                []
+              )
             ),
           ]),
         ]);
@@ -684,7 +687,11 @@ describe('validateTranslationFunctionCallback', () => {
           state
         );
 
-        expect(result.errors.length).toBeGreaterThan(0);
+        expect(result.errors).toEqual([
+          'Template literal contains an invalid escape sequence',
+        ]);
+        expect(result.context).toBeUndefined();
+        expect(result.hasDeriveContext).toBeUndefined();
       });
 
       it('should return error when $id is not a string literal', () => {

--- a/packages/compiler/src/transform/validation/__tests__/validateTranslationFunctionCallback.test.ts
+++ b/packages/compiler/src/transform/validation/__tests__/validateTranslationFunctionCallback.test.ts
@@ -1106,6 +1106,25 @@ describe('validateTranslationFunctionCallback', () => {
       expect(result.hasDeriveContext).toBe(true);
     });
 
+    it('should still report invalid template escapes when autoderive is enabled', () => {
+      const callExpr = t.callExpression(t.identifier('useGT_callback'), [
+        t.templateLiteral(
+          [t.templateElement({ raw: '\\xg', cooked: undefined })],
+          []
+        ),
+      ]);
+
+      const result = validateTranslationFunction(
+        getCallExpressionPath(callExpr),
+        autoderiveState
+      );
+
+      expect(result.errors).toEqual([
+        'Template literal contains an invalid escape sequence',
+      ]);
+      expect(result.hasDeriveContext).toBeUndefined();
+    });
+
     it('should accept concatenation with bare variable when autoderive is enabled', () => {
       // gt("Hello, " + name)
       const callExpr = t.callExpression(t.identifier('useGT_callback'), [

--- a/packages/compiler/src/transform/validation/validateTranslationFunction.ts
+++ b/packages/compiler/src/transform/validation/validateTranslationFunction.ts
@@ -51,12 +51,12 @@ export function validateTranslationFunction(
   );
   // TODO: until we implement derivation, we will only need to check the first value
   const content = resolvedStaticExpression.values?.[0];
-  const nonDynamicResolutionErrors = resolvedStaticExpression.errors.filter(
-    (error) => error !== 'Expression is not a static string'
-  );
 
-  if (nonDynamicResolutionErrors.length > 0) {
-    return { errors: nonDynamicResolutionErrors };
+  if (
+    resolvedStaticExpression.errors.length > 0 &&
+    resolvedStaticExpression.kind !== 'dynamic-expression'
+  ) {
+    return { errors: resolvedStaticExpression.errors };
   }
 
   if (content === undefined && !state.settings.autoderive.strings) {

--- a/packages/compiler/src/transform/validation/validateTranslationFunction.ts
+++ b/packages/compiler/src/transform/validation/validateTranslationFunction.ts
@@ -51,6 +51,13 @@ export function validateTranslationFunction(
   );
   // TODO: until we implement derivation, we will only need to check the first value
   const content = resolvedStaticExpression.values?.[0];
+  const nonDynamicResolutionErrors = resolvedStaticExpression.errors.filter(
+    (error) => error !== 'Expression is not a static string'
+  );
+
+  if (nonDynamicResolutionErrors.length > 0) {
+    return { errors: nonDynamicResolutionErrors };
+  }
 
   if (content === undefined && !state.settings.autoderive.strings) {
     // Not a static expression — check if it contains a derive() function invocation

--- a/packages/compiler/src/transform/validation/validateTranslationFunction.ts
+++ b/packages/compiler/src/transform/validation/validateTranslationFunction.ts
@@ -5,7 +5,10 @@ import {
 } from '../../utils/constants/gt/constants';
 import { TransformState } from '../../state/types';
 import { getCalleeNameFromExpression } from '../../utils/parsing/getCalleeNameFromExpression';
-import { resolveStaticExpression } from '../../utils/string-expressions/resolveStaticExpression';
+import {
+  resolveStaticExpression,
+  type ResolveStaticExpressionError,
+} from '../../utils/string-expressions/resolveStaticExpression';
 import { getTrackedVariable } from '../getTrackedVariable';
 import { NodePath } from '@babel/traverse';
 
@@ -51,19 +54,22 @@ export function validateTranslationFunction(
   );
   // TODO: until we implement derivation, we will only need to check the first value
   const content = resolvedStaticExpression.values?.[0];
+  const resolutionErrors = getResolutionErrorMessages(
+    resolvedStaticExpression.errors,
+    false
+  );
 
-  if (
-    resolvedStaticExpression.errors.length > 0 &&
-    resolvedStaticExpression.kind !== 'dynamic-expression'
-  ) {
-    return { errors: resolvedStaticExpression.errors };
+  if (resolutionErrors.length > 0) {
+    return { errors: resolutionErrors };
   }
 
   if (content === undefined && !state.settings.autoderive.strings) {
     // Not a static expression — check if it contains a derive() function invocation
     validateDerive(callExpr.arguments[0], state, errors);
     if (errors.length > 0) {
-      errors.push(...resolvedStaticExpression.errors);
+      errors.push(
+        ...getResolutionErrorMessages(resolvedStaticExpression.errors)
+      );
       errors.push(
         'registration function must use a string literal or derive() call as the first argument. Variable content is not allowed.'
       );
@@ -176,6 +182,15 @@ export function validateUseMessagesCallback(_callExpr: t.CallExpression): {
 /* Helper Functions */
 /* =============================== */
 
+function getResolutionErrorMessages(
+  errors: ResolveStaticExpressionError[],
+  includeDynamic = true
+): string[] {
+  return errors
+    .filter((error) => includeDynamic || error.kind !== 'dynamic-expression')
+    .map(({ message }) => message);
+}
+
 /**
  * Validate a property from an object expression
  * @param objExpr - The object expression to validate
@@ -249,14 +264,12 @@ function validatePropertyFromObjectExpression(
     const resolved = resolveStaticExpression(
       valuePath.get('value') as NodePath<t.Expression>
     );
+    const resolutionErrors = getResolutionErrorMessages(resolved.errors, false);
     // TODO: until we implement derivation, we will only need to check the first value
     if (resolved.values?.[0] !== undefined) {
       result.value = resolved.values[0];
-    } else if (
-      resolved.errors.length > 0 &&
-      resolved.kind !== 'dynamic-expression'
-    ) {
-      result.errors.push(...resolved.errors);
+    } else if (resolutionErrors.length > 0) {
+      result.errors.push(...resolutionErrors);
     } else if (state) {
       // Static resolution failed — check if it's a valid derive() expression
       const deriveErrors: string[] = [];
@@ -264,10 +277,13 @@ function validatePropertyFromObjectExpression(
       if (deriveErrors.length === 0) {
         result.hasDeriveExpression = true;
       } else {
-        result.errors.push(...resolved.errors, ...deriveErrors);
+        result.errors.push(
+          ...getResolutionErrorMessages(resolved.errors),
+          ...deriveErrors
+        );
       }
     } else {
-      result.errors.push(...resolved.errors);
+      result.errors.push(...getResolutionErrorMessages(resolved.errors));
     }
   } else {
     const validatedValue =

--- a/packages/compiler/src/transform/validation/validateTranslationFunction.ts
+++ b/packages/compiler/src/transform/validation/validateTranslationFunction.ts
@@ -252,6 +252,11 @@ function validatePropertyFromObjectExpression(
     // TODO: until we implement derivation, we will only need to check the first value
     if (resolved.values?.[0] !== undefined) {
       result.value = resolved.values[0];
+    } else if (
+      resolved.errors.length > 0 &&
+      resolved.kind !== 'dynamic-expression'
+    ) {
+      result.errors.push(...resolved.errors);
     } else if (state) {
       // Static resolution failed — check if it's a valid derive() expression
       const deriveErrors: string[] = [];

--- a/packages/compiler/src/utils/string-expressions/__tests__/flattenExpressionToParts.test.ts
+++ b/packages/compiler/src/utils/string-expressions/__tests__/flattenExpressionToParts.test.ts
@@ -4,6 +4,7 @@ import traverse, { NodePath } from '@babel/traverse';
 import * as t from '@babel/types';
 import {
   flattenExpressionToParts,
+  INVALID_TEMPLATE_ESCAPE_ERROR,
   type Part,
 } from '../flattenExpressionToParts';
 import { buildTransformResult } from '../buildTransformationResult';
@@ -130,7 +131,10 @@ describe('flattenExpressionToParts', () => {
       const { parts, errors } = flattenExpressionToParts(path);
       expect(parts).toEqual([]);
       expect(errors).toEqual([
-        'Template literal contains an invalid escape sequence',
+        {
+          kind: 'invalid-template-escape',
+          message: INVALID_TEMPLATE_ESCAPE_ERROR,
+        },
       ]);
     });
   });
@@ -139,7 +143,10 @@ describe('flattenExpressionToParts', () => {
     withTaggedTemplatePath('tag`\\xg${value}\\xh`;', (path) => {
       const { errors } = flattenExpressionToParts(path);
       expect(errors).toEqual([
-        'Template literal contains an invalid escape sequence',
+        {
+          kind: 'invalid-template-escape',
+          message: INVALID_TEMPLATE_ESCAPE_ERROR,
+        },
       ]);
     });
   });
@@ -158,8 +165,12 @@ describe('resolveStaticExpression', () => {
   it('rejects dynamic expressions', () => {
     withExpressionPath('`Hello ${name}`', (path) => {
       expect(resolveStaticExpression(path)).toEqual({
-        kind: 'dynamic-expression',
-        errors: ['Expression is not a static string'],
+        errors: [
+          {
+            kind: 'dynamic-expression',
+            message: 'Expression is not a static string',
+          },
+        ],
       });
     });
   });
@@ -167,7 +178,12 @@ describe('resolveStaticExpression', () => {
   it('reports invalid escape sequences', () => {
     withTaggedTemplatePath('tag`\\xg`;', (path) => {
       expect(resolveStaticExpression(path)).toEqual({
-        errors: ['Template literal contains an invalid escape sequence'],
+        errors: [
+          {
+            kind: 'invalid-template-escape',
+            message: INVALID_TEMPLATE_ESCAPE_ERROR,
+          },
+        ],
       });
     });
   });

--- a/packages/compiler/src/utils/string-expressions/__tests__/flattenExpressionToParts.test.ts
+++ b/packages/compiler/src/utils/string-expressions/__tests__/flattenExpressionToParts.test.ts
@@ -158,6 +158,7 @@ describe('resolveStaticExpression', () => {
   it('rejects dynamic expressions', () => {
     withExpressionPath('`Hello ${name}`', (path) => {
       expect(resolveStaticExpression(path)).toEqual({
+        kind: 'dynamic-expression',
         errors: ['Expression is not a static string'],
       });
     });

--- a/packages/compiler/src/utils/string-expressions/flattenExpressionToParts.ts
+++ b/packages/compiler/src/utils/string-expressions/flattenExpressionToParts.ts
@@ -8,9 +8,27 @@ export type Part =
   | { type: 'derive'; node: t.Expression }
   | { type: 'dynamic'; node: t.Expression };
 
+export const INVALID_TEMPLATE_ESCAPE_ERROR =
+  'Template literal contains an invalid escape sequence';
+
+export type FlattenExpressionError = {
+  kind: 'invalid-template-escape' | 'invalid-expression';
+  message: string;
+};
+
+const INVALID_TEMPLATE_ESCAPE: FlattenExpressionError = {
+  kind: 'invalid-template-escape',
+  message: INVALID_TEMPLATE_ESCAPE_ERROR,
+};
+
+const INVALID_EXPRESSION: FlattenExpressionError = {
+  kind: 'invalid-expression',
+  message: 'Expression is not a valid expression',
+};
+
 type FlattenExpressionResult = {
   parts: ResolutionNode<Part>[];
-  errors: string[];
+  errors: FlattenExpressionError[];
 };
 
 function isStaticPart(
@@ -93,9 +111,7 @@ export function flattenExpressionToParts(
     for (let i = 0; i < expr.quasis.length; i++) {
       const cooked = expr.quasis[i].value.cooked;
       if (cooked == null) {
-        result.errors.push(
-          'Template literal contains an invalid escape sequence'
-        );
+        result.errors.push(INVALID_TEMPLATE_ESCAPE);
         return result;
       } else if (cooked) {
         appendPart(result.parts, { type: 'static', value: cooked });
@@ -103,7 +119,7 @@ export function flattenExpressionToParts(
       if (i < expr.expressions.length) {
         const exprPathIndex = exprPath.get('expressions')[i];
         if (!exprPathIndex.isExpression()) {
-          result.errors.push('Expression is not a valid expression');
+          result.errors.push(INVALID_EXPRESSION);
           return result;
         }
         const expressionResult = flattenExpressionToParts(exprPathIndex);
@@ -118,13 +134,13 @@ export function flattenExpressionToParts(
   if (t.isBinaryExpression(expr) && expr.operator === '+') {
     const leftPath = exprPath.get('left');
     if (!leftPath.isExpression()) {
-      return { parts: [], errors: ['Expression is not a valid expression'] };
+      return { parts: [], errors: [INVALID_EXPRESSION] };
     }
     const { parts: leftParts, errors: leftErrors } =
       flattenExpressionToParts(leftPath);
     const rightPath = exprPath.get('right');
     if (!rightPath.isExpression()) {
-      return { parts: [], errors: ['Expression is not a valid expression'] };
+      return { parts: [], errors: [INVALID_EXPRESSION] };
     }
     const { parts: rightParts, errors: rightErrors } =
       flattenExpressionToParts(rightPath);

--- a/packages/compiler/src/utils/string-expressions/resolveStaticExpression.ts
+++ b/packages/compiler/src/utils/string-expressions/resolveStaticExpression.ts
@@ -14,6 +14,7 @@ import { multiply } from '../multiplication/multiply';
 export function resolveStaticExpression(exprPath: NodePath<t.Expression>): {
   errors: string[];
   values?: string[];
+  kind?: 'dynamic-expression';
 } {
   const { parts, errors } = flattenExpressionToParts(exprPath);
   if (errors.length > 0) return { errors };
@@ -27,7 +28,10 @@ export function resolveStaticExpression(exprPath: NodePath<t.Expression>): {
       if (part.type === 'derive') {
         return { errors: [], values: undefined };
       } else if (part.type !== 'static') {
-        return { errors: ['Expression is not a static string'] };
+        return {
+          kind: 'dynamic-expression',
+          errors: ['Expression is not a static string'],
+        };
       }
       value += part.value;
     }

--- a/packages/compiler/src/utils/string-expressions/resolveStaticExpression.ts
+++ b/packages/compiler/src/utils/string-expressions/resolveStaticExpression.ts
@@ -1,7 +1,22 @@
 import * as t from '@babel/types';
 import type { NodePath } from '@babel/traverse';
-import { flattenExpressionToParts } from './flattenExpressionToParts';
+import {
+  flattenExpressionToParts,
+  type FlattenExpressionError,
+} from './flattenExpressionToParts';
 import { multiply } from '../multiplication/multiply';
+
+export type ResolveStaticExpressionError =
+  | FlattenExpressionError
+  | {
+      kind: 'dynamic-expression';
+      message: string;
+    };
+
+const DYNAMIC_EXPRESSION_ERROR: ResolveStaticExpressionError = {
+  kind: 'dynamic-expression',
+  message: 'Expression is not a static string',
+};
 
 /**
  * Attempt to resolve an expression to static string values at compile time.
@@ -12,9 +27,8 @@ import { multiply } from '../multiplication/multiply';
  * dynamic or derive content.
  */
 export function resolveStaticExpression(exprPath: NodePath<t.Expression>): {
-  errors: string[];
+  errors: ResolveStaticExpressionError[];
   values?: string[];
-  kind?: 'dynamic-expression';
 } {
   const { parts, errors } = flattenExpressionToParts(exprPath);
   if (errors.length > 0) return { errors };
@@ -28,10 +42,7 @@ export function resolveStaticExpression(exprPath: NodePath<t.Expression>): {
       if (part.type === 'derive') {
         return { errors: [], values: undefined };
       } else if (part.type !== 'static') {
-        return {
-          kind: 'dynamic-expression',
-          errors: ['Expression is not a static string'],
-        };
+        return { errors: [DYNAMIC_EXPRESSION_ERROR] };
       }
       value += part.value;
     }


### PR DESCRIPTION
## Summary
- Add typed error kinds to `flattenExpressionToParts` and preserve them through `resolveStaticExpression`.
- Distinguish dynamic-expression fallback from extraction errors before derive/autoderive validation.
- Preserve invalid template escape errors for first arguments and `$context` values.

## Testing
- `pnpm --filter @generaltranslation/compiler test -- src/utils/string-expressions/__tests__/flattenExpressionToParts.test.ts src/transform/validation/__tests__/validateTranslationFunctionCallback.test.ts src/transform/macro-expansion/__tests__/transformTemplateLiteral.test.ts`
- `pnpm --filter @generaltranslation/compiler build`
- `git diff --check`