### PR TITLE
chore: simplify oxlint config

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -4,42 +4,16 @@
     "correctness": "off"
   },
   "env": {
-    "builtin": true
+    "builtin": true,
+    "node": true,
+    "commonjs": true
   },
   "globals": {
-    "console": "readonly",
-    "process": "readonly",
-    "Buffer": "readonly",
-    "__dirname": "readonly",
-    "__filename": "readonly",
-    "global": "readonly",
-    "module": "readonly",
-    "require": "readonly",
-    "exports": "readonly",
-    "fetch": "readonly",
-    "Headers": "readonly",
-    "Request": "readonly",
     "RequestInit": "readonly",
-    "Response": "readonly",
-    "URL": "readonly",
-    "URLSearchParams": "readonly",
-    "AbortController": "readonly",
-    "AbortSignal": "readonly",
-    "TextDecoder": "readonly",
-    "TextEncoder": "readonly",
-    "atob": "readonly",
-    "btoa": "readonly",
-    "clearInterval": "readonly",
-    "clearTimeout": "readonly",
     "document": "readonly",
-    "localStorage": "readonly",
-    "navigator": "readonly",
+    "window": "readonly",
     "NodeJS": "readonly",
     "React": "readonly",
-    "setInterval": "readonly",
-    "setTimeout": "readonly",
-    "structuredClone": "readonly",
-    "window": "readonly",
     "__DEV__": "readonly"
   },
   "ignorePatterns": [
@@ -68,16 +42,8 @@
   "overrides": [
     {
       "files": ["**/*.test.{js,ts,tsx}", "**/*.spec.{js,ts,tsx}"],
-      "globals": {
-        "describe": "readonly",
-        "it": "readonly",
-        "expect": "readonly",
-        "beforeEach": "readonly",
-        "afterEach": "readonly",
-        "beforeAll": "readonly",
-        "afterAll": "readonly",
-        "vi": "readonly",
-        "test": "readonly"
+      "env": {
+        "vitest": true
       }
     },
     {
@@ -120,7 +86,7 @@
     },
     {
       "files": ["packages/locadex/**/*.{ts,tsx}"],
-      "plugins": ["unicorn", "typescript", "oxc", "import"],
+      "plugins": ["import"],
       "rules": {
         "import/extensions": [
           "error",


### PR DESCRIPTION
## Summary

- now based directly on `main` after #1334 was merged
- replace redundant Node/CommonJS globals with oxlint `node` and `commonjs` environments
- replace test-only globals with the oxlint `vitest` environment override
- stop repeating default oxlint plugins in the locadex `import/extensions` override

## Validation

- `pnpm lint` passes with the existing warning set
- targeted locadex missing-extension import is rejected by `import/extensions` with only `plugins: ["import"]`
- targeted vitest globals check passes with the `vitest` env override
- targeted invalid `gt-i18n/fallbacks` import inside `packages/react/src/i18n-context` is still rejected
- `git diff --check`

## Stack

- Previously stacked on #1334, which has now merged into `main`
- Root migration PR: #1332
