### PR TITLE
fix: clear empty block and escape lint warnings

### DIFF
--- a/packages/cli/src/api/collectUserEditDiffs.ts
+++ b/packages/cli/src/api/collectUserEditDiffs.ts
@@ -169,7 +169,9 @@ export async function collectAndSendUserEditDiffs(
         const diff = await getGitUnifiedDiff(tempServerFile, c.outputPath);
         try {
           await fs.promises.unlink(tempServerFile);
-        } catch {}
+        } catch {
+          // Ignore cleanup errors for temporary comparison files.
+        }
 
         if (diff && diff.trim().length > 0) {
           const rawLocalContent = await fs.promises.readFile(

--- a/packages/cli/src/formats/json/__tests__/parseJson.test.ts
+++ b/packages/cli/src/formats/json/__tests__/parseJson.test.ts
@@ -446,7 +446,7 @@ describe('parseJson', () => {
         'en'
       );
 
-      expect(result).toBe('{"\/test":"value"}');
+      expect(result).toBe('{"/test":"value"}');
     });
   });
 

--- a/packages/cli/src/fs/determineFramework/matchSetupPyDependency.ts
+++ b/packages/cli/src/fs/determineFramework/matchSetupPyDependency.ts
@@ -21,7 +21,7 @@ export function matchSetupPyDependency(
 
     // Find the opening bracket after the keyword
     const afterKeyword = content.slice(keywordIndex + keyword.length);
-    const bracketMatch = afterKeyword.match(/\s*=\s*[\[{]/);
+    const bracketMatch = afterKeyword.match(/\s*=\s*(?:\[|{)/);
     if (!bracketMatch) continue;
 
     const openBracket =

--- a/packages/cli/src/hooks/postProcess.ts
+++ b/packages/cli/src/hooks/postProcess.ts
@@ -10,13 +10,17 @@ export async function detectFormatter(): Promise<Formatter | null> {
   try {
     await import('prettier');
     return 'prettier';
-  } catch {}
+  } catch {
+    // Prettier is optional.
+  }
 
   // Try ESLint
   try {
     await import('eslint');
     return 'eslint';
-  } catch {}
+  } catch {
+    // ESLint is optional.
+  }
 
   // Try Biome
   try {
@@ -37,7 +41,9 @@ export async function detectFormatter(): Promise<Formatter | null> {
         }
       });
     });
-  } catch {}
+  } catch {
+    // Biome is optional.
+  }
 
   return null;
 }

--- a/packages/cli/src/react/jsx/utils/__tests__/surroundingLines.integration.test.ts
+++ b/packages/cli/src/react/jsx/utils/__tests__/surroundingLines.integration.test.ts
@@ -26,7 +26,9 @@ describe('sourceCode metadata integration', () => {
     for (const f of tempFiles) {
       try {
         fs.unlinkSync(f);
-      } catch {}
+      } catch {
+        // Temporary files may already be removed by the test.
+      }
     }
     tempFiles.length = 0;
   });

--- a/packages/cli/src/react/jsx/utils/stringParsing/processTaggedTemplateCall/__tests__/processTaggedTemplateCall.test.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/processTaggedTemplateCall/__tests__/processTaggedTemplateCall.test.ts
@@ -31,7 +31,9 @@ afterEach(() => {
   for (const filePath of tempFiles) {
     try {
       fs.unlinkSync(filePath);
-    } catch {}
+    } catch {
+      // Temporary files may already be removed by the test.
+    }
   }
   tempFiles.length = 0;
 });

--- a/packages/cli/src/utils/sharedStaticAssets.ts
+++ b/packages/cli/src/utils/sharedStaticAssets.ts
@@ -49,7 +49,9 @@ async function moveFile(src: string, dest: string) {
       await fs.promises.writeFile(dest, data);
       try {
         await fs.promises.unlink(src);
-      } catch {}
+      } catch {
+        // Ignore cleanup errors for source files that were already moved.
+      }
     } else if (err && err.code === 'ENOENT') {
       // already moved or missing; ignore
       return;
@@ -377,11 +379,15 @@ export default async function processSharedStaticAssets(settings: Settings) {
       const st = await fs.promises.stat(destAbs).catch(() => null);
       if (st && st.isFile()) {
         // Remove source if it still exists
-        await fs.promises.unlink(abs).catch(() => {});
+        await fs.promises.unlink(abs).catch(() => {
+          // Ignore missing source files.
+        });
         await removeEmptyDirsUpwards(path.dirname(abs), cwd);
         continue;
       }
-    } catch {}
+    } catch {
+      // If stat/removal fails, fall through to the normal move path.
+    }
     await moveFile(abs, destAbs);
     await removeEmptyDirsUpwards(path.dirname(abs), cwd);
   }

--- a/packages/cli/src/utils/wrapPlainUrls.ts
+++ b/packages/cli/src/utils/wrapPlainUrls.ts
@@ -13,7 +13,8 @@ import type { Root, Text } from 'mdast';
  *
  */
 export default function wrapPlainUrls(content: string): string {
-  const URL_REGEX = /https?:\/\/[^\s<>\[\]]*[^\s<>\[\].,;:!?'"\]}>]/g;
+  const URL_REGEX =
+    /https?:\/\/[^\s<>\u005b\u005d]*[^\s<>\u005b\u005d.,;:!?'"\u005d}>]/g;
   let ast: Root;
   try {
     const processor = unified()

--- a/packages/cli/src/workflows/steps/BranchStep.ts
+++ b/packages/cli/src/workflows/steps/BranchStep.ts
@@ -141,7 +141,9 @@ export class BranchStep extends WorkflowStep<null, BranchData | null> {
                 defaultBranch: true,
               });
               this.branchData.currentBranch = createBranchResult.branch;
-            } catch {}
+            } catch {
+              // The fallback branch may already exist.
+            }
           }
         }
       } else {

--- a/packages/core/src/derive/utils/sanitizeVar.ts
+++ b/packages/core/src/derive/utils/sanitizeVar.ts
@@ -11,7 +11,7 @@
  */
 export function sanitizeVar(string: string): string {
   // First, double all single quotes (both ASCII and Unicode)
-  let result = string.replace(/['\']/g, "''");
+  let result = string.replace(/'/g, "''");
 
   // Find first and last positions of special characters
   const specialChars = /[{}<>]/;

--- a/packages/next/src/dictionary/getDictionary.ts
+++ b/packages/next/src/dictionary/getDictionary.ts
@@ -25,7 +25,9 @@ export async function getDictionary(): Promise<Dictionary | undefined> {
     } else if (dictionaryFileType === '.ts' || dictionaryFileType === '.js') {
       internalDictionary = require('gt-next/_dictionary').default;
     }
-  } catch {}
+  } catch {
+    // No bundled dictionary module was generated.
+  }
   if (internalDictionary) return internalDictionary;
 
   // Second, check for custom dictionary loader
@@ -38,7 +40,9 @@ export async function getDictionary(): Promise<Dictionary | undefined> {
     // Check for [defaultLocale.json] file
     try {
       internalDictionary = await customLoadDictionary(defaultLocale);
-    } catch {}
+    } catch {
+      // Missing default-locale dictionaries fall through to language fallback.
+    }
 
     // Check the simplified locale name ('en' instead of 'en-US')
     const languageCode = getLocaleProperties(defaultLocale)?.languageCode;

--- a/packages/next/src/middleware-dir/utils.ts
+++ b/packages/next/src/middleware-dir/utils.ts
@@ -72,7 +72,7 @@ export function getResponse({
  * Extracts the locale from the given pathname.
  */
 export function extractLocale(pathname: string): string | null {
-  const matches = pathname.match(/^\/([^\/]+)(?:\/|$)/);
+  const matches = pathname.match(/^\/([^/]+)(?:\/|$)/);
   return matches ? matches[1] : null;
 }
 

--- a/packages/next/src/provider/ClientProviderWrapper.tsx
+++ b/packages/next/src/provider/ClientProviderWrapper.tsx
@@ -7,7 +7,7 @@ import { GT, standardizeLocale } from 'generaltranslation';
 import { useRouter } from 'next/navigation';
 
 function extractLocale(pathname: string, gt: GT): string | null {
-  const matches = pathname.match(/^\/([^\/]+)(?:\/|$)/);
+  const matches = pathname.match(/^\/([^/]+)(?:\/|$)/);
   return matches ? gt.resolveAliasLocale(matches[1]) : null;
 }
 

--- a/packages/next/src/resolvers/resolveDictionaryLoader.ts
+++ b/packages/next/src/resolvers/resolveDictionaryLoader.ts
@@ -15,7 +15,9 @@ export function resolveDictionaryLoader(): CustomLoader | undefined {
   let customLoadDictionaryConfig;
   try {
     customLoadDictionaryConfig = require('gt-next/_load-dictionary');
-  } catch {}
+  } catch {
+    // No custom dictionary loader module was generated.
+  }
 
   // Get custom loader
   customLoadDictionary =

--- a/packages/next/src/resolvers/resolveTranslationLoader.ts
+++ b/packages/next/src/resolvers/resolveTranslationLoader.ts
@@ -15,7 +15,9 @@ export function resolveTranslationLoader(): CustomLoader | undefined {
   let customLoadTranslationsConfig;
   try {
     customLoadTranslationsConfig = require('gt-next/_load-translations');
-  } catch {}
+  } catch {
+    // No custom translation loader module was generated.
+  }
 
   // Get custom loader
   customLoadTranslations =

--- a/packages/react-core-linter/src/rules/static-string/__tests__/edge-escaping.test.ts
+++ b/packages/react-core-linter/src/rules/static-string/__tests__/edge-escaping.test.ts
@@ -280,7 +280,7 @@ describe('escaping: backtick and ${ in static text with derive path', () => {
           import { useGT, derive } from 'gt-react';
           function C() {
             const gt = useGT();
-            return gt(\`a\\\`b\${derive(x)}c\$'{'d'}'\${derive(y)}{var0}\`, { var0: name });
+            return gt(\`a\\\`b\${derive(x)}c$'{'d'}'\${derive(y)}{var0}\`, { var0: name });
           }
         `,
       },

--- a/packages/react-core-linter/src/rules/static-string/__tests__/edge-review-fixes.test.ts
+++ b/packages/react-core-linter/src/rules/static-string/__tests__/edge-review-fixes.test.ts
@@ -424,7 +424,7 @@ describe('review: static text with ${ escaped in template literal output', () =>
           import { useGT, derive } from 'gt-react';
           function C() {
             const gt = useGT();
-            return gt(\`Use \$'{'varName'}' syntax \${derive(x)}{var0}\`, { var0: name });
+            return gt(\`Use $'{'varName'}' syntax \${derive(x)}{var0}\`, { var0: name });
           }
         `,
       },


### PR DESCRIPTION
## Stack
- This PR is intentionally stacked on #1316.
- Base branch: `bg/remove-internal-default-barrels`. Merge/rebase #1316 first, then this PR.
- Follow-up unused-variable lint cleanup is stacked on top in #1319.

## Summary
- add explicit comments to intentionally empty catch/cleanup blocks
- remove unnecessary regex and string escapes flagged by ESLint
- keep changes limited to non-Sanity no-empty and no-useless-escape warnings

## Verification
- pnpm --filter @generaltranslation/react-core-linter lint
- pnpm --filter generaltranslation lint
- pnpm --filter gt-next lint
- pnpm --filter gt lint
- pnpm turbo run lint --filter='./packages/*' --filter='!gt-sanity'
- pnpm --filter @generaltranslation/react-core-linter test
- pnpm --filter gt exec vitest run src/formats/json/__tests__/parseJson.test.ts src/react/jsx/utils/__tests__/surroundingLines.integration.test.ts src/react/jsx/utils/stringParsing/processTaggedTemplateCall/__tests__/processTaggedTemplateCall.test.ts
- pnpm --filter gt-next exec vitest run src/middleware-dir/__tests__/utils.test.ts
- pnpm --filter generaltranslation exec vitest run
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

A pure lint-cleanup PR: all empty `catch` blocks across 10 files received explanatory comments, and useless/redundant regex and string escapes were removed. All changes are non-functional and every regex transformation was verified to be semantically equivalent.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are non-functional lint fixes with no behavior change.

Every change either adds a comment to an empty catch block or removes a provably redundant/useless escape sequence. No logic paths, data structures, or interfaces were altered. One P2 style suggestion exists for the unicode-escape workaround in wrapPlainUrls.ts, but it does not affect correctness.

packages/cli/src/utils/wrapPlainUrls.ts — the Unicode-escape approach for `[`/`]` in the character class is functional but reduces readability.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/utils/wrapPlainUrls.ts | Used Unicode escapes (`\u005b`/`\u005d`) to suppress no-useless-escape; functionally correct but harder to read than using bare `[` and `\]`. |
| packages/core/src/derive/utils/sanitizeVar.ts | Simplified `/['\']/ g` (redundant `'` in character class) to `/'/g` — no behavior change, cleaner. |
| packages/cli/src/fs/determineFramework/matchSetupPyDependency.ts | Replaced character class `[\[{]` with alternation `(?:\[|{)` — functionally equivalent, removes useless-escape warning. |
| packages/cli/src/hooks/postProcess.ts | Three empty catch blocks for optional formatter detection each got a descriptive comment. |
| packages/next/src/middleware-dir/utils.ts | Removed useless `\/` escape inside character class `[^\/]` → `[^/]`; `/` needs no escaping inside `[…]`. |
| packages/next/src/provider/ClientProviderWrapper.tsx | Same `[^\/]` → `[^/]` fix as utils.ts — identical pattern, correct. |
| packages/cli/src/api/collectUserEditDiffs.ts | Empty catch block for temp-file cleanup now has an explanatory comment — purely a lint fix. |
| packages/cli/src/utils/sharedStaticAssets.ts | Two empty catch blocks and one empty arrow function now carry intent-explaining comments. |
| packages/next/src/dictionary/getDictionary.ts | Two empty catch blocks (missing bundle and missing locale dictionary) now have intent comments. |
| packages/next/src/resolvers/resolveDictionaryLoader.ts | Empty catch for missing dictionary-loader module now documents the intent. |
| packages/next/src/resolvers/resolveTranslationLoader.ts | Same pattern as resolveDictionaryLoader — empty catch comment added for missing translation-loader module. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/cli/src/utils/wrapPlainUrls.ts:16-17
**Unicode escapes reduce regex readability**

The fix for `no-useless-escape` uses `\u005b`/`\u005d` to encode `[`/`]`, but this makes the regex significantly harder to read. ESLint flagged `\[` inside `[…]` because `[` has no special meaning in a character class and doesn't need escaping — but `\]` *does* need to stay escaped to avoid closing the class. The idiomatic fix is to drop the unnecessary `\` before `[` while keeping `\]`:

```suggestion
  const URL_REGEX =
    /https?:\/\/[^\s<>[\]]*[^\s<>[\].,;:!?'"}>]/g;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: clear empty block and escape lint w..."](https://github.com/generaltranslation/gt/commit/e52d779d62297367febac4a3b115acc049433ea5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30523213)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->