### PR TITLE
fix(i18n): send runtime metadata fields

### DIFF
--- a/.changeset/green-runtime-metadata.md
+++ b/.changeset/green-runtime-metadata.md
@@ -1,0 +1,5 @@
+---
+'gt-i18n': patch
+---
+
+Fix runtime translation metadata for max character limits.

--- a/packages/i18n/src/i18n-manager/translations-manager/TranslationsCache.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/TranslationsCache.ts
@@ -279,14 +279,14 @@ export class TranslationsCache<
   private _enqueueTranslation(
     key: TranslationKey<TranslationValue>
   ): Promise<TranslationValue> {
-    const cacheKey = this.genKey(key);
+    const hash = this.genKey(key);
     const options = key.options;
     return new Promise<TranslationValue>((resolve, reject) => {
       this._queue.push({
-        key: cacheKey,
+        key: hash,
         source: key.message,
         metadata: {
-          hash: cacheKey,
+          hash,
           ...(options?.$context && { context: options.$context }),
           ...(options?.$id && { id: options.$id }),
           ...('$maxChars' in options &&

--- a/packages/i18n/src/i18n-manager/translations-manager/TranslationsCache.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/TranslationsCache.ts
@@ -286,11 +286,12 @@ export class TranslationsCache<
         key: cacheKey,
         source: key.message,
         metadata: {
+          hash: cacheKey,
           ...(options?.$context && { context: options.$context }),
           ...(options?.$id && { id: options.$id }),
           ...('$maxChars' in options &&
             options.$maxChars != null && {
-              $maxChars: Math.abs(options.$maxChars),
+              maxChars: Math.abs(options.$maxChars),
             }),
           dataFormat: options.$format,
         },

--- a/packages/i18n/src/i18n-manager/translations-manager/__tests__/TranslationsCache.test.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/__tests__/TranslationsCache.test.ts
@@ -261,6 +261,37 @@ describe('TranslationsCache', () => {
     expect(mockTranslateMany).toHaveBeenCalledTimes(2);
   });
 
+  it('miss() maps $maxChars to maxChars metadata', async () => {
+    const options: LookupOptions = {
+      $format: 'ICU',
+      $maxChars: 12,
+    };
+    const { message, hash } = makeKey('Hello', options);
+    mockTranslateMany.mockResolvedValue(
+      mockTranslateManyResponse([{ hash, translation: 'Bonjour' }])
+    );
+
+    const cache = new TranslationsCache({
+      init: {},
+      translateMany: mockTranslateMany,
+    });
+
+    const promise = cache.miss({ message, options });
+    vi.advanceTimersByTime(50);
+    await promise;
+
+    expect(mockTranslateMany).toHaveBeenCalledWith({
+      [hash]: {
+        source: message,
+        metadata: {
+          hash,
+          maxChars: 12,
+          dataFormat: 'ICU',
+        },
+      },
+    });
+  });
+
   it('miss() rejects promise when translateMany throws', async () => {
     const { message, options } = makeKey('Hello');
     mockTranslateMany.mockRejectedValue(new Error('API error'));


### PR DESCRIPTION
## Summary
- include the request hash in runtime translation metadata
- map `$maxChars` lookup options to `maxChars` metadata before calling `translateMany`
- add regression coverage for runtime metadata shape

## Tests
- corepack pnpm --filter gt-i18n test -- src/i18n-manager/translations-manager/__tests__/TranslationsCache.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two missing/incorrectly-named fields in the runtime translation metadata passed to `translateMany`: the request `hash` was not being included, and the lookup option `$maxChars` was forwarded verbatim instead of being mapped to the API-facing `maxChars` field. Both fixes are consistent with how `hashMessage` already handles these fields, and a regression test covers the corrected metadata shape.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — focused bug fix with no regressions and good test coverage.

The changes are minimal, well-understood, and consistent with the existing conventions in `hashMessage.ts`. The regression test directly verifies the corrected metadata shape. No logic is restructured and there are no new dependencies.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/green-runtime-metadata.md | New changeset entry documenting the patch fix for runtime translation metadata. |
| packages/i18n/src/i18n-manager/translations-manager/TranslationsCache.ts | Two-line bug fix: adds missing `hash` field to runtime metadata and renames `$maxChars` → `maxChars` to match the API contract and the existing `hashMessage` utility convention. |
| packages/i18n/src/i18n-manager/translations-manager/__tests__/TranslationsCache.test.ts | Adds a targeted regression test verifying that `$maxChars` is mapped to `maxChars` in metadata and that `hash` is included in the `translateMany` payload. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant TranslationsCache
    participant translateMany API

    Caller->>TranslationsCache: miss({ message, options })
    TranslationsCache->>TranslationsCache: genKey(key) → cacheKey (hash)
    TranslationsCache->>TranslationsCache: _enqueueTranslation(key)
    Note over TranslationsCache: metadata now includes:<br/>hash: cacheKey (added)<br/>maxChars not $maxChars (fixed)<br/>context, id, dataFormat
    TranslationsCache->>translateMany API: { [hash]: { source, metadata } }
    translateMany API-->>TranslationsCache: { [hash]: { success, translation } }
    TranslationsCache-->>Caller: resolved translation
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(i18n): send runtime metadata fields"](https://github.com/generaltranslation/gt/commit/d7173cf6981f03ad815e0ea05c7a242c69dd240f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30726622)</sub>

<!-- /greptile_comment -->