### PR TITLE
refactor(compiler): thread NodePath through JSX collection

### DIFF
--- a/.changeset/slow-jsx-paths.md
+++ b/.changeset/slow-jsx-paths.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/compiler': patch
+---
+
+Thread JSX collection through path-aware helpers for future derivation support.

--- a/packages/compiler/src/processing/collection/processCallExpression.ts
+++ b/packages/compiler/src/processing/collection/processCallExpression.ts
@@ -73,7 +73,7 @@ export function processCallExpression(
       );
     } else if (type === 'react' && isReactFunction(canonicalName)) {
       // Handle react variables (jsxDEV, etc.)
-      handleReactInvocation(callExpr, state);
+      handleReactInvocation(callExprPath, state);
     } else if (
       type === 'generaltranslation' &&
       canonicalName === GT_OTHER_FUNCTIONS.msg
@@ -216,9 +216,10 @@ function handleUseMessagesCallback(
  * We want to check these because they wrap <T> and other components
  */
 function handleReactInvocation(
-  callExpr: t.CallExpression,
+  callExprPath: NodePath<t.CallExpression>,
   state: TransformState
 ) {
+  const callExpr = callExprPath.node;
   // Check if it contains a GT component (first argument)
   if (callExpr.arguments.length === 0) {
     state.errorTracker.addError(
@@ -263,7 +264,7 @@ function handleReactInvocation(
 
   // Validate the arguments
   const { errors, _hash, id, context, children, maxChars, hasDeriveContext } =
-    validateTranslationComponentArgs(callExpr, canonicalName, state);
+    validateTranslationComponentArgs(callExprPath, canonicalName, state);
 
   if (errors.length > 0) {
     state.errorTracker.addErrors(errors);
@@ -284,7 +285,7 @@ function handleReactInvocation(
 
   // Debug: record hash → children mapping
   // Note: children may be undefined when autoderive filters all dynamic-content
-  // errors (the early return in _constructJsxChildren means value is never set).
+  // errors (the early return in constructJsxChildren means value is never set).
   // This is intentional — the compiler signals CLI resolution via hash=''.
   if (state.debugManifest) {
     state.debugManifest.set(hash, children ?? null);

--- a/packages/compiler/src/transform/jsx-children/__tests__/constructJsxChildren.test.ts
+++ b/packages/compiler/src/transform/jsx-children/__tests__/constructJsxChildren.test.ts
@@ -1,5 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import traverse, { type NodePath } from '@babel/traverse';
+import * as t from '@babel/types';
 import { constructJsxChildren } from '../index';
 import { TransformState } from '../../../state/types';
 import { StringCollector } from '../../../state/StringCollector';
@@ -12,6 +14,27 @@ import { ScopeTracker } from '../../../state/ScopeTracker';
 import { PluginSettings } from '../../../config';
 
 // TODO: ignore error if its just keys out of order
+
+function getExpressionPath(expr: t.Expression): NodePath<t.Expression> {
+  const ast = t.file(t.program([t.expressionStatement(expr)]));
+  let expressionPath: NodePath<t.Expression> | undefined;
+
+  traverse(ast, {
+    ExpressionStatement(path) {
+      const pathExpression = path.get('expression');
+      if (pathExpression.isExpression()) {
+        expressionPath = pathExpression;
+        path.stop();
+      }
+    },
+  });
+
+  if (!expressionPath) {
+    throw new Error('Expected expression path');
+  }
+
+  return expressionPath;
+}
 
 function isLeafDir(pathname: string): boolean {
   const statePath = path.join(pathname, 'state.json');
@@ -72,7 +95,10 @@ function createTest(dirPath: string) {
       scopeTracker.unserialize(stateSeed.state.scopeTracker);
 
       // Construct JsxChildren
-      const result = constructJsxChildren(stateSeed.children, state);
+      const result = constructJsxChildren(
+        getExpressionPath(stateSeed.children),
+        state
+      );
 
       // Assert expected output
       if (!result.value) {

--- a/packages/compiler/src/transform/jsx-children/constructJsxChildren.ts
+++ b/packages/compiler/src/transform/jsx-children/constructJsxChildren.ts
@@ -9,6 +9,7 @@ import {
 } from 'generaltranslation/types';
 import { TransformState } from '../../state/types';
 import * as t from '@babel/types';
+import type { NodePath } from '@babel/traverse';
 import { validateIdentifier } from './validation/validateIdentifier';
 import { validateTemplateLiteral } from './validation/validateTemplateLiteral';
 import { validateChildrenElement } from './validation/validateChildrenElement';
@@ -45,31 +46,38 @@ import {
 } from './errors';
 
 /**
- * Given the children of a <T> component, constructs a JsxChildren object
- * Takes an Expression
+ * Given the children of a <T> component, constructs a JsxChildren object.
+ * Takes an Expression path.
  *
- * ONLY does JsxChildren construction + validation, no further processing on any children
+ * ONLY does JsxChildren construction + validation, no further processing on any children.
  *
- * On invalid children, quit immediately
+ * On invalid children, quit immediately.
+ *
+ * The node checks intentionally happen before navigating with .get(). This
+ * keeps runtime validation behavior stable while preserving NodePath scope for
+ * future derivation work.
  */
-export function _constructJsxChildren(
-  children: t.Expression | undefined,
+export function constructJsxChildren(
+  childrenPath: NodePath<t.Expression> | undefined,
   state: TransformState,
   id: IdObject = new IdObject()
 ): { errors: JsxValidationError[]; value?: JsxChildren } {
   const errors: JsxValidationError[] = [];
 
   // Skip if no children
-  if (!children) {
-    return { errors, value: children };
+  if (!childrenPath) {
+    return { errors, value: childrenPath };
   }
 
+  const children = childrenPath.node;
   let value: JsxChildren | undefined;
   if (t.isArrayExpression(children)) {
     // Handle ArrayExpression
     value = [];
+    const elementPaths = childrenPath.get('elements');
 
-    for (const child of children.elements) {
+    for (let i = 0; i < children.elements.length; i++) {
+      const child = children.elements[i];
       // Validate child
       if (!validateChildrenElement(child)) {
         errors.push(
@@ -87,18 +95,25 @@ export function _constructJsxChildren(
       }
 
       // Construct JsxChild
-      const validation = constructJsxChild(child, state, id);
+      const childPath = elementPaths[i] as NodePath<
+        Exclude<t.Expression, t.ArrayExpression>
+      >;
+      const validation = constructJsxChild(childPath, state, id);
       errors.push(...validation.errors);
       if (errors.length > 0) {
         return { errors };
       }
       // Skip if no value
       if (validation.value === undefined) continue;
-      (value as JsxChild[]).push(validation.value!);
+      (value as JsxChild[]).push(validation.value);
     }
   } else {
     // Handle single child
-    const validation = constructJsxChild(children, state, id);
+    const validation = constructJsxChild(
+      childrenPath as NodePath<Exclude<t.Expression, t.ArrayExpression>>,
+      state,
+      id
+    );
     errors.push(...validation.errors);
     if (errors.length > 0) {
       return { errors };
@@ -110,20 +125,25 @@ export function _constructJsxChildren(
 }
 
 /**
- * Given an Expression, constructs a JsxChild
+ * Given an Expression path, constructs a JsxChild.
  * @returns { errors: string[]; value?: JsxChild }
  */
 function constructJsxChild(
-  child: Exclude<t.Expression, t.ArrayExpression>,
+  childPath: NodePath<Exclude<t.Expression, t.ArrayExpression>>,
   state: TransformState,
   id: IdObject
 ): { errors: JsxValidationError[]; value?: JsxChild } {
   const errors: JsxValidationError[] = [];
+  const child = childPath.node;
   let value: JsxChild | undefined;
 
   if (t.isCallExpression(child)) {
     // Construct JsxElement
-    const validation = constructJsxElement(child, state, id);
+    const validation = constructJsxElement(
+      childPath as NodePath<t.CallExpression>,
+      state,
+      id
+    );
     errors.push(...validation.errors);
     if (errors.length > 0) {
       return { errors };
@@ -173,15 +193,16 @@ function constructJsxChild(
 }
 
 /**
- * Given a CallExpression, constructs a JsxChild
+ * Given a CallExpression path, constructs a JsxChild.
  * Handles: Jsx(T, ...children)
  */
 function constructJsxElement(
-  callExpr: t.CallExpression,
+  callExprPath: NodePath<t.CallExpression>,
   state: TransformState,
   id: IdObject
 ): { errors: JsxValidationError[]; value?: JsxElement | Variable } {
   const errors: JsxValidationError[] = [];
+  const callExpr = callExprPath.node;
 
   // Validate that this is a jsx call
   const jsxValidation = validateJsxCall(callExpr, state);
@@ -245,8 +266,7 @@ function constructJsxElement(
     if (variableValidation.errors.length > 0) {
       return { errors };
     }
-    const variable: Variable = variableValidation.value!;
-    return { errors, value: variable };
+    return { errors, value: variableValidation.value! };
   }
 
   // Set the component name
@@ -265,7 +285,7 @@ function constructJsxElement(
       );
       return { errors };
     }
-    // Derive/Static — opaque element, skip children validation
+    // Derive/Static - opaque element, skip children validation
     // The compiler doesn't resolve Derive functions; the CLI handles that.
     if (isDeriveComponent(canonicalName)) {
       return {
@@ -286,8 +306,7 @@ function constructJsxElement(
       );
       return { errors };
     }
-
-    // Get the name of the componet
+    // Get the name of the component
     componentName =
       canonicalName === REACT_COMPONENTS.Fragment
         ? `C${id.get()}`
@@ -298,7 +317,7 @@ function constructJsxElement(
   }
 
   // Get children from args
-  const childrenValidation = validateChildrenFromArgs(callExpr.arguments);
+  const childrenValidation = validateChildrenFromArgs(callExprPath);
   if (childrenValidation.errors.length > 0) {
     errors.push(
       ...childrenValidation.errors.map((msg) => structuralError(msg))
@@ -322,7 +341,7 @@ function constructJsxElement(
 
   // Construct GT Tag
   const tagValidation = constructGTProp(
-    callExpr.arguments,
+    callExprPath,
     id,
     state,
     canonicalName,
@@ -346,14 +365,15 @@ function constructJsxElement(
 
 /**
  * Construct JsxChildren for a JsxElement
- * This is slightly different from _constructJsxChildren in how it handles nullLiteral and booleanLiteral
+ * This is slightly different from constructJsxChildren in how it handles nullLiteral and booleanLiteral
  */
 function constructJsxChildrenForJsxElement(
-  children: t.Expression | undefined,
+  childrenPath: NodePath<t.Expression> | undefined,
   state: TransformState,
   id: IdObject
 ): { errors: JsxValidationError[]; value?: JsxChildren } {
   const errors: JsxValidationError[] = [];
+  const children = childrenPath?.node;
 
   // Special children edge cases: nullLiteral, booleanLiteral
   if (t.isNullLiteral(children)) {
@@ -367,14 +387,14 @@ function constructJsxChildrenForJsxElement(
   }
 
   // Construct JsxChildren
-  return _constructJsxChildren(children, state, id);
+  return constructJsxChildren(childrenPath, state, id);
 }
 
 /**
  * Given a canonical name, constructs a GTProp
  */
 function constructGTProp(
-  args: (t.ArgumentPlaceholder | t.SpreadElement | t.Expression)[],
+  callExprPath: NodePath<t.CallExpression>,
   id: IdObject,
   state: TransformState,
   canonicalName?: string,
@@ -382,6 +402,7 @@ function constructGTProp(
 ): { errors: JsxValidationError[]; value?: GTProp } {
   const errors: JsxValidationError[] = [];
   const value: GTProp = {};
+  const args = callExprPath.node.arguments;
 
   // Validate Parameters
   if (args.length < 2) {
@@ -405,6 +426,10 @@ function constructGTProp(
   }
 
   // For Branch and Plural, get the properties
+  const parametersPath = callExprPath.get(
+    'arguments'
+  )[1] as NodePath<t.ObjectExpression>;
+
   if (
     canonicalName &&
     type === 'generaltranslation' &&
@@ -412,15 +437,14 @@ function constructGTProp(
   ) {
     // Get the branching parameters
     const branchingParameters = getBranchComponentParameters(
-      parameters,
+      parametersPath as NodePath<t.ObjectExpression>,
       canonicalName
     );
-
     // Add branch component branches
     const branches = {} as Record<string, JsxChildren>;
 
-    // Add branch component branches
-    for (const [name, parameter] of branchingParameters) {
+    for (const [name, parameterPath] of branchingParameters) {
+      const parameter = parameterPath.node;
       // Special exceptions for branches:
       if (t.isNullLiteral(parameter)) {
         branches[name] = null as unknown as JsxChildren;
@@ -431,7 +455,7 @@ function constructGTProp(
       }
 
       // Otherwise, construct the JsxChildren
-      const validation = _constructJsxChildren(parameter, state, id.copy());
+      const validation = constructJsxChildren(parameterPath, state, id.copy());
       errors.push(...validation.errors);
       if (validation.errors.length > 0) {
         return { errors };

--- a/packages/compiler/src/transform/jsx-children/index.ts
+++ b/packages/compiler/src/transform/jsx-children/index.ts
@@ -1,1 +1,1 @@
-export { _constructJsxChildren as constructJsxChildren } from './constructJsxChildren';
+export { constructJsxChildren } from './constructJsxChildren';

--- a/packages/compiler/src/transform/jsx-children/utils/__tests__/getBranchComponentParameters.test.ts
+++ b/packages/compiler/src/transform/jsx-children/utils/__tests__/getBranchComponentParameters.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import traverse, { type NodePath } from '@babel/traverse';
 import * as t from '@babel/types';
 import { getBranchComponentParameters } from '../getBranchComponentParameters';
 import { GT_COMPONENT_TYPES } from '../../../../utils/constants/gt/constants';
@@ -12,6 +13,28 @@ function makeObjectExpression(
   return t.objectExpression(properties);
 }
 
+function getObjectExpressionPath(
+  expression: t.ObjectExpression
+): NodePath<t.ObjectExpression> {
+  const ast = t.file(t.program([t.expressionStatement(expression)]));
+  let expressionPath: NodePath<t.ObjectExpression> | undefined;
+
+  traverse(ast, {
+    ObjectExpression(path) {
+      if (path.node === expression) {
+        expressionPath = path;
+        path.stop();
+      }
+    },
+  });
+
+  if (!expressionPath) {
+    throw new Error('Expected object expression path');
+  }
+
+  return expressionPath;
+}
+
 describe('getBranchComponentParameters', () => {
   it('should filter out branch and data-* attributes for Branch components', () => {
     const expression = makeObjectExpression({
@@ -23,12 +46,15 @@ describe('getBranchComponentParameters', () => {
     });
 
     const result = getBranchComponentParameters(
-      expression,
+      getObjectExpressionPath(expression),
       GT_COMPONENT_TYPES.Branch
     );
 
     const keys = result.map(([key]) => key);
     expect(keys).toEqual(['morning', 'evening']);
+    expect(result.every(([, valuePath]) => valuePath.isExpression())).toBe(
+      true
+    );
   });
 
   it('should filter data-* attributes for Plural components', () => {
@@ -41,7 +67,7 @@ describe('getBranchComponentParameters', () => {
     });
 
     const result = getBranchComponentParameters(
-      expression,
+      getObjectExpressionPath(expression),
       GT_COMPONENT_TYPES.Plural
     );
 
@@ -56,7 +82,7 @@ describe('getBranchComponentParameters', () => {
     });
 
     const result = getBranchComponentParameters(
-      expression,
+      getObjectExpressionPath(expression),
       GT_COMPONENT_TYPES.Branch
     );
 

--- a/packages/compiler/src/transform/jsx-children/utils/getBranchComponentParameters.ts
+++ b/packages/compiler/src/transform/jsx-children/utils/getBranchComponentParameters.ts
@@ -1,24 +1,30 @@
 import * as t from '@babel/types';
+import type { NodePath } from '@babel/traverse';
 import {
   BRANCH_CONTROL_PROPS,
   GT_COMPONENT_TYPES,
   PLURAL_FORMS,
 } from '../../../utils/constants/gt/constants';
+
 /**
- * Given object expression, get the branch component args
+ * Given an object expression path, get branch component argument paths.
  */
 export function getBranchComponentParameters(
-  parameters: t.ObjectExpression,
+  parametersPath: NodePath<t.ObjectExpression>,
   canonicalName: string
-): [string, t.Expression][] {
+): [string, NodePath<t.Expression>][] {
   // Get the args
-  const args = parameters.properties
-    .map((property) => {
+  return parametersPath
+    .get('properties')
+    .map((propertyPath) => {
       // filter out non expression values
-      if (!t.isObjectProperty(property)) {
+      if (!propertyPath.isObjectProperty()) {
         return null;
       }
-      if (!t.isExpression(property.value)) {
+      const property = propertyPath.node;
+
+      const valuePath = propertyPath.get('value');
+      if (!valuePath.isExpression()) {
         return null;
       }
 
@@ -58,8 +64,7 @@ export function getBranchComponentParameters(
         return null;
       }
 
-      return [propertyName, property.value];
+      return [propertyName, valuePath as NodePath<t.Expression>];
     })
-    .filter((arg) => arg !== null) as [string, t.Expression][];
-  return args;
+    .filter((arg) => arg !== null) as [string, NodePath<t.Expression>][];
 }

--- a/packages/compiler/src/transform/jsx-children/validation/validateChildrenFromArgs.ts
+++ b/packages/compiler/src/transform/jsx-children/validation/validateChildrenFromArgs.ts
@@ -1,17 +1,19 @@
+import type { NodePath } from '@babel/traverse';
 import * as t from '@babel/types';
 import { validateChildrenPropertyFromObjectExpression } from '../../../utils/validation/validateChildrenFromObjectExpression';
 import { createErrorLocation } from '../../../utils/errors';
 
 /**
- * Given (t.ArgumentPlaceholder | t.SpreadElement | t.Expression)[] extracts children and validates
+ * Given a CallExpression path, extracts children and validates them.
  */
 export function validateChildrenFromArgs(
-  args: (t.ArgumentPlaceholder | t.SpreadElement | t.Expression)[]
+  callExprPath: NodePath<t.CallExpression>
 ): {
   errors: string[];
-  value?: t.Expression;
+  value?: NodePath<t.Expression>;
 } {
   const errors: string[] = [];
+  const args = callExprPath.node.arguments;
 
   if (args.length < 2) {
     errors.push(
@@ -28,5 +30,17 @@ export function validateChildrenFromArgs(
     return { errors };
   }
 
-  return validateChildrenPropertyFromObjectExpression(args[1]);
+  const argsPath = callExprPath.get('arguments')[1];
+  if (!argsPath?.isObjectExpression()) {
+    return {
+      errors: [
+        `Failed to construct JsxElement! Parameter field must be an object expression` +
+          createErrorLocation(args[1]),
+      ],
+    };
+  }
+
+  return validateChildrenPropertyFromObjectExpression(
+    argsPath as NodePath<t.ObjectExpression>
+  );
 }

--- a/packages/compiler/src/transform/validation/validateTranslationComponentArgs.ts
+++ b/packages/compiler/src/transform/validation/validateTranslationComponentArgs.ts
@@ -1,6 +1,7 @@
 import { TransformState } from '../../state/types';
 import { GT_COMPONENT_TYPES } from '../../utils/constants/gt/constants';
 import * as t from '@babel/types';
+import type { NodePath } from '@babel/traverse';
 import { getObjectPropertyFromObjectExpression } from '../../utils/parsing/getObjectPropertyFromObjectExpression';
 import { validateExpressionIsStringLiteral } from '../../utils/validation/validateExpressionIsStringLiteral';
 import { JsxChildren } from 'generaltranslation/types';
@@ -13,7 +14,7 @@ import { JsxValidationError } from '../jsx-children/errors';
  * Given a translation component, validate the arguments
  */
 export function validateTranslationComponentArgs(
-  callExpr: t.CallExpression,
+  callExprPath: NodePath<t.CallExpression>,
   canonicalName: string,
   state: TransformState
 ): {
@@ -25,6 +26,7 @@ export function validateTranslationComponentArgs(
   children?: JsxChildren;
   hasDeriveContext?: boolean;
 } {
+  const callExpr = callExprPath.node;
   // Check that there are at least 2 arguments (identifier, args)
   if (callExpr.arguments.length < 2) {
     const errors = [
@@ -41,12 +43,22 @@ export function validateTranslationComponentArgs(
     ];
     return { errors };
   }
+  const argsPath = callExprPath.get('arguments')[1];
+  if (!argsPath?.isObjectExpression()) {
+    const errors = [
+      'Translation component must have an object expression as the second argument',
+    ];
+    return { errors };
+  }
 
   // Map to appropriate validation function
   switch (canonicalName) {
     case GT_COMPONENT_TYPES.T:
     case GT_COMPONENT_TYPES.GtInternalTranslateJsx:
-      return validateTComponentArgs(args, state);
+      return validateTComponentArgs(
+        argsPath as NodePath<t.ObjectExpression>,
+        state
+      );
     default:
       const errors = [
         `Invalid translation component: ${canonicalName}. You likely passed a non-translation component to validateTranslationComponentArgs`,
@@ -60,7 +72,7 @@ export function validateTranslationComponentArgs(
 /* =============================== */
 
 function validateTComponentArgs(
-  args: t.ObjectExpression,
+  argsPath: NodePath<t.ObjectExpression>,
   state: TransformState
 ): {
   errors: string[];
@@ -72,6 +84,7 @@ function validateTComponentArgs(
   hasDeriveContext?: boolean;
 } {
   const errors: string[] = [];
+  const args = argsPath.node;
 
   // Validate id
   const idValidation = validateStringProperty(args, 'id');
@@ -93,7 +106,7 @@ function validateTComponentArgs(
   const _hash = hashValidation.value;
 
   // Validate children
-  const childrenValidation = validateChildrenProperty(args, state);
+  const childrenValidation = validateChildrenProperty(argsPath, state);
   errors.push(...childrenValidation.errors);
   const children = childrenValidation.value;
 
@@ -107,7 +120,7 @@ function validateTComponentArgs(
  * Validate that the children property is a string literal
  */
 export function validateChildrenProperty(
-  args: t.ObjectExpression,
+  argsPath: NodePath<t.ObjectExpression>,
   state: TransformState
 ): {
   errors: string[];
@@ -117,7 +130,8 @@ export function validateChildrenProperty(
   const errors: string[] = [];
 
   // Get the children property
-  const childrenValidation = validateChildrenPropertyFromObjectExpression(args);
+  const childrenValidation =
+    validateChildrenPropertyFromObjectExpression(argsPath);
   if (childrenValidation.errors.length > 0) {
     errors.push(...childrenValidation.errors);
     return { errors };

--- a/packages/compiler/src/utils/parsing/getObjectPropertyFromObjectExpression.ts
+++ b/packages/compiler/src/utils/parsing/getObjectPropertyFromObjectExpression.ts
@@ -1,4 +1,22 @@
+import type { NodePath } from '@babel/traverse';
 import * as t from '@babel/types';
+
+function objectPropertyMatchesName(
+  property: t.ObjectExpression['properties'][0],
+  name: string
+): boolean {
+  if (t.isSpreadElement(property)) {
+    return false;
+  }
+  if (t.isIdentifier(property.key) && property.key.name === name) {
+    return true;
+  }
+  if (t.isStringLiteral(property.key) && property.key.value === name) {
+    return true;
+  }
+  return false;
+}
+
 /**
  * Given an expression, return the object property
  */
@@ -6,16 +24,21 @@ export function getObjectPropertyFromObjectExpression(
   objExpr: t.ObjectExpression,
   name: string
 ): t.ObjectExpression['properties'][0] | undefined {
-  return objExpr.properties.find((property) => {
-    if (t.isSpreadElement(property)) {
-      return false;
-    }
-    if (t.isIdentifier(property.key) && property.key.name === name) {
-      return true;
-    }
-    if (t.isStringLiteral(property.key) && property.key.value === name) {
-      return true;
-    }
-    return false;
-  });
+  return objExpr.properties.find((property) =>
+    objectPropertyMatchesName(property, name)
+  );
+}
+
+/**
+ * Given an expression path, return the object property path
+ */
+export function getObjectPropertyPathFromObjectExpression(
+  objExprPath: NodePath<t.ObjectExpression>,
+  name: string
+): NodePath<t.ObjectExpression['properties'][0]> | undefined {
+  return objExprPath
+    .get('properties')
+    .find((propertyPath) =>
+      objectPropertyMatchesName(propertyPath.node, name)
+    ) as NodePath<t.ObjectExpression['properties'][0]> | undefined;
 }

--- a/packages/compiler/src/utils/validation/validateChildrenFromObjectExpression.ts
+++ b/packages/compiler/src/utils/validation/validateChildrenFromObjectExpression.ts
@@ -1,39 +1,42 @@
 import * as t from '@babel/types';
+import type { NodePath } from '@babel/traverse';
 import { GT_COMPONENT_TYPES } from '../constants/gt/constants';
-import { getObjectPropertyFromObjectExpression } from '../parsing/getObjectPropertyFromObjectExpression';
+import { getObjectPropertyPathFromObjectExpression } from '../parsing/getObjectPropertyFromObjectExpression';
 
 /**
- * Given an object expression validates and extracts children property
+ * Given an object expression path validates and extracts children property
  * This is only for use as children of <T> components
  */
 export function validateChildrenPropertyFromObjectExpression(
-  args: t.ObjectExpression
+  argsPath: NodePath<t.ObjectExpression>
 ): {
   errors: string[];
-  value?: t.Expression;
+  value?: NodePath<t.Expression>;
 } {
   const errors: string[] = [];
 
   // Get the children property
-  const childrenObjectProperty = getObjectPropertyFromObjectExpression(
-    args,
+  const childrenObjectPropertyPath = getObjectPropertyPathFromObjectExpression(
+    argsPath,
     'children'
   );
-  if (!childrenObjectProperty) {
+  if (!childrenObjectPropertyPath) {
     return { errors, value: undefined };
   }
-  if (!t.isObjectProperty(childrenObjectProperty)) {
+  if (!childrenObjectPropertyPath.isObjectProperty()) {
     errors.push(
       `The children property of the <${GT_COMPONENT_TYPES.T}> component must be an object property`
     );
     return { errors };
   }
-  if (!t.isExpression(childrenObjectProperty.value)) {
+
+  const valuePath = childrenObjectPropertyPath.get('value');
+  if (!valuePath.isExpression()) {
     errors.push(
       `The children properties of the <${GT_COMPONENT_TYPES.T}> component must be an expression`
     );
     return { errors };
   }
 
-  return { errors, value: childrenObjectProperty.value };
+  return { errors, value: valuePath as NodePath<t.Expression> };
 }


### PR DESCRIPTION
## Summary
- pass React JSX collection calls through as NodePath values
- retrofit the existing JSX children extraction helpers to use NodePath, with a small fixture-test adapter for serialized AST nodes
- add path-aware object/children/Branch parameter helpers and a patch changeset for @generaltranslation/compiler

## Tests
- PATH=/opt/homebrew/bin:$PATH node_modules/.bin/tsc -p packages/compiler/tsconfig.json --noEmit
- PATH=/opt/homebrew/bin:$PATH node_modules/.bin/vitest run packages/compiler/src
- PATH=/opt/homebrew/bin:$PATH node_modules/.bin/prettier --check .changeset/slow-jsx-paths.md packages/compiler/src/processing/collection/processCallExpression.ts packages/compiler/src/transform/validation/validateTranslationComponentArgs.ts packages/compiler/src/transform/jsx-children/constructJsxChildren.ts packages/compiler/src/transform/jsx-children/index.ts packages/compiler/src/utils/validation/validateChildrenFromObjectExpression.ts packages/compiler/src/utils/parsing/getObjectPropertyFromObjectExpression.ts packages/compiler/src/transform/jsx-children/utils/getBranchComponentParameters.ts packages/compiler/src/transform/jsx-children/__tests__/constructJsxChildren.test.ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This refactor threads `NodePath<T>` values through the JSX collection pipeline — replacing raw AST node arguments in `constructJsxChildren`, `validateChildrenFromArgs`, `validateTranslationComponentArgs`, `getBranchComponentParameters`, and their helpers — so that future derivation work has access to full Babel scope/path information. A small `getExpressionPath` / `getObjectExpressionPath` adapter is added to the fixture tests to wrap serialised AST nodes into real `NodePath` instances, keeping existing snapshot tests working without change.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the only finding is a pre-existing dead-code pattern that carries no runtime risk.

All changes are mechanical node→NodePath substitutions with consistent .node extraction at each entry point. The single P2 comment identifies dead code (a redundant isObjectExpression guard) that cannot cause incorrect behaviour. No P0 or P1 issues found.

packages/compiler/src/transform/jsx-children/validation/validateChildrenFromArgs.ts — redundant double-check.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/compiler/src/processing/collection/processCallExpression.ts | Passes callExprPath instead of callExpr to handleReactInvocation and validateTranslationComponentArgs; change is mechanical and correct. |
| packages/compiler/src/transform/jsx-children/constructJsxChildren.ts | Full NodePath threading through constructJsxChildren/constructJsxChild/constructJsxElement/constructGTProp; node extraction via .node at each entry point is consistent, and element path indexing mirrors the elements array correctly. |
| packages/compiler/src/transform/jsx-children/validation/validateChildrenFromArgs.ts | Returns a NodePath instead of a raw node; contains a redundant isObjectExpression node+path double-check (dead-code second guard). |
| packages/compiler/src/transform/validation/validateTranslationComponentArgs.ts | Accepts NodePath<CallExpression> and threads argsPath into validateTComponentArgs; contains a redundant node+path double-check (previously flagged). |
| packages/compiler/src/transform/jsx-children/utils/getBranchComponentParameters.ts | Refactored to use propertyPath.get('value') and return NodePath<Expression> pairs; logic is equivalent to original and well-tested. |
| packages/compiler/src/utils/validation/validateChildrenFromObjectExpression.ts | Switches from raw node to NodePath-based lookup via getObjectPropertyPathFromObjectExpression; logic is correct. |
| packages/compiler/src/utils/parsing/getObjectPropertyFromObjectExpression.ts | Adds getObjectPropertyPathFromObjectExpression alongside the existing node-based helper; shared objectPropertyMatchesName predicate is clean. |
| packages/compiler/src/transform/jsx-children/__tests__/constructJsxChildren.test.ts | Adds getExpressionPath adapter to wrap serialised AST nodes in a real NodePath for fixture tests; implementation is correct. |
| packages/compiler/src/transform/jsx-children/utils/__tests__/getBranchComponentParameters.test.ts | Adds getObjectExpressionPath adapter and a new assertion that returned values are Expression paths; tests are thorough. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["processCallExpression\n(callExprPath: NodePath<CallExpression>)"]
    A -->|react fn| B["handleReactInvocation\n(callExprPath)"]
    B --> C["validateTranslationComponentArgs\n(callExprPath)"]
    C --> D["validateTComponentArgs\n(argsPath: NodePath<ObjectExpression>)"]
    D --> E["validateChildrenProperty\n(argsPath)"]
    E --> F["validateChildrenPropertyFromObjectExpression\n(argsPath)"]
    F --> G["getObjectPropertyPathFromObjectExpression\n-> NodePath<ObjectProperty>"]
    G --> H["valuePath: NodePath<Expression>"]
    H --> I["constructJsxChildren\n(childrenPath: NodePath<Expression>)"]
    I -->|ArrayExpression| J["constructJsxChild\n(elementPath[i])"]
    I -->|single| J
    J -->|CallExpression| K["constructJsxElement\n(callExprPath)"]
    K --> L["validateChildrenFromArgs\n(callExprPath)"]
    K --> M["constructGTProp\n(callExprPath)"]
    M --> N["getBranchComponentParameters\n(parametersPath: NodePath<ObjectExpression>)\n-> [string, NodePath<Expression>][]"]
    N --> I
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/compiler/src/transform/jsx-children/validation/validateChildrenFromArgs.ts:25-41
**Redundant double-check mirrors already-noted pattern**

`t.isObjectExpression(args[1])` (the node check on line 25) and `argsPath?.isObjectExpression()` (the path check on line 34) guard the identical condition. Once the node check on line 25 passes, `argsPath` is guaranteed to wrap that same `ObjectExpression` node, so the second branch at lines 33–40 is dead code. The same pattern was flagged in `validateTranslationComponentArgs` and `constructGTPropFromPath`; this file has the same issue.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["refactor(compiler): thread NodePath thro..."](https://github.com/generaltranslation/gt/commit/675cde5b4f3d354e8fa92bda7f446c28d311d6a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30749945)</sub>

<!-- /greptile_comment -->