### PR TITLE
ci: remove gtx-cli binary job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,82 +205,6 @@ jobs:
         shell: bash
         run: cd tests/apps/cli-test-app && pnpm install && pnpm gt --help
 
-  test-gtx-cli-binaries:
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-            arch: x64
-            binary: gtx-cli-linux-x64
-          - os: ubuntu-latest
-            arch: arm64
-            binary: gtx-cli-linux-arm64
-          - os: macos-latest
-            arch: x64
-            binary: gtx-cli-darwin-x64
-          - os: macos-latest
-            arch: arm64
-            binary: gtx-cli-darwin-arm64
-          - os: windows-latest
-            arch: x64
-            binary: gtx-cli-win32-x64.exe
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Check if gtx-cli wrapper or CLI dependency changed
-        id: gtx_cli_changed
-        shell: bash
-        run: |
-          if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -qE "^packages/(cli|gtx-cli|python-extractor)/"; then
-            echo "changed=true" >> $GITHUB_OUTPUT
-          else
-            echo "changed=false" >> $GITHUB_OUTPUT
-          fi
-
-      - uses: pnpm/action-setup@v4
-        if: steps.gtx_cli_changed.outputs.changed == 'true'
-        name: Install pnpm
-
-      - name: Setup Node.js
-        if: steps.gtx_cli_changed.outputs.changed == 'true'
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: 'pnpm'
-
-      - name: Setup Bun
-        if: steps.gtx_cli_changed.outputs.changed == 'true'
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Setup Rust
-        if: steps.gtx_cli_changed.outputs.changed == 'true'
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-wasip1
-
-      - name: Install dependencies
-        if: steps.gtx_cli_changed.outputs.changed == 'true'
-        run: pnpm install
-
-      - name: Build packages
-        if: steps.gtx_cli_changed.outputs.changed == 'true'
-        run: pnpm exec turbo build --filter='gtx-cli...'
-
-      - name: Build gtx-cli binaries
-        if: steps.gtx_cli_changed.outputs.changed == 'true'
-        run: cd packages/gtx-cli && pnpm run build:bin:clean
-
-      - name: Test gtx-cli in test environment
-        if: steps.gtx_cli_changed.outputs.changed == 'true'
-        shell: bash
-        run: cd tests/apps/cli-test-app && pnpm install && pnpm gtx-cli --help
-
   size:
     runs-on: ubuntu-latest
     steps:
@@ -311,7 +235,7 @@ jobs:
         run: pnpm size
 
   run-tests:
-    needs: [lint, tests, test-builds, test-cli-binaries, test-gtx-cli-binaries, size]
+    needs: [lint, tests, test-builds, test-cli-binaries, size]
     runs-on: ubuntu-latest
     steps:
       - run: echo "All tests passed"


### PR DESCRIPTION
## Summary
- remove the dedicated gtx-cli binary CI matrix
- keep the gt binary job as the CLI binary coverage path
- update the aggregate run-tests dependencies

## Validation
- git diff --check -- .github/workflows/ci.yml
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'yaml ok'"

Note: pnpm exec prettier --check .github/workflows/ci.yml could not run locally because prettier was not available through pnpm exec in this workspace.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the `test-gtx-cli-binaries` CI matrix job (which built and smoke-tested the `gtx-cli` binary across 5 OS/arch targets) and drops it from the `run-tests` aggregator's `needs` list. Unit tests for `packages/gtx-cli` still execute through the `tests` job via the turbo `--filter='...[origin/${{ github.base_ref }}]'` filter, so package-level coverage is preserved; only the binary build verification is intentionally dropped.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — clean removal of a CI job with no logic or runtime impact.

Single YAML change that removes a job and updates its downstream dependency; the diff is minimal, the `needs` array is correctly updated, and the remaining jobs are unaffected.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Removes the `test-gtx-cli-binaries` matrix job (5 OS/arch combos) and drops it from the `run-tests` needs list; unit tests for `packages/gtx-cli` still run through the `tests` job via turbo. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    lint --> run-tests
    tests --> run-tests
    test-builds --> run-tests
    test-cli-binaries --> run-tests
    size --> run-tests

    subgraph removed [Removed]
        test-gtx-cli-binaries
    end

    style removed fill:#ffcccc,stroke:#cc0000,color:#000
```
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: remove gtx-cli binary job"](https://github.com/generaltranslation/gt/commit/bf28134e4c176604cf8c6adf6fa7c0a4f3c7f709) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30779081)</sub>

<!-- /greptile_comment -->