### PR TITLE
lint: add no-default-exports rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -67,6 +67,14 @@ export default [
       'no-empty': 'warn',
       'no-useless-escape': 'warn',
       'prettier/prettier': 'error',
+      'no-restricted-syntax': [
+        'warn',
+        {
+          selector: 'ExportDefaultDeclaration',
+          message:
+            'Prefer named exports. Default exports make refactoring harder and hurt tree-shaking.',
+        },
+      ],
     },
   },
   {


### PR DESCRIPTION
Adds a `no-restricted-syntax` lint rule (set to `warn`) that flags `export default` declarations across the monorepo.

Named exports are preferred because they:
- Make refactoring safer (rename propagates automatically)
- Improve tree-shaking
- Enforce consistent import names across consumers

Set to **warn** so existing code isn't blocked. No existing default exports are changed here — a separate PR handles the migration.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `no-restricted-syntax: warn` ESLint rule to the monorepo's flat config that flags `export default` declarations in favour of named exports. No existing code is modified; the rule is advisory only.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge as-is; both findings are advisory P2 gaps, not blocking issues.

Only P2 findings: a coverage gap for the `export { x as default }` syntax and `.mjs` files being outside the glob. Neither causes incorrect behavior — the rule simply won't fire in those cases.

eslint.config.mjs — the `files` glob and the AST selector are both slightly narrower than the stated intent.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| eslint.config.mjs | Adds a `no-restricted-syntax` warn rule targeting `ExportDefaultDeclaration`; minor gap: `export { x as default }` syntax is not covered, and `.mjs` files are outside the lint glob. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ESLint parses file] --> B{Matches js/ts/tsx glob?}
    B -- No --> C[Rule not applied]
    B -- Yes --> D{Node is ExportDefaultDeclaration?}
    D -- No --> E[No warning]
    D -- Yes --> F[warn: Prefer named exports]
    G["export { x as default }"] --> H[ExportNamedDeclaration node]
    H --> E
    I[".mjs files"] --> C
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
eslint.config.mjs:73-74
**`export { foo as default }` not covered**

The selector `ExportDefaultDeclaration` only catches `export default <expr/decl>` syntax. The re-export alias form `export { something as default }` produces an `ExportNamedDeclaration` node with a specifier whose `exported.name` is `"default"`, so it silently escapes the rule. If the goal is to ban all default-export patterns, a second entry (or a combined selector) is needed.

```suggestion
          selector:
            'ExportDefaultDeclaration, ExportNamedDeclaration > ExportSpecifier[exported.name="default"]',
```

### Issue 2 of 2
eslint.config.mjs:70-77
**`.mjs` files excluded from the rule**

The top-level `files` glob is `**/*.{js,ts,tsx}`, which does not match `.mjs` files. `eslint.config.mjs` itself (and any other `.mjs` files in the monorepo) will never trigger this warning even though the file uses `export default [...]` on line 6. If `.mjs` source files exist or are added later, they won't be covered. Consider adding `mjs` to the glob if full coverage is desired.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["lint: add no-default-exports rule"](https://github.com/generaltranslation/gt/commit/fe57e5c80153dcbaa854d31323b57d4f9b8c3873) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30543738)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->