### PR TITLE
chore(i18n): add dictionary cache primitives

### DIFF
--- a/.changeset/add-i18n-dictionary-cache.md
+++ b/.changeset/add-i18n-dictionary-cache.md
@@ -1,0 +1,5 @@
+---
+"gt-i18n": patch
+---
+
+Add dictionary cache primitives.

--- a/packages/i18n/src/i18n-manager/lifecycle-hooks/types.ts
+++ b/packages/i18n/src/i18n-manager/lifecycle-hooks/types.ts
@@ -4,6 +4,13 @@ import type {
   Hash,
 } from '../translations-manager/TranslationsCache';
 import type { Locale, CacheEntry } from '../translations-manager/LocalesCache';
+import type {
+  DictionaryKey,
+  DictionaryPath,
+  DictionaryValue,
+  DictionaryEntry,
+} from '../translations-manager/DictionaryCache';
+import type { DictionaryCacheEntry } from '../translations-manager/LocalesDictionaryCache';
 
 // ===== Base Cache Lifecycle ===== //
 
@@ -64,6 +71,39 @@ export type LocalesCacheLifecycleCallbacks<
   onLocalesCacheMiss?: LocalesCacheLifecycleCallback<TranslationValue>;
   onTranslationsCacheHit?: TranslationsCacheLifecycleCallback<TranslationValue>;
   onTranslationsCacheMiss?: TranslationsCacheLifecycleCallback<TranslationValue>;
+};
+
+// ===== Locales Dictionary Cache Lifecycle ===== //
+
+/**
+ * Locales dictionary cache lifecycle callback
+ */
+export type LocalesDictionaryCacheLifecycleCallback = LifecycleCallback<
+  Locale,
+  Locale,
+  DictionaryCacheEntry,
+  DictionaryCacheEntry['dictionaryCache']
+>;
+
+/**
+ * Dictionary cache lifecycle callback with locale embedded as first param.
+ */
+export type DictionaryCacheLifecycleCallback = (params: {
+  locale: Locale;
+  inputKey: DictionaryKey;
+  cacheKey: DictionaryPath;
+  cacheValue: DictionaryValue;
+  outputValue: DictionaryEntry;
+}) => void;
+
+/**
+ * Combined locales dictionary cache lifecycle callbacks
+ */
+export type LocalesDictionaryCacheLifecycleCallbacks = {
+  onLocalesDictionaryCacheHit?: LocalesDictionaryCacheLifecycleCallback;
+  onLocalesDictionaryCacheMiss?: LocalesDictionaryCacheLifecycleCallback;
+  onDictionaryCacheHit?: DictionaryCacheLifecycleCallback;
+  onDictionaryCacheMiss?: DictionaryCacheLifecycleCallback;
 };
 
 // ===== Consumer API ===== //

--- a/packages/i18n/src/i18n-manager/translations-manager/Cache.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/Cache.ts
@@ -109,7 +109,7 @@ abstract class Cache<
       const value = await fallbackPromise;
 
       // Update cache
-      this.cache[cacheKey] = value;
+      this.setCache(cacheKey, value);
       return value;
     } finally {
       delete this.fallbackPromises[cacheKey];

--- a/packages/i18n/src/i18n-manager/translations-manager/DictionaryCache.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/DictionaryCache.ts
@@ -73,7 +73,7 @@ export class DictionaryCache extends Cache<
       return undefined;
     }
 
-    if (typeof value === 'string' && this.onHit) {
+    if (this.onHit) {
       this.onHit({
         inputKey: key,
         cacheKey: this.genKey(key),

--- a/packages/i18n/src/i18n-manager/translations-manager/DictionaryCache.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/DictionaryCache.ts
@@ -1,0 +1,191 @@
+import { Cache } from './Cache';
+import type { LifecycleParam } from '../lifecycle-hooks/types';
+
+/**
+ * A dictionary is a nested object with strings as leaf values
+ */
+export type Dictionary = {
+  [key: string]: DictionaryValue;
+};
+
+/**
+ * Value stored in a dictionary
+ */
+export type DictionaryValue = string | Dictionary;
+
+/**
+ * Value returned from a dictionary lookup
+ */
+export type DictionaryEntry = string;
+
+/**
+ * Just a way to be more explicit about what "dictionary path" is
+ */
+export type DictionaryPath = string;
+
+/**
+ * InputKey type for lookups
+ */
+export type DictionaryKey = DictionaryPath;
+
+/**
+ * A cache for a single locale's dictionary
+ *
+ * Principles:
+ * - This class is language agnostic, and should never store the locale code as a parameter.
+ *   Locale logic is handled at the LocalesDictionaryCache level. Use a callback function
+ *   that has the locale parameter embedded if you wish to use the locale code.
+ */
+export class DictionaryCache extends Cache<
+  DictionaryKey,
+  DictionaryPath,
+  DictionaryValue,
+  DictionaryEntry
+> {
+  /**
+   * Constructor
+   * @param {Object} params - The parameters for the cache
+   * @param {Dictionary} params.init - The initial cache
+   */
+  constructor({
+    init,
+    lifecycle,
+  }: {
+    init: Dictionary;
+    lifecycle?: LifecycleParam<
+      DictionaryKey,
+      DictionaryPath,
+      DictionaryValue,
+      DictionaryEntry
+    >;
+  }) {
+    super(init, lifecycle);
+  }
+
+  /**
+   * Get the dictionary value for a given key
+   * @param key - The dictionary key
+   * @returns The dictionary value
+   */
+  public get(key: DictionaryKey): DictionaryEntry | undefined {
+    const value = this.getCache(key);
+    if (typeof value !== 'string') {
+      return undefined;
+    }
+
+    if (typeof value === 'string' && this.onHit) {
+      this.onHit({
+        inputKey: key,
+        cacheKey: this.genKey(key),
+        cacheValue: value,
+        outputValue: value,
+      });
+    }
+    return value;
+  }
+
+  /**
+   * Miss the cache
+   * @param key - The dictionary key
+   * @returns The dictionary value
+   */
+  public async miss(key: DictionaryKey): Promise<DictionaryEntry | undefined> {
+    const value = await this.missCache(key);
+    if (typeof value === 'string' && this.onMiss) {
+      this.onMiss({
+        inputKey: key,
+        cacheKey: this.genKey(key),
+        cacheValue: value,
+        outputValue: value,
+      });
+    }
+    return typeof value === 'string' ? value : undefined;
+  }
+
+  /**
+   * Set the value for a key
+   */
+  protected setCache(cacheKey: DictionaryPath, value: DictionaryValue): void {
+    const cache = this.getInternalCache() as Dictionary;
+    const dictionaryPath = getDictionaryPath(cacheKey);
+
+    if (dictionaryPath.length === 0) {
+      if (typeof value !== 'string') {
+        replaceDictionary(cache, value);
+      }
+      return;
+    }
+
+    let current = cache;
+    for (const key of dictionaryPath.slice(0, -1)) {
+      const next = current[key];
+      if (typeof next !== 'object' || next == null) {
+        current[key] = {};
+      }
+      current = current[key] as Dictionary;
+    }
+
+    current[dictionaryPath[dictionaryPath.length - 1]] = value;
+  }
+
+  /**
+   * Look up the key
+   */
+  protected getCache(key: DictionaryKey): DictionaryValue | undefined {
+    const dictionaryPath = getDictionaryPath(this.genKey(key));
+    let current: DictionaryValue = this.getInternalCache() as Dictionary;
+
+    if (dictionaryPath.length === 0) {
+      return current;
+    }
+
+    for (const pathSegment of dictionaryPath) {
+      if (typeof current !== 'object' || current == null) {
+        return undefined;
+      }
+      current = current[pathSegment];
+    }
+
+    return current;
+  }
+
+  /**
+   * Generate a key for the cache
+   * @param key - The dictionary key
+   * @returns The key
+   */
+  protected genKey(key: DictionaryKey): DictionaryPath {
+    return key;
+  }
+
+  /**
+   * Get the fallback value for a cache miss
+   * @param key - The dictionary key
+   * @returns The fallback value
+   *
+   * @throws {Error} - If the fallback is not implemented
+   */
+  protected fallback(): Promise<DictionaryValue> {
+    throw new Error('DictionaryCache fallback is not implemented');
+  }
+}
+
+/**
+ * Convert a dictionary path string to path segments
+ */
+function getDictionaryPath(id: DictionaryPath): string[] {
+  if (!id) {
+    return [];
+  }
+  return id.split('.');
+}
+
+/**
+ * Replace a dictionary object while preserving its reference
+ */
+function replaceDictionary(target: Dictionary, source: Dictionary): void {
+  for (const key of Object.keys(target)) {
+    delete target[key];
+  }
+  Object.assign(target, source);
+}

--- a/packages/i18n/src/i18n-manager/translations-manager/LocalesDictionaryCache.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/LocalesDictionaryCache.ts
@@ -1,0 +1,227 @@
+import { Cache } from './Cache';
+import { DictionaryCache } from './DictionaryCache';
+import type {
+  Dictionary,
+  DictionaryEntry,
+  DictionaryKey,
+  DictionaryPath,
+  DictionaryValue,
+} from './DictionaryCache';
+import { DEFAULT_CACHE_EXPIRY_TIME } from './utils/constants';
+import type {
+  DictionaryCacheLifecycleCallback,
+  LocalesDictionaryCacheLifecycleCallbacks,
+  LifecycleParam,
+} from '../lifecycle-hooks/types';
+import type { Locale } from './LocalesCache';
+
+/**
+ * Cache entry
+ * @typedef {Object} DictionaryCacheEntry
+ * @property {number} expiresAt - The time at which the cache entry expires.
+ * @property {DictionaryCache} dictionaryCache - The dictionary cache for the locale.
+ */
+export type DictionaryCacheEntry = {
+  expiresAt: number;
+  dictionaryCache: DictionaryCache;
+};
+
+/**
+ * Dictionary loader function type
+ */
+export type DictionaryLoader = (locale: string) => Promise<Dictionary>;
+
+/**
+ * Safe dictionary loader function type
+ * @returns A promise that resolves to a dictionary
+ * TODO: rename this because we are no longer doing try/catch around the dictionary loader
+ */
+export type SafeDictionaryLoader = (locale: string) => Promise<Dictionary>;
+
+/**
+ * Cache for looking up dictionaries by locale
+ */
+export class LocalesDictionaryCache extends Cache<
+  Locale,
+  Locale,
+  DictionaryCacheEntry,
+  DictionaryCacheEntry['dictionaryCache']
+> {
+  /**
+   * Dictionary loader function
+   */
+  private _dictionaryLoader: SafeDictionaryLoader;
+
+  /**
+   * Time to live for cache entries
+   */
+  private ttl: number = DEFAULT_CACHE_EXPIRY_TIME;
+
+  /**
+   * Dictionary cache lifecycle callbacks (locale embedded)
+   */
+  private _onDictionaryCacheHit?: DictionaryCacheLifecycleCallback;
+  private _onDictionaryCacheMiss?: DictionaryCacheLifecycleCallback;
+
+  /**
+   * Constructor
+   * @param {Object} params - The parameters for the cache
+   * @param {Record<string, DictionaryCacheEntry>} params.init - The initial cache
+   * @param {number | null} params.ttl - The time to live for cache entries
+   * @param {SafeDictionaryLoader} params.loadDictionary - The dictionary loader function
+   */
+  constructor({
+    init = {},
+    ttl,
+    defaultLocale,
+    dictionary = {},
+    loadDictionary,
+    lifecycle: {
+      onLocalesDictionaryCacheHit: onHit,
+      onLocalesDictionaryCacheMiss: onMiss,
+      onDictionaryCacheHit,
+      onDictionaryCacheMiss,
+    },
+  }: {
+    init?: Record<string, DictionaryCacheEntry>;
+    ttl?: number | null;
+    defaultLocale: Locale;
+    dictionary?: Dictionary;
+    loadDictionary: SafeDictionaryLoader;
+    lifecycle: LocalesDictionaryCacheLifecycleCallbacks;
+  }) {
+    super(init, { onHit, onMiss });
+
+    // Set time to live
+    this.ttl = ttl === null ? -1 : (ttl ?? DEFAULT_CACHE_EXPIRY_TIME);
+
+    this._dictionaryLoader = loadDictionary;
+    this._onDictionaryCacheHit = onDictionaryCacheHit;
+    this._onDictionaryCacheMiss = onDictionaryCacheMiss;
+
+    // The default locale dictionary is always available.
+    this.setCache(defaultLocale, {
+      dictionaryCache: new DictionaryCache({
+        init: dictionary,
+        lifecycle: this._createDictionaryCacheLifecycle(defaultLocale),
+      }),
+      expiresAt: -1,
+    });
+  }
+
+  /**
+   * Get the dictionary for a given locale
+   * @param key - The locale
+   * @returns The dictionary
+   */
+  public get(key: Locale): DictionaryCacheEntry['dictionaryCache'] | undefined {
+    // Get the cache entry
+    const entry = this.getCache(key);
+    if (!entry || (entry.expiresAt > 0 && entry.expiresAt < Date.now())) {
+      return undefined;
+    }
+    const value = entry.dictionaryCache;
+
+    // Life cycle callback
+    if (value != null && this.onHit) {
+      this.onHit({
+        inputKey: key,
+        cacheKey: this.genKey(key),
+        cacheValue: entry,
+        outputValue: value,
+      });
+    }
+
+    return value;
+  }
+
+  /**
+   * Miss the cache
+   * @param key - The locale
+   * @returns The dictionary cache
+   */
+  public async miss(
+    key: Locale
+  ): Promise<DictionaryCacheEntry['dictionaryCache']> {
+    // Miss the cache
+    const cacheValue = await this.missCache(key);
+
+    // Life cycle callback
+    const value = cacheValue.dictionaryCache;
+    if (value != null && this.onMiss) {
+      this.onMiss({
+        inputKey: key,
+        cacheKey: this.genKey(key),
+        cacheValue: cacheValue,
+        outputValue: value,
+      });
+    }
+
+    return value;
+  }
+
+  /**
+   * Generate the cache key for a given locale
+   * @param key - The locale
+   * @returns The cache key
+   *
+   * This is just an identity function, no transformation needed
+   */
+  protected genKey(key: Locale): Locale {
+    return key;
+  }
+
+  /**
+   * Fallback for a cache miss
+   * @param locale - The locale
+   * @returns The cache entry
+   */
+  protected async fallback(locale: Locale): Promise<DictionaryCacheEntry> {
+    // Fetch dictionary
+    const dictionaryPromise = this._dictionaryLoader(locale);
+
+    // Get cache expiry time
+    const expiresAt = this.ttl < 0 ? this.ttl : Date.now() + this.ttl;
+
+    // Cache the promise and expiry timestamp
+    const dictionaryCache = new DictionaryCache({
+      init: await dictionaryPromise,
+      lifecycle: this._createDictionaryCacheLifecycle(locale),
+    });
+
+    return { dictionaryCache, expiresAt };
+  }
+
+  // ===== PRIVATE METHODS ===== //
+
+  /**
+   * Create the dictionary cache lifecycle
+   * @param locale - The locale
+   * @returns The dictionary cache lifecycle
+   */
+  private _createDictionaryCacheLifecycle(
+    locale: Locale
+  ): LifecycleParam<
+    DictionaryKey,
+    DictionaryPath,
+    DictionaryValue,
+    DictionaryEntry
+  > {
+    return {
+      onHit: this._onDictionaryCacheHit
+        ? (params) =>
+            this._onDictionaryCacheHit!({
+              locale,
+              ...params,
+            })
+        : undefined,
+      onMiss: this._onDictionaryCacheMiss
+        ? (params) =>
+            this._onDictionaryCacheMiss!({
+              locale,
+              ...params,
+            })
+        : undefined,
+    };
+  }
+}

--- a/packages/i18n/src/i18n-manager/translations-manager/LocalesDictionaryCache.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/LocalesDictionaryCache.ts
@@ -59,12 +59,10 @@ export class LocalesDictionaryCache extends Cache<
   /**
    * Constructor
    * @param {Object} params - The parameters for the cache
-   * @param {Record<string, DictionaryCacheEntry>} params.init - The initial cache
    * @param {number | null} params.ttl - The time to live for cache entries
    * @param {DictionaryLoader} params.loadDictionary - The dictionary loader function
    */
   constructor({
-    init = {},
     ttl,
     defaultLocale,
     dictionary = {},
@@ -76,14 +74,13 @@ export class LocalesDictionaryCache extends Cache<
       onDictionaryCacheMiss,
     },
   }: {
-    init?: Record<string, DictionaryCacheEntry>;
     ttl?: number | null;
     defaultLocale: Locale;
     dictionary?: Dictionary;
     loadDictionary: DictionaryLoader;
     lifecycle: LocalesDictionaryCacheLifecycleCallbacks;
   }) {
-    super(init, { onHit, onMiss });
+    super({}, { onHit, onMiss });
 
     // Set time to live
     this.ttl = ttl === null ? -1 : (ttl ?? DEFAULT_CACHE_EXPIRY_TIME);

--- a/packages/i18n/src/i18n-manager/translations-manager/LocalesDictionaryCache.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/LocalesDictionaryCache.ts
@@ -32,13 +32,6 @@ export type DictionaryCacheEntry = {
 export type DictionaryLoader = (locale: string) => Promise<Dictionary>;
 
 /**
- * Safe dictionary loader function type
- * @returns A promise that resolves to a dictionary
- * TODO: rename this because we are no longer doing try/catch around the dictionary loader
- */
-export type SafeDictionaryLoader = (locale: string) => Promise<Dictionary>;
-
-/**
  * Cache for looking up dictionaries by locale
  */
 export class LocalesDictionaryCache extends Cache<
@@ -50,7 +43,7 @@ export class LocalesDictionaryCache extends Cache<
   /**
    * Dictionary loader function
    */
-  private _dictionaryLoader: SafeDictionaryLoader;
+  private _dictionaryLoader: DictionaryLoader;
 
   /**
    * Time to live for cache entries
@@ -68,7 +61,7 @@ export class LocalesDictionaryCache extends Cache<
    * @param {Object} params - The parameters for the cache
    * @param {Record<string, DictionaryCacheEntry>} params.init - The initial cache
    * @param {number | null} params.ttl - The time to live for cache entries
-   * @param {SafeDictionaryLoader} params.loadDictionary - The dictionary loader function
+   * @param {DictionaryLoader} params.loadDictionary - The dictionary loader function
    */
   constructor({
     init = {},
@@ -87,7 +80,7 @@ export class LocalesDictionaryCache extends Cache<
     ttl?: number | null;
     defaultLocale: Locale;
     dictionary?: Dictionary;
-    loadDictionary: SafeDictionaryLoader;
+    loadDictionary: DictionaryLoader;
     lifecycle: LocalesDictionaryCacheLifecycleCallbacks;
   }) {
     super(init, { onHit, onMiss });

--- a/packages/i18n/src/i18n-manager/translations-manager/__tests__/DictionaryCache.test.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/__tests__/DictionaryCache.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DictionaryCache, Dictionary } from '../DictionaryCache';
+
+describe('DictionaryCache', () => {
+  let mockTranslateMany: ReturnType<typeof vi.fn>;
+  const dictionary: Dictionary = {
+    greeting: 'Hello',
+    user: {
+      profile: {
+        name: 'Name',
+      },
+    },
+  };
+
+  beforeEach(() => {
+    mockTranslateMany = vi.fn();
+  });
+
+  // ===== REGRESSION TESTS ===== //
+
+  it('get() returns cached dictionary leaf when init is pre-populated', () => {
+    const cache = new DictionaryCache({
+      init: dictionary,
+    });
+
+    const result = cache.get('user.profile.name');
+    expect(result).toBe('Name');
+    expect(mockTranslateMany).not.toHaveBeenCalled();
+  });
+
+  it('get() returns cached dictionary subtree when init is pre-populated', () => {
+    const cache = new DictionaryCache({
+      init: dictionary,
+    });
+
+    const result = cache.get('user');
+    expect(result).toBeUndefined();
+  });
+
+  it('get() returns undefined on cache miss', () => {
+    const cache = new DictionaryCache({
+      init: dictionary,
+    });
+
+    const result = cache.get('missing.entry');
+    expect(result).toBeUndefined();
+  });
+
+  it('miss() rejects because fallback is not implemented', async () => {
+    const cache = new DictionaryCache({
+      init: {},
+    });
+
+    await expect(cache.miss('user.profile.name')).rejects.toThrow(
+      'DictionaryCache fallback is not implemented'
+    );
+    expect(mockTranslateMany).not.toHaveBeenCalled();
+    expect(cache.get('user.profile.name')).toBeUndefined();
+    expect(cache.getInternalCache()).toEqual({});
+  });
+
+  // ===== NEW BEHAVIOR TESTS ===== //
+
+  it('get() returns undefined for the root dictionary object', () => {
+    const cache = new DictionaryCache({
+      init: dictionary,
+    });
+
+    const result = cache.get('');
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/i18n/src/i18n-manager/translations-manager/__tests__/LocalesDictionaryCache.test.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/__tests__/LocalesDictionaryCache.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
+  DictionaryLoader,
   LocalesDictionaryCache,
-  SafeDictionaryLoader,
 } from '../LocalesDictionaryCache';
 import { DEFAULT_CACHE_EXPIRY_TIME } from '../utils/constants';
 import { Dictionary } from '../DictionaryCache';
@@ -31,7 +31,7 @@ describe('LocalesDictionaryCache', () => {
     return new LocalesDictionaryCache({
       defaultLocale: 'en',
       dictionary: enDictionary,
-      loadDictionary: mockLoadDictionary as SafeDictionaryLoader,
+      loadDictionary: mockLoadDictionary as DictionaryLoader,
       lifecycle: {},
       ...(opts?.ttl !== undefined ? { ttl: opts.ttl } : {}),
     });

--- a/packages/i18n/src/i18n-manager/translations-manager/__tests__/LocalesDictionaryCache.test.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/__tests__/LocalesDictionaryCache.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  LocalesDictionaryCache,
+  SafeDictionaryLoader,
+} from '../LocalesDictionaryCache';
+import { DEFAULT_CACHE_EXPIRY_TIME } from '../utils/constants';
+import { Dictionary } from '../DictionaryCache';
+
+describe('LocalesDictionaryCache', () => {
+  let mockLoadDictionary: ReturnType<typeof vi.fn>;
+  const enDictionary: Dictionary = {
+    greeting: 'Hello',
+  };
+  const frDictionary: Dictionary = {
+    greeting: 'Bonjour',
+    user: {
+      name: 'Nom',
+    },
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockLoadDictionary = vi.fn().mockResolvedValue(frDictionary);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function createCache(opts?: { ttl?: number | null }) {
+    return new LocalesDictionaryCache({
+      defaultLocale: 'en',
+      dictionary: enDictionary,
+      loadDictionary: mockLoadDictionary as SafeDictionaryLoader,
+      lifecycle: {},
+      ...(opts?.ttl !== undefined ? { ttl: opts.ttl } : {}),
+    });
+  }
+
+  // ===== REGRESSION TESTS ===== //
+
+  it('get() returns the default locale dictionary cache without loading', () => {
+    const cache = createCache();
+    const dictionaryCache = cache.get('en');
+
+    expect(dictionaryCache).toBeDefined();
+    expect(dictionaryCache!.getInternalCache()).toEqual(enDictionary);
+    expect(mockLoadDictionary).not.toHaveBeenCalled();
+  });
+
+  it('get() returns undefined when non-default locale is not loaded', () => {
+    const cache = createCache();
+    const result = cache.get('fr');
+    expect(result).toBeUndefined();
+  });
+
+  it('miss() calls loadDictionary and returns a DictionaryCache', async () => {
+    const cache = createCache();
+    const dictionaryCache = await cache.miss('fr');
+
+    expect(mockLoadDictionary).toHaveBeenCalledWith('fr');
+    expect(dictionaryCache).toBeDefined();
+    expect(dictionaryCache.getInternalCache()).toEqual(frDictionary);
+  });
+
+  it('miss() deduplicates concurrent loads for same locale', async () => {
+    const cache = createCache();
+
+    const p1 = cache.miss('fr');
+    const p2 = cache.miss('fr');
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(mockLoadDictionary).toHaveBeenCalledTimes(1);
+    expect(r1).toBe(r2);
+  });
+
+  // ===== NEW BEHAVIOR TESTS ===== //
+
+  it('get() returns DictionaryCache after miss() populates it', async () => {
+    const cache = createCache();
+
+    expect(cache.get('fr')).toBeUndefined();
+
+    await cache.miss('fr');
+
+    const dictionaryCache = cache.get('fr');
+    expect(dictionaryCache).toBeDefined();
+    expect(dictionaryCache!.getInternalCache()).toEqual(frDictionary);
+  });
+
+  it('get() returns undefined after default TTL (60s) expires', async () => {
+    const cache = createCache();
+
+    await cache.miss('fr');
+    expect(cache.get('fr')).toBeDefined();
+
+    vi.advanceTimersByTime(DEFAULT_CACHE_EXPIRY_TIME + 1);
+
+    expect(cache.get('fr')).toBeUndefined();
+  });
+
+  it('ttl: null means cache never expires', async () => {
+    const cache = createCache({ ttl: null });
+
+    await cache.miss('fr');
+    expect(cache.get('fr')).toBeDefined();
+
+    vi.advanceTimersByTime(999_999_999);
+
+    expect(cache.get('fr')).toBeDefined();
+  });
+
+  it('default locale dictionary never expires', () => {
+    const cache = createCache();
+
+    vi.advanceTimersByTime(999_999_999);
+
+    expect(cache.get('en')).toBeDefined();
+  });
+});


### PR DESCRIPTION
What
- Add dictionary cache primitives for per-locale dictionary persistence.
- Add focused cache tests and a patch changeset.

Why
- Split dictionary support into a shippable foundation before wiring it into I18nManager.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `DictionaryCache` and `LocalesDictionaryCache` as the foundational cache primitives for per-locale dictionary persistence, intentionally keeping them decoupled from `I18nManager` until a follow-up wiring PR. The implementation closely mirrors the existing `LocalesCache`/`TranslationsCache` pattern with TTL support, inflight deduplication, and embedded lifecycle callbacks.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all findings are P2 design notes or already-addressed previous thread items.

No P0 or P1 issues found. The one new finding is a P2 design note about the base class missCache bypassing the setCache override — currently harmless because fallback() always throws. The implementation is a faithful copy of the battle-tested LocalesCache pattern.

DictionaryCache.ts — the missCache/setCache override contract should be documented or resolved before a real fallback is wired in.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/i18n-manager/translations-manager/DictionaryCache.ts | New cache class for a single locale's nested dictionary with path-traversal get/set; fallback always throws, so the missCache path is intentionally a no-op for now. |
| packages/i18n/src/i18n-manager/translations-manager/LocalesDictionaryCache.ts | Locale-keyed wrapper around DictionaryCache with TTL, lazy loading, and per-locale lifecycle callbacks; mirrors LocalesCache closely. |
| packages/i18n/src/i18n-manager/lifecycle-hooks/types.ts | Adds four new lifecycle callback types for the dictionary cache layer, consistent with existing translations-cache types. |
| packages/i18n/src/i18n-manager/translations-manager/__tests__/DictionaryCache.test.ts | Unit tests covering leaf lookup, subtree/root returns, cache miss, and the always-throwing fallback; good coverage for the current API surface. |
| packages/i18n/src/i18n-manager/translations-manager/__tests__/LocalesDictionaryCache.test.ts | Tests default locale pre-population, lazy loading, TTL expiry, infinite TTL, and inflight deduplication; comprehensive for the current feature set. |
| .changeset/add-i18n-dictionary-cache.md | Patch changeset for gt-i18n; version bump and description are appropriate for a new primitive with no public API changes yet. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant LocalesDictionaryCache
    participant DictionaryCache
    participant DictionaryLoader

    Caller->>LocalesDictionaryCache: get(locale)
    alt entry exists and not expired
        LocalesDictionaryCache-->>Caller: DictionaryCache instance (onHit)
    else cache miss or expired
        LocalesDictionaryCache-->>Caller: undefined
        Caller->>LocalesDictionaryCache: miss(locale)
        LocalesDictionaryCache->>DictionaryLoader: loadDictionary(locale)
        DictionaryLoader-->>LocalesDictionaryCache: Dictionary
        LocalesDictionaryCache->>DictionaryCache: new DictionaryCache(init, lifecycle)
        LocalesDictionaryCache-->>Caller: DictionaryCache instance (onMiss)
    end

    Caller->>DictionaryCache: get("a.b.c")
    alt path resolves to a string
        DictionaryCache-->>Caller: string value (onHit)
    else path missing or returns object
        DictionaryCache-->>Caller: undefined
    end

    Caller->>DictionaryCache: miss("a.b.c")
    DictionaryCache->>DictionaryCache: fallback() throws
    DictionaryCache-->>Caller: rejects (not implemented)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/i18n/src/i18n-manager/translations-manager/DictionaryCache.ts:161-170
The base `Cache.missCache` writes directly to the private `this.cache` field, bypassing the `setCache` override. If `DictionaryCache.fallback()` is ever implemented to return real values, the result would be stored as a flat key (e.g. `cache["user.profile.name"] = "John"`) rather than as nested entries. The subsequent `getCache` path traversal would then silently fail to find those values. Consider overriding `missCache` here, or documenting that any future `fallback()` implementation must also override `missCache`.

```suggestion
  /**
   * Get the fallback value for a cache miss
   * @param key - The dictionary key
   * @returns The fallback value
   *
   * @throws {Error} - If the fallback is not implemented
   *
   * NOTE: If overriding this method, also override missCache to ensure the
   * returned value is stored via setCache (path-traversal), not directly into
   * the flat cache map as the base Cache.missCache does.
   */
  protected fallback(): Promise<DictionaryValue> {
    throw new Error('DictionaryCache fallback is not implemented');
  }
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["chore(i18n): consolidate dictionary load..."](https://github.com/generaltranslation/gt/commit/71e94108358faa1bcc80b13dae579b4981e37eed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30726492)</sub>

<!-- /greptile_comment -->