### PR TITLE
chore(i18n): wire dictionary loading

### DIFF
--- a/.changeset/add-i18n-dictionary-cache.md
+++ b/.changeset/add-i18n-dictionary-cache.md
@@ -1,0 +1,5 @@
+---
+"gt-i18n": patch
+---
+
+Add dictionary cache primitives.

--- a/.changeset/load-i18n-dictionaries.md
+++ b/.changeset/load-i18n-dictionaries.md
@@ -1,0 +1,5 @@
+---
+"gt-i18n": patch
+---
+
+Wire dictionary loading into the i18n manager.

--- a/packages/i18n/src/i18n-manager/I18nManager.ts
+++ b/packages/i18n/src/i18n-manager/I18nManager.ts
@@ -20,7 +20,7 @@ import { Locale, LocalesCache } from './translations-manager/LocalesCache';
 import { Hash } from './translations-manager/TranslationsCache';
 import type { Dictionary } from './translations-manager/DictionaryCache';
 import { LocalesDictionaryCache } from './translations-manager/LocalesDictionaryCache';
-import type { SafeDictionaryLoader } from './translations-manager/LocalesDictionaryCache';
+import type { DictionaryLoader } from './translations-manager/LocalesDictionaryCache';
 import { createLifecycleCallbacks } from './lifecycle-hooks/createLifecycleCallbacks';
 import { EventEmitter } from './event-subscription/EventEmitter';
 import { subscribeLifecycleCallbacks } from './lifecycle-hooks/subscribeLifecycleCallbacks';
@@ -707,6 +707,6 @@ function createTranslationLoader<TranslationType extends Translation>(
  */
 function createDictionaryLoader<TranslationType extends Translation>(
   params: I18nManagerConstructorParams<TranslationType>
-): SafeDictionaryLoader {
+): DictionaryLoader {
   return params.loadDictionary ?? (() => Promise.resolve({}));
 }

--- a/packages/i18n/src/i18n-manager/I18nManager.ts
+++ b/packages/i18n/src/i18n-manager/I18nManager.ts
@@ -18,6 +18,9 @@ import { routeCreateTranslationLoader } from './translations-manager/translation
 import { getLoadTranslationsType } from './utils/getLoadTranslationsType';
 import { Locale, LocalesCache } from './translations-manager/LocalesCache';
 import { Hash } from './translations-manager/TranslationsCache';
+import type { Dictionary } from './translations-manager/DictionaryCache';
+import { LocalesDictionaryCache } from './translations-manager/LocalesDictionaryCache';
+import type { SafeDictionaryLoader } from './translations-manager/LocalesDictionaryCache';
 import { createLifecycleCallbacks } from './lifecycle-hooks/createLifecycleCallbacks';
 import { EventEmitter } from './event-subscription/EventEmitter';
 import { subscribeLifecycleCallbacks } from './lifecycle-hooks/subscribeLifecycleCallbacks';
@@ -69,6 +72,11 @@ class I18nManager<
   private localesCache: LocalesCache<TranslationValue>;
 
   /**
+   * Cache for dictionaries
+   */
+  private localesDictionaryCache: LocalesDictionaryCache;
+
+  /**
    * Runtime-safe locale and formatting helpers
    */
   private localeConfig: LocaleConfig;
@@ -95,6 +103,7 @@ class I18nManager<
     });
     // Create cache miss handlers
     const loadTranslations = createTranslationLoader<TranslationValue>(params);
+    const loadDictionary = createDictionaryLoader(params);
     const runtimeTranslationTimeout =
       this.config.runtimeTranslation?.timeout ?? DEFAULT_TRANSLATION_TIMEOUT;
     const runtimeTranslationMetadata =
@@ -117,6 +126,14 @@ class I18nManager<
       ttl: this.config.cacheExpiryTime,
       batchConfig: this.config.batchConfig,
       lifecycle: createLifecycleCallbacks((...args) => this.emit(...args)),
+    });
+
+    // Setup dictionary cache
+    this.localesDictionaryCache = new LocalesDictionaryCache({
+      defaultLocale: this.config.defaultLocale,
+      dictionary: params.dictionary,
+      loadDictionary,
+      lifecycle: {},
     });
   }
 
@@ -229,6 +246,31 @@ class I18nManager<
       // Get the translations
       const translations = txCache.getInternalCache();
       return translations;
+    } catch (error) {
+      this.handleError(error);
+      return {};
+    }
+  }
+
+  /**
+   * Loads in the dictionary for a given locale
+   * Edge case usage: access the dictionary object directly
+   */
+  async loadDictionary(locale: string): Promise<Dictionary> {
+    try {
+      // Validate
+      const resolvedLocale = this.resolveLocale(locale);
+
+      // Get the locale dictionary cache
+      let dictionaryCache = this.localesDictionaryCache.get(resolvedLocale);
+      if (!dictionaryCache) {
+        dictionaryCache =
+          await this.localesDictionaryCache.miss(resolvedLocale);
+      }
+
+      // Get the dictionary
+      const dictionary = dictionaryCache.getInternalCache();
+      return dictionary;
     } catch (error) {
       this.handleError(error);
       return {};
@@ -658,4 +700,13 @@ function createTranslationLoader<TranslationType extends Translation>(
       customMapping: params.customMapping,
     },
   }) as SafeTranslationsLoader<TranslationType>;
+}
+
+/**
+ * Helper function for creating a dictionary loader
+ */
+function createDictionaryLoader<TranslationType extends Translation>(
+  params: I18nManagerConstructorParams<TranslationType>
+): SafeDictionaryLoader {
+  return params.loadDictionary ?? (() => Promise.resolve({}));
 }

--- a/packages/i18n/src/i18n-manager/I18nManager.ts
+++ b/packages/i18n/src/i18n-manager/I18nManager.ts
@@ -261,6 +261,13 @@ class I18nManager<
     try {
       // Validate
       const resolvedLocale = this.resolveLocale(locale);
+      if (!this.requiresTranslation(resolvedLocale)) {
+        return (
+          this.localesDictionaryCache
+            .get(this.config.defaultLocale)
+            ?.getInternalCache() ?? {}
+        );
+      }
 
       // Get the locale dictionary cache
       let dictionaryCache = this.localesDictionaryCache.get(resolvedLocale);

--- a/packages/i18n/src/i18n-manager/I18nManager.ts
+++ b/packages/i18n/src/i18n-manager/I18nManager.ts
@@ -133,6 +133,7 @@ class I18nManager<
       defaultLocale: this.config.defaultLocale,
       dictionary: params.dictionary,
       loadDictionary,
+      ttl: this.config.cacheExpiryTime,
       lifecycle: {},
     });
   }

--- a/packages/i18n/src/i18n-manager/__tests__/I18nManager.test.ts
+++ b/packages/i18n/src/i18n-manager/__tests__/I18nManager.test.ts
@@ -79,6 +79,49 @@ describe('I18nManager', () => {
     expect(translations[expectedHash]).toBe(translatedString);
   });
 
+  it('loadDictionary() returns default locale dictionary without calling loadDictionary', async () => {
+    const loadDictionary = vi.fn().mockResolvedValue({ greeting: 'Bonjour' });
+    const manager = createManager({
+      dictionary: {
+        greeting: 'Hello',
+      },
+      loadDictionary,
+    });
+
+    const dictionary = await manager.loadDictionary('en');
+
+    expect(dictionary).toEqual({ greeting: 'Hello' });
+    expect(loadDictionary).not.toHaveBeenCalled();
+  });
+
+  it('loadDictionary() loads and caches dictionary for requested locale', async () => {
+    const loadDictionary = vi.fn().mockResolvedValue({
+      greeting: 'Bonjour',
+      user: {
+        name: 'Nom',
+      },
+    });
+    const manager = createManager({
+      dictionary: {
+        greeting: 'Hello',
+      },
+      loadDictionary,
+    });
+
+    const dictionary = await manager.loadDictionary('fr');
+    const cachedDictionary = await manager.loadDictionary('fr');
+
+    expect(loadDictionary).toHaveBeenCalledTimes(1);
+    expect(loadDictionary).toHaveBeenCalledWith('fr');
+    expect(dictionary).toEqual({
+      greeting: 'Bonjour',
+      user: {
+        name: 'Nom',
+      },
+    });
+    expect(cachedDictionary).toBe(dictionary);
+  });
+
   it('lookupTranslation() returns undefined before load, translation after', async () => {
     const manager = createManager();
 

--- a/packages/i18n/src/i18n-manager/__tests__/I18nManager.test.ts
+++ b/packages/i18n/src/i18n-manager/__tests__/I18nManager.test.ts
@@ -94,6 +94,22 @@ describe('I18nManager', () => {
     expect(loadDictionary).not.toHaveBeenCalled();
   });
 
+  it('loadDictionary() returns source dictionary without loading when i18n is disabled', async () => {
+    const loadDictionary = vi.fn().mockResolvedValue({ greeting: 'Bonjour' });
+    const manager = createManager({
+      enableI18n: false,
+      dictionary: {
+        greeting: 'Hello',
+      },
+      loadDictionary,
+    });
+
+    const dictionary = await manager.loadDictionary('fr');
+
+    expect(dictionary).toEqual({ greeting: 'Hello' });
+    expect(loadDictionary).not.toHaveBeenCalled();
+  });
+
   it('loadDictionary() loads and caches dictionary for requested locale', async () => {
     const loadDictionary = vi.fn().mockResolvedValue({
       greeting: 'Bonjour',

--- a/packages/i18n/src/i18n-manager/lifecycle-hooks/types.ts
+++ b/packages/i18n/src/i18n-manager/lifecycle-hooks/types.ts
@@ -4,6 +4,13 @@ import type {
   Hash,
 } from '../translations-manager/TranslationsCache';
 import type { Locale, CacheEntry } from '../translations-manager/LocalesCache';
+import type {
+  DictionaryKey,
+  DictionaryPath,
+  DictionaryValue,
+  DictionaryEntry,
+} from '../translations-manager/DictionaryCache';
+import type { DictionaryCacheEntry } from '../translations-manager/LocalesDictionaryCache';
 
 // ===== Base Cache Lifecycle ===== //
 
@@ -64,6 +71,39 @@ export type LocalesCacheLifecycleCallbacks<
   onLocalesCacheMiss?: LocalesCacheLifecycleCallback<TranslationValue>;
   onTranslationsCacheHit?: TranslationsCacheLifecycleCallback<TranslationValue>;
   onTranslationsCacheMiss?: TranslationsCacheLifecycleCallback<TranslationValue>;
+};
+
+// ===== Locales Dictionary Cache Lifecycle ===== //
+
+/**
+ * Locales dictionary cache lifecycle callback
+ */
+export type LocalesDictionaryCacheLifecycleCallback = LifecycleCallback<
+  Locale,
+  Locale,
+  DictionaryCacheEntry,
+  DictionaryCacheEntry['dictionaryCache']
+>;
+
+/**
+ * Dictionary cache lifecycle callback with locale embedded as first param.
+ */
+export type DictionaryCacheLifecycleCallback = (params: {
+  locale: Locale;
+  inputKey: DictionaryKey;
+  cacheKey: DictionaryPath;
+  cacheValue: DictionaryValue;
+  outputValue: DictionaryEntry;
+}) => void;
+
+/**
+ * Combined locales dictionary cache lifecycle callbacks
+ */
+export type LocalesDictionaryCacheLifecycleCallbacks = {
+  onLocalesDictionaryCacheHit?: LocalesDictionaryCacheLifecycleCallback;
+  onLocalesDictionaryCacheMiss?: LocalesDictionaryCacheLifecycleCallback;
+  onDictionaryCacheHit?: DictionaryCacheLifecycleCallback;
+  onDictionaryCacheMiss?: DictionaryCacheLifecycleCallback;
 };
 
 // ===== Consumer API ===== //

--- a/packages/i18n/src/i18n-manager/translations-manager/Cache.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/Cache.ts
@@ -109,7 +109,7 @@ abstract class Cache<
       const value = await fallbackPromise;
 
       // Update cache
-      this.cache[cacheKey] = value;
+      this.setCache(cacheKey, value);
       return value;
     } finally {
       delete this.fallbackPromises[cacheKey];

--- a/packages/i18n/src/i18n-manager/translations-manager/DictionaryCache.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/DictionaryCache.ts
@@ -73,7 +73,7 @@ export class DictionaryCache extends Cache<
       return undefined;
     }
 
-    if (typeof value === 'string' && this.onHit) {
+    if (this.onHit) {
       this.onHit({
         inputKey: key,
         cacheKey: this.genKey(key),

--- a/packages/i18n/src/i18n-manager/translations-manager/DictionaryCache.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/DictionaryCache.ts
@@ -1,0 +1,191 @@
+import { Cache } from './Cache';
+import type { LifecycleParam } from '../lifecycle-hooks/types';
+
+/**
+ * A dictionary is a nested object with strings as leaf values
+ */
+export type Dictionary = {
+  [key: string]: DictionaryValue;
+};
+
+/**
+ * Value stored in a dictionary
+ */
+export type DictionaryValue = string | Dictionary;
+
+/**
+ * Value returned from a dictionary lookup
+ */
+export type DictionaryEntry = string;
+
+/**
+ * Just a way to be more explicit about what "dictionary path" is
+ */
+export type DictionaryPath = string;
+
+/**
+ * InputKey type for lookups
+ */
+export type DictionaryKey = DictionaryPath;
+
+/**
+ * A cache for a single locale's dictionary
+ *
+ * Principles:
+ * - This class is language agnostic, and should never store the locale code as a parameter.
+ *   Locale logic is handled at the LocalesDictionaryCache level. Use a callback function
+ *   that has the locale parameter embedded if you wish to use the locale code.
+ */
+export class DictionaryCache extends Cache<
+  DictionaryKey,
+  DictionaryPath,
+  DictionaryValue,
+  DictionaryEntry
+> {
+  /**
+   * Constructor
+   * @param {Object} params - The parameters for the cache
+   * @param {Dictionary} params.init - The initial cache
+   */
+  constructor({
+    init,
+    lifecycle,
+  }: {
+    init: Dictionary;
+    lifecycle?: LifecycleParam<
+      DictionaryKey,
+      DictionaryPath,
+      DictionaryValue,
+      DictionaryEntry
+    >;
+  }) {
+    super(init, lifecycle);
+  }
+
+  /**
+   * Get the dictionary value for a given key
+   * @param key - The dictionary key
+   * @returns The dictionary value
+   */
+  public get(key: DictionaryKey): DictionaryEntry | undefined {
+    const value = this.getCache(key);
+    if (typeof value !== 'string') {
+      return undefined;
+    }
+
+    if (typeof value === 'string' && this.onHit) {
+      this.onHit({
+        inputKey: key,
+        cacheKey: this.genKey(key),
+        cacheValue: value,
+        outputValue: value,
+      });
+    }
+    return value;
+  }
+
+  /**
+   * Miss the cache
+   * @param key - The dictionary key
+   * @returns The dictionary value
+   */
+  public async miss(key: DictionaryKey): Promise<DictionaryEntry | undefined> {
+    const value = await this.missCache(key);
+    if (typeof value === 'string' && this.onMiss) {
+      this.onMiss({
+        inputKey: key,
+        cacheKey: this.genKey(key),
+        cacheValue: value,
+        outputValue: value,
+      });
+    }
+    return typeof value === 'string' ? value : undefined;
+  }
+
+  /**
+   * Set the value for a key
+   */
+  protected setCache(cacheKey: DictionaryPath, value: DictionaryValue): void {
+    const cache = this.getInternalCache() as Dictionary;
+    const dictionaryPath = getDictionaryPath(cacheKey);
+
+    if (dictionaryPath.length === 0) {
+      if (typeof value !== 'string') {
+        replaceDictionary(cache, value);
+      }
+      return;
+    }
+
+    let current = cache;
+    for (const key of dictionaryPath.slice(0, -1)) {
+      const next = current[key];
+      if (typeof next !== 'object' || next == null) {
+        current[key] = {};
+      }
+      current = current[key] as Dictionary;
+    }
+
+    current[dictionaryPath[dictionaryPath.length - 1]] = value;
+  }
+
+  /**
+   * Look up the key
+   */
+  protected getCache(key: DictionaryKey): DictionaryValue | undefined {
+    const dictionaryPath = getDictionaryPath(this.genKey(key));
+    let current: DictionaryValue = this.getInternalCache() as Dictionary;
+
+    if (dictionaryPath.length === 0) {
+      return current;
+    }
+
+    for (const pathSegment of dictionaryPath) {
+      if (typeof current !== 'object' || current == null) {
+        return undefined;
+      }
+      current = current[pathSegment];
+    }
+
+    return current;
+  }
+
+  /**
+   * Generate a key for the cache
+   * @param key - The dictionary key
+   * @returns The key
+   */
+  protected genKey(key: DictionaryKey): DictionaryPath {
+    return key;
+  }
+
+  /**
+   * Get the fallback value for a cache miss
+   * @param key - The dictionary key
+   * @returns The fallback value
+   *
+   * @throws {Error} - If the fallback is not implemented
+   */
+  protected fallback(): Promise<DictionaryValue> {
+    throw new Error('DictionaryCache fallback is not implemented');
+  }
+}
+
+/**
+ * Convert a dictionary path string to path segments
+ */
+function getDictionaryPath(id: DictionaryPath): string[] {
+  if (!id) {
+    return [];
+  }
+  return id.split('.');
+}
+
+/**
+ * Replace a dictionary object while preserving its reference
+ */
+function replaceDictionary(target: Dictionary, source: Dictionary): void {
+  for (const key of Object.keys(target)) {
+    delete target[key];
+  }
+  Object.assign(target, source);
+}

--- a/packages/i18n/src/i18n-manager/translations-manager/LocalesDictionaryCache.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/LocalesDictionaryCache.ts
@@ -1,0 +1,227 @@
+import { Cache } from './Cache';
+import { DictionaryCache } from './DictionaryCache';
+import type {
+  Dictionary,
+  DictionaryEntry,
+  DictionaryKey,
+  DictionaryPath,
+  DictionaryValue,
+} from './DictionaryCache';
+import { DEFAULT_CACHE_EXPIRY_TIME } from './utils/constants';
+import type {
+  DictionaryCacheLifecycleCallback,
+  LocalesDictionaryCacheLifecycleCallbacks,
+  LifecycleParam,
+} from '../lifecycle-hooks/types';
+import type { Locale } from './LocalesCache';
+
+/**
+ * Cache entry
+ * @typedef {Object} DictionaryCacheEntry
+ * @property {number} expiresAt - The time at which the cache entry expires.
+ * @property {DictionaryCache} dictionaryCache - The dictionary cache for the locale.
+ */
+export type DictionaryCacheEntry = {
+  expiresAt: number;
+  dictionaryCache: DictionaryCache;
+};
+
+/**
+ * Dictionary loader function type
+ */
+export type DictionaryLoader = (locale: string) => Promise<Dictionary>;
+
+/**
+ * Safe dictionary loader function type
+ * @returns A promise that resolves to a dictionary
+ * TODO: rename this because we are no longer doing try/catch around the dictionary loader
+ */
+export type SafeDictionaryLoader = (locale: string) => Promise<Dictionary>;
+
+/**
+ * Cache for looking up dictionaries by locale
+ */
+export class LocalesDictionaryCache extends Cache<
+  Locale,
+  Locale,
+  DictionaryCacheEntry,
+  DictionaryCacheEntry['dictionaryCache']
+> {
+  /**
+   * Dictionary loader function
+   */
+  private _dictionaryLoader: SafeDictionaryLoader;
+
+  /**
+   * Time to live for cache entries
+   */
+  private ttl: number = DEFAULT_CACHE_EXPIRY_TIME;
+
+  /**
+   * Dictionary cache lifecycle callbacks (locale embedded)
+   */
+  private _onDictionaryCacheHit?: DictionaryCacheLifecycleCallback;
+  private _onDictionaryCacheMiss?: DictionaryCacheLifecycleCallback;
+
+  /**
+   * Constructor
+   * @param {Object} params - The parameters for the cache
+   * @param {Record<string, DictionaryCacheEntry>} params.init - The initial cache
+   * @param {number | null} params.ttl - The time to live for cache entries
+   * @param {SafeDictionaryLoader} params.loadDictionary - The dictionary loader function
+   */
+  constructor({
+    init = {},
+    ttl,
+    defaultLocale,
+    dictionary = {},
+    loadDictionary,
+    lifecycle: {
+      onLocalesDictionaryCacheHit: onHit,
+      onLocalesDictionaryCacheMiss: onMiss,
+      onDictionaryCacheHit,
+      onDictionaryCacheMiss,
+    },
+  }: {
+    init?: Record<string, DictionaryCacheEntry>;
+    ttl?: number | null;
+    defaultLocale: Locale;
+    dictionary?: Dictionary;
+    loadDictionary: SafeDictionaryLoader;
+    lifecycle: LocalesDictionaryCacheLifecycleCallbacks;
+  }) {
+    super(init, { onHit, onMiss });
+
+    // Set time to live
+    this.ttl = ttl === null ? -1 : (ttl ?? DEFAULT_CACHE_EXPIRY_TIME);
+
+    this._dictionaryLoader = loadDictionary;
+    this._onDictionaryCacheHit = onDictionaryCacheHit;
+    this._onDictionaryCacheMiss = onDictionaryCacheMiss;
+
+    // The default locale dictionary is always available.
+    this.setCache(defaultLocale, {
+      dictionaryCache: new DictionaryCache({
+        init: dictionary,
+        lifecycle: this._createDictionaryCacheLifecycle(defaultLocale),
+      }),
+      expiresAt: -1,
+    });
+  }
+
+  /**
+   * Get the dictionary for a given locale
+   * @param key - The locale
+   * @returns The dictionary
+   */
+  public get(key: Locale): DictionaryCacheEntry['dictionaryCache'] | undefined {
+    // Get the cache entry
+    const entry = this.getCache(key);
+    if (!entry || (entry.expiresAt > 0 && entry.expiresAt < Date.now())) {
+      return undefined;
+    }
+    const value = entry.dictionaryCache;
+
+    // Life cycle callback
+    if (value != null && this.onHit) {
+      this.onHit({
+        inputKey: key,
+        cacheKey: this.genKey(key),
+        cacheValue: entry,
+        outputValue: value,
+      });
+    }
+
+    return value;
+  }
+
+  /**
+   * Miss the cache
+   * @param key - The locale
+   * @returns The dictionary cache
+   */
+  public async miss(
+    key: Locale
+  ): Promise<DictionaryCacheEntry['dictionaryCache']> {
+    // Miss the cache
+    const cacheValue = await this.missCache(key);
+
+    // Life cycle callback
+    const value = cacheValue.dictionaryCache;
+    if (value != null && this.onMiss) {
+      this.onMiss({
+        inputKey: key,
+        cacheKey: this.genKey(key),
+        cacheValue: cacheValue,
+        outputValue: value,
+      });
+    }
+
+    return value;
+  }
+
+  /**
+   * Generate the cache key for a given locale
+   * @param key - The locale
+   * @returns The cache key
+   *
+   * This is just an identity function, no transformation needed
+   */
+  protected genKey(key: Locale): Locale {
+    return key;
+  }
+
+  /**
+   * Fallback for a cache miss
+   * @param locale - The locale
+   * @returns The cache entry
+   */
+  protected async fallback(locale: Locale): Promise<DictionaryCacheEntry> {
+    // Fetch dictionary
+    const dictionaryPromise = this._dictionaryLoader(locale);
+
+    // Get cache expiry time
+    const expiresAt = this.ttl < 0 ? this.ttl : Date.now() + this.ttl;
+
+    // Cache the promise and expiry timestamp
+    const dictionaryCache = new DictionaryCache({
+      init: await dictionaryPromise,
+      lifecycle: this._createDictionaryCacheLifecycle(locale),
+    });
+
+    return { dictionaryCache, expiresAt };
+  }
+
+  // ===== PRIVATE METHODS ===== //
+
+  /**
+   * Create the dictionary cache lifecycle
+   * @param locale - The locale
+   * @returns The dictionary cache lifecycle
+   */
+  private _createDictionaryCacheLifecycle(
+    locale: Locale
+  ): LifecycleParam<
+    DictionaryKey,
+    DictionaryPath,
+    DictionaryValue,
+    DictionaryEntry
+  > {
+    return {
+      onHit: this._onDictionaryCacheHit
+        ? (params) =>
+            this._onDictionaryCacheHit!({
+              locale,
+              ...params,
+            })
+        : undefined,
+      onMiss: this._onDictionaryCacheMiss
+        ? (params) =>
+            this._onDictionaryCacheMiss!({
+              locale,
+              ...params,
+            })
+        : undefined,
+    };
+  }
+}

--- a/packages/i18n/src/i18n-manager/translations-manager/LocalesDictionaryCache.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/LocalesDictionaryCache.ts
@@ -59,12 +59,10 @@ export class LocalesDictionaryCache extends Cache<
   /**
    * Constructor
    * @param {Object} params - The parameters for the cache
-   * @param {Record<string, DictionaryCacheEntry>} params.init - The initial cache
    * @param {number | null} params.ttl - The time to live for cache entries
    * @param {DictionaryLoader} params.loadDictionary - The dictionary loader function
    */
   constructor({
-    init = {},
     ttl,
     defaultLocale,
     dictionary = {},
@@ -76,14 +74,13 @@ export class LocalesDictionaryCache extends Cache<
       onDictionaryCacheMiss,
     },
   }: {
-    init?: Record<string, DictionaryCacheEntry>;
     ttl?: number | null;
     defaultLocale: Locale;
     dictionary?: Dictionary;
     loadDictionary: DictionaryLoader;
     lifecycle: LocalesDictionaryCacheLifecycleCallbacks;
   }) {
-    super(init, { onHit, onMiss });
+    super({}, { onHit, onMiss });
 
     // Set time to live
     this.ttl = ttl === null ? -1 : (ttl ?? DEFAULT_CACHE_EXPIRY_TIME);

--- a/packages/i18n/src/i18n-manager/translations-manager/LocalesDictionaryCache.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/LocalesDictionaryCache.ts
@@ -32,13 +32,6 @@ export type DictionaryCacheEntry = {
 export type DictionaryLoader = (locale: string) => Promise<Dictionary>;
 
 /**
- * Safe dictionary loader function type
- * @returns A promise that resolves to a dictionary
- * TODO: rename this because we are no longer doing try/catch around the dictionary loader
- */
-export type SafeDictionaryLoader = (locale: string) => Promise<Dictionary>;
-
-/**
  * Cache for looking up dictionaries by locale
  */
 export class LocalesDictionaryCache extends Cache<
@@ -50,7 +43,7 @@ export class LocalesDictionaryCache extends Cache<
   /**
    * Dictionary loader function
    */
-  private _dictionaryLoader: SafeDictionaryLoader;
+  private _dictionaryLoader: DictionaryLoader;
 
   /**
    * Time to live for cache entries
@@ -68,7 +61,7 @@ export class LocalesDictionaryCache extends Cache<
    * @param {Object} params - The parameters for the cache
    * @param {Record<string, DictionaryCacheEntry>} params.init - The initial cache
    * @param {number | null} params.ttl - The time to live for cache entries
-   * @param {SafeDictionaryLoader} params.loadDictionary - The dictionary loader function
+   * @param {DictionaryLoader} params.loadDictionary - The dictionary loader function
    */
   constructor({
     init = {},
@@ -87,7 +80,7 @@ export class LocalesDictionaryCache extends Cache<
     ttl?: number | null;
     defaultLocale: Locale;
     dictionary?: Dictionary;
-    loadDictionary: SafeDictionaryLoader;
+    loadDictionary: DictionaryLoader;
     lifecycle: LocalesDictionaryCacheLifecycleCallbacks;
   }) {
     super(init, { onHit, onMiss });

--- a/packages/i18n/src/i18n-manager/translations-manager/__tests__/DictionaryCache.test.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/__tests__/DictionaryCache.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DictionaryCache, Dictionary } from '../DictionaryCache';
+
+describe('DictionaryCache', () => {
+  let mockTranslateMany: ReturnType<typeof vi.fn>;
+  const dictionary: Dictionary = {
+    greeting: 'Hello',
+    user: {
+      profile: {
+        name: 'Name',
+      },
+    },
+  };
+
+  beforeEach(() => {
+    mockTranslateMany = vi.fn();
+  });
+
+  // ===== REGRESSION TESTS ===== //
+
+  it('get() returns cached dictionary leaf when init is pre-populated', () => {
+    const cache = new DictionaryCache({
+      init: dictionary,
+    });
+
+    const result = cache.get('user.profile.name');
+    expect(result).toBe('Name');
+    expect(mockTranslateMany).not.toHaveBeenCalled();
+  });
+
+  it('get() returns cached dictionary subtree when init is pre-populated', () => {
+    const cache = new DictionaryCache({
+      init: dictionary,
+    });
+
+    const result = cache.get('user');
+    expect(result).toBeUndefined();
+  });
+
+  it('get() returns undefined on cache miss', () => {
+    const cache = new DictionaryCache({
+      init: dictionary,
+    });
+
+    const result = cache.get('missing.entry');
+    expect(result).toBeUndefined();
+  });
+
+  it('miss() rejects because fallback is not implemented', async () => {
+    const cache = new DictionaryCache({
+      init: {},
+    });
+
+    await expect(cache.miss('user.profile.name')).rejects.toThrow(
+      'DictionaryCache fallback is not implemented'
+    );
+    expect(mockTranslateMany).not.toHaveBeenCalled();
+    expect(cache.get('user.profile.name')).toBeUndefined();
+    expect(cache.getInternalCache()).toEqual({});
+  });
+
+  // ===== NEW BEHAVIOR TESTS ===== //
+
+  it('get() returns undefined for the root dictionary object', () => {
+    const cache = new DictionaryCache({
+      init: dictionary,
+    });
+
+    const result = cache.get('');
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/i18n/src/i18n-manager/translations-manager/__tests__/LocalesDictionaryCache.test.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/__tests__/LocalesDictionaryCache.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
+  DictionaryLoader,
   LocalesDictionaryCache,
-  SafeDictionaryLoader,
 } from '../LocalesDictionaryCache';
 import { DEFAULT_CACHE_EXPIRY_TIME } from '../utils/constants';
 import { Dictionary } from '../DictionaryCache';
@@ -31,7 +31,7 @@ describe('LocalesDictionaryCache', () => {
     return new LocalesDictionaryCache({
       defaultLocale: 'en',
       dictionary: enDictionary,
-      loadDictionary: mockLoadDictionary as SafeDictionaryLoader,
+      loadDictionary: mockLoadDictionary as DictionaryLoader,
       lifecycle: {},
       ...(opts?.ttl !== undefined ? { ttl: opts.ttl } : {}),
     });

--- a/packages/i18n/src/i18n-manager/translations-manager/__tests__/LocalesDictionaryCache.test.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/__tests__/LocalesDictionaryCache.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  LocalesDictionaryCache,
+  SafeDictionaryLoader,
+} from '../LocalesDictionaryCache';
+import { DEFAULT_CACHE_EXPIRY_TIME } from '../utils/constants';
+import { Dictionary } from '../DictionaryCache';
+
+describe('LocalesDictionaryCache', () => {
+  let mockLoadDictionary: ReturnType<typeof vi.fn>;
+  const enDictionary: Dictionary = {
+    greeting: 'Hello',
+  };
+  const frDictionary: Dictionary = {
+    greeting: 'Bonjour',
+    user: {
+      name: 'Nom',
+    },
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockLoadDictionary = vi.fn().mockResolvedValue(frDictionary);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function createCache(opts?: { ttl?: number | null }) {
+    return new LocalesDictionaryCache({
+      defaultLocale: 'en',
+      dictionary: enDictionary,
+      loadDictionary: mockLoadDictionary as SafeDictionaryLoader,
+      lifecycle: {},
+      ...(opts?.ttl !== undefined ? { ttl: opts.ttl } : {}),
+    });
+  }
+
+  // ===== REGRESSION TESTS ===== //
+
+  it('get() returns the default locale dictionary cache without loading', () => {
+    const cache = createCache();
+    const dictionaryCache = cache.get('en');
+
+    expect(dictionaryCache).toBeDefined();
+    expect(dictionaryCache!.getInternalCache()).toEqual(enDictionary);
+    expect(mockLoadDictionary).not.toHaveBeenCalled();
+  });
+
+  it('get() returns undefined when non-default locale is not loaded', () => {
+    const cache = createCache();
+    const result = cache.get('fr');
+    expect(result).toBeUndefined();
+  });
+
+  it('miss() calls loadDictionary and returns a DictionaryCache', async () => {
+    const cache = createCache();
+    const dictionaryCache = await cache.miss('fr');
+
+    expect(mockLoadDictionary).toHaveBeenCalledWith('fr');
+    expect(dictionaryCache).toBeDefined();
+    expect(dictionaryCache.getInternalCache()).toEqual(frDictionary);
+  });
+
+  it('miss() deduplicates concurrent loads for same locale', async () => {
+    const cache = createCache();
+
+    const p1 = cache.miss('fr');
+    const p2 = cache.miss('fr');
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(mockLoadDictionary).toHaveBeenCalledTimes(1);
+    expect(r1).toBe(r2);
+  });
+
+  // ===== NEW BEHAVIOR TESTS ===== //
+
+  it('get() returns DictionaryCache after miss() populates it', async () => {
+    const cache = createCache();
+
+    expect(cache.get('fr')).toBeUndefined();
+
+    await cache.miss('fr');
+
+    const dictionaryCache = cache.get('fr');
+    expect(dictionaryCache).toBeDefined();
+    expect(dictionaryCache!.getInternalCache()).toEqual(frDictionary);
+  });
+
+  it('get() returns undefined after default TTL (60s) expires', async () => {
+    const cache = createCache();
+
+    await cache.miss('fr');
+    expect(cache.get('fr')).toBeDefined();
+
+    vi.advanceTimersByTime(DEFAULT_CACHE_EXPIRY_TIME + 1);
+
+    expect(cache.get('fr')).toBeUndefined();
+  });
+
+  it('ttl: null means cache never expires', async () => {
+    const cache = createCache({ ttl: null });
+
+    await cache.miss('fr');
+    expect(cache.get('fr')).toBeDefined();
+
+    vi.advanceTimersByTime(999_999_999);
+
+    expect(cache.get('fr')).toBeDefined();
+  });
+
+  it('default locale dictionary never expires', () => {
+    const cache = createCache();
+
+    vi.advanceTimersByTime(999_999_999);
+
+    expect(cache.get('en')).toBeDefined();
+  });
+});

--- a/packages/i18n/src/i18n-manager/types.ts
+++ b/packages/i18n/src/i18n-manager/types.ts
@@ -1,10 +1,22 @@
 import type { RuntimeTranslateManyOptions } from 'generaltranslation/internal';
 import type { CustomMapping } from 'generaltranslation/types';
-import { GTConfig } from '../config/types';
-import { TranslationsLoader } from './translations-manager/translations-loaders/types';
-import { Translation } from './translations-manager/utils/types/translation-data';
+import type { GTConfig } from '../config/types';
+import type { TranslationsLoader } from './translations-manager/translations-loaders/types';
+import type { Translation } from './translations-manager/utils/types/translation-data';
 import type { LifecycleCallbacks } from './lifecycle-hooks/types';
+import type { Dictionary } from './translations-manager/DictionaryCache';
+import type { DictionaryLoader } from './translations-manager/LocalesDictionaryCache';
 import type { TranslationBatchConfig } from './translations-manager/TranslationsCache';
+
+type DictionaryConfig =
+  | {
+      dictionary: Dictionary;
+      loadDictionary?: DictionaryLoader;
+    }
+  | {
+      dictionary?: Dictionary;
+      loadDictionary?: undefined;
+    };
 
 type RuntimeTranslationConfig = {
   timeout?: number;
@@ -16,20 +28,21 @@ type RuntimeTranslationConfig = {
  */
 export type I18nManagerConstructorParams<
   TranslationValue extends Translation = Translation,
-> = Omit<GTConfig, 'cacheExpiryTime'> & {
-  /**
-   * Locale cache TTL in milliseconds. Undefined uses the default TTL, null
-   * disables expiry, and a number sets an explicit TTL.
-   */
-  cacheExpiryTime?: number | null;
-  loadTranslations?: TranslationsLoader;
-  environment?: 'development' | 'production';
-  batchConfig?: TranslationBatchConfig;
-  runtimeTranslation?: RuntimeTranslationConfig;
-  // Cache lifecycle hooks
-  /** @deprecated - move to subscription api instead */
-  lifecycle?: LifecycleCallbacks<TranslationValue>;
-};
+> = DictionaryConfig &
+  Omit<GTConfig, 'cacheExpiryTime'> & {
+    /**
+     * Locale cache TTL in milliseconds. Undefined uses the default TTL, null
+     * disables expiry, and a number sets an explicit TTL.
+     */
+    cacheExpiryTime?: number | null;
+    loadTranslations?: TranslationsLoader;
+    environment?: 'development' | 'production';
+    batchConfig?: TranslationBatchConfig;
+    runtimeTranslation?: RuntimeTranslationConfig;
+    // Cache lifecycle hooks
+    /** @deprecated - move to subscription api instead */
+    lifecycle?: LifecycleCallbacks<TranslationValue>;
+  };
 
 /**
  * I18nManager class configuration
@@ -87,4 +100,9 @@ export interface ScopedConditionStore extends ConditionStore {
   run<T>(locale: string, callback: () => T): T;
 }
 
-export type { TranslationsLoader, LifecycleCallbacks };
+export type {
+  TranslationsLoader,
+  LifecycleCallbacks,
+  Dictionary,
+  DictionaryLoader,
+};

--- a/packages/i18n/src/i18n-manager/validation/config-validation/validateDictionary.ts
+++ b/packages/i18n/src/i18n-manager/validation/config-validation/validateDictionary.ts
@@ -1,0 +1,25 @@
+import type { DictionaryLoader } from '../../translations-manager/LocalesDictionaryCache';
+import type { Dictionary } from '../../translations-manager/DictionaryCache';
+import type { ValidationResult } from '../types';
+
+/**
+ * Dictionary configuration
+ *
+ * Requirements:
+ * - loadDictionary requires dictionary so the default locale always has a source dictionary
+ */
+export function validateDictionary(params: {
+  dictionary?: Dictionary;
+  loadDictionary?: DictionaryLoader;
+}): ValidationResult[] {
+  const results: ValidationResult[] = [];
+
+  if (params.loadDictionary && !params.dictionary) {
+    results.push({
+      type: 'error',
+      message: 'dictionary is required when loadDictionary is provided',
+    });
+  }
+
+  return results;
+}

--- a/packages/i18n/src/i18n-manager/validation/validateConfig.ts
+++ b/packages/i18n/src/i18n-manager/validation/validateConfig.ts
@@ -3,6 +3,7 @@ import { I18nManagerConstructorParams } from '../types';
 import { validateLoadTranslations } from './config-validation/validateLoadTranslations';
 import { validateTranslationApi } from './config-validation/validateTranslationApi';
 import { validateLocales } from './config-validation/validateLocales';
+import { validateDictionary } from './config-validation/validateDictionary';
 import type { Translation } from '../translations-manager/utils/types/translation-data';
 
 /**
@@ -18,6 +19,7 @@ export function validateConfig<TranslationValue extends Translation>(
   results.push(...validateLoadTranslations(config));
   results.push(...validateTranslationApi(config));
   results.push(...validateLocales(config));
+  results.push(...validateDictionary(config));
 
   return results;
 }

--- a/packages/i18n/src/internal-types.ts
+++ b/packages/i18n/src/internal-types.ts
@@ -8,8 +8,16 @@ export type {
   ConditionStore,
   WritableConditionStore,
   ScopedConditionStore,
+  Dictionary,
+  DictionaryLoader,
 } from './i18n-manager/types';
 export type { LocaleCandidates } from './i18n-manager/condition-store/localeResolver';
+export type {
+  DictionaryValue,
+  DictionaryEntry,
+  DictionaryPath,
+  DictionaryKey,
+} from './i18n-manager/translations-manager/DictionaryCache';
 
 // Translation Options (Function types exported by /types)
 export type * from './translation-functions/types/options';

--- a/packages/i18n/src/types.ts
+++ b/packages/i18n/src/types.ts
@@ -1,3 +1,10 @@
 // Translation functions
 export type * from './translation-functions/types';
 export type { Translation } from './i18n-manager/translations-manager/utils/types/translation-data';
+export type {
+  Dictionary,
+  DictionaryEntry,
+  DictionaryValue,
+  DictionaryPath,
+  DictionaryKey,
+} from './i18n-manager/translations-manager/DictionaryCache';


### PR DESCRIPTION
What
- Add I18nManager dictionary/loadDictionary configuration and validation.
- Add loadDictionary(locale), exported dictionary types, tests, and a patch changeset.

Why
- Make dictionary data loadable before adding lookup behavior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires dictionary loading into `I18nManager` by introducing `DictionaryCache` and `LocalesDictionaryCache`, a discriminated `DictionaryConfig` union type (enforcing `dictionary` is required when `loadDictionary` is supplied), a runtime `validateDictionary` validator, and a public `loadDictionary(locale)` method with deduplication and cache-hit short-circuiting.

- **New cache primitives** — `DictionaryCache` provides nested dot-path lookups over a flat `Dictionary` object; `LocalesDictionaryCache` manages per-locale instances with TTL expiry, defaulting the source locale to never expire.
- **Type-safe config** — `DictionaryConfig` discriminated union prevents passing `loadDictionary` without `dictionary` at compile time, mirrored by the new `validateDictionary` runtime check.
- **Base `Cache` fix** — the single-line change in `Cache.ts` (`this.cache[cacheKey] = value` → `this.setCache(cacheKey, value)`) is required to make `DictionaryCache`'s custom path-based `setCache` work when `missCache` resolves.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all changes are additive and well-tested, with no regressions introduced to the existing translation cache path.

The dictionary loading is cleanly isolated from the existing translation cache. The one finding (TTL computed before the async load completes) is a minor timing edge-case that only affects slow loaders with short TTLs, and it does not break correctness. The discriminated union type, runtime validator, deduplication logic, and test coverage are all solid.

No files require special attention; the TTL note in LocalesDictionaryCache.ts is the only item worth a quick look.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/i18n/src/i18n-manager/translations-manager/LocalesDictionaryCache.ts | New LocalesDictionaryCache: manages per-locale DictionaryCache instances with TTL; expiresAt timestamp is computed before the async dictionary load completes, slightly under-counting TTL for slow fetches. |
| packages/i18n/src/i18n-manager/translations-manager/DictionaryCache.ts | New DictionaryCache class: path-based nested lookup of a flat string dictionary; fallback() intentionally throws since DictionaryCache is always pre-populated on creation. |
| packages/i18n/src/i18n-manager/I18nManager.ts | Wires dictionary loading: constructs LocalesDictionaryCache with correct TTL forwarding and exposes loadDictionary() public method with proper cache-hit short-circuiting and deduplication. |
| packages/i18n/src/i18n-manager/translations-manager/Cache.ts | Single-line fix: delegates the post-miss cache write to the overridable setCache() instead of writing directly to this.cache, enabling DictionaryCache's path-based setCache() to work correctly. |
| packages/i18n/src/i18n-manager/types.ts | Adds DictionaryConfig discriminated union to I18nManagerConstructorParams, correctly enforcing that loadDictionary requires dictionary at the TypeScript level. |
| packages/i18n/src/i18n-manager/validation/config-validation/validateDictionary.ts | Runtime validation: flags error when loadDictionary is supplied without dictionary; mirrors the compile-time DictionaryConfig constraint. |
| packages/i18n/src/i18n-manager/lifecycle-hooks/types.ts | Adds lifecycle callback types for the dictionary cache layer; onDictionaryCacheMiss can never fire today because DictionaryCache.fallback() always throws, but the types are harmlessly forward-looking. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["loadDictionary(locale)"] --> B["resolveLocale(locale)"]
    B --> C{"requiresTranslation?"}
    C -- No --> D["LocalesDictionaryCache.get(defaultLocale)"]
    D --> E["return defaultDictionary"]
    C -- Yes --> F["LocalesDictionaryCache.get(resolvedLocale)"]
    F -- Hit & not expired --> G["return dictionaryCache"]
    F -- Miss or expired --> H["LocalesDictionaryCache.miss(resolvedLocale)"]
    H --> I{"fallbackPromise in flight?"}
    I -- Yes --> J["await existing promise"]
    I -- No --> K["_dictionaryLoader(locale)"]
    K --> L["new DictionaryCache(init: dictionary)"]
    L --> M["setCache(locale, entry + expiresAt)"]
    M --> J
    J --> G
    G --> N["dictionaryCache.getInternalCache()"]
    N --> O["return Dictionary"]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/i18n/src/i18n-manager/translations-manager/LocalesDictionaryCache.ts`, line 32-39 ([link](https://github.com/generaltranslation/gt/blob/d61db78682f672e26cbd4bed1c68d4e2cd51436c/packages/i18n/src/i18n-manager/translations-manager/LocalesDictionaryCache.ts#L32-L39)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`DictionaryLoader` and `SafeDictionaryLoader` are identical types**

   Both are declared as `(locale: string) => Promise<Dictionary>` and the TODO comment on line 37 already acknowledges that the distinction is no longer meaningful. Keeping two names for the same type creates confusion at call sites — `createDictionaryLoader` returns a `SafeDictionaryLoader`, but `DictionaryLoader` is the public-facing exported type. The two should be unified (one type, one name) before this lands in a stable public API.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/i18n/src/i18n-manager/translations-manager/LocalesDictionaryCache.ts
   Line: 32-39

   Comment:
   **`DictionaryLoader` and `SafeDictionaryLoader` are identical types**

   Both are declared as `(locale: string) => Promise<Dictionary>` and the TODO comment on line 37 already acknowledges that the distinction is no longer meaningful. Keeping two names for the same type creates confusion at call sites — `createDictionaryLoader` returns a `SafeDictionaryLoader`, but `DictionaryLoader` is the public-facing exported type. The two should be unified (one type, one name) before this lands in a stable public API.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/i18n/src/i18n-manager/translations-manager/LocalesDictionaryCache.ts:169-183
`expiresAt` is computed from `Date.now()` before `await dictionaryPromise` resolves. For a slow loader (e.g., 20 s network round-trip on a 60 s TTL), the stored entry already has only 40 s of useful life the moment it is cached. Moving the timestamp calculation to after the await makes the TTL count from when the entry is ready, matching how `LocalesCache` handles it.

```suggestion
  protected async fallback(locale: Locale): Promise<DictionaryCacheEntry> {
    // Fetch dictionary
    const dictionary = await this._dictionaryLoader(locale);

    // Get cache expiry time (computed after load so TTL counts from when data is ready)
    const expiresAt = this.ttl < 0 ? this.ttl : Date.now() + this.ttl;

    const dictionaryCache = new DictionaryCache({
      init: dictionary,
      lifecycle: this._createDictionaryCacheLifecycle(locale),
    });

    return { dictionaryCache, expiresAt };
  }
```


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(i18n): skip dictionary loads when tr..."](https://github.com/generaltranslation/gt/commit/417ef77aa9700c16e412f14dd1fce1836e9a2a6b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30727060)</sub>

<!-- /greptile_comment -->