### PR TITLE
docs(core): normalize comments

### DIFF
--- a/packages/core/src/backwards-compatability/dataConversion.ts
+++ b/packages/core/src/backwards-compatability/dataConversion.ts
@@ -16,51 +16,41 @@ import {
 } from './typeChecking';
 
 /**
- * Convert request data from old format to new format
+ * Converts request data from the old JSX format to the current format.
  */
-
 export function getNewJsxChild(child: OldJsxChild): JsxChild {
-  // string (end case)
   if (typeof child === 'string') {
     return child;
   }
 
-  // VariableObject
   if (isOldVariableObject(child)) {
     return getNewVariableObject(child);
   }
 
-  // JsxElement
   return getNewJsxElement(child);
 }
 
 export function getNewJsxChildren(children: OldJsxChildren): JsxChildren {
-  // string (end case)
   if (typeof children === 'string') {
     return children;
   }
 
-  // Array
   if (Array.isArray(children)) {
     return children.map(getNewJsxChild);
   }
 
-  // Object
   return getNewJsxChild(children);
 }
 
 export function getNewJsxElement(element: OldJsxElement): JsxElement {
-  // string (end case)
   if (typeof element === 'string') {
     return element;
   }
 
-  // type
   let t: string | undefined = undefined;
   if (element.type != null) {
     t = element.type;
   }
-  // children
   let c: JsxChildren | undefined = undefined;
   if (element.props?.children != null) {
     c = getNewJsxChildren(element.props.children);
@@ -98,12 +88,10 @@ export function getNewVariableType(variable: OldVariableType): VariableType {
 export function getNewVariableObject(
   variable: OldVariableObject
 ): VariableObject {
-  // variable type
   let v: VariableType | undefined = undefined;
   if (variable.variable != null) {
     v = getNewVariableType(variable.variable);
   }
-  // variable id
   let i: number | undefined = undefined;
   if (variable.id != null) {
     i = variable.id;
@@ -116,7 +104,6 @@ export function getNewVariableObject(
 }
 
 export function getNewGTProp(dataGT: OldGTProp): GTProp {
-  // branches
   let b: Record<string, JsxChildren> | undefined = undefined;
   if (dataGT.branches) {
     b = Object.fromEntries(
@@ -126,7 +113,6 @@ export function getNewGTProp(dataGT: OldGTProp): GTProp {
       ])
     );
   }
-  // transformation
   let t: 'b' | 'p' | undefined;
   if (dataGT.transformation) {
     t = getNewBranchType(dataGT.transformation);
@@ -135,55 +121,44 @@ export function getNewGTProp(dataGT: OldGTProp): GTProp {
 }
 
 /**
- * Convert response data from old format to new format
+ * Converts response data from the current JSX format to the old format.
  */
-
 export function getOldJsxChild(child: JsxChild): OldJsxChild {
-  // string (end case)
   if (typeof child === 'string') {
     return child;
   }
 
-  // VariableObject
   if (isNewVariableObject(child)) {
     return getOldVariableObject(child);
   }
 
-  // JsxElement
   return getOldJsxElement(child);
 }
 
 export function getOldJsxChildren(
   children: JsxChildren | OldJsxChildren
 ): OldJsxChildren {
-  // if children is already old, return it
   if (isOldJsxChildren(children)) {
     return children;
   }
 
-  // string (end case)
   if (typeof children === 'string') {
     return children;
   }
 
-  // Array
   if (Array.isArray(children)) {
     return children.map(getOldJsxChild);
   }
 
-  // Object
   return getOldJsxChild(children);
 }
 
 export function getOldJsxElement(element: JsxElement): OldJsxElement {
-  // type (can assume that type will exist here)
   const type: string = element.t as string;
-  // children
   let children: OldJsxChildren | undefined = undefined;
   if (element.c != null) {
     children = getOldJsxChildren(element.c);
   }
-  // data-_gt (can assume id will exist here)
   const dataGT: OldGTProp = getOldGTProp(element.d || {}, element.i as number);
   return {
     type,
@@ -216,12 +191,10 @@ export function getOldVariableType(variable: VariableType): OldVariableType {
 export function getOldVariableObject(
   variable: VariableObject
 ): OldVariableObject {
-  // variable type
   let v: OldVariableType | undefined = undefined;
   if (variable.v != null) {
     v = getOldVariableType(variable.v);
   }
-  // variable id
   let i: number | undefined = undefined;
   if (variable.i != null) {
     i = variable.i;
@@ -234,12 +207,10 @@ export function getOldVariableObject(
 }
 
 export function getOldGTProp(dataGT: GTProp, i: number): OldGTProp {
-  // transformation
   let transformation: OldBranchType | undefined = undefined;
   if (dataGT.t != null) {
     transformation = getOldBranchType(dataGT.t);
   }
-  // branches
   let branches: Record<string, OldJsxChildren> | undefined = undefined;
   if (dataGT.b != null) {
     branches = Object.fromEntries(

--- a/packages/core/src/backwards-compatability/oldHashJsxChildren.ts
+++ b/packages/core/src/backwards-compatability/oldHashJsxChildren.ts
@@ -1,16 +1,13 @@
-// Functions provided to other GT libraries
-
 import { OldJsxChild, OldJsxChildren, OldVariableObject } from './oldTypes';
 import { stableStringify as stringify } from '../utils/stableStringify';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { bytesToHex, utf8ToBytes } from '@noble/hashes/utils.js';
 
-// ----- FUNCTIONS ----- //
 /**
- * Calculates a unique hash for a given string using sha256.
+ * Calculates a unique hash for a given string using SHA-256.
  *
  * @param {string} string - The string to be hashed.
- * @returns {string} - The resulting hash as a hexadecimal string.
+ * @returns {string} The resulting hash as a hexadecimal string.
  */
 export function oldHashString(string: string): string {
   return bytesToHex(sha256(utf8ToBytes(string)));
@@ -20,10 +17,10 @@ export function oldHashString(string: string): string {
  * Calculates a unique ID for the given children objects by hashing their sanitized JSON string representation.
  *
  * @param {any} childrenAsObjects - The children objects to be hashed.
- * @param {string} context - The context for the children
- * @param {string} id - The id for the JSX Children object
- * @param {function} hashFunction custom hash function
- * @returns {string} - The unique has of the children.
+ * @param {string} context - The context for the children.
+ * @param {string} id - The ID for the JSX children object.
+ * @param {function} hashFunction - Custom hash function.
+ * @returns {string} The unique hash of the children.
  */
 export function oldHashJsxChildren(
   {
@@ -66,9 +63,8 @@ const sanitizeChild = (child: OldJsxChild): SanitizedChild => {
       const newChild: SanitizedChild = {};
       const dataGt = child?.props?.['data-_gt'];
       if (dataGt?.branches) {
-        // The only thing that prevents sanitizeJsx from being stable is
-        // the order of the keys in the branches object.
-        // We don't sort them because stable-stringify sorts them anyways
+        // Branch key order is the only source of instability here.
+        // stableStringify sorts keys when serializing the sanitized tree.
         newChild.branches = Object.fromEntries(
           Object.entries(dataGt.branches).map(([key, value]) => [
             key,

--- a/packages/core/src/backwards-compatability/typeChecking.ts
+++ b/packages/core/src/backwards-compatability/typeChecking.ts
@@ -8,9 +8,9 @@ import {
 import { Variable as VariableObject } from '../types';
 
 /**
- * Checks if a JSX child is an old variable object format
- * @param child - The JSX child to check
- * @returns True if the child is an old variable object (has 'key' property)
+ * Checks whether a JSX child uses the old variable object format.
+ * @param child - The JSX child to check.
+ * @returns True if the child is an old variable object with a 'key' property.
  */
 export function isOldVariableObject(
   child: OldJsxChild | JsxChild
@@ -19,9 +19,9 @@ export function isOldVariableObject(
 }
 
 /**
- * Checks if a JSX child is a new variable object format
- * @param child - The JSX child to check
- * @returns True if the child is a new variable object (has 'k' property)
+ * Checks whether a JSX child uses the current variable object format.
+ * @param child - The JSX child to check.
+ * @returns True if the child is a current variable object with a 'k' property.
  */
 export function isNewVariableObject(
   child: OldJsxChild | JsxChild
@@ -30,9 +30,9 @@ export function isNewVariableObject(
 }
 
 /**
- * Checks if a JSX child is an old JSX element format
- * @param child - The JSX child to check
- * @returns True if the child is an old JSX element (has 'type' and 'props' properties)
+ * Checks whether a JSX child uses the old JSX element format.
+ * @param child - The JSX child to check.
+ * @returns True if the child is an old JSX element with 'type' and 'props' properties.
  */
 function isOldJsxElement(
   child: OldJsxChild | JsxChild
@@ -46,43 +46,37 @@ function isOldJsxElement(
 }
 
 /**
- * Checks if a JSX child follows the old format (string, old variable object, or old JSX element)
- * @param child - The JSX child to check
- * @returns True if the child is in the old format
+ * Checks whether a JSX child follows the old format.
+ * @param child - The JSX child to check.
+ * @returns True if the child is in the old format.
  */
 function isOldJsxChild(child: OldJsxChild | JsxChild): child is OldJsxChild {
-  // string
   if (typeof child === 'string') {
     return true;
   }
 
-  // variable object
   if (isOldVariableObject(child)) {
     return true;
   }
 
-  // element
   return isOldJsxElement(child);
 }
 
 /**
- * Checks if JSX children follow the old format
- * @param children - The JSX children to check (can be string, array, or single child)
- * @returns True if all children are in the old format
+ * Checks whether JSX children follow the old format.
+ * @param children - The JSX children to check.
+ * @returns True if all children are in the old format.
  */
 export function isOldJsxChildren(
   children: OldJsxChildren | JsxChildren
 ): children is OldJsxChildren {
-  // string
   if (typeof children === 'string') {
     return true;
   }
 
-  // array
   if (Array.isArray(children)) {
     return !children.some((child) => !isOldJsxChild(child));
   }
 
-  // object
   return isOldJsxChild(children);
 }

--- a/packages/core/src/cache/IntlCache.ts
+++ b/packages/core/src/cache/IntlCache.ts
@@ -8,8 +8,8 @@ import {
 } from './types';
 
 /**
- * Object mapping constructor names to their respective constructor functions
- * Includes all native Intl constructors plus custom ones like CutoffFormat
+ * Maps constructor names to constructor functions.
+ * Includes native Intl constructors and custom constructors such as CutoffFormat.
  */
 const CustomIntl: CustomIntlType = {
   Collator: Intl.Collator,
@@ -25,8 +25,8 @@ const CustomIntl: CustomIntlType = {
 };
 
 /**
- * Cache for Intl and custom format instances to avoid repeated instantiation
- * Uses a two-level structure: constructor name -> cache key -> instance
+ * Caches Intl and custom format instances to avoid repeated instantiation.
+ * Uses a two-level structure: constructor name -> cache key -> instance.
  */
 class IntlCache {
   private cache: IntlCacheObject;
@@ -36,18 +36,18 @@ class IntlCache {
   }
 
   /**
-   * Generates a consistent cache key from locales and options
-   * Handles all LocalesArgument types (string, Locale, array, undefined)
+   * Generates a consistent cache key from locales and options.
+   * Handles all LocalesArgument types (string, Locale, array, undefined).
    */
   private _generateKey(locales: Intl.LocalesArgument, options = {}) {
-    // Normalize locales to string representation
+    // Normalize locales to a string representation.
     const localeKey = !locales
       ? 'undefined'
       : Array.isArray(locales)
         ? locales.map((l) => String(l)).join(',')
         : String(locales);
 
-    // Sort option keys to ensure consistent key generation regardless of property order
+    // Sort option keys so property order does not affect cache keys.
     const sortedOptions = options
       ? JSON.stringify(options, Object.keys(options).sort())
       : '{}';
@@ -55,10 +55,10 @@ class IntlCache {
   }
 
   /**
-   * Gets a cached Intl instance or creates a new one if not found
-   * @param constructor The name of the Intl constructor to use
-   * @param args Constructor arguments (locales, options)
-   * @returns Cached or newly created Intl instance
+   * Gets a cached Intl instance, or creates one when missing.
+   * @param constructor The name of the Intl constructor to use.
+   * @param args Constructor arguments (locales, options).
+   * @returns Cached or newly created Intl instance.
    */
   get<K extends keyof CustomIntlConstructors>(
     constructor: K,
@@ -69,7 +69,7 @@ class IntlCache {
     let intlObject = this.cache[constructor]?.[key];
 
     if (intlObject === undefined) {
-      // Create new instance and cache it
+      // Create and cache a new instance.
       intlObject = new CustomIntl[constructor](...args);
       if (!this.cache[constructor]) this.cache[constructor] = {};
       this.cache[constructor][key] = intlObject;
@@ -80,6 +80,6 @@ class IntlCache {
 }
 
 /**
- * Global instance of the Intl cache for use throughout the application
+ * Shared Intl cache instance used throughout the package.
  */
 export const intlCache = new IntlCache();

--- a/packages/core/src/cache/types.ts
+++ b/packages/core/src/cache/types.ts
@@ -1,8 +1,8 @@
 import { CutoffFormatConstructor } from '../formatting/custom-formats/CutoffFormat/CutoffFormat';
 
 /**
- * Extracts only the constructor functions from the Intl namespace,
- * filtering out static methods like getCanonicalLocales and supportedValuesOf
+ * Extracts constructor functions from the Intl namespace,
+ * filtering out static methods such as getCanonicalLocales and supportedValuesOf.
  */
 type IntlConstructors = {
   [K in keyof typeof Intl as (typeof Intl)[K] extends new (
@@ -15,22 +15,22 @@ type IntlConstructors = {
 };
 
 /**
- * Extended interface that includes all native Intl constructors plus custom ones
+ * Extends native Intl constructors with custom constructors.
  */
 export interface CustomIntlConstructors extends IntlConstructors {
   CutoffFormat: typeof CutoffFormatConstructor;
 }
 
 /**
- * Helper type to represent a constructor function for a given Intl constructor key
+ * Represents a constructor function for a given Intl constructor key.
  */
 export type ConstructorType<K extends keyof CustomIntlConstructors> = new (
   ...args: ConstructorParameters<CustomIntlConstructors[K]>
 ) => InstanceType<CustomIntlConstructors[K]>;
 
 /**
- * Type for the cache object structure - each constructor gets its own Record
- * mapping cache keys to instances of that specific constructor type
+ * Cache object structure.
+ * Each constructor gets its own record mapping cache keys to instances.
  */
 export type IntlCacheObject = {
   [K in keyof CustomIntlConstructors]?: Record<
@@ -40,7 +40,7 @@ export type IntlCacheObject = {
 };
 
 /**
- * Type for the CustomIntl object that maps constructor names to constructor functions
+ * Maps constructor names to constructor functions.
  */
 export type CustomIntlType = {
   [K in keyof CustomIntlConstructors]: ConstructorType<K>;

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -38,13 +38,13 @@ export {
  * @param {string | string[]} [options.locales] - The locales to use for terminator selection.
  * @param {number} [options.maxChars] - The maximum number of characters to display.
  * - Undefined values are treated as no cutoff.
- * - Negative values follow .slice() behavior and terminator will be added before the value.
- * - 0 will result in an empty string.
+ * - Negative values follow .slice() behavior, and the terminator is added before the value.
+ * - 0 results in an empty string.
  * - If cutoff results in an empty string, no terminator is added.
- * @param {CutoffFormatStyle} [options.style='ellipsis'] - The style of the terminator.
- * @param {string} [options.terminator] - Optional override the terminator to use.
- * @param {string} [options.separator] - Optional override the separator to use between the terminator and the value.
- * - If no terminator is provided, then separator is ignored.
+ * @param {CutoffFormatStyle} [options.style='ellipsis'] - The terminator style.
+ * @param {string} [options.terminator] - Optional terminator override.
+ * @param {string} [options.separator] - Optional separator override between the terminator and value.
+ * - If no terminator is provided, the separator is ignored.
  * @returns {string} The formatted string with terminator applied if cutoff occurs.
  *
  * @example
@@ -110,11 +110,11 @@ export function formatMessage(
 }
 
 /**
- * Checks if a given BCP 47 locale code is valid.
+ * Checks whether a BCP 47 locale code is valid.
  *
  * @param {string} locale - The BCP 47 locale code to validate.
  * @param {CustomMapping} [customMapping] - The custom mapping to use for validation.
- * @returns {boolean} True if the BCP 47 code is valid, false otherwise.
+ * @returns {boolean} True if the BCP 47 code is valid; otherwise false.
  *
  * @example
  * isValidLocale('en-US');
@@ -129,11 +129,11 @@ export function isValidLocale(locale: string, customMapping?: CustomMapping) {
 }
 
 /**
- * Resolves the canonical locale for a given locale.
+ * Resolves the canonical locale for a custom alias.
  *
- * @param {string} locale - The locale to resolve the canonical locale for.
- * @param {CustomMapping} [customMapping] - The custom mapping to use for resolving the canonical locale.
- * @returns {string} The canonical locale.
+ * @param {string} locale - The locale to resolve.
+ * @param {CustomMapping} [customMapping] - The custom mapping to inspect.
+ * @returns {string} The canonical locale, or the input locale when no canonical mapping exists.
  *
  * @example
  * resolveCanonicalLocale('en-US');
@@ -154,15 +154,12 @@ export function resolveCanonicalLocale(
  * Standardizes a BCP 47 locale code to ensure correct formatting.
  *
  * @param {string} locale - The BCP 47 locale code to standardize.
- * @returns {string} The standardized BCP 47 locale code or an empty string if it is an invalid code.
+ * @returns {string} The standardized BCP 47 locale code, or the input string if it cannot be standardized.
  *
  * @example
  * standardizeLocale('en-us');
  * // Returns: 'en-US'
  *
- * @example
- * standardizeLocale('not a locale');
- * // Returns: ''
  */
 export function standardizeLocale(locale: string) {
   return _standardizeLocale(locale);

--- a/packages/core/src/derive/declareVar.ts
+++ b/packages/core/src/derive/declareVar.ts
@@ -2,7 +2,8 @@ import { VAR_IDENTIFIER, VAR_NAME_IDENTIFIER } from './utils/constants';
 import { sanitizeVar } from './utils/sanitizeVar';
 
 /**
- * Mark as a non-translatable string. Use within a derive() call to mark content as not derivable (e.g., not possible to statically analyze).
+ * Marks content as a non-translatable variable. Use within a derive() call for
+ * content that cannot be statically analyzed.
  *
  * @example
  * function nonDerivableFunction() {
@@ -28,17 +29,17 @@ export function declareVar(
   variable: string | number | boolean | null | undefined,
   options?: { $name?: string }
 ): string {
-  // variable section
+  // Variable section.
   const sanitizedVariable = sanitizeVar(String(variable ?? ''));
   const variableSection = ` other {${sanitizedVariable}}`;
 
-  // name section
+  // Name section.
   let nameSection = '';
   if (options?.$name) {
     const sanitizedName = sanitizeVar(options.$name);
     nameSection = ` ${VAR_NAME_IDENTIFIER} {${sanitizedName}}`;
   }
 
-  // interpolate
+  // Interpolate into ICU select syntax.
   return `{${VAR_IDENTIFIER}, select,${variableSection}${nameSection}}`;
 }

--- a/packages/core/src/derive/decodeVars.ts
+++ b/packages/core/src/derive/decodeVars.ts
@@ -10,7 +10,7 @@ type Location = {
 };
 
 /**
- * Given an encoded ICU string, interpolate only _gt_ variables that have been marked with declareVar()
+ * Interpolates only _gt_ variables that have been marked with declareVar().
  * @example
  * const encodedIcu = "Hi" + declareVar("Brian") + ", my name is {name}"
  * // 'Hi {_gt_, select, other {Brian}}, my name is {name}'
@@ -18,12 +18,12 @@ type Location = {
  * // 'Hi Brian, my name is {name}'
  */
 export function decodeVars(icuString: string): string {
-  // Check if the string contains _gt_
+  // Return early if the string contains no _gt_ variables.
   if (!icuString.includes(VAR_IDENTIFIER)) {
     return icuString;
   }
 
-  // Record the location of the variable
+  // Record variable locations.
   const variableLocations: Location[] = [];
   function visitor(child: GTUnindexedSelectElement): void {
     variableLocations.push({
@@ -36,7 +36,7 @@ export function decodeVars(icuString: string): string {
     });
   }
 
-  // Find all variable identifiers
+  // Find all variable identifiers.
   traverseIcu({
     icuString,
     shouldVisit: isGTUnindexedSelectElement,
@@ -47,7 +47,7 @@ export function decodeVars(icuString: string): string {
     },
   });
 
-  // Construct output string
+  // Construct the output string.
   let previousIndex = 0;
   const outputList = [];
   for (let i = 0; i < variableLocations.length; i++) {

--- a/packages/core/src/derive/derive.ts
+++ b/packages/core/src/derive/derive.ts
@@ -1,7 +1,7 @@
 /**
- * derive() is a powerful but dangerous function which marks its argument as derivable (statically analyzable) for the compiler and CLI tool.
+ * derive() marks its argument as derivable, meaning statically analyzable by the compiler and CLI.
  *
- * This function is dangerous because it can cause the compiler and CLI tool to throw an error if the argument is not derivable.
+ * This function can cause the compiler and CLI to throw an error if the argument is not actually derivable.
  *
  * @example
  * ```jsx
@@ -13,7 +13,7 @@
  * ```
  *
  * @param {T extends string | boolean | number | null | undefined} content - Content to mark as derivable.
- * @returns content
+ * @returns The original content.
  */
 export function derive<T extends string | boolean | number | null | undefined>(
   content: T
@@ -24,9 +24,9 @@ export function derive<T extends string | boolean | number | null | undefined>(
 /**
  * @deprecated Use derive() instead.
  *
- * declareStatic() is a powerful but dangerous function which marks its argument as derivable (statically analyzable) for the compiler and CLI tool.
+ * declareStatic() marks its argument as derivable, meaning statically analyzable by the compiler and CLI.
  *
- * This function is dangerous because it can cause the compiler and CLI tool to throw an error if the argument is not derivable.
+ * This function can cause the compiler and CLI to throw an error if the argument is not actually derivable.
  *
  * @example
  * ```jsx
@@ -38,6 +38,6 @@ export function derive<T extends string | boolean | number | null | undefined>(
  * ```
  *
  * @param {T extends string | boolean | number | null | undefined} content - Content to mark as derivable.
- * @returns content
+ * @returns The original content.
  */
 export const declareStatic = derive;

--- a/packages/core/src/derive/extractVars.ts
+++ b/packages/core/src/derive/extractVars.ts
@@ -3,7 +3,7 @@ import { isGTUnindexedSelectElement } from './utils/traverseHelpers';
 import { traverseIcu } from './utils/traverseIcu';
 import { GTUnindexedSelectElement } from './utils/types';
 /**
- * Given an unindexed ICU string, extracts all the _gt_ variables and an indexed mapping of the variable to the values
+ * Extracts _gt_ variables from an unindexed ICU string and returns an indexed value mapping.
  *
  * extractVars('Hello {_gt_, select, other {World}}') => { _gt_1: 'World' }
  *
@@ -11,12 +11,12 @@ import { GTUnindexedSelectElement } from './utils/types';
  * @returns {Record<string, string>} A mapping of the variable to the value.
  */
 export function extractVars(icuString: string): Record<string, string> {
-  // Check if the string contains _gt_
+  // Return early if the string contains no _gt_ variables.
   if (!icuString.includes(VAR_IDENTIFIER)) {
     return {};
   }
 
-  // Extract all the _gt_# variables
+  // Extract all _gt_ variables.
   let index = 1;
   const variables: Record<string, string> = {};
   function visitor(child: GTUnindexedSelectElement): void {

--- a/packages/core/src/derive/indexVars.ts
+++ b/packages/core/src/derive/indexVars.ts
@@ -11,7 +11,7 @@ import { GTUnindexedSelectElement } from './utils/types';
 import { isGTUnindexedSelectElement } from './utils/traverseHelpers';
 import { IcuMessage } from '../types-dir/jsx/content';
 
-// Used for temporarily tracking variable indices in the AST
+// Temporarily marks variable indices while traversing the AST.
 const VAR_FLAG_SUFFIX = '_flag';
 
 interface GTFlaggedSelectElement extends SelectElement {
@@ -31,16 +31,16 @@ type Location = {
 };
 
 /**
- * Given an ICU string adds identifiers to each _gt_ placeholder
+ * Adds identifiers to each _gt_ placeholder in an ICU string.
  * indexVars('Hello {_gt_} {_gt_} World') => 'Hello {_gt_1_} {_gt_2_} World'
  */
 export function indexVars(icuString: IcuMessage): string {
-  // Check if the string contains _gt_
+  // Return early if the string contains no _gt_ variables.
   if (!icuString.includes(VAR_IDENTIFIER)) {
     return icuString;
   }
 
-  // Record the location of the variable
+  // Record variable locations.
   const variableLocations: Location[] = [];
   function visitor(child: GTUnindexedSelectElement): void {
     variableLocations.push({
@@ -51,7 +51,7 @@ export function indexVars(icuString: IcuMessage): string {
     });
   }
 
-  // Find all variable identifiers
+  // Find all variable identifiers.
   traverseIcu({
     icuString,
     shouldVisit: isGTUnindexedSelectElement,
@@ -59,23 +59,23 @@ export function indexVars(icuString: IcuMessage): string {
     options: { recurseIntoVisited: false, captureLocation: true },
   });
 
-  // Index each variable and collapse the other option
+  // Index each variable and collapse the other option.
   const result = [];
   let current = 0;
   for (let i = 0; i < variableLocations.length; i++) {
     const { start, end, otherStart, otherEnd } = variableLocations[i];
-    // Before the variable
+    // Preserve content before the variable.
     result.push(icuString.slice(current, start));
-    // Replace the variable with the new identifier (+1 is for the curly brace)
+    // Replace the variable with the new identifier; +1 includes the opening brace.
     result.push(icuString.slice(start, start + VAR_IDENTIFIER.length + 1));
 
-    // Add the new identifier
+    // Add the new identifier.
     result.push(String(i + 1));
-    // After the variable
+    // Preserve content after the variable name.
     result.push(icuString.slice(start + VAR_IDENTIFIER.length + 1, otherStart));
-    // Before the other option
+    // Collapse the other option.
     result.push('{}');
-    // The other option
+    // Preserve content after the other option.
     result.push(icuString.slice(otherEnd, end));
     current = end;
   }

--- a/packages/core/src/derive/utils/regex.ts
+++ b/packages/core/src/derive/utils/regex.ts
@@ -1,6 +1,6 @@
 import { VAR_IDENTIFIER } from './constants';
 
-// Regex  for _gt_# select
+// Regex for _gt_# select identifiers.
 export const GT_INDEXED_IDENTIFIER_REGEX = new RegExp(
   `^${VAR_IDENTIFIER}\\d+$`
 );

--- a/packages/core/src/derive/utils/sanitizeVar.ts
+++ b/packages/core/src/derive/utils/sanitizeVar.ts
@@ -1,7 +1,7 @@
 /**
- * Sanitizes string by escaping ICU syntax
+ * Sanitizes a string by escaping ICU syntax.
  *
- * Sanitize arbitrary string so it does not break the following ICU message syntax:
+ * Sanitizes arbitrary strings so they do not break the following ICU message syntax:
  * {_gt_, select, other {string_here}}
  *
  * Escapes ICU special characters by:
@@ -10,19 +10,19 @@
  * 3. Adding a single quote after the last special character ({}<>)
  */
 export function sanitizeVar(string: string): string {
-  // First, double all single quotes (both ASCII and Unicode)
+  // First, double all single quotes (both ASCII and Unicode).
   let result = string.replace(/['\']/g, "''");
 
-  // Find first and last positions of special characters
+  // Find the first and last positions of special characters.
   const specialChars = /[{}<>]/;
   const firstSpecialIndex = result.search(specialChars);
 
   if (firstSpecialIndex === -1) {
-    // No special characters, return with just doubled quotes
+    // No special characters; return with just doubled quotes.
     return result;
   }
 
-  // Find last special character position
+  // Find the last special character position.
   let lastSpecialIndex = -1;
   for (let i = result.length - 1; i >= 0; i--) {
     if (specialChars.test(result[i])) {
@@ -31,7 +31,7 @@ export function sanitizeVar(string: string): string {
     }
   }
 
-  // Insert quotes around the special character region
+  // Insert quotes around the special character region.
   result =
     result.slice(0, firstSpecialIndex) +
     "'" +

--- a/packages/core/src/derive/utils/traverseHelpers.ts
+++ b/packages/core/src/derive/utils/traverseHelpers.ts
@@ -8,7 +8,7 @@ import {
   TYPE,
 } from '@formatjs/icu-messageformat-parser/types.js';
 
-// Visit any _gt_# select
+// Matches indexed _gt_# select elements.
 export function isGTIndexedSelectElement(
   child: MessageFormatElement
 ): child is GTIndexedSelectElement {
@@ -22,7 +22,7 @@ export function isGTIndexedSelectElement(
   );
 }
 
-// Visit any _gt_ select
+// Matches unindexed _gt_ select elements.
 export function isGTUnindexedSelectElement(
   child: MessageFormatElement
 ): child is GTUnindexedSelectElement {

--- a/packages/core/src/derive/utils/traverseIcu.ts
+++ b/packages/core/src/derive/utils/traverseIcu.ts
@@ -10,13 +10,13 @@ type TraverseIcuOptions = ParserOptions & {
 };
 
 /**
- * Given an ICU string, traverse the AST and call the visitor function for each element that matches the type T
- * @param icu - The ICU string to traverse
- * @param shouldVisit - A function that returns true if the element should be visited
- * @param visitor - A function that is called for each element that matches the type T
- * @returns The modified AST of the ICU string
+ * Traverses an ICU AST and calls the visitor for each element that matches type T.
+ * @param icuString - The ICU string to traverse.
+ * @param shouldVisit - Function that returns true if the element should be visited.
+ * @param visitor - Function called for each matching element.
+ * @returns The modified AST of the ICU string.
  *
- * @note This function is a heavy operation, use sparingly
+ * @note This function is expensive; use it sparingly.
  */
 export function traverseIcu<T extends MessageFormatElement>({
   icuString,
@@ -38,13 +38,13 @@ export function traverseIcu<T extends MessageFormatElement>({
   }
 
   function handleChild(child: MessageFormatElement) {
-    // handle select var
+    // Visit matching elements.
     let visited = false;
     if (shouldVisit(child)) {
       visitor(child);
       visited = true;
     }
-    // recurse on children
+    // Recurse into children.
     if (!visited || recurseIntoVisited) {
       if (child.type === TYPE.select || child.type === TYPE.plural) {
         Object.values(child.options)

--- a/packages/core/src/formatting/custom-formats/CutoffFormat/CutoffFormat.ts
+++ b/packages/core/src/formatting/custom-formats/CutoffFormat/CutoffFormat.ts
@@ -20,18 +20,18 @@ export class CutoffFormatConstructor implements CutoffFormat {
   private options: ResolvedCutoffFormatOptions;
   private additionLength: number;
   /**
-   * Constructor
-   * @param {string | string[]} locales - The locales to use for formatting.
+   * Creates a cutoff formatter.
+   * @param {Intl.LocalesArgument} locales - The locales to use for formatting.
    * @param {CutoffFormatOptions} options - The options for formatting.
-   * @param {number} [option.maxChars] - The maximum number of characters to display.
+   * @param {number} [options.maxChars] - The maximum number of characters to display.
    * - Undefined values are treated as no cutoff.
-   * - Negative values follow .slice() behavior and terminator will be added before the value.
-   * - 0 will result in an empty string.
+   * - Negative values follow .slice() behavior, and the terminator is added before the value.
+   * - 0 results in an empty string.
    * - If cutoff results in an empty string, no terminator is added.
-   * @param {CutoffFormatStyle} [option.style='ellipsis'] - The style of the terminator.
-   * @param {string} [option.terminator] - Optional override the terminator to use.
-   * @param {string} [option.separator] - Optional override the separator to use between the terminator and the value.
-   * - If no terminator is provided, then separator is ignored.
+   * @param {CutoffFormatStyle} [options.style='ellipsis'] - The terminator style.
+   * @param {string} [options.terminator] - Optional terminator override.
+   * @param {string} [options.separator] - Optional separator override between the terminator and value.
+   * - If no terminator is provided, the separator is ignored.
    *
    * @example
    * const format = new CutoffFormat('en', { maxChars: 5 });
@@ -44,9 +44,9 @@ export class CutoffFormatConstructor implements CutoffFormat {
     locales: Intl.LocalesArgument,
     options: CutoffFormatOptions = {}
   ) {
-    // Determine locale (this replicates Intl.NumberFormat behavior including silent failure)
+    // Replicate Intl.NumberFormat locale resolution behavior, including silent fallback.
     try {
-      // Normalize locales to string
+      // Normalize locales to strings.
       const localesList = !locales
         ? [libraryDefaultLocale]
         : Array.isArray(locales)
@@ -60,7 +60,7 @@ export class CutoffFormatConstructor implements CutoffFormat {
       this.locale = libraryDefaultLocale;
     }
 
-    // Follows Intl.NumberFormat behavior of throwing an error when currency is invalid
+    // Follow Intl.NumberFormat behavior by throwing when an option value is invalid.
     if (!TERMINATOR_MAP[options.style ?? DEFAULT_CUTOFF_FORMAT_STYLE]) {
       throw new Error(
         createInvalidCutoffStyleError(
@@ -69,12 +69,12 @@ export class CutoffFormatConstructor implements CutoffFormat {
       );
     }
 
-    // Resolve terminator options
+    // Resolve terminator options.
     let style: CutoffFormatStyle | undefined;
     let presetTerminatorOptions: ResolvedTerminatorOptions | undefined;
     if (options.maxChars !== undefined) {
       style = options.style ?? DEFAULT_CUTOFF_FORMAT_STYLE;
-      // TODO: need more sophisticated locale negotiation if we want to add support for region/script/etc.-specific terminators in the future
+      // TODO: Use locale negotiation if we add region- or script-specific terminators.
       const languageCode = new Intl.Locale(this.locale).language;
       presetTerminatorOptions =
         TERMINATOR_MAP[style][languageCode] ||
@@ -86,7 +86,7 @@ export class CutoffFormatConstructor implements CutoffFormat {
       terminator != null
         ? (options.separator ?? presetTerminatorOptions?.separator)
         : undefined;
-    // // Remove terminator and separator if maxChars does have enough space
+    // Remove the terminator and separator when maxChars cannot fit them.
     this.additionLength = (terminator?.length ?? 0) + (separator?.length ?? 0);
     if (
       options.maxChars !== undefined &&
@@ -135,8 +135,7 @@ export class CutoffFormatConstructor implements CutoffFormat {
   formatToParts(value: string): PrependedCutoffParts | PostpendedCutoffParts {
     const { maxChars, terminator, separator } = this.options;
 
-    // Slice our value
-    // const additionLength = (terminator?.length ?? 0) + (separator?.length ?? 0);
+    // Adjust the slice length to reserve space for the terminator and separator.
     const adjustedChars =
       maxChars === undefined || Math.abs(maxChars) >= value.length
         ? maxChars
@@ -148,7 +147,7 @@ export class CutoffFormatConstructor implements CutoffFormat {
         ? value.slice(0, adjustedChars)
         : value.slice(adjustedChars);
 
-    // No cutoff, no terminator -> value only
+    // Return only the value when no cutoff or terminator applies.
     if (
       maxChars == null ||
       adjustedChars == null ||
@@ -159,13 +158,13 @@ export class CutoffFormatConstructor implements CutoffFormat {
       return [slicedValue];
     }
 
-    // Postpended cutoff
+    // Postpended cutoff.
     if (adjustedChars > 0) {
       return separator != null
         ? [slicedValue, separator, terminator]
         : [slicedValue, terminator];
     }
-    // Prepended cutoff
+    // Prepended cutoff.
     else {
       return separator != null
         ? [terminator, separator, slicedValue]
@@ -174,7 +173,7 @@ export class CutoffFormatConstructor implements CutoffFormat {
   }
 
   /**
-   * Get the resolved options
+   * Gets the resolved options.
    * @returns {ResolvedCutoffFormatOptions} The resolved options.
    */
   resolvedOptions(): ResolvedCutoffFormatOptions {

--- a/packages/core/src/formatting/custom-formats/CutoffFormat/types.ts
+++ b/packages/core/src/formatting/custom-formats/CutoffFormat/types.ts
@@ -1,33 +1,29 @@
-// ========== Base Types ========== //
-
-/** Type of terminator */
+/** Terminator style. */
 export type CutoffFormatStyle = 'none' | 'ellipsis';
 
-/** Terminator options */
+/** Terminator options. */
 export interface TerminatorOptions {
-  /** The terminator to use */
+  /** The terminator to use. */
   terminator?: string;
-  /** An optional separator between the terminator and the value */
+  /** Optional separator between the terminator and the value. */
   separator?: string;
 }
 
-/** Input formatting options (for constructor) */
+/** Input formatting options for the constructor. */
 export interface CutoffFormatOptions extends TerminatorOptions {
-  /** Cutoff length */
+  /** Cutoff length. */
   maxChars?: number;
-  /** Type of terminator */
+  /** Terminator style. */
   style?: CutoffFormatStyle;
 }
 
-// ========== Resolved Options ========== //
-
-/** Resolved terminator options */
+/** Resolved terminator options. */
 export interface ResolvedTerminatorOptions extends TerminatorOptions {
   terminator: string | undefined;
   separator: string | undefined;
 }
 
-/** Resolved options (after constructor) */
+/** Options resolved by the constructor. */
 export interface ResolvedCutoffFormatOptions
   extends CutoffFormatOptions,
     ResolvedTerminatorOptions {
@@ -37,9 +33,7 @@ export interface ResolvedCutoffFormatOptions
   separator: string | undefined;
 }
 
-// ========== Formatting Parts ========== //
-
-/** Prepended cutoff list */
+/** Parts for a cutoff added before the value. */
 export type PrependedCutoffParts =
   | [string]
   | [ResolvedTerminatorOptions['terminator'], string]
@@ -49,7 +43,7 @@ export type PrependedCutoffParts =
       string,
     ];
 
-/** Postpended cutoff list */
+/** Parts for a cutoff added after the value. */
 export type PostpendedCutoffParts =
   | [string]
   | [string, ResolvedTerminatorOptions['terminator']]
@@ -59,10 +53,8 @@ export type PostpendedCutoffParts =
       ResolvedTerminatorOptions['terminator'],
     ];
 
-// ========== Cutoff Format Class ========== //
-
 /**
- * Cutoff Class interface
+ * Cutoff format interface.
  */
 export interface CutoffFormat {
   format: (value: string) => string;

--- a/packages/core/src/formatting/format.ts
+++ b/packages/core/src/formatting/format.ts
@@ -28,8 +28,6 @@ import {
  *
  * @example
  * _formatCutoff({ value: 'Hello, world!', options: { maxChars: 8 } }); // Returns 'Hello, w...'
- *
- * Will fallback to an empty string if formatting fails.
  */
 export function _formatCutoff({
   value,
@@ -52,8 +50,8 @@ export function _formatCutoff({
  * @returns {string} The formatted message.
  * @internal
  *
- * Will fallback to an empty string
- * TODO: add this to custom formats
+ * Returns an empty string if IntlMessageFormat produces no output.
+ * TODO: Add this to custom formats.
  */
 export function _formatMessageICU(
   message: string,
@@ -71,7 +69,7 @@ export function _formatMessageICU(
  * @returns {string} The original message, unchanged.
  * @internal
  *
- * TODO: add this to custom formats
+ * TODO: Add this to custom formats.
  */
 export function _formatMessageString(message: string): string {
   return message;
@@ -191,15 +189,15 @@ export function _formatList({
 }): string {
   return intlCache
     .get('ListFormat', locales, {
-      type: 'conjunction', // Default type, can be overridden via options
-      style: 'long', // Default style, can be overridden via options
+      type: 'conjunction', // Default type; can be overridden via options.
+      style: 'long', // Default style; can be overridden via options.
       ...options,
     })
     .format(value);
 }
 
 /**
- * Formats a list of items according to the specified locales and options.
+ * Formats a list of items to parts according to the specified locales and options.
  * @param {Object} params - The parameters for the list formatting.
  * @param {Array<T>} params.value - The list of items to format.
  * @param {string | string[]} [params.locales=['en']] - The locales to use for formatting.
@@ -218,8 +216,8 @@ export function _formatListToParts<T>({
 }) {
   const formatListParts = intlCache
     .get('ListFormat', locales, {
-      type: 'conjunction', // Default type, can be overridden via options
-      style: 'long', // Default style, can be overridden via options
+      type: 'conjunction', // Default type; can be overridden via options.
+      style: 'long', // Default style; can be overridden via options.
       ...options,
     })
     .formatToParts(value.map(() => '1'));
@@ -251,7 +249,7 @@ export function _selectRelativeTimeUnit(
   const sign = diffMs < 0 ? -1 : 1;
 
   // Use Math.floor to avoid confusing jumps near boundaries
-  // (e.g. 3.5 days rounding to "1 week ago" instead of "3 days ago")
+  // (for example, 3.5 days rounding to "1 week ago" instead of "3 days ago").
   const seconds = Math.floor(absDiffMs / 1000);
   const minutes = Math.floor(absDiffMs / (1000 * 60));
   const hours = Math.floor(absDiffMs / (1000 * 60 * 60));

--- a/packages/core/src/id/hashSource.ts
+++ b/packages/core/src/id/hashSource.ts
@@ -1,5 +1,3 @@
-// Functions provided to other GT libraries
-
 import { JsxChild, JsxChildren, Variable } from '../types';
 import { stableStringify as stringify } from '../utils/stableStringify';
 import { sha256 } from '@noble/hashes/sha2.js';
@@ -7,14 +5,13 @@ import { bytesToHex, utf8ToBytes } from '@noble/hashes/utils.js';
 import isVariable from '../utils/isVariable';
 import { HashMetadata } from './types';
 
-// ----- FUNCTIONS ----- //
 /**
- * Calculates a unique hash for a given string using sha256.
+ * Calculates a unique hash for a given string using SHA-256.
  *
- * First 16 characters of hash, hex encoded.
+ * Returns the first 16 hex-encoded characters of the hash.
  *
  * @param {string} string - The string to be hashed.
- * @returns {string} - The resulting hash as a hexadecimal string.
+ * @returns {string} The resulting hash as a hexadecimal string.
  */
 export function hashString(string: string): string {
   return bytesToHex(sha256(utf8ToBytes(string))).slice(0, 16);
@@ -24,12 +21,12 @@ export function hashString(string: string): string {
  * Calculates a unique ID for the given children objects by hashing their sanitized JSON string representation.
  *
  * @param {any} childrenAsObjects - The children objects to be hashed.
- * @param {string} [context] - The context for the children
- * @param {string} [id] - The id for the JSX Children object
- * @param {number} [maxChars] - The maxChars for the JSX Children object
- * @param {string} [dataFormat] - The data format of the sources
- * @param {function} [hashFunction] custom hash function
- * @returns {string} - The unique has of the children.
+ * @param {string} [context] - The context for the children.
+ * @param {string} [id] - The ID for the JSX children object.
+ * @param {number} [maxChars] - The maxChars limit for the JSX children object.
+ * @param {string} [dataFormat] - The data format of the sources.
+ * @param {function} [hashFunction] - Custom hash function.
+ * @returns {string} The unique hash of the children.
  */
 export function hashSource(
   {
@@ -66,10 +63,10 @@ type SanitizedVariable = Omit<Variable, 'i'>;
 
 type SanitizedElement = {
   b?: {
-    [k: string]: SanitizedChildren; // Branches
+    [k: string]: SanitizedChildren;
   };
-  c?: SanitizedChildren; // Children
-  t?: string; // Branch Transformation
+  c?: SanitizedChildren;
+  t?: string;
 };
 type SanitizedChild = SanitizedElement | SanitizedVariable | string;
 type SanitizedChildren = SanitizedChild | SanitizedChild[];
@@ -90,9 +87,8 @@ const sanitizeChild = (child: JsxChild): SanitizedChild => {
     if ('d' in child) {
       const generaltranslation = child?.d;
       if (generaltranslation?.b) {
-        // The only thing that prevents sanitizeJsx from being stable is
-        // the order of the keys in the branches object.
-        // We don't sort them because stable-stringify sorts them anyways
+        // Branch key order is the only source of instability here.
+        // stableStringify sorts keys when serializing the sanitized tree.
         newChild.b = Object.fromEntries(
           Object.entries(generaltranslation.b).map(([key, value]) => [
             key,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,8 +1,6 @@
 // `generaltranslation` language toolkit
 // © 2026, General Translation, Inc.
 
-// ----- IMPORTS ----- //
-
 import _requiresTranslation from './locales/requiresTranslation';
 import _determineLocale from './locales/determineLocale';
 import {
@@ -135,9 +133,6 @@ export {
   standardizeLocale,
 } from './core';
 
-// ============================================================ //
-//                        Core Class                            //
-// ============================================================ //
 /**
  * Type representing the constructor parameters for the GT class.
  * @typedef {Object} GTConstructorParams
@@ -230,13 +225,12 @@ export class GT {
    * });
    */
   constructor(params: GTConstructorParams = {}) {
-    // Read environment
+    // Read environment variables.
     if (typeof process !== 'undefined') {
       this.apiKey ||= process.env?.GT_API_KEY;
       this.devApiKey ||= process.env?.GT_DEV_API_KEY;
       this.projectId ||= process.env?.GT_PROJECT_ID;
     }
-    // Set up config
     this.setConfig(params);
   }
 
@@ -250,28 +244,22 @@ export class GT {
     customMapping,
     baseUrl,
   }: GTConstructorParams) {
-    // ----- Environment properties ----- //
     if (apiKey) this.apiKey = apiKey;
     if (devApiKey) this.devApiKey = devApiKey;
     if (projectId) this.projectId = projectId;
 
-    // ----- Standardize locales ----- //
-
-    // source locale
     if (sourceLocale) {
       this.sourceLocale = _standardizeLocale(sourceLocale);
       if (!_isValidLocale(this.sourceLocale, customMapping))
         throw new Error(invalidLocaleError(this.sourceLocale));
     }
 
-    // target locale
     if (targetLocale) {
       this.targetLocale = _standardizeLocale(targetLocale);
       if (!_isValidLocale(this.targetLocale, customMapping))
         throw new Error(invalidLocaleError(this.targetLocale));
     }
 
-    // locales
     if (locales) {
       const result: string[] = [];
       const invalidLocales: string[] = [];
@@ -289,7 +277,6 @@ export class GT {
       this.locales = result;
     }
 
-    // ----- Other properties ----- //
     if (baseUrl) this.baseUrl = baseUrl;
     if (customMapping) {
       this.customMapping = customMapping;
@@ -307,8 +294,6 @@ export class GT {
       customMapping: this.customMapping,
     });
   }
-
-  // -------------- Private Methods -------------- //
 
   private _getTranslationConfig(): TranslationRequestConfig {
     return {
@@ -333,13 +318,11 @@ export class GT {
     }
   }
 
-  // -------------- Branch Methods -------------- //
-
   /**
    * Queries branch information from the API.
    *
-   * @param {BranchQuery} query - Object mapping the current branch and incoming branches
-   * @returns {Promise<BranchDataResult>} The branch information
+   * @param {BranchQuery} query - Branch names to query.
+   * @returns {Promise<BranchDataResult>} The branch information.
    */
   async queryBranchData(query: BranchQuery): Promise<BranchDataResult> {
     this._validateAuth('queryBranchData');
@@ -349,8 +332,8 @@ export class GT {
   /**
    * Creates a new branch in the API. If the branch already exists, it will be returned.
    *
-   * @param {CreateBranchQuery} query - Object mapping the branch name and default branch flag
-   * @returns {Promise<CreateBranchResult>} The created branch information
+   * @param {CreateBranchQuery} query - The branch name and default branch flag.
+   * @returns {Promise<CreateBranchResult>} The created branch information.
    */
   async createBranch(query: CreateBranchQuery): Promise<CreateBranchResult> {
     this._validateAuth('createBranch');
@@ -358,12 +341,12 @@ export class GT {
   }
 
   /**
-   * Processes file moves by cloning source files and translations with new fileIds.
-   * This is called when files have been moved/renamed and we want to preserve translations.
+   * Processes file moves by cloning source files and translations with new file IDs.
+   * This is called when files have been moved or renamed and translations should be preserved.
    *
-   * @param {MoveMapping[]} moves - Array of move mappings (old fileId to new fileId)
-   * @param {ProcessMovesOptions} options - Options including branchId and timeout
-   * @returns {Promise<ProcessMovesResponse>} The move processing results
+   * @param {MoveMapping[]} moves - Move mappings from old file ID to new file ID.
+   * @param {ProcessMovesOptions} options - Options including branch ID and timeout.
+   * @returns {Promise<ProcessMovesResponse>} The move processing results.
    *
    * @example
    * const result = await gt.processFileMoves([
@@ -383,14 +366,13 @@ export class GT {
   }
 
   /**
-   * Gets orphaned files for a branch - files that exist on the branch
-   * but whose fileIds are not in the provided list.
-   * Used for move detection.
+   * Gets orphaned files for a branch: files that exist on the branch but whose
+   * file IDs are not in the provided list. Used for move detection.
    *
-   * @param {string} branchId - The branch to check for orphaned files
-   * @param {string[]} fileIds - List of current file IDs (files that are NOT orphaned)
-   * @param {Object} options - Options including timeout
-   * @returns {Promise<GetOrphanedFilesResult>} The orphaned files
+   * @param {string} branchId - The branch to check for orphaned files.
+   * @param {string[]} fileIds - Current file IDs that are not orphaned.
+   * @param {Object} options - Options including timeout.
+   * @returns {Promise<GetOrphanedFilesResult>} The orphaned files.
    *
    * @example
    * const result = await gt.getOrphanedFiles('branch-id', ['file-1', 'file-2']);
@@ -409,19 +391,17 @@ export class GT {
     );
   }
 
-  // -------------- Translation Methods -------------- //
-
   /**
-   * Enqueues project setup job using the specified file references
+   * Enqueues a project setup job using the specified file references.
    *
    * This method creates setup jobs that will process source file references
    * and generate a project setup. The files parameter contains references (IDs) to source
    * files that have already been uploaded via uploadSourceFiles. The setup jobs are queued
    * for processing and will generate a project setup based on the source files.
    *
-   * @param {FileReference[]} files - Array of file references containing IDs of previously uploaded source files
-   * @param {SetupProjectOptions} [options] - Optional settings for target locales and timeout
-   * @returns {Promise<SetupProjectResult>} Object containing the jobId and status
+   * @param {FileReference[]} files - File references for previously uploaded source files.
+   * @param {SetupProjectOptions} [options] - Optional settings for target locales and timeout.
+   * @returns {Promise<SetupProjectResult>} Object containing the job ID and status.
    */
   async setupProject(
     files: FileReference[],
@@ -443,9 +423,9 @@ export class GT {
    * This method polls the API to determine whether one or more jobs are still running,
    * have completed successfully, or have failed. Jobs are created after calling either enqueueFiles or setupProject.
    *
-   * @param {string[]} jobIds - The unique identifiers of the jobs to check
-   * @param {number} [timeoutMs] - Optional timeout in milliseconds for the API request
-   * @returns {Promise<CheckJobStatusResult>} Object containing the job status
+   * @param {string[]} jobIds - The unique identifiers of the jobs to check.
+   * @param {number} [timeoutMs] - Optional timeout in milliseconds for the API request.
+   * @returns {Promise<CheckJobStatusResult>} Object containing the job status.
    *
    * @example
    * const result = await gt.checkJobStatus([
@@ -470,9 +450,9 @@ export class GT {
   /**
    * Polls job statuses until all jobs from enqueueFiles are finished or the timeout is reached.
    *
-   * @param {EnqueueFilesResult} enqueueResult - The result returned from enqueueFiles
-   * @param {AwaitJobsOptions} [options] - Polling configuration (interval, timeout)
-   * @returns {Promise<AwaitJobsResult>} The final status of all jobs and whether they all completed
+   * @param {EnqueueFilesResult} enqueueResult - The result returned from enqueueFiles.
+   * @param {AwaitJobsOptions} [options] - Polling configuration (interval, timeout).
+   * @returns {Promise<AwaitJobsResult>} The final status of all jobs and whether they all completed.
    */
   async awaitJobs(
     enqueueResult: EnqueueFilesResult,
@@ -495,32 +475,31 @@ export class GT {
    * uploadSourceFiles. The translation jobs are queued for processing and will
    * generate translated content based on the source files and target locales provided.
    *
-   * @param {FileReferenceIds[]} files - Array of file references containing IDs of previously uploaded source files
-   * @param {EnqueueOptions} options - Configuration options including source locale, target locales, and job settings
-   * @returns {Promise<EnqueueFilesResult>} Result containing job IDs, queue status, and processing information
+   * @param {FileReferenceIds[]} files - File references for previously uploaded source files.
+   * @param {EnqueueOptions} options - Configuration options including source locale, target locales, and job settings.
+   * @returns {Promise<EnqueueFilesResult>} Result containing job IDs, queue status, and processing information.
    */
   async enqueueFiles(
     files: FileReferenceIds[],
     options: EnqueueOptions
   ): Promise<EnqueueFilesResult> {
-    // Validation
     this._validateAuth('enqueueFiles');
 
-    // Merge instance settings with options
+    // Merge instance settings with options.
     let mergedOptions: EnqueueOptions = {
       ...options,
       sourceLocale: options.sourceLocale ?? this.sourceLocale!,
       targetLocales: options.targetLocales ?? [this.targetLocale!],
     };
 
-    // Require source locale
+    // Require a source locale.
     if (!mergedOptions.sourceLocale) {
       const error = noSourceLocaleProvidedError('enqueueFiles');
       gtInstanceLogger.error(error);
       throw new Error(error);
     }
 
-    // Require target locale(s)
+    // Require at least one target locale.
     if (
       !mergedOptions.targetLocales ||
       mergedOptions.targetLocales.length === 0
@@ -530,7 +509,7 @@ export class GT {
       throw new Error(error);
     }
 
-    // Replace target locales with canonical locales
+    // Resolve target locales to canonical locales.
     mergedOptions = {
       ...mergedOptions,
       targetLocales: mergedOptions.targetLocales.map((locale) =>
@@ -549,8 +528,8 @@ export class GT {
    * Creates or upserts a file tag, associating a set of source files
    * with a user-defined tag ID and optional message.
    *
-   * @param {CreateTagOptions} options - Tag creation options including tagId, sourceFileIds, and optional message
-   * @returns {Promise<CreateTagResult>} The created or updated tag
+   * @param {CreateTagOptions} options - Tag creation options including tag ID, source file IDs, and optional message.
+   * @returns {Promise<CreateTagResult>} The created or updated tag.
    */
   async createTag(options: CreateTagOptions): Promise<CreateTagResult> {
     this._validateAuth('createTag');
@@ -560,8 +539,8 @@ export class GT {
   /**
    * Publishes or unpublishes files on the CDN.
    *
-   * @param {PublishFileEntry[]} files - Array of file entries with publish flags
-   * @returns {Promise<PublishFilesResult>} Result containing per-file success/failure
+   * @param {PublishFileEntry[]} files - File entries with publish flags.
+   * @returns {Promise<PublishFilesResult>} Result containing per-file success or failure.
    */
   async publishFiles(files: PublishFileEntry[]): Promise<PublishFilesResult> {
     this._validateAuth('publishFiles');
@@ -578,7 +557,7 @@ export class GT {
     payload: SubmitUserEditDiffsPayload
   ): Promise<void> {
     this._validateAuth('submitUserEditDiffs');
-    // Normalize locales to canonical form before submission
+    // Normalize locales to canonical form before submission.
     const normalized: SubmitUserEditDiffsPayload = {
       ...payload,
       diffs: (payload.diffs || []).map((d) => ({
@@ -613,23 +592,22 @@ export class GT {
     data: FileDataQuery,
     options: CheckFileTranslationsOptions = {}
   ): Promise<FileDataResult> {
-    // Validation
     this._validateAuth('queryFileData');
 
-    // Replace target locales with canonical locales
+    // Resolve target locales to canonical locales before querying.
     data.translatedFiles = data.translatedFiles?.map((item) => ({
       ...item,
       locale: this.resolveCanonicalLocale(item.locale),
     }));
 
-    // Request the file translation status
+    // Request file metadata.
     const result = await _queryFileData(
       data,
       options,
       this._getTranslationConfig()
     );
 
-    // Resolve canonical locales
+    // Resolve service locales back to aliases.
     result.translatedFiles = result.translatedFiles?.map((item) => ({
       ...item,
       ...(item.locale && { locale: this.resolveAliasLocale(item.locale) }),
@@ -662,16 +640,15 @@ export class GT {
     data: FileQuery,
     options: CheckFileTranslationsOptions = {}
   ): Promise<FileQueryResult> {
-    // Validation
     this._validateAuth('querySourceFile');
 
-    // Request the file translation status
+    // Request source file metadata and translations.
     const result = await _querySourceFile(
       data,
       options,
       this._getTranslationConfig()
     );
-    // Replace locales with canonical locales
+    // Resolve service locales back to aliases.
     result.translations = result.translations.map((item) => ({
       ...item,
       ...(item.locale && { locale: this.resolveAliasLocale(item.locale) }),
@@ -687,7 +664,7 @@ export class GT {
     return result;
   }
   /**
-   * Get project data for a given project ID.
+   * Gets project data for a given project ID.
    *
    * @param {string} projectId - The ID of the project to get the data for.
    * @returns {Promise<ProjectData>} The project data.
@@ -702,16 +679,15 @@ export class GT {
     projectId: string,
     options: { timeout?: number } = {}
   ): Promise<ProjectData> {
-    // Validation
     this._validateAuth('getProjectData');
 
-    // Request the file translation status
+    // Request project metadata.
     const result = await _getProjectData(
       projectId,
       options,
       this._getTranslationConfig()
     );
-    // Replace locales with canonical locales
+    // Resolve service locales back to aliases.
     result.currentLocales = result.currentLocales.map((item) =>
       this.resolveAliasLocale(item)
     );
@@ -750,7 +726,6 @@ export class GT {
     },
     options: DownloadFileOptions = {}
   ): Promise<string> {
-    // Validation
     this._validateAuth('downloadTranslatedFile');
 
     const result = await _downloadFileBatch(
@@ -791,7 +766,6 @@ export class GT {
     requests: DownloadFileBatchRequest,
     options: DownloadFileBatchOptions = {}
   ): Promise<DownloadFileBatchResult> {
-    // Validation
     this._validateAuth('downloadFileBatch');
 
     requests = requests.map((request) => ({
@@ -801,7 +775,7 @@ export class GT {
         : undefined,
     }));
 
-    // Request the batch download
+    // Request the batch download.
     const result = await _downloadFileBatch(
       requests,
       options,
@@ -842,15 +816,14 @@ export class GT {
     options: string | TranslateOptions,
     timeout?: number
   ): Promise<TranslationResult | TranslationError> {
-    // Normalize string shorthand to options object
+    // Normalize string shorthand to an options object.
     if (typeof options === 'string') {
       options = { targetLocale: options };
     }
 
-    // Validation
     this._validateAuth('translate');
 
-    // Require target locale
+    // Require a target locale.
     let targetLocale = options?.targetLocale || this.targetLocale;
     if (!targetLocale) {
       const error = noTargetLocaleProvidedError('translate');
@@ -858,14 +831,14 @@ export class GT {
       throw new Error(error);
     }
 
-    // Replace target locale with canonical locale
+    // Resolve target locale to canonical locale.
     targetLocale = this.resolveCanonicalLocale(targetLocale);
 
     const sourceLocale = this.resolveCanonicalLocale(
       options?.sourceLocale || this.sourceLocale || libraryDefaultLocale
     );
 
-    // Request the translation
+    // Request the translation.
     const results = await _translateMany(
       [source],
       {
@@ -920,15 +893,14 @@ export class GT {
     options: string | TranslateOptions,
     timeout?: number
   ): Promise<TranslateManyResult | Record<string, TranslationResult>> {
-    // Normalize string shorthand to options object
+    // Normalize string shorthand to an options object.
     if (typeof options === 'string') {
       options = { targetLocale: options };
     }
 
-    // Validation
     this._validateAuth('translateMany');
 
-    // Require target locale
+    // Require a target locale.
     let targetLocale = options?.targetLocale || this.targetLocale;
     if (!targetLocale) {
       const error = noTargetLocaleProvidedError('translateMany');
@@ -936,14 +908,14 @@ export class GT {
       throw new Error(error);
     }
 
-    // Replace target locale with canonical locale
+    // Resolve target locale to canonical locale.
     targetLocale = this.resolveCanonicalLocale(targetLocale);
 
     const sourceLocale = this.resolveCanonicalLocale(
       options?.sourceLocale || this.sourceLocale || libraryDefaultLocale
     );
 
-    // Request the translation
+    // Request the translation.
     return await _translateMany(
       sources,
       {
@@ -964,18 +936,17 @@ export class GT {
    * are processed and stored as base entries that serve as the foundation for generating
    * translations through the translation workflow.
    *
-   * @param {Array<{source: FileUpload}>} files - Array of objects containing source file data to upload
-   * @param {UploadFilesOptions} options - Configuration options including source locale and other upload settings
-   * @returns {Promise<UploadFilesResponse>} Upload result containing file IDs, version information, and upload status
+   * @param {Array<{source: FileUpload}>} files - Source file data to upload.
+   * @param {UploadFilesOptions} options - Configuration options including source locale and other upload settings.
+   * @returns {Promise<UploadFilesResponse>} Upload result containing file IDs, version information, and upload status.
    */
   async uploadSourceFiles(
     files: { source: FileUpload }[],
     options: UploadFilesOptions
   ): Promise<UploadFilesResponse> {
-    // Validation
     this._validateAuth('uploadSourceFiles');
 
-    // Merge instance settings with options
+    // Merge instance settings with options.
     const mergedOptions: UploadFilesOptions = {
       ...options,
       sourceLocale: this.resolveCanonicalLocale(
@@ -983,7 +954,7 @@ export class GT {
       ),
     };
 
-    // resolve canonical locales
+    // Resolve source locales to canonical locales.
     files = files.map((f) => ({
       ...f,
       source: {
@@ -992,7 +963,7 @@ export class GT {
       },
     }));
 
-    // Process files in batches and convert result to UploadFilesResponse
+    // Process files in batches and convert the result to UploadFilesResponse.
     const result = await _uploadSourceFiles(
       files,
       mergedOptions as RequiredUploadFilesOptions,
@@ -1014,29 +985,28 @@ export class GT {
    * along with the target locale information. This is used when you have pre-existing translations
    * that you want to upload directly rather than generating them through the translation service.
    *
-   * @param {Array<{source: FileUpload, translations: FileUpload[]}>} files - Array of file objects where:
-   *   - `source`: Reference to the existing source file (contains IDs but no content)
-   *   - `translations`: Array of translated files, each containing content, locale, and reference IDs
-   * @param {UploadFilesOptions} options - Configuration options including source locale and upload settings
-   * @returns {Promise<UploadFilesResponse>} Upload result containing translation IDs, status, and processing information
+   * @param {Array<{source: FileUpload, translations: FileUpload[]}>} files - File objects where:
+   *   - `source`: Reference to the existing source file (contains IDs but no content).
+   *   - `translations`: Translated files containing content, locale, and reference IDs.
+   * @param {UploadFilesOptions} options - Configuration options including source locale and upload settings.
+   * @returns {Promise<UploadFilesResponse>} Upload result containing translation IDs, status, and processing information.
    */
   async uploadTranslations(
     files: {
-      source: FileUpload; // reference only (no content)
-      translations: FileUpload[]; // each has content + ids + locale
+      source: FileUpload; // Reference only; no content.
+      translations: FileUpload[]; // Contains content, IDs, and locale.
     }[],
     options: UploadFilesOptions
   ): Promise<UploadFilesResponse> {
-    // Validation
     this._validateAuth('uploadTranslations');
 
-    // Merge instance settings with options
+    // Merge instance settings with options.
     const mergedOptions: UploadFilesOptions = {
       ...options,
       sourceLocale: options.sourceLocale ?? this.sourceLocale,
     };
 
-    // Require source locale
+    // Require a source locale.
     if (!mergedOptions.sourceLocale) {
       const error = noSourceLocaleProvidedError('uploadTranslations');
       gtInstanceLogger.error(error);
@@ -1052,7 +1022,7 @@ export class GT {
       })),
     }));
 
-    // Process files in batches and convert result to UploadFilesResponse
+    // Process files in batches and convert the result to UploadFilesResponse.
     const result = await _uploadTranslations(
       targetFiles,
       mergedOptions as RequiredUploadFilesOptions,
@@ -1066,8 +1036,6 @@ export class GT {
     };
   }
 
-  // -------------- Formatting -------------- //
-
   /**
    * Formats a string with cutoff behavior, applying a terminator when the string exceeds the maximum character limit.
    *
@@ -1079,13 +1047,13 @@ export class GT {
    * @param {string | string[]} [options.locales] - The locales to use for terminator selection. Defaults to instance's rendering locales.
    * @param {number} [options.maxChars] - The maximum number of characters to display.
    * - Undefined values are treated as no cutoff.
-   * - Negative values follow .slice() behavior and terminator will be added before the value.
-   * - 0 will result in an empty string.
+   * - Negative values follow .slice() behavior, and the terminator is added before the value.
+   * - 0 results in an empty string.
    * - If cutoff results in an empty string, no terminator is added.
-   * @param {CutoffFormatStyle} [options.style='ellipsis'] - The style of the terminator.
-   * @param {string} [options.terminator] - Optional override the terminator to use.
-   * @param {string} [options.separator] - Optional override the separator to use between the terminator and the value.
-   * - If no terminator is provided, then separator is ignored.
+   * @param {CutoffFormatStyle} [options.style='ellipsis'] - The terminator style.
+   * @param {string} [options.terminator] - Optional terminator override.
+   * @param {string} [options.separator] - Optional separator override between the terminator and value.
+   * - If no terminator is provided, the separator is ignored.
    * @returns {string} The formatted string with terminator applied if cutoff occurs.
    *
    * @example
@@ -1135,11 +1103,11 @@ export class GT {
   /**
    * Formats a number according to the specified locales and options.
    *
-   * @param {number} number - The number to format
-   * @param {Object} [options] - Additional options for number formatting
-   * @param {string | string[]} [options.locales] - The locales to use for formatting
-   * @param {Intl.NumberFormatOptions} [options] - Additional Intl.NumberFormat options
-   * @returns {string} The formatted number
+   * @param {number} number - The number to format.
+   * @param {Object} [options] - Additional options for number formatting.
+   * @param {string | string[]} [options.locales] - The locales to use for formatting.
+   * @param {Intl.NumberFormatOptions} [options] - Additional Intl.NumberFormat options.
+   * @returns {string} The formatted number.
    *
    * @example
    * gt.formatNum(1234.56, { style: 'currency', currency: 'USD' });
@@ -1157,11 +1125,11 @@ export class GT {
   /**
    * Formats a date according to the specified locales and options.
    *
-   * @param {Date} date - The date to format
-   * @param {Object} [options] - Additional options for date formatting
-   * @param {string | string[]} [options.locales] - The locales to use for formatting
-   * @param {Intl.DateTimeFormatOptions} [options] - Additional Intl.DateTimeFormat options
-   * @returns {string} The formatted date
+   * @param {Date} date - The date to format.
+   * @param {Object} [options] - Additional options for date formatting.
+   * @param {string | string[]} [options.locales] - The locales to use for formatting.
+   * @param {Intl.DateTimeFormatOptions} [options] - Additional Intl.DateTimeFormat options.
+   * @returns {string} The formatted date.
    *
    * @example
    * gt.formatDateTime(new Date(), { dateStyle: 'full', timeStyle: 'long' });
@@ -1179,12 +1147,12 @@ export class GT {
   /**
    * Formats a currency value according to the specified locales and options.
    *
-   * @param {number} value - The currency value to format
-   * @param {string} currency - The currency code (e.g., 'USD', 'EUR')
-   * @param {Object} [options] - Additional options for currency formatting
-   * @param {string | string[]} [options.locales] - The locales to use for formatting
-   * @param {Intl.NumberFormatOptions} [options] - Additional Intl.NumberFormat options
-   * @returns {string} The formatted currency value
+   * @param {number} value - The currency value to format.
+   * @param {string} currency - The currency code (for example, 'USD' or 'EUR').
+   * @param {Object} [options] - Additional options for currency formatting.
+   * @param {string | string[]} [options.locales] - The locales to use for formatting.
+   * @param {Intl.NumberFormatOptions} [options] - Additional Intl.NumberFormat options.
+   * @returns {string} The formatted currency value.
    *
    * @example
    * gt.formatCurrency(1234.56, 'USD', { style: 'currency' });
@@ -1208,11 +1176,11 @@ export class GT {
   /**
    * Formats a list of items according to the specified locales and options.
    *
-   * @param {Array<string | number>} array - The list of items to format
-   * @param {Object} [options] - Additional options for list formatting
-   * @param {string | string[]} [options.locales] - The locales to use for formatting
-   * @param {Intl.ListFormatOptions} [options] - Additional Intl.ListFormat options
-   * @returns {string} The formatted list
+   * @param {Array<string | number>} array - The list of items to format.
+   * @param {Object} [options] - Additional options for list formatting.
+   * @param {string | string[]} [options.locales] - The locales to use for formatting.
+   * @param {Intl.ListFormatOptions} [options] - Additional Intl.ListFormat options.
+   * @returns {string} The formatted list.
    *
    * @example
    * gt.formatList(['apple', 'banana', 'orange'], { type: 'conjunction' });
@@ -1228,12 +1196,12 @@ export class GT {
   }
 
   /**
-   * Formats a list of items according to the specified locales and options.
-   * @param {Array<T>} array - The list of items to format
-   * @param {Object} [options] - Additional options for list formatting
-   * @param {string | string[]} [options.locales] - The locales to use for formatting
-   * @param {Intl.ListFormatOptions} [options] - Additional Intl.ListFormat options
-   * @returns {Array<T | string>} The formatted list parts
+   * Formats a list of items to parts according to the specified locales and options.
+   * @param {Array<T>} array - The list of items to format.
+   * @param {Object} [options] - Additional options for list formatting.
+   * @param {string | string[]} [options.locales] - The locales to use for formatting.
+   * @param {Intl.ListFormatOptions} [options] - Additional Intl.ListFormat options.
+   * @returns {Array<T | string>} The formatted list parts.
    *
    * @example
    * gt.formatListToParts(['apple', 42, { foo: 'bar' }], { type: 'conjunction', style: 'short', locales: ['en'] });
@@ -1255,12 +1223,12 @@ export class GT {
   /**
    * Formats a relative time value according to the specified locales and options.
    *
-   * @param {number} value - The relative time value to format
-   * @param {Intl.RelativeTimeFormatUnit} unit - The unit of time (e.g., 'second', 'minute', 'hour', 'day', 'week', 'month', 'year')
-   * @param {Object} options - Additional options for relative time formatting
-   * @param {string | string[]} [options.locales] - The locales to use for formatting
-   * @param {Intl.RelativeTimeFormatOptions} [options] - Additional Intl.RelativeTimeFormat options
-   * @returns {string} The formatted relative time string
+   * @param {number} value - The relative time value to format.
+   * @param {Intl.RelativeTimeFormatUnit} unit - The unit of time (for example, 'second', 'minute', 'hour', 'day', 'week', 'month', or 'year').
+   * @param {Object} options - Additional options for relative time formatting.
+   * @param {string | string[]} [options.locales] - The locales to use for formatting.
+   * @param {Intl.RelativeTimeFormatOptions} [options] - Additional Intl.RelativeTimeFormat options.
+   * @returns {string} The formatted relative time string.
    *
    * @example
    * gt.formatRelativeTime(-1, 'day', { locales: ['en-US'], numeric: 'auto' });
@@ -1284,10 +1252,10 @@ export class GT {
   /**
    * Formats a relative time string from a Date, automatically selecting the best unit.
    *
-   * @param {Date} date - The date to format relative to now
-   * @param {Object} [options] - Additional options for relative time formatting
-   * @param {string | string[]} [options.locales] - The locales to use for formatting
-   * @returns {string} The formatted relative time string (e.g., "2 hours ago", "in 3 days")
+   * @param {Date} date - The date to format relative to now.
+   * @param {Object} [options] - Additional options for relative time formatting.
+   * @param {string | string[]} [options.locales] - The locales to use for formatting.
+   * @returns {string} The formatted relative time string (for example, "2 hours ago" or "in 3 days").
    *
    * @example
    * gt.formatRelativeTimeFromDate(new Date(Date.now() - 3600000));
@@ -1307,14 +1275,12 @@ export class GT {
     );
   }
 
-  // -------------- Locale Properties -------------- //
-
   /**
    * Retrieves the display name of a locale code using Intl.DisplayNames, returning an empty string if no name is found.
    *
-   * @param {string} [locale=this.targetLocale] - A BCP-47 locale code
-   * @returns {string} The display name corresponding to the code
-   * @throws {Error} If no target locale is provided
+   * @param {string} [locale=this.targetLocale] - A BCP-47 locale code.
+   * @returns {string} The display name corresponding to the code.
+   * @throws {Error} If no target locale is provided.
    *
    * @example
    * gt.getLocaleName('es-ES');
@@ -1329,9 +1295,9 @@ export class GT {
    * Retrieves an emoji based on a given locale code.
    * Uses the locale's region (if present) to select an emoji or falls back on default emojis.
    *
-   * @param {string} [locale=this.targetLocale] - A BCP-47 locale code (e.g., 'en-US', 'fr-CA')
-   * @returns {string} The emoji representing the locale or its region
-   * @throws {Error} If no target locale is provided
+   * @param {string} [locale=this.targetLocale] - A BCP-47 locale code (for example, 'en-US' or 'fr-CA').
+   * @returns {string} The emoji representing the locale or its region.
+   * @throws {Error} If no target locale is provided.
    *
    * @example
    * gt.getLocaleEmoji('es-ES');
@@ -1423,7 +1389,7 @@ export class GT {
   ): { code: string; name: string; emoji: string } {
     if (!customMapping) {
       if (this.customMapping && !this.customRegionMapping) {
-        // Lazy derive custom region mapping from customMapping
+        // Lazily derive custom region mapping from customMapping.
         const customRegionMapping: CustomRegionMapping = {};
         for (const [locale, lp] of Object.entries(this.customMapping)) {
           if (
@@ -1446,7 +1412,7 @@ export class GT {
     }
     return _getRegionProperties(
       region,
-      this.targetLocale, // this.targetLocale because we want it in the user's language
+      this.targetLocale, // Localize region names in the user's target locale.
       customMapping
     );
   }
@@ -1454,12 +1420,12 @@ export class GT {
   /**
    * Determines whether a translation is required based on the source and target locales.
    *
-   * @param {string} [sourceLocale=this.sourceLocale] - The locale code for the original content
-   * @param {string} [targetLocale=this.targetLocale] - The locale code to translate into
-   * @param {string[]} [approvedLocales=this.locales] - Optional array of approved target locales
-   * @returns {boolean} True if translation is required, false otherwise
-   * @throws {Error} If no source locale is provided
-   * @throws {Error} If no target locale is provided
+   * @param {string} [sourceLocale=this.sourceLocale] - The locale code for the original content.
+   * @param {string} [targetLocale=this.targetLocale] - The locale code to translate into.
+   * @param {string[]} [approvedLocales=this.locales] - Optional array of approved target locales.
+   * @returns {boolean} True if translation is required; otherwise false.
+   * @throws {Error} If no source locale is provided.
+   * @throws {Error} If no target locale is provided.
    *
    * @example
    * gt.requiresTranslation('en-US', 'es-ES');
@@ -1493,9 +1459,9 @@ export class GT {
   /**
    * Determines the best matching locale from the provided approved locales list.
    *
-   * @param {string | string[]} locales - A single locale or array of locales in preference order
-   * @param {string[]} [approvedLocales=this.locales] - Array of approved locales in preference order
-   * @returns {string | undefined} The best matching locale or undefined if no match is found
+   * @param {string | string[]} locales - A single locale or array of locales in preference order.
+   * @param {string[]} [approvedLocales=this.locales] - Array of approved locales in preference order.
+   * @returns {string | undefined} The best matching locale, or undefined if no match is found.
    *
    * @example
    * gt.determineLocale(['fr-CA', 'fr-FR'], ['en-US', 'fr-FR', 'es-ES']);
@@ -1515,9 +1481,9 @@ export class GT {
   /**
    * Gets the text direction for a given locale code.
    *
-   * @param {string} [locale=this.targetLocale] - A BCP-47 locale code
-   * @returns {'ltr' | 'rtl'} 'rtl' if the locale is right-to-left, otherwise 'ltr'
-   * @throws {Error} If no target locale is provided
+   * @param {string} [locale=this.targetLocale] - A BCP-47 locale code.
+   * @returns {'ltr' | 'rtl'} 'rtl' if the locale is right-to-left; otherwise 'ltr'.
+   * @throws {Error} If no target locale is provided.
    *
    * @example
    * gt.getLocaleDirection('ar-SA');
@@ -1530,12 +1496,12 @@ export class GT {
   }
 
   /**
-   * Checks if a given BCP 47 locale code is valid.
+   * Checks whether a BCP 47 locale code is valid.
    *
-   * @param {string} [locale=this.targetLocale] - The BCP 47 locale code to validate
-   * @param {customMapping} [customMapping=this.customMapping] - The custom mapping to use for validation
-   * @returns {boolean} True if the locale code is valid, false otherwise
-   * @throws {Error} If no target locale is provided
+   * @param {string} [locale=this.targetLocale] - The BCP 47 locale code to validate.
+   * @param {CustomMapping} [customMapping=this.customMapping] - The custom mapping to use for validation.
+   * @returns {boolean} True if the locale code is valid; otherwise false.
+   * @throws {Error} If no target locale is provided.
    *
    * @example
    * gt.isValidLocale('en-US');
@@ -1553,10 +1519,10 @@ export class GT {
   }
 
   /**
-   * Resolves the canonical locale for a given locale.
-   * @param locale - The locale to resolve the canonical locale for
-   * @param customMapping - The custom mapping to use for resolving the canonical locale
-   * @returns The canonical locale
+   * Resolves the canonical locale for a custom alias.
+   * @param locale - The locale to resolve.
+   * @param customMapping - The custom mapping to inspect.
+   * @returns The canonical locale, or the input locale when no canonical mapping exists.
    */
   resolveCanonicalLocale(
     locale: string | undefined = this.targetLocale,
@@ -1571,10 +1537,10 @@ export class GT {
   }
 
   /**
-   * Resolves the alias locale for a given locale.
-   * @param locale - The locale to resolve the alias locale for
-   * @param customMapping - The custom mapping to use for resolving the alias locale
-   * @returns The alias locale
+   * Resolves the alias locale for a canonical locale.
+   * @param locale - The canonical locale to resolve.
+   * @param customMapping - The custom mapping to inspect.
+   * @returns The alias locale, or the input locale when no alias exists.
    */
   resolveAliasLocale(
     locale: string,
@@ -1591,9 +1557,9 @@ export class GT {
   /**
    * Standardizes a BCP 47 locale code to ensure correct formatting.
    *
-   * @param {string} [locale=this.targetLocale] - The BCP 47 locale code to standardize
-   * @returns {string} The standardized locale code or empty string if invalid
-   * @throws {Error} If no target locale is provided
+   * @param {string} [locale=this.targetLocale] - The BCP 47 locale code to standardize.
+   * @returns {string} The standardized locale code, or the input string if it cannot be standardized.
+   * @throws {Error} If no target locale is provided.
    *
    * @example
    * gt.standardizeLocale('en_us');
@@ -1606,10 +1572,10 @@ export class GT {
   }
 
   /**
-   * Checks if multiple BCP 47 locale codes represent the same dialect.
+   * Checks whether multiple BCP 47 locale codes represent the same dialect.
    *
-   * @param {...(string | string[])} locales - The BCP 47 locale codes to compare
-   * @returns {boolean} True if all codes represent the same dialect, false otherwise
+   * @param {...(string | string[])} locales - The BCP 47 locale codes to compare.
+   * @returns {boolean} True if all codes represent the same dialect; otherwise false.
    *
    * @example
    * gt.isSameDialect('en-US', 'en-GB');
@@ -1623,10 +1589,10 @@ export class GT {
   }
 
   /**
-   * Checks if multiple BCP 47 locale codes represent the same language.
+   * Checks whether multiple BCP 47 locale codes represent the same language.
    *
-   * @param {...(string | string[])} locales - The BCP 47 locale codes to compare
-   * @returns {boolean} True if all codes represent the same language, false otherwise
+   * @param {...(string | string[])} locales - The BCP 47 locale codes to compare.
+   * @returns {boolean} True if all codes represent the same language; otherwise false.
    *
    * @example
    * gt.isSameLanguage('en-US', 'en-GB');
@@ -1637,11 +1603,11 @@ export class GT {
   }
 
   /**
-   * Checks if a locale is a superset of another locale.
+   * Checks whether a locale is a superset of another locale.
    *
-   * @param {string} superLocale - The locale to check if it is a superset
-   * @param {string} subLocale - The locale to check if it is a subset
-   * @returns {boolean} True if superLocale is a superset of subLocale, false otherwise
+   * @param {string} superLocale - The locale to check as a superset.
+   * @param {string} subLocale - The locale to check as a subset.
+   * @returns {boolean} True if superLocale is a superset of subLocale; otherwise false.
    *
    * @example
    * gt.isSupersetLocale('en', 'en-US');
@@ -1654,12 +1620,6 @@ export class GT {
     return this.localeConfig.isSupersetLocale(superLocale, subLocale);
   }
 }
-
-// ============================================================ //
-//                    Utility methods                           //
-// ============================================================ //
-
-// -------------- Formatting -------------- //
 
 /**
  * Formats a number according to the specified locales and options.
@@ -1683,11 +1643,11 @@ export function formatNum(
 }
 
 /**
- * Formats a date according to the specified languages and options.
+ * Formats a date according to the specified locales and options.
  * @param {Object} params - The parameters for the date formatting.
  * @param {Date} params.value - The date to format.
  * @param {Intl.DateTimeFormatOptions} [params.options] - Additional options for date formatting.
- * @param {string | string[]} [params.options.locales] - The languages to use for formatting.
+ * @param {string | string[]} [params.options.locales] - The locales to use for formatting.
  * @returns {string} The formatted date.
  */
 export function formatDateTime(
@@ -1704,7 +1664,7 @@ export function formatDateTime(
 }
 
 /**
- * Formats a currency value according to the specified languages, currency, and options.
+ * Formats a currency value according to the specified locales, currency, and options.
  * @param {Object} params - The parameters for the currency formatting.
  * @param {number} params.value - The currency value to format.
  * @param {string} params.currency - The currency code (e.g., 'USD').
@@ -1749,12 +1709,12 @@ export function formatList(
 }
 
 /**
- * Formats a list of items according to the specified locales and options.
- * @param {Array<T>} array - The list of items to format
- * @param {Object} [options] - Additional options for list formatting
- * @param {string | string[]} [options.locales] - The locales to use for formatting
- * @param {Intl.ListFormatOptions} [options] - Additional Intl.ListFormat options
- * @returns {Array<T | string>} The formatted list parts
+ * Formats a list of items to parts according to the specified locales and options.
+ * @param {Array<T>} array - The list of items to format.
+ * @param {Object} [options] - Additional options for list formatting.
+ * @param {string | string[]} [options.locales] - The locales to use for formatting.
+ * @param {Intl.ListFormatOptions} [options] - Additional Intl.ListFormat options.
+ * @returns {Array<T | string>} The formatted list parts.
  */
 export function formatListToParts<T>(
   array: Array<T>,
@@ -1817,10 +1777,8 @@ export function formatRelativeTimeFromDate(
   });
 }
 
-// -------------- Locale Properties -------------- //
-
 /**
- * Retrieves the display name of locale code using Intl.DisplayNames.
+ * Retrieves the display name of a locale code using Intl.DisplayNames.
  *
  * @param {string} locale - A BCP-47 locale code.
  * @param {string} [defaultLocale] - The default locale to use for formatting.
@@ -1836,9 +1794,9 @@ export function getLocaleName(
 }
 
 /**
- * Retrieves an emoji based on a given locale code, taking into account region, language, and specific exceptions.
+ * Retrieves an emoji for a locale code, taking into account region, language, and specific exceptions.
  *
- * This function uses the locale's region (if present) to select an emoji or falls back on default emojis for certain languages.
+ * This function uses the locale's region, when present, to select an emoji or falls back to default emojis for certain languages.
  *
  * @param locale - A string representing the locale code (e.g., 'en-US', 'fr-CA').
  * @param {CustomMapping} [customMapping] - A custom mapping of locale codes to their names.
@@ -1854,9 +1812,9 @@ export function getLocaleEmoji(
 /**
  * Generates linguistic details for a given locale code.
  *
- * This function returns information about the locale,
- * script, and region of a given language code both in a standard form and in a maximized form (with likely script and region).
- * The function provides these names in both your default language and native forms, and an associated emoji.
+ * Returns information about the locale, script, and region of a language code in
+ * standard and maximized forms. Names are provided in both the default display
+ * language and native forms, along with an associated emoji.
  *
  * @param {string} locale - The locale code to get properties for (e.g., "de-AT").
  * @param {string} [defaultLocale] - The default locale to use for formatting.
@@ -1905,7 +1863,7 @@ export function getLocaleProperties(
  * - Otherwise, uses `Intl.DisplayNames` to get the localized region name in the given `defaultLocale`,
  *   falling back to `libraryDefaultLocale`.
  * - Falls back to the region code as `name` if display name resolution fails.
- * - Falls back to `defaultEmoji` if no emoji mapping is found in `emojis` or `customMapping`.
+ * - Falls back to `defaultEmoji` if no emoji mapping is found in built-in data or `customMapping`.
  *
  * @param {string} region - The region code to look up (e.g., `"US"`, `"GB"`, `"DE"`).
  * @param {string} [defaultLocale=libraryDefaultLocale] - The locale to use when localizing the region name.
@@ -1945,9 +1903,9 @@ export function getRegionProperties(
  *
  * @param {string} sourceLocale - The locale code for the original content (BCP 47 locale code).
  * @param {string} targetLocale - The locale code of the language to translate the content into (BCP 47 locale code).
- * @param {string[]} [approvedLocale] - An optional array of approved target locales.
+ * @param {string[]} [approvedLocales] - An optional array of approved target locales.
  *
- * @returns {boolean} - Returns `true` if translation is required, otherwise `false`.
+ * @returns {boolean} True if translation is required; otherwise false.
  */
 export function requiresTranslation(
   sourceLocale: string,
@@ -1978,20 +1936,20 @@ export function determineLocale(
 }
 
 /**
- * Get the text direction for a given locale code using the Intl.Locale API.
+ * Gets the text direction for a given locale code using Intl.Locale when available.
  *
  * @param {string} locale - A BCP-47 locale code.
- * @returns {string} - 'rtl' if the locale is right-to-left, otherwise 'ltr'.
+ * @returns {string} 'rtl' if the locale is right-to-left; otherwise 'ltr'.
  */
 export function getLocaleDirection(locale: string): 'ltr' | 'rtl' {
   return _getLocaleDirection(locale);
 }
 
 /**
- * Resolves the alias locale for a given locale.
- * @param {string} locale - The locale to resolve the alias locale for
- * @param {CustomMapping} [customMapping] - The custom mapping to use for resolving the alias locale
- * @returns {string} The alias locale
+ * Resolves the alias locale for a canonical locale.
+ * @param {string} locale - The canonical locale to resolve.
+ * @param {CustomMapping} [customMapping] - The custom mapping to inspect.
+ * @returns {string} The alias locale, or the input locale when no alias exists.
  */
 export function resolveAliasLocale(
   locale: string,
@@ -2001,30 +1959,30 @@ export function resolveAliasLocale(
 }
 
 /**
- * Checks if multiple BCP 47 locale codes represent the same dialect.
+ * Checks whether multiple BCP 47 locale codes represent the same dialect.
  * @param {string[]} locales - The BCP 47 locale codes to compare.
- * @returns {boolean} True if all BCP 47 codes represent the same dialect, false otherwise.
+ * @returns {boolean} True if all BCP 47 codes represent the same dialect; otherwise false.
  */
 export function isSameDialect(...locales: (string | string[])[]): boolean {
   return _isSameDialect(...locales);
 }
 
 /**
- * Checks if multiple BCP 47 locale codes represent the same language.
+ * Checks whether multiple BCP 47 locale codes represent the same language.
  * @param {string[]} locales - The BCP 47 locale codes to compare.
- * @returns {boolean} True if all BCP 47 codes represent the same language, false otherwise.
+ * @returns {boolean} True if all BCP 47 codes represent the same language; otherwise false.
  */
 export function isSameLanguage(...locales: (string | string[])[]): boolean {
   return _isSameLanguage(...locales);
 }
 
 /**
- * Checks if a locale is a superset of another locale.
- * A subLocale is a subset of superLocale if it is an extension of superLocale or are otherwise identical.
+ * Checks whether a locale is a superset of another locale.
+ * A subLocale is a subset of superLocale if it extends superLocale or is otherwise identical.
  *
- * @param {string} superLocale - The locale to check if it is a superset of the other locale.
- * @param {string} subLocale - The locale to check if it is a subset of the other locale.
- * @returns {boolean} True if the first locale is a superset of the second locale, false otherwise.
+ * @param {string} superLocale - The locale to check as a superset.
+ * @param {string} subLocale - The locale to check as a subset.
+ * @returns {boolean} True if the first locale is a superset of the second; otherwise false.
  */
 export function isSupersetLocale(
   superLocale: string,

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -31,10 +31,10 @@ export {
   validateFileFormatTransforms,
 };
 
-// derive
+// Derivation helpers.
 export * from './derive';
 
-// backwards compatability
+// Backward compatibility helpers.
 export {
   getNewJsxChild,
   getNewJsxChildren,

--- a/packages/core/src/locales/customLocaleMapping.ts
+++ b/packages/core/src/locales/customLocaleMapping.ts
@@ -19,10 +19,10 @@ export const getCustomProperty = (
 };
 
 /**
- * Checks if a given locale should use the canonical locale.
- * @param locale - The locale to check if it should use the canonical locale
- * @param customMapping - The custom mapping to use for checking if the locale should use the canonical locale
- * @returns True if the locale should use the canonical locale, false otherwise
+ * Checks whether a custom locale entry points to a valid canonical locale.
+ * @param locale - The locale to check.
+ * @param customMapping - The custom mapping to inspect.
+ * @returns True if the locale should resolve to its canonical code.
  */
 export const shouldUseCanonicalLocale = (
   locale: string,

--- a/packages/core/src/locales/determineLocale.ts
+++ b/packages/core/src/locales/determineLocale.ts
@@ -5,8 +5,8 @@ import _getLocaleProperties from './getLocaleProperties';
 import { CustomMapping } from './customLocaleMapping';
 
 /**
- * Given a list of locales and a list of approved locales, sorted in preference order
- * Determines which locale is the best match among the approved locales, prioritizing exact matches and falling back to dialects of the same language
+ * Determines the best approved locale match for a preference-ordered locale list.
+ * Prioritizes exact matches and falls back to dialects of the same language.
  * @internal
  */
 export default function _determineLocale(
@@ -39,10 +39,10 @@ export default function _determineLocale(
       scriptCode: string;
     }) => {
       const locales = [
-        locale, // If the full locale is supported under this language category
-        `${languageCode}-${regionCode}`, // Attempt to match parts
-        `${languageCode}-${scriptCode}`,
-        minimizedCode, // If a minimized variant of this locale is supported
+        locale, // Full locale match.
+        `${languageCode}-${regionCode}`, // Language-region match.
+        `${languageCode}-${scriptCode}`, // Language-script match.
+        minimizedCode, // Minimized locale match.
       ];
       for (const l of locales) {
         if (candidates.includes(l)) return l;

--- a/packages/core/src/locales/getLocaleDirection.ts
+++ b/packages/core/src/locales/getLocaleDirection.ts
@@ -2,14 +2,14 @@ import { intlCache } from '../cache/IntlCache';
 import _getLocaleProperties from './getLocaleProperties';
 
 /**
- * Get the text direction for a given locale code using the Intl.Locale API.
+ * Gets the text direction for a given locale code using Intl.Locale when available.
  *
  * @param {string} code - The locale code to check.
- * @returns {string} - 'rtl' if the language is right-to-left, otherwise 'ltr'.
+ * @returns {string} 'rtl' if the language is right-to-left; otherwise 'ltr'.
  * @internal
  */
 export function _getLocaleDirection(code: string): 'ltr' | 'rtl' {
-  // Extract via textInfo property
+  // Prefer the Intl.Locale textInfo property when it is available.
   try {
     const locale = intlCache.get('Locale', code);
     const textInfoDirection = extractDirectionWithTextInfo(locale);
@@ -17,20 +17,17 @@ export function _getLocaleDirection(code: string): 'ltr' | 'rtl' {
       return textInfoDirection;
     }
   } catch {
-    // silent
+    // Fall back to heuristics if Intl.Locale cannot parse the code.
   }
 
-  // Fallback to simple heuristics
+  // Fall back to script and language heuristics.
   const { scriptCode, languageCode } = _getLocaleProperties(code);
 
-  // Handle RTL script or language
   if (scriptCode) return isRtlScript(scriptCode) ? 'rtl' : 'ltr';
   if (languageCode) return isRtlLanguage(languageCode) ? 'rtl' : 'ltr';
 
   return 'ltr';
 }
-
-// ===== HELPER CONSTANTS ===== //
 
 const RTL_SCRIPTS = new Set([
   'arab',
@@ -64,15 +61,13 @@ const RTL_LANGUAGES = new Set([
   'yi',
 ]);
 
-// ===== HELPER FUNCTIONS ===== //
-
 /**
- * Handles extracting direction via textInfo property
- * @param Locale - Intl.Locale object
- * @returns {'ltr' | 'rtl'} - The direction of the locale
+ * Extracts direction from the Intl.Locale textInfo property.
+ * @param locale - Intl.Locale object.
+ * @returns The direction of the locale, if available.
  *
- * Intl.Locale.prototype.getTextInfo() / textInfo property incorporated in ES2024 Specification.
- * This is not supported by all browsers yet.
+ * Intl.Locale.prototype.getTextInfo() / the textInfo property is incorporated in the ES2024 specification.
+ * It is not supported by all browsers yet.
  * See: {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getTextInfo#browser_compatibility}
  */
 function extractDirectionWithTextInfo(

--- a/packages/core/src/locales/getLocaleEmoji.ts
+++ b/packages/core/src/locales/getLocaleEmoji.ts
@@ -44,12 +44,12 @@ export default function _getLocaleEmoji(
   }
 }
 
-// Default language emoji for when none else can be found
+// Default language emoji when no region-specific emoji is available.
 const europeAfricaGlobe = '🌍';
 const asiaAustraliaGlobe = '🌏';
 export const defaultEmoji = europeAfricaGlobe;
 
-// Exceptions to better reflect linguistic and cultural identities
+// Exceptions that better reflect linguistic and cultural identities.
 const exceptions = {
   ca: europeAfricaGlobe,
   eu: europeAfricaGlobe,

--- a/packages/core/src/locales/getLocaleName.ts
+++ b/packages/core/src/locales/getLocaleName.ts
@@ -20,10 +20,9 @@ export function _getLocaleName(
   defaultLocale: string = libraryDefaultLocale,
   customMapping?: CustomMapping
 ): string {
-  // Check for canonical locale
+  // Resolve custom aliases to canonical locales before processing.
   const aliasedLocale = locale;
   if (customMapping && shouldUseCanonicalLocale(locale, customMapping)) {
-    // Override locale with canonical locale
     locale = (customMapping[locale] as { code: string }).code;
   }
 
@@ -43,12 +42,12 @@ export function _getLocaleName(
     }
     const displayNames = intlCache.get(
       'DisplayNames',
-      [defaultLocale, standardizedLocale, libraryDefaultLocale], // default locale order
+      [defaultLocale, standardizedLocale, libraryDefaultLocale], // Locale fallback order.
       { type: 'language' }
     );
     return displayNames.of(standardizedLocale) || '';
   } catch {
-    // In case Intl.DisplayNames construction fails, return empty string(s)
+    // Return an empty string if Intl.DisplayNames construction fails.
     return '';
   }
 }

--- a/packages/core/src/locales/getLocaleProperties.ts
+++ b/packages/core/src/locales/getLocaleProperties.ts
@@ -6,41 +6,54 @@ import { intlCache } from '../cache/IntlCache';
 import { CustomMapping, shouldUseCanonicalLocale } from './customLocaleMapping';
 
 export type LocaleProperties = {
-  // assume code = "de-AT", defaultLocale = "en-US"
+  /** ex. "de-AT" - Standardized locale code. */
+  code: string;
+  /** ex. "Austrian German" - Display name in the requested display locale. */
+  name: string;
+  /** ex. "Österreichisches Deutsch" - Display name in the locale's native language. */
+  nativeName: string;
 
-  code: string; // "de-AT"
-  name: string; // "Austrian German"
-  nativeName: string; // "Österreichisches Deutsch"
+  /** ex. "de" - Language subtag. */
+  languageCode: string;
+  /** ex. "German" - Language name in the requested display locale. */
+  languageName: string;
+  /** ex. "Deutsch" - Language name in the locale's native language. */
+  nativeLanguageName: string;
 
-  languageCode: string; // "de"
-  languageName: string; // "German"
-  nativeLanguageName: string; // "Deutsch"
+  /** ex. "German (AT)" - Display name with the explicit region code, without maximizing the locale. */
+  nameWithRegionCode: string;
+  /** ex. "Deutsch (AT)" - Native display name with the explicit region code, without maximizing the locale. */
+  nativeNameWithRegionCode: string;
 
-  // note that maximize() is NOT called here!
+  /** ex. "AT" - Most likely region subtag after maximizing the locale. */
+  regionCode: string;
+  /** ex. "Austria" - Region name in the requested display locale. */
+  regionName: string;
+  /** ex. "Österreich" - Region name in the locale's native language. */
+  nativeRegionName: string;
 
-  nameWithRegionCode: string; // "German (AT)"
-  nativeNameWithRegionCode: string; // "Deutsch (AT)"
+  /** ex. "Latn" - Most likely script subtag after maximizing the locale. */
+  scriptCode: string;
+  /** ex. "Latin" - Script name in the requested display locale. */
+  scriptName: string;
+  /** ex. "Lateinisch" - Script name in the locale's native language. */
+  nativeScriptName: string;
 
-  // for most likely script and region, maximize() is called
+  /** ex. "de-Latn-AT" - Maximized locale code. */
+  maximizedCode: string;
+  /** ex. "Austrian German (Latin)" - Maximized locale name. */
+  maximizedName: string;
+  /** ex. "Österreichisches Deutsch (Lateinisch)" - Native maximized locale name. */
+  nativeMaximizedName: string;
 
-  regionCode: string; // "AT"
-  regionName: string; // "Austria"
-  nativeRegionName: string; // Österreich
+  /** ex. "de-AT" or "de" for "de-DE" - Minimized locale code. */
+  minimizedCode: string;
+  /** ex. "Austrian German" - Minimized locale name. */
+  minimizedName: string;
+  /** ex. "Österreichisches Deutsch" - Native minimized locale name. */
+  nativeMinimizedName: string;
 
-  scriptCode: string; // "Latn"
-  scriptName: string; // "Latin"
-  nativeScriptName: string; // "Lateinisch"
-
-  maximizedCode: string; // "de-Latn-AT"
-  maximizedName: string; // "Austrian German (Latin)"
-  nativeMaximizedName: string; // Österreichisches Deutsch (Lateinisch)
-
-  minimizedCode: string; // "de-AT", but for "de-DE" it would just be "de"
-  minimizedName: string; // ""Austrian German";
-  nativeMinimizedName: string; // "Österreichisches Deutsch"
-
-  // Emoji depending on region code
-  // In order not to accidentally spark international conflict, some emojis are hard-coded
+  /** Locale emoji, with overrides for some linguistic and cultural identities. */
   emoji: string;
 };
 
@@ -80,43 +93,42 @@ export default function _getLocaleProperties(
   defaultLocale: string = libraryDefaultLocale,
   customMapping?: CustomMapping
 ): LocaleProperties {
-  // Check for canonical locale
+  // Resolve custom aliases to canonical locales before processing.
   const aliasedLocale = locale;
   if (customMapping && shouldUseCanonicalLocale(locale, customMapping)) {
-    // Override locale with canonical locale
     locale = (customMapping[locale] as { code: string }).code;
   }
 
   defaultLocale ||= libraryDefaultLocale;
 
   try {
-    const standardizedLocale = _standardizeLocale(locale); // "de-AT"
+    const standardizedLocale = _standardizeLocale(locale);
 
     const localeObject = intlCache.get('Locale', locale);
-    const languageCode = localeObject.language; // "de"
+    const languageCode = localeObject.language;
 
     const customLocaleProperties = createCustomLocaleProperties(
       [aliasedLocale, locale, standardizedLocale, languageCode],
       customMapping
     );
 
-    const baseRegion = localeObject.region; // "AT"
+    const baseRegion = localeObject.region;
 
     const maximizedLocale = localeObject.maximize();
-    const maximizedCode = maximizedLocale.toString(); // "de-Latn-AT"
+    const maximizedCode = maximizedLocale.toString();
     const regionCode =
       localeObject.region ||
       customLocaleProperties?.regionCode ||
       maximizedLocale.region ||
-      ''; // "AT"
+      '';
     const scriptCode =
       localeObject.script ||
       customLocaleProperties?.scriptCode ||
       maximizedLocale.script ||
-      ''; // "Latn"
+      '';
 
     const minimizedLocale = localeObject.minimize();
-    const minimizedCode = minimizedLocale.toString(); // "de-AT"
+    const minimizedCode = minimizedLocale.toString();
 
     // Language names (default and native)
 
@@ -136,51 +148,51 @@ export default function _getLocaleProperties(
     const customNativeName =
       customLocaleProperties?.nativeName || customLocaleProperties?.name;
 
-    const name = customName || languageNames.of(locale) || locale; // "Austrian German"
+    const name = customName || languageNames.of(locale) || locale;
     const nativeName =
-      customNativeName || nativeLanguageNames.of(locale) || locale; // "Österreichisches Deutsch"
+      customNativeName || nativeLanguageNames.of(locale) || locale;
 
     const maximizedName =
       customLocaleProperties?.maximizedName ||
       customName ||
       languageNames.of(maximizedCode) ||
-      locale; // "Austrian German (Latin)"
+      locale;
     const nativeMaximizedName =
       customLocaleProperties?.nativeMaximizedName ||
       customNativeName ||
       nativeLanguageNames.of(maximizedCode) ||
-      locale; // "Österreichisches Deutsch (Lateinisch)"
+      locale;
 
     const minimizedName =
       customLocaleProperties?.minimizedName ||
       customName ||
       languageNames.of(minimizedCode) ||
-      locale; // "Austrian German", but for "de-DE" would just be "German"
+      locale;
     const nativeMinimizedName =
       customLocaleProperties?.nativeMinimizedName ||
       customNativeName ||
       nativeLanguageNames.of(minimizedCode) ||
-      locale; // "Österreichisches Deutsch", but for "de-DE" would just be "Deutsch"
+      locale;
 
     const languageName =
       customLocaleProperties?.languageName ||
       customName ||
       languageNames.of(languageCode) ||
-      locale; // "German"
+      locale;
     const nativeLanguageName =
       customLocaleProperties?.nativeLanguageName ||
       customNativeName ||
       nativeLanguageNames.of(languageCode) ||
-      locale; // "Deutsch"
+      locale;
 
     const nameWithRegionCode =
       customLocaleProperties?.nameWithRegionCode || baseRegion
         ? `${languageName} (${baseRegion})`
-        : name; // German (AT)
+        : name;
     const nativeNameWithRegionCode =
       customLocaleProperties?.nativeNameWithRegionCode ||
       (baseRegion ? `${nativeLanguageName} (${baseRegion})` : nativeName) ||
-      nameWithRegionCode; // "Deutsch (AT)"
+      nameWithRegionCode;
 
     // Region names (default and native)
 
@@ -196,11 +208,11 @@ export default function _getLocaleProperties(
     const regionName =
       customLocaleProperties?.regionName ||
       (regionCode ? regionNames.of(regionCode) : '') ||
-      ''; // "Austria"
+      '';
     const nativeRegionName =
       customLocaleProperties?.nativeRegionName ||
       (regionCode ? nativeRegionNames.of(regionCode) : '') ||
-      ''; // "Österreich"
+      '';
 
     // Script names (default and native)
 
@@ -216,11 +228,11 @@ export default function _getLocaleProperties(
     const scriptName =
       customLocaleProperties?.scriptName ||
       (scriptCode ? scriptNames.of(scriptCode) : '') ||
-      ''; // "Latin"
+      '';
     const nativeScriptName =
       customLocaleProperties?.nativeScriptName ||
       (scriptCode ? nativeScriptNames.of(scriptCode) : '') ||
-      ''; // "Lateinisch"
+      '';
 
     // Emoji
 

--- a/packages/core/src/locales/getPluralForm.ts
+++ b/packages/core/src/locales/getPluralForm.ts
@@ -3,10 +3,10 @@ import { pluralForms, PluralType } from '../settings/plurals';
 import { libraryDefaultLocale } from '../settings/settings';
 
 /**
- * Given a number and a list of allowed plural forms, return the plural form that best fits the number.
+ * Returns the allowed plural form that best fits a number.
  *
  * @param {number} n - The number to determine the plural form for.
- * @param {locales[]} forms - The allowed plural forms.
+ * @param {PluralType[]} forms - The allowed plural forms.
  * @returns {PluralType} The determined plural form, or an empty string if none fit.
  */
 export default function _getPluralForm(
@@ -16,42 +16,35 @@ export default function _getPluralForm(
 ): PluralType | '' {
   const pluralRules = intlCache.get('PluralRules', locales);
   const provisionalBranchName = pluralRules.select(n);
-  // aliases
+  // Prefer supported aliases for exact numeric matches.
   const absN = Math.abs(n);
-  // 0
-  if (absN === 0 && forms.includes('zero')) return 'zero'; // override
-  // 1
+  if (absN === 0 && forms.includes('zero')) return 'zero';
   if (absN === 1) {
-    if (forms.includes('singular')) return 'singular'; // override
-    if (forms.includes('one')) return 'one'; // override
+    if (forms.includes('singular')) return 'singular';
+    if (forms.includes('one')) return 'one';
   }
   if (provisionalBranchName === 'one' && forms.includes('singular'))
     return 'singular';
-  // 2
   if (absN === 2) {
-    if (forms.includes('dual')) return 'dual'; // override
-    if (forms.includes('two')) return 'two'; // override
+    if (forms.includes('dual')) return 'dual';
+    if (forms.includes('two')) return 'two';
   }
   if (provisionalBranchName === 'two' && forms.includes('dual')) return 'dual';
-  // fallbacks
+  // Fall back from Intl plural categories to supported aliases.
   if (forms.includes(provisionalBranchName)) return provisionalBranchName;
-  // two
   if (provisionalBranchName === 'two' && forms.includes('dual')) return 'dual';
   if (provisionalBranchName === 'two' && forms.includes('plural'))
     return 'plural';
   if (provisionalBranchName === 'two' && forms.includes('other'))
     return 'other';
-  // few
   if (provisionalBranchName === 'few' && forms.includes('plural'))
     return 'plural';
   if (provisionalBranchName === 'few' && forms.includes('other'))
     return 'other';
-  // many
   if (provisionalBranchName === 'many' && forms.includes('plural'))
     return 'plural';
   if (provisionalBranchName === 'many' && forms.includes('other'))
     return 'other';
-  // other
   if (provisionalBranchName === 'other' && forms.includes('plural'))
     return 'plural';
   return '';

--- a/packages/core/src/locales/getRegionProperties.ts
+++ b/packages/core/src/locales/getRegionProperties.ts
@@ -49,13 +49,14 @@ export function _getRegionProperties(
   code: string;
   name: string;
   emoji: string;
-  locale?: string; // locale is a hidden return field, because we don't want to guarantee it, but we also need customMapping to work with it
+  /** Internal detail used when resolving custom locale mappings. */
+  locale?: string;
 } {
   defaultLocale ||= libraryDefaultLocale;
   try {
     const displayNames = intlCache.get(
       'DisplayNames',
-      [defaultLocale, libraryDefaultLocale], // default language order
+      [defaultLocale, libraryDefaultLocale], // Locale fallback order.
       { type: 'region' }
     );
     return {

--- a/packages/core/src/locales/isSameDialect.ts
+++ b/packages/core/src/locales/isSameDialect.ts
@@ -19,17 +19,19 @@ function checkTwoLocalesAreSameDialect(codeA: string, codeB: string) {
 }
 
 /**
- * Test two or more language codes to determine if they are exactly the same
- * e.g. "en-US" and "en" would be exactly the same.
- * "en-GB" and "en" would be exactly the same.
- * "en-GB" and "en-US" would be different.
+ * Tests whether two or more locale codes describe the same dialect.
+ * Locale pairs are compatible when their languages match and any shared
+ * region or script subtags are equal.
+ *
+ * For example, "en-US" matches "en", "en-GB" matches "en",
+ * and "en-GB" does not match "en-US".
  * @internal
  */
 export default function _isSameDialect(
   ...locales: (string | string[])[]
 ): boolean {
   try {
-    // standardize codes
+    // Standardize locale codes before comparing subtags.
     const flattenedCodes = locales.flat().map(_standardizeLocale);
 
     for (let i = 0; i < flattenedCodes.length; i++) {

--- a/packages/core/src/locales/isSameLanguage.ts
+++ b/packages/core/src/locales/isSameLanguage.ts
@@ -8,7 +8,7 @@ export default function _isSameLanguage(
 ): boolean {
   try {
     const flattenedCodes = locales.flat();
-    // Get the language for each code
+    // Compare the language subtag for each locale code.
     const languages = flattenedCodes.map(
       (locale) => intlCache.get('Locale', locale).language
     );

--- a/packages/core/src/locales/isValidLocale.ts
+++ b/packages/core/src/locales/isValidLocale.ts
@@ -4,23 +4,23 @@ import { CustomMapping } from './customLocaleMapping';
 
 const scriptExceptions = ['Cham', 'Jamo', 'Kawi', 'Lisu', 'Toto', 'Thai'];
 
-//// According to BCP 47, the range qaa–qtz is reserved for private-use language codes
+// BCP 47 reserves the qaa–qtz range for private-use language codes.
 const isCustomLanguage = (language: string) => {
   return language >= 'qaa' && language <= 'qtz';
 };
 
 /**
- * Checks if a given BCP 47 language code is valid.
- * @param {string} code - The BCP 47 language code to validate.
+ * Checks whether a BCP 47 locale code is valid.
+ * @param {string} locale - The BCP 47 locale code to validate.
  * @param {CustomMapping} [customMapping] - The custom mapping to use for validation.
- * @returns {boolean} True if the BCP 47 code is valid, false otherwise.
+ * @returns {boolean} True if the BCP 47 locale code is valid, false otherwise.
  * @internal
  */
 export const _isValidLocale = (
   locale: string,
   customMapping?: CustomMapping
 ): boolean => {
-  // If in custom mapping, return true
+  // Resolve custom aliases before validation.
   if (
     customMapping?.[locale] &&
     typeof customMapping[locale] === 'object' &&
@@ -87,7 +87,7 @@ export const _isValidLocale = (
 /**
  * Standardizes a BCP 47 locale to ensure correct formatting.
  * @param {string} locale - The BCP 47 locale to standardize.
- * @returns {string} The standardized BCP 47 locale, or an empty string if invalid.
+ * @returns {string} The standardized BCP 47 locale, or the input string if it cannot be standardized.
  * @internal
  */
 export const _standardizeLocale = (locale: string): string => {

--- a/packages/core/src/locales/requiresTranslation.ts
+++ b/packages/core/src/locales/requiresTranslation.ts
@@ -4,9 +4,9 @@ import _isSameLanguage from './isSameLanguage';
 import { _isValidLocale } from './isValidLocale';
 
 /**
- * Given a target locale and a source locale, determines whether a translation is required
- * If the target locale and the source locale are the same, returns false, otherwise returns true
- * If a translation is not possible due to the target locale being outside of the optional approvedLanguages scope, also returns false
+ * Determines whether a translation is required between source and target locales.
+ * Returns false when locales are invalid, the target is the same dialect as the source,
+ * or the target is outside the optional approved locale scope.
  * @internal
  */
 export default function _requiresTranslation(
@@ -15,7 +15,7 @@ export default function _requiresTranslation(
   approvedLocales?: string[],
   customMapping?: CustomMapping
 ): boolean {
-  // If codes are invalid
+  // Invalid locale codes cannot be translated.
   if (
     !_isValidLocale(sourceLocale, customMapping) ||
     !_isValidLocale(targetLocale, customMapping) ||
@@ -27,13 +27,12 @@ export default function _requiresTranslation(
     return false;
   }
 
-  // Check if the languages are identical, if so, a translation is not required
+  // Matching dialects do not require translation.
   if (_isSameDialect(sourceLocale, targetLocale)) {
     return false;
   }
 
-  // Check that the target locale is within the approvedLocales scope, if not, a translation is not required
-  // isSameLanguage rather than checkTwoLocalesAreSameDialect so we can show different dialects as a fallback
+  // Match approved locales by language so different dialects can be used as fallbacks.
   if (
     approvedLocales &&
     !approvedLocales.some((approvedLocale) =>
@@ -42,6 +41,5 @@ export default function _requiresTranslation(
   ) {
     return false;
   }
-  // Otherwise, a translation is required!
   return true;
 }

--- a/packages/core/src/locales/resolveAliasLocale.ts
+++ b/packages/core/src/locales/resolveAliasLocale.ts
@@ -1,10 +1,10 @@
 import { CustomMapping } from './customLocaleMapping';
 
 /**
- * Resolves the alias locale for a given locale.
- * @param locale - The locale to resolve the alias locale for
- * @param customMapping - The custom mapping to use for resolving the alias locale
- * @returns The alias locale
+ * Resolves the alias locale for a canonical locale.
+ * @param locale - The canonical locale to resolve.
+ * @param customMapping - The custom mapping to inspect.
+ * @returns The alias locale, or the input locale when no alias exists.
  */
 export function _resolveAliasLocale(
   locale: string,

--- a/packages/core/src/locales/resolveCanonicalLocale.ts
+++ b/packages/core/src/locales/resolveCanonicalLocale.ts
@@ -2,10 +2,10 @@ import { shouldUseCanonicalLocale } from './customLocaleMapping';
 import { CustomMapping } from './customLocaleMapping';
 
 /**
- * Resolves the canonical locale for a given locale.
- * @param locale - The locale to resolve the canonical locale for
- * @param customMapping - The custom mapping to use for resolving the canonical locale
- * @returns The canonical locale
+ * Resolves the canonical locale for a custom alias.
+ * @param locale - The locale to resolve.
+ * @param customMapping - The custom mapping to inspect.
+ * @returns The canonical locale, or the input locale when no canonical mapping exists.
  */
 export function _resolveCanonicalLocale(
   locale: string,

--- a/packages/core/src/logging/logger.ts
+++ b/packages/core/src/logging/logger.ts
@@ -1,6 +1,6 @@
 /**
- * Comprehensive logging system for the General Translation library
- * Provides structured logging with multiple levels and configurable output
+ * Comprehensive logging system for the General Translation library.
+ * Provides structured logging with multiple levels and configurable output.
  */
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'off';
@@ -14,17 +14,17 @@ export interface LogEntry {
 }
 
 export interface LoggerConfig {
-  /** Minimum log level to output */
+  /** Minimum log level to output. */
   level: LogLevel;
-  /** Whether to include timestamps in log output */
+  /** Whether to include timestamps in log output. */
   includeTimestamp: boolean;
-  /** Whether to include context information */
+  /** Whether to include context information. */
   includeContext: boolean;
-  /** Custom prefix for all log messages */
+  /** Custom prefix for all log messages. */
   prefix?: string;
-  /** Whether to output to console (default: true) */
+  /** Whether to output to console. Defaults to true. */
   enableConsole: boolean;
-  /** Custom log handlers */
+  /** Custom log handlers. */
   handlers?: LogHandler[];
 }
 
@@ -45,13 +45,13 @@ const LOG_COLORS: Record<LogLevel, string> = {
   info: '\x1b[32m', // Green
   warn: '\x1b[33m', // Yellow
   error: '\x1b[31m', // Red
-  off: '', // No color needed since 'off' level logs are never displayed
+  off: '', // No color needed because 'off' level logs are never displayed.
 };
 
 const RESET_COLOR = '\x1b[0m';
 
 /**
- * Get the configured log level from environment variable or default to 'warn'
+ * Gets the configured log level from the environment variable, or defaults to 'warn'.
  */
 function getConfiguredLogLevel(): LogLevel {
   if (typeof process !== 'undefined' && process.env?._GT_LOG_LEVEL) {
@@ -64,7 +64,7 @@ function getConfiguredLogLevel(): LogLevel {
 }
 
 /**
- * Console log handler that outputs formatted messages to console
+ * Console log handler that outputs formatted messages to the console.
  */
 export class ConsoleLogHandler implements LogHandler {
   private config: LoggerConfig;
@@ -76,37 +76,36 @@ export class ConsoleLogHandler implements LogHandler {
   handle(entry: LogEntry): void {
     const parts: string[] = [];
 
-    // Add timestamp if enabled
+    // Add a timestamp if enabled.
     if (this.config.includeTimestamp) {
       parts.push(`[${entry.timestamp.toISOString()}]`);
     }
 
-    // Add level with color
+    // Add the level with color.
     const colorCode = LOG_COLORS[entry.level];
     const levelText = `[${entry.level.toUpperCase()}]`;
     parts.push(`${colorCode}${levelText}${RESET_COLOR}`);
 
-    // Add prefix if configured
+    // Add a prefix if configured.
     if (this.config.prefix) {
       parts.push(`[${this.config.prefix}]`);
     }
 
-    // Add context if available and enabled
+    // Add context if available and enabled.
     if (this.config.includeContext && entry.context) {
       parts.push(`[${entry.context}]`);
     }
 
-    // Add the main message
     parts.push(entry.message);
 
-    // Format metadata if available
+    // Format metadata if available.
     if (entry.metadata && Object.keys(entry.metadata).length > 0) {
       parts.push(`\n  Metadata: ${JSON.stringify(entry.metadata, null, 2)}`);
     }
 
     const formattedMessage = parts.join(' ');
 
-    // Output to appropriate console method based on level
+    // Output to the appropriate console method based on level.
     switch (entry.level) {
       case 'debug':
         console.debug(formattedMessage);
@@ -125,7 +124,7 @@ export class ConsoleLogHandler implements LogHandler {
 }
 
 /**
- * Main Logger class providing structured logging capabilities
+ * Main Logger class providing structured logging capabilities.
  */
 export class Logger {
   private config: LoggerConfig;
@@ -143,21 +142,21 @@ export class Logger {
 
     this.handlers = [...(this.config.handlers || [])];
 
-    // Add console handler if enabled
+    // Add a console handler if enabled.
     if (this.config.enableConsole) {
       this.handlers.push(new ConsoleLogHandler(this.config));
     }
   }
 
   /**
-   * Add a custom log handler
+   * Adds a custom log handler.
    */
   addHandler(handler: LogHandler): void {
     this.handlers.push(handler);
   }
 
   /**
-   * Remove a log handler
+   * Removes a log handler.
    */
   removeHandler(handler: LogHandler): void {
     const index = this.handlers.indexOf(handler);
@@ -167,21 +166,21 @@ export class Logger {
   }
 
   /**
-   * Update logger configuration
+   * Updates logger configuration.
    */
   configure(config: Partial<LoggerConfig>): void {
     this.config = { ...this.config, ...config };
   }
 
   /**
-   * Check if a log level should be output based on current configuration
+   * Checks whether a log level should be output based on current configuration.
    */
   private shouldLog(level: LogLevel): boolean {
     return LOG_LEVELS[level] >= LOG_LEVELS[this.config.level];
   }
 
   /**
-   * Internal logging method that creates log entries and passes them to handlers
+   * Creates log entries and passes them to handlers.
    */
   private log(
     level: LogLevel,
@@ -201,20 +200,20 @@ export class Logger {
       metadata,
     };
 
-    // Pass to all handlers
+    // Pass entries to all handlers.
     this.handlers.forEach((handler) => {
       try {
         handler.handle(entry);
       } catch (error) {
-        // Prevent logging errors from breaking the application
+        // Prevent logging errors from breaking application code.
         console.error('Error in log handler:', error);
       }
     });
   }
 
   /**
-   * Log a debug message
-   * Used for detailed diagnostic information, typically of interest only when diagnosing problems
+   * Logs a debug message.
+   * Used for detailed diagnostic information, typically only when diagnosing problems.
    */
   debug(
     message: string,
@@ -225,8 +224,8 @@ export class Logger {
   }
 
   /**
-   * Log an info message
-   * Used for general information about application operation
+   * Logs an info message.
+   * Used for general information about application operation.
    */
   info(
     message: string,
@@ -237,8 +236,8 @@ export class Logger {
   }
 
   /**
-   * Log a warning message
-   * Used for potentially problematic situations that don't prevent operation
+   * Logs a warning message.
+   * Used for potentially problematic situations that do not prevent operation.
    */
   warn(
     message: string,
@@ -249,8 +248,8 @@ export class Logger {
   }
 
   /**
-   * Log an error message
-   * Used for error events that might still allow the application to continue
+   * Logs an error message.
+   * Used for error events that might still allow the application to continue.
    */
   error(
     message: string,
@@ -261,14 +260,14 @@ export class Logger {
   }
 
   /**
-   * Create a child logger with a specific context
+   * Creates a child logger with a specific context.
    */
   child(context: string): ContextLogger {
     return new ContextLogger(this, context);
   }
 
   /**
-   * Get current logger configuration
+   * Gets current logger configuration.
    */
   getConfig(): LoggerConfig {
     return { ...this.config };
@@ -276,7 +275,7 @@ export class Logger {
 }
 
 /**
- * Context logger that automatically includes context information
+ * Context logger that automatically includes context information.
  */
 export class ContextLogger {
   private logger: Logger;
@@ -308,7 +307,7 @@ export class ContextLogger {
   }
 }
 
-// Default logger instance
+// Default logger instance.
 export const defaultLogger = new Logger({
   level: getConfiguredLogLevel(),
   includeTimestamp: true,
@@ -316,7 +315,7 @@ export const defaultLogger = new Logger({
   prefix: 'GT',
 });
 
-// Convenience functions using the default logger
+// Convenience functions using the default logger.
 export const debug = (
   message: string,
   context?: string,
@@ -341,12 +340,11 @@ export const error = (
   metadata?: Record<string, any>
 ) => defaultLogger.error(message, context, metadata);
 
-// Create context-specific loggers for different parts of the system
+// Context-specific loggers for different parts of the system.
 export const fetchLogger = defaultLogger.child('fetch');
 export const validationLogger = defaultLogger.child('validation');
 export const formattingLogger = defaultLogger.child('formatting');
 export const localeLogger = defaultLogger.child('locale');
 export const gtInstanceLogger = defaultLogger.child('GT instance');
 
-// Export types and classes
 export { Logger as GTLogger };

--- a/packages/core/src/projects/getProjectData.ts
+++ b/packages/core/src/projects/getProjectData.ts
@@ -9,11 +9,11 @@ import { ProjectData } from '../types-dir/api/project';
 
 /**
  * @internal
- * Gets the project data for a given project ID.
- * @param projectId - The project ID to get the project data for
- * @param options - The options for the API call
- * @param config - The configuration for the request
- * @returns The project data for the given project ID
+ * Gets project data for a given project ID.
+ * @param projectId - The project ID to query.
+ * @param options - The options for the API call.
+ * @param config - The configuration for the request.
+ * @returns The project data for the given project ID.
  */
 export default async function _getProjectData(
   projectId: string,
@@ -24,7 +24,6 @@ export default async function _getProjectData(
   const timeout = options.timeout ? options.timeout : defaultTimeout;
   const url = `${baseUrl || defaultBaseUrl}/v2/project/info/${encodeURIComponent(projectId)}`;
 
-  // Get the project data
   let response;
   try {
     response = await fetchWithTimeout(
@@ -39,7 +38,6 @@ export default async function _getProjectData(
     handleFetchError(error, timeout);
   }
 
-  // Validate the response
   await validateResponse(response);
 
   const result = await response.json();

--- a/packages/core/src/translate/awaitJobs.ts
+++ b/packages/core/src/translate/awaitJobs.ts
@@ -5,7 +5,7 @@ import { _checkJobStatus, JobStatus } from './checkJobStatus';
 export type AwaitJobsOptions = {
   /** Polling interval in seconds. Defaults to 5. */
   pollingIntervalSeconds?: number;
-  /** Timeout in seconds. Defaults to 600 (10 minutes). If reached, resolves with whatever status is current. */
+  /** Timeout in seconds. Defaults to 600 (10 minutes). If reached, resolves with the current statuses. */
   timeoutSeconds?: number;
 };
 
@@ -24,10 +24,10 @@ export type AwaitJobsResult = {
 /**
  * @internal
  * Polls job statuses until all jobs are finished or the timeout is reached.
- * @param enqueueResult - The result from enqueueFiles
- * @param options - Polling configuration
- * @param config - API credentials and configuration
- * @returns The final status of all jobs
+ * @param enqueueResult - The result from enqueueFiles.
+ * @param options - Polling configuration.
+ * @param config - API credentials and configuration.
+ * @returns The final status of all jobs.
  */
 export default async function _awaitJobs(
   enqueueResult: EnqueueFilesResult,
@@ -35,7 +35,7 @@ export default async function _awaitJobs(
   config: TranslationRequestConfig
 ): Promise<AwaitJobsResult> {
   const pollingInterval = (options?.pollingIntervalSeconds ?? 5) * 1000;
-  const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+  const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes.
   const timeout =
     options?.timeoutSeconds !== undefined
       ? options.timeoutSeconds * 1000

--- a/packages/core/src/translate/checkJobStatus.ts
+++ b/packages/core/src/translate/checkJobStatus.ts
@@ -16,11 +16,11 @@ export type CheckJobStatusResult = {
 
 /**
  * @internal
- * Queries job statuses for a project
- * @param jobIds - Job IDs
- * @param config - The configuration for the API call
- * @param timeoutMS - The timeout in milliseconds
- * @returns The result of the API call
+ * Queries job statuses for a project.
+ * @param jobIds - Job IDs.
+ * @param config - The configuration for the API call.
+ * @param timeoutMs - The timeout in milliseconds.
+ * @returns The result of the API call.
  */
 export async function _checkJobStatus(
   jobIds: string[],

--- a/packages/core/src/translate/createBranch.ts
+++ b/packages/core/src/translate/createBranch.ts
@@ -13,9 +13,9 @@ export type CreateBranchResult = {
 /**
  * @internal
  * Creates a new branch in the API.
- * @param query - Object mapping the branch name and default branch flag
- * @param config - The configuration for the API call
- * @returns The created branch information
+ * @param query - The branch name and default branch flag.
+ * @param config - The configuration for the API call.
+ * @returns The created branch information.
  */
 export default async function _createBranch(
   query: CreateBranchQuery,

--- a/packages/core/src/translate/createTag.ts
+++ b/packages/core/src/translate/createTag.ts
@@ -26,9 +26,9 @@ export type CreateTagResult = {
 /**
  * @internal
  * Creates or upserts a file tag in the General Translation API.
- * @param options - The tag creation options
- * @param config - The configuration for the API call
- * @returns The created or updated tag
+ * @param options - The tag creation options.
+ * @param config - The configuration for the API call.
+ * @returns The created or updated tag.
  */
 export default async function _createTag(
   options: CreateTagOptions,

--- a/packages/core/src/translate/downloadFileBatch.ts
+++ b/packages/core/src/translate/downloadFileBatch.ts
@@ -11,10 +11,10 @@ import { processBatches } from './utils/batch';
 /**
  * @internal
  * Downloads multiple translation files in batches.
- * @param files - Array of files to download
- * @param options - The options for the API call
- * @param config - The configuration for the request
- * @returns Promise resolving to a BatchList with all downloaded files
+ * @param requests - The file requests to download.
+ * @param options - The options for the API call.
+ * @param config - The configuration for the request.
+ * @returns A BatchList with all downloaded files.
  */
 export default async function _downloadFileBatch(
   requests: DownloadFileBatchRequest,
@@ -30,7 +30,7 @@ export default async function _downloadFileBatch(
         { body: batch, timeout: options.timeout }
       );
 
-      // convert from base64 to string
+      // Decode file data from base64.
       const files = result.files.map((file) => ({
         ...file,
         data: decode(file.data),

--- a/packages/core/src/translate/enqueueFiles.ts
+++ b/packages/core/src/translate/enqueueFiles.ts
@@ -16,10 +16,10 @@ export type EnqueueOptions = {
 /**
  * @internal
  * Enqueues files for translation in the General Translation API.
- * @param files - References of files to translate (file content already uploaded)
- * @param options - The options for the API call
- * @param config - The configuration for the API call
- * @returns The result of the API call
+ * @param files - References to files whose content is already uploaded.
+ * @param options - The options for the API call.
+ * @param config - The configuration for the API call.
+ * @returns The result of the API call.
  */
 export default async function _enqueueFiles(
   files: FileReferenceIds[],
@@ -55,7 +55,7 @@ export default async function _enqueueFiles(
     },
     { batchSize: 100 }
   );
-  // flatten the result
+  // Flatten batch results into the API response shape.
   const jobs = Object.fromEntries(
     result.data.map(([jobId, jobData]) => [jobId, jobData])
   );

--- a/packages/core/src/translate/getOrphanedFiles.ts
+++ b/packages/core/src/translate/getOrphanedFiles.ts
@@ -14,14 +14,13 @@ export type GetOrphanedFilesResult = {
 
 /**
  * @internal
- * Gets orphaned files for a branch - files that exist on the branch
- * but whose fileIds are not in the provided list.
- * Used for move detection.
- * @param branchId - The branch to check for orphaned files
- * @param fileIds - List of current file IDs (files that are NOT orphaned)
- * @param options - The options for the API call
- * @param config - The configuration for the API call
- * @returns The orphaned files
+ * Gets orphaned files for a branch: files that exist on the branch but whose
+ * file IDs are not in the provided list. Used for move detection.
+ * @param branchId - The branch to check for orphaned files.
+ * @param fileIds - Current file IDs that are not orphaned.
+ * @param options - The options for the API call.
+ * @param config - The configuration for the API call.
+ * @returns The orphaned files.
  */
 export default async function _getOrphanedFiles(
   branchId: string,
@@ -35,17 +34,16 @@ export default async function _getOrphanedFiles(
       timeout: options.timeout,
     });
 
-  // If no fileIds, make a single request
+  // If no file IDs are provided, make a single request.
   if (fileIds.length === 0) {
     return makeRequest([]);
   }
 
-  // Split fileIds into batches of 100
+  // Split file IDs into batches of 100.
   const batches = createBatches(fileIds, 100);
 
-  // Process batches in parallel
-  // Each batch returns files NOT in that batch's fileIds
-  // True orphans are files that appear in ALL batch responses (intersection)
+  // Each batch returns files not present in that batch's file IDs.
+  // True orphans appear in every batch response, so take the intersection.
   const batchResults = await Promise.all(
     batches.map((batch) => makeRequest(batch))
   );
@@ -54,15 +52,13 @@ export default async function _getOrphanedFiles(
     return batchResults[0];
   }
 
-  // Find intersection of orphaned files across all batches
-  // A file is truly orphaned only if it's not in ANY of our fileId batches
-  // Start with first batch's orphans
+  // Start the intersection with the first batch's orphaned files.
   const orphanedFileMap = new Map<string, OrphanedFile>();
   for (const orphan of batchResults[0].orphanedFiles) {
     orphanedFileMap.set(orphan.fileId, orphan);
   }
 
-  // Intersect with each subsequent batch
+  // Intersect with each subsequent batch.
   for (let i = 1; i < batchResults.length; i++) {
     const batchOrphanIds = new Set(
       batchResults[i].orphanedFiles.map((f) => f.fileId)

--- a/packages/core/src/translate/processFileMoves.ts
+++ b/packages/core/src/translate/processFileMoves.ts
@@ -33,12 +33,12 @@ export type ProcessMovesOptions = {
 
 /**
  * @internal
- * Processes file moves by cloning source files and translations with new fileIds.
- * Called when the CLI detects that files have been moved/renamed.
- * @param moves - Array of move mappings (old fileId to new fileId)
- * @param options - Options including branchId and timeout
- * @param config - The configuration for the API call
- * @returns Promise resolving to the move results
+ * Processes file moves by cloning source files and translations with new file IDs.
+ * Called when the CLI detects that files have been moved or renamed.
+ * @param moves - Move mappings from old file ID to new file ID.
+ * @param options - Options including branch ID and timeout.
+ * @param config - The configuration for the API call.
+ * @returns The move results.
  */
 export default async function _processFileMoves(
   moves: MoveMapping[],

--- a/packages/core/src/translate/publishFiles.ts
+++ b/packages/core/src/translate/publishFiles.ts
@@ -13,7 +13,8 @@ export type PublishFilesResult = {
   results: {
     fileId: string;
     versionId: string;
-    locale?: string; // if locale is provided, it means this result is for a translation. Else it is for a source file.
+    // Present for translation files; omitted for source files.
+    locale?: string;
     branchId: string;
     success: boolean;
     error?: string;
@@ -23,9 +24,9 @@ export type PublishFilesResult = {
 /**
  * @internal
  * Publishes or unpublishes files on the CDN.
- * @param files - Array of file entries with publish flags
- * @param config - The configuration for the API call
- * @returns The result of the API call
+ * @param files - File entries with publish flags.
+ * @param config - The configuration for the API call.
+ * @returns The result of the API call.
  */
 export default async function _publishFiles(
   files: PublishFileEntry[],

--- a/packages/core/src/translate/queryBranchData.ts
+++ b/packages/core/src/translate/queryBranchData.ts
@@ -9,9 +9,9 @@ export type BranchQuery = {
 /**
  * @internal
  * Queries branch information from the API.
- * @param query - Object mapping the current branch and incoming branches
- * @param config - The configuration for the API call
- * @returns The branch information
+ * @param query - Branch names to query.
+ * @param config - The configuration for the API call.
+ * @returns The branch information.
  */
 export default async function _queryBranchData(
   query: BranchQuery,

--- a/packages/core/src/translate/queryFileData.ts
+++ b/packages/core/src/translate/queryFileData.ts
@@ -49,10 +49,10 @@ export type FileDataResult = {
 /**
  * @internal
  * Queries data about one or more source or translation files.
- * @param data - Object mapping source or translation file information
- * @param options - The options for the API call
- * @param config - The configuration for the API call
- * @returns The file data
+ * @param data - Source or translation file identifiers to query.
+ * @param options - The options for the API call.
+ * @param config - The configuration for the API call.
+ * @returns The file data.
  */
 export default async function _queryFileData(
   data: FileDataQuery,

--- a/packages/core/src/translate/querySourceFile.ts
+++ b/packages/core/src/translate/querySourceFile.ts
@@ -8,11 +8,11 @@ import apiRequest from './utils/apiRequest';
 
 /**
  * @internal
- * Gets the source file and translation information for a given file ID and version ID.
- * @param query - The file ID and version ID to get the source file and translation information for
- * @param options - The options for the API call
- * @param config - The configuration for the request
- * @returns The source file and translation information for the given file ID and version ID
+ * Gets source file and translation information for a given file ID and version ID.
+ * @param query - The file ID and version ID to query.
+ * @param options - The options for the API call.
+ * @param config - The configuration for the request.
+ * @returns The source file and translation information.
  */
 export default async function _querySourceFile(
   query: FileQuery,

--- a/packages/core/src/translate/setupProject.ts
+++ b/packages/core/src/translate/setupProject.ts
@@ -14,11 +14,11 @@ export type SetupProjectOptions = {
 
 /**
  * @internal
- * Enqueues files for project setup the General Translation API.
- * @param files - References of files to translate (file content already uploaded)
- * @param config - The configuration for the API call
- * @param timeoutMS - The timeout in milliseconds
- * @returns The result of the API call
+ * Enqueues files for project setup in the General Translation API.
+ * @param files - References to files whose content is already uploaded.
+ * @param config - The configuration for the API call.
+ * @param options - Project setup options.
+ * @returns The result of the API call.
  */
 export default async function _setupProject(
   files: FileReference[],

--- a/packages/core/src/translate/translateMany.ts
+++ b/packages/core/src/translate/translateMany.ts
@@ -20,10 +20,11 @@ import { hashSource } from '../id';
  * This function batches multiple translation requests together and sends them
  * to the GT translation API in one call.
  *
- * @param requests - The entries to translate. Can be an array (entries are hashed and results returned in order) or a record keyed by hash (skips hash calculation, returns a record).
+ * @param requests - The entries to translate. Arrays are hashed and returned in order; records are keyed by hash and returned as records.
  * @param globalMetadata - The metadata for the translation.
  * @param config - The configuration for the translation.
- * @returns The results of the translation. An array if requests was an array, a record if requests was a record.
+ * @param timeout - The timeout in milliseconds.
+ * @returns The translation results in the same shape as the input requests.
  */
 export default async function _translateMany<
   T extends TranslateManyEntry[] | Record<string, TranslateManyEntry>,
@@ -51,7 +52,7 @@ export default async function _translateMany(
 ): Promise<TranslateManyResult | Record<string, TranslationResult>> {
   const isArray = Array.isArray(requests);
 
-  // normalize and map from requests to requests record
+  // Normalize requests to a record keyed by hash.
   const hashOrder: string[] | undefined = isArray ? [] : undefined;
   const requestsObject: Record<
     string,
@@ -96,7 +97,7 @@ export default async function _translateMany(
     }
   );
 
-  // If input was an array, map the record response back to an array in input order
+  // Map array input back to array output in input order.
   if (hashOrder) {
     return hashOrder.map(
       (hash) =>
@@ -108,6 +109,5 @@ export default async function _translateMany(
     );
   }
 
-  // If input was a record, return the record response directly
   return response;
 }

--- a/packages/core/src/translate/uploadSourceFiles.ts
+++ b/packages/core/src/translate/uploadSourceFiles.ts
@@ -12,10 +12,10 @@ import {
 /**
  * @internal
  * Uploads source files to the General Translation API in batches.
- * @param files - The files to upload
- * @param options - The options for the API call
- * @param config - The configuration for the API call
- * @returns Promise resolving to a BatchList with all uploaded files
+ * @param files - The files to upload.
+ * @param options - The options for the API call.
+ * @param config - The configuration for the API call.
+ * @returns A BatchList with all uploaded files.
  */
 export default async function _uploadSourceFiles(
   files: { source: FileUpload }[],

--- a/packages/core/src/translate/uploadTranslations.ts
+++ b/packages/core/src/translate/uploadTranslations.ts
@@ -13,10 +13,10 @@ import { validateFileFormatTransforms } from './utils/validateFileFormatTransfor
 /**
  * @internal
  * Uploads multiple translations to the General Translation API in batches.
- * @param files - Translations to upload with their source
- * @param options - The options for the API call
- * @param config - The configuration for the API call
- * @returns Promise resolving to a BatchList with all uploaded files
+ * @param files - Translations to upload with their source files.
+ * @param options - The options for the API call.
+ * @param config - The configuration for the API call.
+ * @returns A BatchList with all uploaded files.
  */
 export default async function _uploadTranslations(
   files: {

--- a/packages/core/src/translate/utils/apiRequest.ts
+++ b/packages/core/src/translate/utils/apiRequest.ts
@@ -34,10 +34,10 @@ function getRetryDelay(policy: RetryPolicy, attempt: number): number {
  * Encapsulates URL construction, fetch with timeout, error handling,
  * response validation, and JSON parsing.
  *
- * @param config - The configuration for the API call
- * @param endpoint - The API endpoint path (e.g. '/v2/project/jobs/info')
- * @param options - Optional request options
- * @returns The parsed JSON response
+ * @param config - The configuration for the API call.
+ * @param endpoint - The API endpoint path (for example, '/v2/project/jobs/info').
+ * @param options - Optional request options.
+ * @returns The parsed JSON response.
  */
 export default async function apiRequest<T>(
   config: TranslationRequestConfig,
@@ -75,7 +75,7 @@ export default async function apiRequest<T>(
       handleFetchError(error, timeout);
     }
 
-    // Retry on 5XX server errors
+    // Retry on 5XX server errors.
     if (response!.status >= 500 && attempt < maxRetries) {
       await sleep(getRetryDelay(retryPolicy, attempt));
       continue;

--- a/packages/core/src/translate/utils/batch.ts
+++ b/packages/core/src/translate/utils/batch.ts
@@ -1,8 +1,8 @@
 /**
  * Splits an array into batches of a specified size.
- * @param items - The array to split into batches
- * @param batchSize - The maximum size of each batch
- * @returns An array of batches
+ * @param items - The array to split into batches.
+ * @param batchSize - The maximum size of each batch.
+ * @returns An array of batches.
  */
 export function createBatches<T>(items: T[], batchSize: number): T[][] {
   const batches: T[][] = [];
@@ -13,34 +13,34 @@ export function createBatches<T>(items: T[], batchSize: number): T[][] {
 }
 
 /**
- * Result of processing batches
+ * Result of processing batches.
  */
 export interface BatchList<T> {
-  /** The items successfully processed across all batches */
+  /** Items successfully processed across all batches. */
   data: T[];
-  /** The total number of items processed */
+  /** Total number of items processed. */
   count: number;
-  /** The number of batches processed */
+  /** Number of batches processed. */
   batchCount: number;
 }
 
 /**
- * Options for batch processing
+ * Options for batch processing.
  */
 export interface BatchProcessOptions {
-  /** Maximum number of items per batch (default: 100) */
+  /** Maximum number of items per batch. Defaults to 100. */
   batchSize?: number;
-  /** Whether to process batches in parallel (default: true) */
+  /** Whether to process batches in parallel. Defaults to true. */
   parallel?: boolean;
 }
 
 /**
  * Processes items in batches using a provided processor function.
  *
- * @param items - The items to process
- * @param processor - Async function that processes a single batch and returns items
- * @param options - Optional configuration for batch processing
- * @returns Promise that resolves to a BatchList containing all processed items
+ * @param items - The items to process.
+ * @param processor - Async function that processes a single batch and returns items.
+ * @param options - Optional configuration for batch processing.
+ * @returns Promise that resolves to a BatchList containing all processed items.
  *
  * @example
  * ```typescript
@@ -77,7 +77,7 @@ export async function processBatches<TInput, TOutput>(
   const allItems: TOutput[] = [];
 
   if (parallel) {
-    // Process all batches in parallel
+    // Process all batches in parallel.
     const results = await Promise.all(batches.map((batch) => processor(batch)));
     for (const result of results) {
       if (result) {
@@ -85,7 +85,7 @@ export async function processBatches<TInput, TOutput>(
       }
     }
   } else {
-    // Process batches sequentially
+    // Process batches sequentially.
     for (const batch of batches) {
       const result = await processor(batch);
       if (result) {

--- a/packages/core/src/translate/utils/validateResponse.ts
+++ b/packages/core/src/translate/utils/validateResponse.ts
@@ -13,7 +13,7 @@ export default async function validateResponse(response: Response) {
         errorMsg = text || 'Unknown error';
       }
     } catch {
-      // response.text() failed, keep 'Unknown error'
+      // Keep the default message if response.text() fails.
     }
     const errorMessage = apiError(
       response.status,

--- a/packages/core/src/types-dir/api/branch.ts
+++ b/packages/core/src/types-dir/api/branch.ts
@@ -1,10 +1,10 @@
 export type BranchDataResult = {
   branches: {
     id: string;
-    name: string; // branch name
+    name: string; // Branch name.
   }[];
   defaultBranch: {
     id: string;
-    name: string; // branch name
+    name: string; // Branch name.
   } | null;
 };

--- a/packages/core/src/types-dir/api/checkFileTranslations.ts
+++ b/packages/core/src/types-dir/api/checkFileTranslations.ts
@@ -1,7 +1,6 @@
-// Types for the checkFileTranslations function
 export type FileTranslationQuery = {
   versionId: string;
-  fileName?: string; // Between fileName and fileId, one is required
+  fileName?: string; // Either fileName or fileId is required.
   fileId?: string;
   locale: string;
 };

--- a/packages/core/src/types-dir/api/downloadFile.ts
+++ b/packages/core/src/types-dir/api/downloadFile.ts
@@ -1,4 +1,3 @@
-// Types for the downloadFile function
 export type DownloadFileOptions = {
   timeout?: number;
 };

--- a/packages/core/src/types-dir/api/downloadFileBatch.ts
+++ b/packages/core/src/types-dir/api/downloadFileBatch.ts
@@ -1,12 +1,11 @@
 import { FileFormat } from './file';
-// Types for the downloadFileBatch function
 
 export type DownloadFileBatchRequest = {
   fileId: string;
-  branchId?: string; // if not provided, will use the default branch
-  versionId?: string; // if not provided, will use the latest version
-  locale?: string; // if not provided, will download the source file
-  useLatestAvailableVersion?: boolean; // if true and versionId is not found, falls back to the latest available version
+  branchId?: string; // Defaults to the default branch.
+  versionId?: string; // Defaults to the latest version.
+  locale?: string; // Downloads the source file when omitted.
+  useLatestAvailableVersion?: boolean; // Falls back to the latest available version when versionId is not found.
 }[];
 
 export type DownloadFileBatchOptions = {
@@ -28,7 +27,7 @@ export type DownloadedFile = {
   fileId: string;
   versionId: string;
   locale?: string;
-  fileName?: string; // Only present for source files (if locale is not present)
+  fileName?: string; // Only present for source files.
   data: string;
   metadata: Record<string, any>;
   fileFormat: FileFormat;

--- a/packages/core/src/types-dir/api/enqueueEntries.ts
+++ b/packages/core/src/types-dir/api/enqueueEntries.ts
@@ -2,7 +2,7 @@ import { DataFormat } from '../jsx/content';
 
 export type { Updates } from './enqueueFiles';
 
-// ApiOptions type that matches sendUpdates interface more closely
+// API options aligned with the sendUpdates interface.
 export type EnqueueEntriesOptions = {
   timeout?: number;
   sourceLocale?: string;

--- a/packages/core/src/types-dir/api/enqueueFiles.ts
+++ b/packages/core/src/types-dir/api/enqueueFiles.ts
@@ -1,6 +1,5 @@
 import { JsxChildren } from '../jsx/content';
 
-// Types for the enqueueTranslationEntries function
 export type Updates = ({
   metadata: Record<string, any> & { staticId?: string };
 } & (
@@ -23,22 +22,24 @@ export type Updates = ({
 ))[];
 
 /**
- * Options for enqueueing files
- * @param requireApproval - Whether to require approval for the files
- * @param description - Optional description for the project
- * @param sourceLocale - The project's source locale
- * @param targetLocales - The locales to translate the files to
- * @param version - Optional custom version ID to specify
- * @param timeout - Optional timeout for the request
- * @param modelProvider - Optional model provider to use
+ * Options for enqueuing files.
+ * @param requireApproval - Whether to require approval for the files.
+ * @param description - Optional description for the project.
+ * @param sourceLocale - The project's source locale.
+ * @param targetLocales - The locales to translate the files to.
+ * @param version - Optional custom version ID to specify.
+ * @param timeout - Optional timeout for the request.
+ * @param modelProvider - Optional model provider to use.
  */
 export type EnqueueFilesOptions = {
   requireApproval?: boolean;
-  description?: string; // @deprecated Will be removed in v8.0.0
+  /** @deprecated Will be removed in v8.0.0. */
+  description?: string;
   sourceLocale?: string;
   targetLocales: string[];
   version?: string;
-  _versionId?: string; // @deprecated Will be removed in v8.0.0
+  /** @deprecated Will be removed in v8.0.0. */
+  _versionId?: string;
   timeout?: number;
   modelProvider?: string;
   force?: boolean;

--- a/packages/core/src/types-dir/api/entry.ts
+++ b/packages/core/src/types-dir/api/entry.ts
@@ -3,16 +3,16 @@ import { Content, DataFormat } from '../../types';
 /**
  * ActionType is the type of action to perform on the request.
  *
- * @param fast - The fast action type (mini model).
+ * @param fast - Fast action type (mini model).
  */
-export type ActionType = 'fast'; // TODO: Add standard action type when available in the API
+export type ActionType = 'fast'; // TODO: Add the standard action type when it is available in the API.
 
 /**
  * EntryMetadata is the metadata for a GTRequest.
  *
  * @param context - The context of the request.
- * @param id - The id of the request.
- * @param maxChars - The maxChars of the request.
+ * @param id - The ID of the request.
+ * @param maxChars - The maxChars limit of the request.
  * @param hash - The hash of the request.
  */
 export type EntryMetadata = {

--- a/packages/core/src/types-dir/api/fetchTranslations.ts
+++ b/packages/core/src/types-dir/api/fetchTranslations.ts
@@ -1,11 +1,10 @@
-// Types for the fetchTranslations function
 export type FetchTranslationsOptions = {
   timeout?: number;
 };
 
 export type RetrievedTranslation = {
   locale: string;
-  // TODO: explicitly define type from cloud
+  // TODO: Replace with the explicit API response type.
   translation: any;
 };
 

--- a/packages/core/src/types-dir/api/file.ts
+++ b/packages/core/src/types-dir/api/file.ts
@@ -16,18 +16,18 @@ export type FileFormat =
   | 'TWILIO_CONTENT_JSON';
 
 /**
- * Metadata for files or entries
+ * Metadata for files or entries.
  */
 type FormatMetadata = Record<string, any> | Updates[number]['metadata'];
 
 /**
- * File object structure for uploading files
- * @see {@link FileReferenceOptionalBranchId}
- * @property {string} content - Content of the file
- * @property {string} locale - The locale of the file (e.g. 'en', 'de', 'es', etc.)
- * @property {FormatMetadata} [formatMetadata] - Optional metadata for the file, specific to the format of the file
- * @property {string} [incomingBranchId] - The ID of the incoming branch of the file
- * @property {string} [checkedOutBranchId] - The ID of the checked out branch of the file
+ * File object structure for uploading files.
+ * @see {@link FileReferenceIds}
+ * @property {string} content - Content of the file.
+ * @property {string} locale - The locale of the file (for example, 'en', 'de', or 'es').
+ * @property {FormatMetadata} [formatMetadata] - Optional metadata for the file, specific to the file format.
+ * @property {string} [incomingBranchId] - The ID of the incoming branch of the file.
+ * @property {string} [checkedOutBranchId] - The ID of the checked-out branch of the file.
  */
 export type FileToUpload = Omit<FileReference, 'branchId'> & {
   content: string;
@@ -41,14 +41,14 @@ export type FileToUpload = Omit<FileReference, 'branchId'> & {
 };
 
 /**
- * File object structure for referencing files
- * @property {string} fileId - The ID of the file
- * @property {string} versionId - The ID of the version of the file
- * @property {string} branchId - The ID of the branch of the file
- * @property {string} locale - The locale of the file (e.g. 'en', 'de', 'es', etc.)
- * @property {string} fileName - The name of the file
- * @property {FileFormat} fileFormat - The format of the file (JSON, MDX, MD, etc.)
- * @property {DataFormat} [dataFormat] - Optional format of the data within the file
+ * File object structure for referencing files.
+ * @property {string} fileId - The ID of the file.
+ * @property {string} versionId - The ID of the file version.
+ * @property {string} branchId - The ID of the file branch.
+ * @property {string} locale - The locale of the file (for example, 'en', 'de', or 'es').
+ * @property {string} fileName - The name of the file.
+ * @property {FileFormat} fileFormat - The format of the file (JSON, MDX, MD, etc.).
+ * @property {DataFormat} [dataFormat] - Optional format of the data within the file.
  */
 export type FileReference = {
   fileId: string;
@@ -62,9 +62,9 @@ export type FileReference = {
 };
 
 /**
- * File reference object structure for referencing files
+ * File reference object structure for referencing files.
  * @see {@link FileReference}
- * @property {string} [branchId] - The ID of the branch of the file
+ * @property {string} [branchId] - The ID of the file branch.
  */
 export type FileReferenceIds = Omit<
   FileReference,

--- a/packages/core/src/types-dir/api/translate.ts
+++ b/packages/core/src/types-dir/api/translate.ts
@@ -6,7 +6,7 @@ import {
 } from '../jsx/content';
 
 /**
- * TranslationResultReference is used to store the reference for a translation result.
+ * Stores the reference for a translation result.
  */
 export type TranslationResultReference = {
   id?: string;
@@ -14,12 +14,11 @@ export type TranslationResultReference = {
 };
 
 /**
- * TypedResult is a union type that represents the different types of translations that can be returned.
+ * Represents the different translation payload types that can be returned.
  */
 export type TypedResult =
   | {
-      // TODO: omit the t property (tag name) from the translated element
-      // I have to double check that this is the case, but I think it is
+      // TODO: Verify whether translated JSX elements can omit the tag name (`t`).
       translation: JsxChildren;
       dataFormat: 'JSX';
     }
@@ -29,7 +28,7 @@ export type TypedResult =
     };
 
 /**
- * RequestError is a type that represents an error that occurred during a translation request.
+ * Represents an error that occurred during a translation request.
  */
 export type TranslationError = {
   success: false;
@@ -38,7 +37,7 @@ export type TranslationError = {
 };
 
 /**
- * RequestSuccess is a type that represents a successful translation request.
+ * Represents a successful translation request.
  */
 export type RequestSuccess = TypedResult & {
   success: true;

--- a/packages/core/src/types-dir/api/translateMany.ts
+++ b/packages/core/src/types-dir/api/translateMany.ts
@@ -1,6 +1,6 @@
 import { TranslationResult } from './translate';
 
 /**
- * BatchTranslationResult is the result of a batch translation request.
+ * Result of a batch translation request.
  */
 export type TranslateManyResult = TranslationResult[];

--- a/packages/core/src/types-dir/api/uploadFiles.ts
+++ b/packages/core/src/types-dir/api/uploadFiles.ts
@@ -23,9 +23,9 @@ export type GTJsonFormatMetadata = Record<
 >;
 
 export type FileUpload = {
-  branchId?: string; // optional branch id. If not provided, will use the default branch.
-  incomingBranchId?: string; // optional branch id to use for incoming translations
-  checkedOutBranchId?: string; // optional branch id to use for checked out translations
+  branchId?: string; // Optional branch ID. Defaults to the default branch.
+  incomingBranchId?: string; // Optional branch ID for incoming translations.
+  checkedOutBranchId?: string; // Optional branch ID for checked-out translations.
   content: string;
   fileName: string;
   fileFormat: FileFormat;
@@ -34,8 +34,8 @@ export type FileUpload = {
   dataFormat?: DataFormat;
   locale: string;
   formatMetadata?: GTJsonFormatMetadata;
-  versionId?: string; // Optional versionId. Only use this if you know what you are doing.
-  fileId?: string; // Optional fileId. Only use this if you know what you are doing.
+  versionId?: string; // Optional version ID. Only use when preserving an existing version.
+  fileId?: string; // Optional file ID. Only use when preserving an existing file.
 };
 
 export type UploadFilesOptions = {

--- a/packages/core/src/types-dir/jsx/content.ts
+++ b/packages/core/src/types-dir/jsx/content.ts
@@ -1,7 +1,7 @@
 import { Variable } from './variables';
 
 /**
- * Map of data-_gt properties to their corresponding React props
+ * Maps data-_gt properties to their corresponding React props.
  */
 export const HTML_CONTENT_PROPS = {
   pl: 'placeholder',
@@ -20,59 +20,59 @@ export type HtmlContentPropValuesRecord = Partial<
 >;
 
 /**
- * GTProp is an internal property used to contain data for translating and rendering elements.
- * note, transformations are only read on the server side if they are 'plural' or 'branch'
+ * GTProp contains internal data for translating and rendering elements.
+ * Transformations are only read on the server side when they are 'plural' or 'branch'.
  */
 export type GTProp = {
-  b?: Record<string, JsxChildren>; // Branches
-  t?: 'p' | 'b'; // Branch Transformation
+  b?: Record<string, JsxChildren>; // Branches.
+  t?: 'p' | 'b'; // Branch transformation.
 } & HtmlContentPropKeysRecord;
 
 export type JsxElement = {
-  t?: string; // tag name
-  i?: number; // id
-  d?: GTProp; // GT data
-  c?: JsxChildren; // children
+  t?: string; // Tag name.
+  i?: number; // ID.
+  d?: GTProp; // GT data.
+  c?: JsxChildren; // Children.
 };
 
 export type JsxChild = string | JsxElement | Variable;
 
 /**
- * The format of the string content
+ * The format of string content.
  */
 export type StringFormat = 'ICU' | 'I18NEXT' | 'STRING';
 
 /**
- * The format of the content
+ * The format of the content.
  */
 export type DataFormat = 'JSX' | StringFormat;
 
 /**
- * String format content
+ * String format content.
  */
 export type StringContent = IcuMessage | StringMessage | I18nextMessage;
 
 /**
- * A content type representing JSX, ICU, and I18next messages
+ * A content type representing JSX, ICU, and I18next messages.
  */
 export type Content = JsxChildren | StringContent;
 
 /**
- * A content type representing JSX elements
+ * A content type representing JSX elements.
  */
 export type JsxChildren = JsxChild | JsxChild[];
 
 /**
- * A content type representing ICU messages
+ * A content type representing ICU messages.
  */
 export type IcuMessage = string;
 
 /**
- * A content type representing I18next messages
+ * A content type representing I18next messages.
  */
 export type I18nextMessage = string;
 
 /**
- * A content type representing plain strings
+ * A content type representing plain strings.
  */
 export type StringMessage = string;

--- a/packages/core/src/types-dir/jsx/variables.ts
+++ b/packages/core/src/types-dir/jsx/variables.ts
@@ -1,12 +1,12 @@
 export type VariableType =
-  | 'v' // Variable
-  | 'n' // Number
-  | 'd' // Date
-  | 'c' // Currency
-  | 'rt'; // Relative Time
+  | 'v' // Variable.
+  | 'n' // Number.
+  | 'd' // Date.
+  | 'c' // Currency.
+  | 'rt'; // Relative time.
 
 /**
- * Variables are used to store the variable name and type.
+ * Stores the variable name and type.
  */
 export type Variable = {
   k: string;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -221,16 +221,12 @@ export type JsxTranslationResult = {
 
 export type { CustomMapping } from './locales/customLocaleMapping';
 
-// ----- VARIABLES ----- //
-
-// ----- TRANSLATION REQUEST TYPES ----- //
-
 /**
- * TranslationRequestConfig is used to configure the translation request.
+ * Configures a translation request.
  *
- * @param projectId - The project id of the translation request.
- * @param baseUrl - The base url of the translation request.
- * @param apiKey - The api key of the translation request.
+ * @param projectId - The project ID of the translation request.
+ * @param baseUrl - The base URL of the translation request.
+ * @param apiKey - The API key of the translation request.
  */
 export type TranslationRequestConfig = {
   projectId: string;

--- a/packages/core/src/utils/base64.ts
+++ b/packages/core/src/utils/base64.ts
@@ -1,10 +1,10 @@
-// Encode a string to base64
+// Encodes a string to base64.
 export function encode(data: string): string {
   if (typeof Buffer !== 'undefined') {
-    // Node.js path
+    // Node.js path.
     return Buffer.from(data, 'utf8').toString('base64');
   }
-  // Browser path
+  // Browser path.
   const bytes = new TextEncoder().encode(data);
   let binary = '';
   for (let i = 0; i < bytes.length; i++) {
@@ -13,13 +13,13 @@ export function encode(data: string): string {
   return btoa(binary);
 }
 
-// Decode a base64 string to a string
+// Decodes a base64 string.
 export function decode(base64: string): string {
   if (typeof Buffer !== 'undefined') {
-    // Node.js path
+    // Node.js path.
     return Buffer.from(base64, 'base64').toString('utf8');
   }
-  // Browser path
+  // Browser path.
   const binary = atob(base64);
   const bytes = new Uint8Array(binary.length);
   for (let i = 0; i < binary.length; i++) {

--- a/packages/core/src/utils/isSupportedFileFormatTransform.ts
+++ b/packages/core/src/utils/isSupportedFileFormatTransform.ts
@@ -17,10 +17,10 @@ const SUPPORTED_TRANSFORMATIONS = {
 } as const satisfies Record<FileFormat, FileFormat[]>;
 
 /**
- * This function checks if a file format transformation is supported during translation
- * @param from - The source file format
- * @param to - The target file format
- * @returns True if the transformation is supported, false otherwise
+ * Checks whether a file format transformation is supported during translation.
+ * @param from - The source file format.
+ * @param to - The target file format.
+ * @returns True if the transformation is supported; otherwise false.
  */
 export function isSupportedFileFormatTransform(
   from: FileFormat,


### PR DESCRIPTION
## TL;DR

Normalize comments and JSDoc across `packages/core` for clarity and consistency.

## Code Changes

- Fixed typos, grammar, punctuation, and capitalization in comments.
- Removed or rewrote vacuous comments and stale section dividers.
- Corrected misleading comments around locale handling, cutoff formatting, standardization behavior, and API helper parameters.
- Standardized terminology such as file IDs, branch IDs, canonical/alias locales, and locale fallback order.

## Notes / Flags

- Comment-only/docs-only change; no changeset added.
- Validation run:
  - `pnpm exec prettier --write "packages/core/src/**/*.ts"`
  - `pnpm --filter generaltranslation lint` (passes with existing warnings)
  - `pnpm --filter generaltranslation test`
  - `pnpm --filter generaltranslation build` (passes with existing module-type warnings)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR performs a documentation-only normalization pass across all 73 source files in `packages/core`. It standardizes JSDoc style (sentence-case, terminal periods, `@returns` prose), removes vacuous inline comments and section dividers, and corrects several factually wrong descriptions — notably that `standardizeLocale` returns the input string (not an empty string) on failure, that `getOldJsxChild*` converts *from* the current format *to* the old format (not the reverse), and that `_formatCutoff` has no empty-string fallback. No logic is changed.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change with no logic modifications; safe to merge.

All 73 changed files are comment/JSDoc-only edits. The author validated with lint, tests, and build. Several previously incorrect doc strings are fixed to match the actual implementation.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/locales/isValidLocale.ts | Updated @returns on _standardizeLocale to correctly state it returns the input string (not an empty string) on failure — matches the actual try/catch implementation. |
| packages/core/src/backwards-compatability/dataConversion.ts | Section comment for getOldJsx* functions corrected from "old→new" to "current→old"; removed low-value inline type labels on branches. |
| packages/core/src/formatting/format.ts | Removed incorrect "fallback to empty string" note from _formatCutoff (implementation has no try/catch); TODO capitalization normalized. |
| packages/core/src/core.ts | Removed the misleading standardizeLocale example showing '' for an invalid locale; updated resolveCanonicalLocale @returns to clarify input is returned when no mapping exists. |
| packages/core/src/index.ts | Removed section divider banners and redundant inline comments; minor JSDoc punctuation normalization across the GT class methods. |
| packages/core/src/cache/IntlCache.ts | JSDoc wording tightened; "Global instance" changed to "Shared … instance"; no behavioral changes. |
| packages/core/src/formatting/custom-formats/CutoffFormat/CutoffFormat.ts | Constructor param docs updated: `option.*` typos fixed to `options.*`; behavior descriptions clarified; commented-out dead code removed. |
| packages/core/src/locales/resolveCanonicalLocale.ts | @returns updated to note the function returns the input locale when no canonical mapping exists, matching the implementation. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR: normalize comments] --> B[Comment-only changes]
    B --> C[Fix wrong @returns]
    B --> D[Fix wrong section comments]
    B --> E[Standardize JSDoc style]
    C --> C1["standardizeLocale: empty string → input string"]
    C --> C2["_formatCutoff: remove false empty-string fallback note"]
    D --> D1["getOldJsx*: 'old→new' → 'current→old'"]
    E --> E1[Terminal periods on all tags]
    E --> E2[Sentence-case descriptions]
    E --> E3[Remove section divider banners]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(core): normalize comments"](https://github.com/generaltranslation/gt/commit/46f2d6ffc4dbfbf174da6ae7f959c956932740d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30532535)</sub>

<!-- /greptile_comment -->