### PR TITLE
chore(next): add anonymous dev server telemetry

### DIFF
--- a/.changeset/anonymous-next-dev-telemetry.md
+++ b/.changeset/anonymous-next-dev-telemetry.md
@@ -1,5 +1,5 @@
 ---
-'gt-next': minor
+'gt-next': patch
 ---
 
 Add anonymous Next.js dev server telemetry for gt-next plugin usage.

--- a/.changeset/anonymous-next-dev-telemetry.md
+++ b/.changeset/anonymous-next-dev-telemetry.md
@@ -1,0 +1,5 @@
+---
+'gt-next': minor
+---
+
+Add anonymous Next.js dev server telemetry for gt-next plugin usage.

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -20,6 +20,7 @@
     "@generaltranslation/supported-locales": "workspace:*",
     "@generaltranslation/compiler": "workspace:*",
     "@generaltranslation/next-internal": "workspace:*",
+    "conf": "5.0.0",
     "generaltranslation": "workspace:*",
     "gt-react": "workspace:*",
     "gt-i18n": "workspace:*"

--- a/packages/next/src/__tests__/config.test.ts
+++ b/packages/next/src/__tests__/config.test.ts
@@ -18,6 +18,10 @@ vi.mock('../plugin/getStableNextVersionInfo', () => ({
   babelPluginCompatible: true,
 }));
 
+vi.mock('../telemetry/nextDevTelemetry', () => ({
+  recordNextDevTelemetry: vi.fn(),
+}));
+
 // ---- Helpers ---- //
 
 function parseConfigParams(result: NextConfig) {
@@ -1214,6 +1218,44 @@ describe('withGTConfig', () => {
 
       expect(wc.cache).toBe(false);
     });
+
+    it('records anonymous dev telemetry only for webpack dev', async () => {
+      const withGTConfig = await getWithGTConfig();
+      const { recordNextDevTelemetry } = await import(
+        '../telemetry/nextDevTelemetry'
+      );
+
+      const result = withGTConfig(
+        {},
+        {
+          devServerTelemetryUrl:
+            'https://api.example.com/v2/telemetry/next-dev',
+        }
+      );
+
+      result.webpack!(
+        makeWebpackConfig() as any,
+        { ...makeWebpackOptions(), dev: false } as any
+      );
+      expect(recordNextDevTelemetry).not.toHaveBeenCalled();
+
+      result.webpack!(
+        makeWebpackConfig() as any,
+        { ...makeWebpackOptions(), dev: true } as any
+      );
+
+      expect(recordNextDevTelemetry).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bundler: 'webpack',
+          gtServicesEnabled: false,
+          localDictionary: false,
+          localTranslations: false,
+        })
+      );
+      expect(
+        vi.mocked(recordNextDevTelemetry).mock.calls[0][0].config
+      ).not.toHaveProperty('projectId');
+    });
   });
 
   // ==============================
@@ -1253,6 +1295,29 @@ describe('withGTConfig', () => {
       expect(result.turbopack!.resolveAlias).toHaveProperty(
         'gt-next/_dictionary'
       );
+    });
+
+    it('records anonymous dev telemetry for turbopack development config', async () => {
+      const withGTConfig = await getWithGTConfig();
+      const { recordNextDevTelemetry } = await import(
+        '../telemetry/nextDevTelemetry'
+      );
+      process.env.TURBOPACK = '1';
+      process.env.NODE_ENV = 'development';
+
+      withGTConfig();
+
+      expect(recordNextDevTelemetry).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bundler: 'turbopack',
+          gtServicesEnabled: false,
+          localDictionary: false,
+          localTranslations: false,
+        })
+      );
+      expect(
+        vi.mocked(recordNextDevTelemetry).mock.calls[0][0].config
+      ).not.toHaveProperty('projectId');
     });
   });
 

--- a/packages/next/src/config-dir/props/defaultWithGTConfigProps.ts
+++ b/packages/next/src/config-dir/props/defaultWithGTConfigProps.ts
@@ -1,5 +1,6 @@
 import {
   libraryDefaultLocale,
+  defaultBaseUrl,
   defaultCacheUrl,
   defaultRuntimeApiUrl,
 } from 'generaltranslation/internal';
@@ -21,6 +22,8 @@ type DefaultGTConfigProps = {
   config: string;
   runtimeUrl: string;
   cacheUrl: string;
+  devServerTelemetry: boolean;
+  devServerTelemetryUrl: string;
   defaultLocale: string;
   getLocale: () => Promise<string>;
   locales: string[];
@@ -51,6 +54,8 @@ export const defaultWithGTConfigProps: DefaultGTConfigProps = {
   config: './gt.config.json',
   runtimeUrl: defaultRuntimeApiUrl,
   cacheUrl: defaultCacheUrl,
+  devServerTelemetry: true,
+  devServerTelemetryUrl: `${defaultBaseUrl}/v2/telemetry/next-dev`,
   defaultLocale: libraryDefaultLocale,
   getLocale: async () => libraryDefaultLocale,
   locales: [] as string[],

--- a/packages/next/src/config-dir/props/withGTConfigProps.ts
+++ b/packages/next/src/config-dir/props/withGTConfigProps.ts
@@ -57,6 +57,8 @@ export type withGTConfigProps = {
   runtimeUrl?: string | null;
   cacheUrl?: string | null;
   cacheExpiryTime?: number;
+  devServerTelemetry?: boolean;
+  devServerTelemetryUrl?: string | null;
   // Locale info
   locales?: string[];
   defaultLocale?: string;

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -38,6 +38,7 @@ import {
 import { resolveConfigFilepath } from './config-dir/utils/resolveConfigFilepath';
 import { ssgChecks } from './plugin/checks/ssgChecks';
 import { cacheComponentsChecks } from './plugin/checks/cacheComponentsChecks';
+import { recordNextDevTelemetry } from './telemetry/nextDevTelemetry';
 
 /**
  * Initializes General Translation settings for a Next.js application.
@@ -574,6 +575,29 @@ export function withGTConfig(
     (!nextConfig.experimental?.turbo || nextConfig.turbopack?.resolveAlias)
   );
 
+  const telemetryConfig = {
+    devServerTelemetry: mergedConfig.devServerTelemetry,
+    devServerTelemetryUrl: mergedConfig.devServerTelemetryUrl,
+    experimentalCompilerOptions: mergedConfig.experimentalCompilerOptions,
+    experimentalEnableSSG: mergedConfig.experimentalEnableSSG,
+    experimentalLocaleResolution: mergedConfig.experimentalLocaleResolution,
+  };
+
+  const recordDevTelemetry = (bundler: 'webpack' | 'turbopack') => {
+    recordNextDevTelemetry({
+      config: telemetryConfig,
+      bundler,
+      distDir: nextConfig.distDir,
+      gtServicesEnabled,
+      localDictionary: !!customLoadDictionaryPath,
+      localTranslations: !!customLoadTranslationsPath,
+    });
+  };
+
+  if (turboPackEnabled && process.env.NODE_ENV === 'development') {
+    recordDevTelemetry('turbopack');
+  }
+
   const config: NextConfig = {
     ...nextConfig,
     env: {
@@ -654,6 +678,10 @@ export function withGTConfig(
         NonNullable<NextConfig['webpack']>
       >
     ) {
+      if (options.dev) {
+        recordDevTelemetry('webpack');
+      }
+
       // Only apply webpack aliases if we're using webpack (not Turbopack)
       if (!turboPackEnabled) {
         // Try to load GT compiler if available

--- a/packages/next/src/telemetry/__tests__/nextDevTelemetry.test.ts
+++ b/packages/next/src/telemetry/__tests__/nextDevTelemetry.test.ts
@@ -181,14 +181,14 @@ describe('next dev telemetry', () => {
       storageOptions: { store: createStore() },
     };
 
-    process.env.NEXT_TELEMETRY_DISABLED = '1';
+    process.env.NEXT_TELEMETRY_DISABLED = 'yes';
     recordNextDevTelemetry(baseOptions);
     await flushPromises();
     expect(fetchMock).not.toHaveBeenCalled();
 
     resetNextDevTelemetryForTests();
     delete process.env.NEXT_TELEMETRY_DISABLED;
-    process.env.GT_TELEMETRY_DISABLED = '1';
+    process.env.GT_TELEMETRY_DISABLED = 'on';
     recordNextDevTelemetry(baseOptions);
     await flushPromises();
     expect(fetchMock).not.toHaveBeenCalled();

--- a/packages/next/src/telemetry/__tests__/nextDevTelemetry.test.ts
+++ b/packages/next/src/telemetry/__tests__/nextDevTelemetry.test.ts
@@ -195,7 +195,7 @@ describe('next dev telemetry', () => {
 
     resetNextDevTelemetryForTests();
     delete process.env.GT_TELEMETRY_DISABLED;
-    process.env.DO_NOT_TRACK = 'true';
+    process.env.DO_NOT_TRACK = 'yes';
     recordNextDevTelemetry(baseOptions);
     await flushPromises();
     expect(fetchMock).not.toHaveBeenCalled();

--- a/packages/next/src/telemetry/__tests__/nextDevTelemetry.test.ts
+++ b/packages/next/src/telemetry/__tests__/nextDevTelemetry.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const execMock = vi.hoisted(() => vi.fn());
+
+vi.mock('child_process', () => ({
+  exec: execMock,
+}));
+
+type StoreData = Record<string, unknown>;
+
+function createStore(initial: StoreData = {}) {
+  const data = { ...initial };
+  return {
+    data,
+    get: vi.fn((key: string) => data[key]),
+    set: vi.fn((key: string, value: unknown) => {
+      data[key] = value;
+    }),
+  };
+}
+
+async function flushPromises() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('next dev telemetry', () => {
+  let savedEnv: NodeJS.ProcessEnv;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    savedEnv = { ...process.env };
+    process.env.NODE_ENV = 'development';
+    delete process.env.CI;
+    delete process.env.NEXT_TELEMETRY_DISABLED;
+    delete process.env.GT_TELEMETRY_DISABLED;
+    delete process.env.DO_NOT_TRACK;
+    delete process.env.NEXT_TELEMETRY_DEBUG;
+    delete process.env.GT_TELEMETRY_DEBUG;
+    delete process.env.REPOSITORY_URL;
+
+    execMock.mockReset();
+    execMock.mockImplementation(
+      (
+        _command: string,
+        _options: unknown,
+        callback: (error: Error | null, stdout: string) => void
+      ) => callback(null, 'git@github.com:org/repo.git\n')
+    );
+
+    fetchMock = vi.fn(() => Promise.resolve({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const telemetry = await import('../nextDevTelemetry');
+    telemetry.resetNextDevTelemetryForTests();
+  });
+
+  afterEach(() => {
+    process.env = savedEnv;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('persists anonymous ID and salt in the configured store', async () => {
+    const { TelemetryStorage } = await import('../storage');
+    const store = createStore();
+    const storage = new TelemetryStorage({ store });
+
+    const anonymousId = storage.anonymousId;
+    const salt = storage.salt;
+
+    expect(anonymousId).toHaveLength(64);
+    expect(salt).toHaveLength(32);
+    expect(storage.anonymousId).toBe(anonymousId);
+    expect(storage.salt).toBe(salt);
+    expect(store.data['telemetry.anonymousId']).toBe(anonymousId);
+    expect(store.data['telemetry.salt']).toBe(salt);
+  });
+
+  it('computes a stable salted anonymous project hash', async () => {
+    const { TelemetryStorage } = await import('../storage');
+    const store = createStore({
+      'telemetry.salt': 'salt-one',
+    });
+    const storage = new TelemetryStorage({ store });
+
+    expect(storage.oneWayHash('raw-input')).toBe(
+      storage.oneWayHash('raw-input')
+    );
+
+    const otherStorage = new TelemetryStorage({
+      store: createStore({ 'telemetry.salt': 'salt-two' }),
+    });
+    expect(otherStorage.oneWayHash('raw-input')).not.toBe(
+      storage.oneWayHash('raw-input')
+    );
+  });
+
+  it('uses Next.js raw dedupe fallback order without exposing raw values', async () => {
+    const { getRawDedupeInput } = await import('../projectHash');
+
+    expect(await getRawDedupeInput()).toBe('git@github.com:org/repo.git');
+
+    execMock.mockImplementationOnce(
+      (_command: string, _options: unknown, callback: (error: Error) => void) =>
+        callback(new Error('missing remote'))
+    );
+    process.env.REPOSITORY_URL = 'https://example.com/fallback.git';
+    expect(await getRawDedupeInput()).toBe('https://example.com/fallback.git');
+
+    execMock.mockImplementationOnce(
+      (_command: string, _options: unknown, callback: (error: Error) => void) =>
+        callback(new Error('missing remote'))
+    );
+    delete process.env.REPOSITORY_URL;
+    expect(await getRawDedupeInput()).toBe(process.cwd());
+  });
+
+  it('posts only anonymous and coarse fields for webpack dev', async () => {
+    const { recordNextDevTelemetry } = await import('../nextDevTelemetry');
+    const store = createStore({
+      'telemetry.anonymousId': 'a'.repeat(64),
+      'telemetry.salt': 'test-salt',
+      'telemetry.notifiedAt': '1',
+    });
+
+    recordNextDevTelemetry({
+      config: {
+        devServerTelemetry: true,
+        devServerTelemetryUrl: 'https://api.example.com/v2/telemetry/next-dev',
+        experimentalCompilerOptions: { type: 'swc' },
+        experimentalEnableSSG: true,
+        experimentalLocaleResolution: true,
+      },
+      bundler: 'webpack',
+      gtServicesEnabled: true,
+      localDictionary: true,
+      localTranslations: false,
+      storageOptions: { store },
+    });
+
+    await flushPromises();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    const payload = JSON.parse(init.body);
+    const serialized = JSON.stringify(payload);
+
+    expect(url).toBe('https://api.example.com/v2/telemetry/next-dev');
+    expect(payload.context.anonymousId).toBe('a'.repeat(64));
+    expect(payload.context.anonymousProjectHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(payload.context.sessionId).toMatch(/^[a-f0-9]{64}$/);
+    expect(payload.fields.bundler).toBe('webpack');
+    expect(payload.fields.compiler).toBe('swc');
+    expect(payload.fields.features).toEqual({
+      gtServicesEnabled: true,
+      localDictionary: true,
+      localTranslations: false,
+      ssg: true,
+      localeResolution: true,
+    });
+    expect(serialized).not.toContain('projectId');
+    expect(serialized).not.toContain('anonymousProjectId');
+    expect(serialized).not.toContain('git@github.com:org/repo.git');
+    expect(serialized).not.toContain(process.cwd());
+  });
+
+  it('does not send when disabled by env or config', async () => {
+    const { recordNextDevTelemetry, resetNextDevTelemetryForTests } =
+      await import('../nextDevTelemetry');
+    const baseOptions = {
+      config: {
+        devServerTelemetry: true,
+        devServerTelemetryUrl: 'https://api.example.com/v2/telemetry/next-dev',
+        experimentalCompilerOptions: { type: 'none' as const },
+      },
+      bundler: 'webpack' as const,
+      gtServicesEnabled: false,
+      localDictionary: false,
+      localTranslations: false,
+      storageOptions: { store: createStore() },
+    };
+
+    process.env.NEXT_TELEMETRY_DISABLED = '1';
+    recordNextDevTelemetry(baseOptions);
+    await flushPromises();
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    resetNextDevTelemetryForTests();
+    delete process.env.NEXT_TELEMETRY_DISABLED;
+    process.env.GT_TELEMETRY_DISABLED = '1';
+    recordNextDevTelemetry(baseOptions);
+    await flushPromises();
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    resetNextDevTelemetryForTests();
+    delete process.env.GT_TELEMETRY_DISABLED;
+    process.env.DO_NOT_TRACK = 'true';
+    recordNextDevTelemetry(baseOptions);
+    await flushPromises();
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    resetNextDevTelemetryForTests();
+    delete process.env.DO_NOT_TRACK;
+    recordNextDevTelemetry({
+      ...baseOptions,
+      config: { ...baseOptions.config, devServerTelemetry: false },
+    });
+    await flushPromises();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('prints debug payload without calling fetch', async () => {
+    const { recordNextDevTelemetry } = await import('../nextDevTelemetry');
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    process.env.GT_TELEMETRY_DEBUG = '1';
+
+    recordNextDevTelemetry({
+      config: {
+        devServerTelemetry: true,
+        devServerTelemetryUrl: 'https://api.example.com/v2/telemetry/next-dev',
+        experimentalCompilerOptions: { type: 'babel' },
+      },
+      bundler: 'turbopack',
+      gtServicesEnabled: false,
+      localDictionary: false,
+      localTranslations: true,
+      storageOptions: {
+        store: createStore({
+          'telemetry.anonymousId': 'b'.repeat(64),
+          'telemetry.salt': 'test-salt',
+        }),
+      },
+    });
+
+    await flushPromises();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[gt-next telemetry]')
+    );
+    expect(errorSpy.mock.calls[0][0]).not.toContain('projectId');
+    expect(errorSpy.mock.calls[0][0]).not.toContain('anonymousProjectId');
+  });
+
+  it('dedupes repeated records in one process', async () => {
+    const { recordNextDevTelemetry } = await import('../nextDevTelemetry');
+    const options = {
+      config: {
+        devServerTelemetry: true,
+        devServerTelemetryUrl: 'https://api.example.com/v2/telemetry/next-dev',
+        experimentalCompilerOptions: { type: 'none' as const },
+      },
+      bundler: 'webpack' as const,
+      gtServicesEnabled: false,
+      localDictionary: false,
+      localTranslations: false,
+      storageOptions: {
+        store: createStore({
+          'telemetry.anonymousId': 'c'.repeat(64),
+          'telemetry.salt': 'test-salt',
+          'telemetry.notifiedAt': '1',
+        }),
+      },
+    };
+
+    recordNextDevTelemetry(options);
+    recordNextDevTelemetry(options);
+    await flushPromises();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/next/src/telemetry/__tests__/storage.test.ts
+++ b/packages/next/src/telemetry/__tests__/storage.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const confConstructorMock = vi.hoisted(() =>
+  vi.fn(function MockConf(this: { get: () => undefined; set: () => void }) {
+    this.get = vi.fn(() => undefined);
+    this.set = vi.fn();
+  })
+);
+const existsSyncMock = vi.hoisted(() => vi.fn(() => false));
+const readFileSyncMock = vi.hoisted(() => vi.fn(() => ''));
+
+vi.mock('conf', () => ({
+  default: confConstructorMock,
+}));
+
+vi.mock('fs', () => ({
+  default: {
+    existsSync: existsSyncMock,
+    readFileSync: readFileSyncMock,
+  },
+}));
+
+describe('telemetry storage', () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = {
+      CI: process.env.CI,
+      GITHUB_ACTIONS: process.env.GITHUB_ACTIONS,
+      GITLAB_CI: process.env.GITLAB_CI,
+      CIRCLECI: process.env.CIRCLECI,
+      BUILDKITE: process.env.BUILDKITE,
+      VERCEL: process.env.VERCEL,
+      NETLIFY: process.env.NETLIFY,
+    };
+    delete process.env.CI;
+    delete process.env.GITHUB_ACTIONS;
+    delete process.env.GITLAB_CI;
+    delete process.env.CIRCLECI;
+    delete process.env.BUILDKITE;
+    delete process.env.VERCEL;
+    delete process.env.NETLIFY;
+    existsSyncMock.mockReturnValue(false);
+    readFileSyncMock.mockReturnValue('');
+    confConstructorMock.mockClear();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('delegates local OS-native storage resolution to conf', async () => {
+    const { TelemetryStorage } = await import('../storage');
+
+    new TelemetryStorage({ distDir: '.next' });
+
+    expect(confConstructorMock).toHaveBeenCalledWith({
+      projectName: 'gt-next',
+      cwd: undefined,
+    });
+  });
+
+  it('uses project cache storage in CI environments', async () => {
+    process.env.CI = '1';
+    const { TelemetryStorage } = await import('../storage');
+
+    new TelemetryStorage({ distDir: '.next' });
+
+    expect(confConstructorMock).toHaveBeenCalledWith({
+      projectName: 'gt-next',
+      cwd: '.next/cache',
+    });
+  });
+});

--- a/packages/next/src/telemetry/nextDevTelemetry.ts
+++ b/packages/next/src/telemetry/nextDevTelemetry.ts
@@ -56,8 +56,8 @@ function isTruthy(value: string | undefined) {
 function isTelemetryDisabled(config: withGTConfigProps) {
   return (
     config.devServerTelemetry === false ||
-    isTruthy(process.env.NEXT_TELEMETRY_DISABLED) ||
-    isTruthy(process.env.GT_TELEMETRY_DISABLED) ||
+    !!process.env.NEXT_TELEMETRY_DISABLED ||
+    !!process.env.GT_TELEMETRY_DISABLED ||
     !!process.env.DO_NOT_TRACK
   );
 }

--- a/packages/next/src/telemetry/nextDevTelemetry.ts
+++ b/packages/next/src/telemetry/nextDevTelemetry.ts
@@ -2,6 +2,7 @@ import type { withGTConfigProps } from '../config-dir/props/withGTConfigProps';
 import { getAnonymousProjectHash } from './projectHash';
 import { TelemetryStorage, type TelemetryStorageOptions } from './storage';
 import { postTelemetryPayload } from './postTelemetryPayload';
+import { isCI } from './utils';
 import packageJson from '../../package.json';
 
 export type NextDevTelemetryPayload = {
@@ -57,7 +58,7 @@ function isTelemetryDisabled(config: withGTConfigProps) {
     config.devServerTelemetry === false ||
     isTruthy(process.env.NEXT_TELEMETRY_DISABLED) ||
     isTruthy(process.env.GT_TELEMETRY_DISABLED) ||
-    isTruthy(process.env.DO_NOT_TRACK)
+    !!process.env.DO_NOT_TRACK
   );
 }
 
@@ -65,18 +66,6 @@ function isTelemetryDebug() {
   return (
     isTruthy(process.env.NEXT_TELEMETRY_DEBUG) ||
     isTruthy(process.env.GT_TELEMETRY_DEBUG)
-  );
-}
-
-function isCI() {
-  return !!(
-    process.env.CI ||
-    process.env.GITHUB_ACTIONS ||
-    process.env.GITLAB_CI ||
-    process.env.CIRCLECI ||
-    process.env.BUILDKITE ||
-    process.env.VERCEL ||
-    process.env.NETLIFY
   );
 }
 

--- a/packages/next/src/telemetry/nextDevTelemetry.ts
+++ b/packages/next/src/telemetry/nextDevTelemetry.ts
@@ -1,0 +1,161 @@
+import type { withGTConfigProps } from '../config-dir/props/withGTConfigProps';
+import { getAnonymousProjectHash } from './projectHash';
+import { TelemetryStorage, type TelemetryStorageOptions } from './storage';
+import { postTelemetryPayload } from './postTelemetryPayload';
+import packageJson from '../../package.json';
+
+export type NextDevTelemetryPayload = {
+  eventName: 'GT_NEXT_DEV_SERVER_STARTED';
+  eventVersion: 1;
+  context: {
+    anonymousId: string;
+    anonymousProjectHash: string;
+    sessionId: string;
+  };
+  fields: {
+    gtNextVersion: string;
+    nextVersion: string | null;
+    bundler: 'webpack' | 'turbopack';
+    compiler: 'babel' | 'swc' | 'none';
+    isCI: boolean;
+    features: {
+      gtServicesEnabled: boolean;
+      localDictionary: boolean;
+      localTranslations: boolean;
+      ssg: boolean;
+      localeResolution: boolean;
+    };
+  };
+};
+
+export type RecordNextDevTelemetryOptions = {
+  config: Pick<
+    withGTConfigProps,
+    | 'devServerTelemetry'
+    | 'devServerTelemetryUrl'
+    | 'experimentalCompilerOptions'
+    | 'experimentalEnableSSG'
+    | 'experimentalLocaleResolution'
+  >;
+  bundler: 'webpack' | 'turbopack';
+  endpoint?: string | null;
+  distDir?: string;
+  gtServicesEnabled: boolean;
+  localDictionary: boolean;
+  localTranslations: boolean;
+  storageOptions?: TelemetryStorageOptions;
+};
+
+const recordedKeys = new Set<string>();
+
+function isTruthy(value: string | undefined) {
+  return value === '1' || value === 'true';
+}
+
+function isTelemetryDisabled(config: withGTConfigProps) {
+  return (
+    config.devServerTelemetry === false ||
+    isTruthy(process.env.NEXT_TELEMETRY_DISABLED) ||
+    isTruthy(process.env.GT_TELEMETRY_DISABLED) ||
+    isTruthy(process.env.DO_NOT_TRACK)
+  );
+}
+
+function isTelemetryDebug() {
+  return (
+    isTruthy(process.env.NEXT_TELEMETRY_DEBUG) ||
+    isTruthy(process.env.GT_TELEMETRY_DEBUG)
+  );
+}
+
+function isCI() {
+  return !!(
+    process.env.CI ||
+    process.env.GITHUB_ACTIONS ||
+    process.env.GITLAB_CI ||
+    process.env.CIRCLECI ||
+    process.env.BUILDKITE ||
+    process.env.VERCEL ||
+    process.env.NETLIFY
+  );
+}
+
+function getNextVersion() {
+  try {
+    const nextPackageJson = require('next/package.json');
+    return typeof nextPackageJson.version === 'string'
+      ? nextPackageJson.version
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export function resetNextDevTelemetryForTests() {
+  recordedKeys.clear();
+}
+
+export function recordNextDevTelemetry(options: RecordNextDevTelemetryOptions) {
+  const { config, bundler } = options;
+  const endpoint = options.endpoint ?? config.devServerTelemetryUrl;
+
+  if (isTelemetryDisabled(config) || endpoint === null) return;
+
+  const key = `${bundler}:${process.cwd()}`;
+  if (recordedKeys.has(key)) return;
+  recordedKeys.add(key);
+
+  const storage = new TelemetryStorage({
+    distDir: options.distDir,
+    ...options.storageOptions,
+  });
+  if (!storage.isEnabled) return;
+
+  void submitNextDevTelemetry({ ...options, endpoint, storage });
+}
+
+async function submitNextDevTelemetry(
+  options: RecordNextDevTelemetryOptions & {
+    endpoint: string | undefined;
+    storage: TelemetryStorage;
+  }
+) {
+  const anonymousId = options.storage.anonymousId;
+  const anonymousProjectHash = await getAnonymousProjectHash(options.storage);
+
+  if (!anonymousId || !anonymousProjectHash) return;
+
+  const payload: NextDevTelemetryPayload = {
+    eventName: 'GT_NEXT_DEV_SERVER_STARTED',
+    eventVersion: 1,
+    context: {
+      anonymousId,
+      anonymousProjectHash,
+      sessionId: options.storage.sessionId,
+    },
+    fields: {
+      gtNextVersion: packageJson.version,
+      nextVersion: getNextVersion(),
+      bundler: options.bundler,
+      compiler: options.config.experimentalCompilerOptions?.type || 'none',
+      isCI: isCI(),
+      features: {
+        gtServicesEnabled: options.gtServicesEnabled,
+        localDictionary: options.localDictionary,
+        localTranslations: options.localTranslations,
+        ssg: !!options.config.experimentalEnableSSG,
+        localeResolution: !!options.config.experimentalLocaleResolution,
+      },
+    },
+  };
+
+  if (isTelemetryDebug()) {
+    console.error('[gt-next telemetry] ' + JSON.stringify(payload, null, 2));
+    return;
+  }
+
+  options.storage.notify();
+
+  if (!options.endpoint) return;
+  await postTelemetryPayload(options.endpoint, payload);
+}

--- a/packages/next/src/telemetry/postTelemetryPayload.ts
+++ b/packages/next/src/telemetry/postTelemetryPayload.ts
@@ -1,0 +1,22 @@
+import type { NextDevTelemetryPayload } from './nextDevTelemetry';
+
+export function postTelemetryPayload(
+  endpoint: string,
+  payload: NextDevTelemetryPayload
+) {
+  if (typeof fetch !== 'function') return Promise.resolve();
+
+  return fetch(endpoint, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+    headers: {
+      'content-type': 'application/json',
+    },
+    signal:
+      typeof AbortSignal !== 'undefined' && 'timeout' in AbortSignal
+        ? AbortSignal.timeout(5000)
+        : undefined,
+  })
+    .then(() => {})
+    .catch(() => {});
+}

--- a/packages/next/src/telemetry/projectHash.ts
+++ b/packages/next/src/telemetry/projectHash.ts
@@ -1,0 +1,40 @@
+import { exec } from 'child_process';
+import { TelemetryStorage } from './storage';
+
+export async function getGitRemoteOriginUrl(timeoutMs = 1000) {
+  try {
+    const stdout = await new Promise<Buffer | string>((resolve, reject) => {
+      exec(
+        'git config --local --get remote.origin.url',
+        {
+          timeout: timeoutMs,
+          windowsHide: true,
+        },
+        (error, output) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve(output);
+        }
+      );
+    });
+
+    const remote = String(stdout).trim();
+    return remote || null;
+  } catch {
+    return null;
+  }
+}
+
+export async function getRawDedupeInput() {
+  return (
+    (await getGitRemoteOriginUrl()) ||
+    process.env.REPOSITORY_URL ||
+    process.cwd()
+  );
+}
+
+export async function getAnonymousProjectHash(storage: TelemetryStorage) {
+  return storage.oneWayHash(await getRawDedupeInput());
+}

--- a/packages/next/src/telemetry/storage.ts
+++ b/packages/next/src/telemetry/storage.ts
@@ -1,0 +1,136 @@
+import { createHash, randomBytes, type BinaryLike } from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import Conf from 'conf';
+
+const TELEMETRY_KEY_ENABLED = 'telemetry.enabled';
+const TELEMETRY_KEY_NOTIFY_DATE = 'telemetry.notifiedAt';
+const TELEMETRY_KEY_ID = 'telemetry.anonymousId';
+const TELEMETRY_KEY_SALT = 'telemetry.salt';
+
+type TelemetryStore = {
+  get(key: string): unknown;
+  set(key: string, value: unknown): void;
+};
+
+export type TelemetryStorageOptions = {
+  distDir?: string;
+  store?: TelemetryStore;
+};
+
+function isCI() {
+  return !!(
+    process.env.CI ||
+    process.env.GITHUB_ACTIONS ||
+    process.env.GITLAB_CI ||
+    process.env.CIRCLECI ||
+    process.env.BUILDKITE ||
+    process.env.VERCEL ||
+    process.env.NETLIFY
+  );
+}
+
+function isDockerLike() {
+  try {
+    if (fs.existsSync('/.dockerenv')) return true;
+  } catch {
+    return false;
+  }
+
+  try {
+    return fs.readFileSync('/proc/self/cgroup', 'utf8').includes('docker');
+  } catch {
+    return false;
+  }
+}
+
+export function getStorageDirectory(distDir = '.next') {
+  if (isCI() || isDockerLike()) {
+    return path.join(distDir, 'cache');
+  }
+  return undefined;
+}
+
+export class TelemetryStorage {
+  readonly sessionId = randomBytes(32).toString('hex');
+  private readonly store: TelemetryStore | null;
+
+  constructor({ distDir = '.next', store }: TelemetryStorageOptions = {}) {
+    if (store) {
+      this.store = store;
+      return;
+    }
+
+    try {
+      this.store = new Conf({
+        projectName: 'gt-next',
+        cwd: getStorageDirectory(distDir),
+      });
+    } catch {
+      this.store = null;
+    }
+  }
+
+  get isEnabled() {
+    if (!this.store) return false;
+
+    try {
+      return this.store.get(TELEMETRY_KEY_ENABLED) !== false;
+    } catch {
+      return false;
+    }
+  }
+
+  notify() {
+    if (!this.isEnabled || !this.store) return;
+
+    try {
+      if (this.store.get(TELEMETRY_KEY_NOTIFY_DATE)) return;
+      this.store.set(TELEMETRY_KEY_NOTIFY_DATE, Date.now().toString());
+      console.log(
+        'Attention: General Translation now collects completely anonymous telemetry regarding gt-next development usage.'
+      );
+      console.log(
+        "This information is used to shape General Translation's roadmap and prioritize features."
+      );
+      console.log('You can learn more, including how to opt out, by visiting:');
+      console.log('https://generaltranslation.com/docs/telemetry');
+      console.log();
+    } catch {
+      return;
+    }
+  }
+
+  get anonymousId() {
+    return this.getOrCreateRandomHex(TELEMETRY_KEY_ID, 32);
+  }
+
+  get salt() {
+    return this.getOrCreateRandomHex(TELEMETRY_KEY_SALT, 16);
+  }
+
+  oneWayHash(payload: BinaryLike) {
+    const salt = this.salt;
+    if (!salt) return null;
+
+    const hash = createHash('sha256');
+    hash.update(salt);
+    hash.update(payload);
+    return hash.digest('hex');
+  }
+
+  private getOrCreateRandomHex(key: string, bytes: number) {
+    if (!this.store) return null;
+
+    try {
+      const value = this.store.get(key);
+      if (typeof value === 'string' && value.length > 0) return value;
+
+      const generated = randomBytes(bytes).toString('hex');
+      this.store.set(key, generated);
+      return generated;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/packages/next/src/telemetry/storage.ts
+++ b/packages/next/src/telemetry/storage.ts
@@ -2,6 +2,7 @@ import { createHash, randomBytes, type BinaryLike } from 'crypto';
 import fs from 'fs';
 import path from 'path';
 import Conf from 'conf';
+import { isCI } from './utils';
 
 const TELEMETRY_KEY_ENABLED = 'telemetry.enabled';
 const TELEMETRY_KEY_NOTIFY_DATE = 'telemetry.notifiedAt';
@@ -17,18 +18,6 @@ export type TelemetryStorageOptions = {
   distDir?: string;
   store?: TelemetryStore;
 };
-
-function isCI() {
-  return !!(
-    process.env.CI ||
-    process.env.GITHUB_ACTIONS ||
-    process.env.GITLAB_CI ||
-    process.env.CIRCLECI ||
-    process.env.BUILDKITE ||
-    process.env.VERCEL ||
-    process.env.NETLIFY
-  );
-}
 
 function isDockerLike() {
   try {
@@ -87,15 +76,15 @@ export class TelemetryStorage {
     try {
       if (this.store.get(TELEMETRY_KEY_NOTIFY_DATE)) return;
       this.store.set(TELEMETRY_KEY_NOTIFY_DATE, Date.now().toString());
-      console.log(
-        'Attention: General Translation now collects completely anonymous telemetry regarding gt-next development usage.'
+      process.stderr.write(
+        [
+          'Attention: General Translation now collects completely anonymous telemetry regarding gt-next development usage.',
+          "This information is used to shape General Translation's roadmap and prioritize features.",
+          'You can learn more, including how to opt out, by visiting:',
+          'https://generaltranslation.com/docs/telemetry',
+          '',
+        ].join('\n')
       );
-      console.log(
-        "This information is used to shape General Translation's roadmap and prioritize features."
-      );
-      console.log('You can learn more, including how to opt out, by visiting:');
-      console.log('https://generaltranslation.com/docs/telemetry');
-      console.log();
     } catch {
       return;
     }

--- a/packages/next/src/telemetry/utils.ts
+++ b/packages/next/src/telemetry/utils.ts
@@ -1,0 +1,11 @@
+export function isCI() {
+  return !!(
+    process.env.CI ||
+    process.env.GITHUB_ACTIONS ||
+    process.env.GITLAB_CI ||
+    process.env.CIRCLECI ||
+    process.env.BUILDKITE ||
+    process.env.VERCEL ||
+    process.env.NETLIFY
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -582,6 +582,9 @@ importers:
       '@generaltranslation/supported-locales':
         specifier: workspace:*
         version: link:../supported-locales
+      conf:
+        specifier: 5.0.0
+        version: 5.0.0
       generaltranslation:
         specifier: workspace:*
         version: link:../core
@@ -8094,6 +8097,10 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  conf@5.0.0:
+    resolution: {integrity: sha512-lRNyt+iRD4plYaOSVTxu1zPWpaH0EOxgFIR1l3mpC/DGZ7XzhoGFMKmbl54LAgXcSu6knqWgOwdINkqm58N85A==}
+    engines: {node: '>=8'}
+
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
@@ -8497,6 +8504,10 @@ packages:
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  dot-prop@5.3.0:
+    resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
+    engines: {node: '>=8'}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -9929,6 +9940,10 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-obj@2.0.0:
+    resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
+    engines: {node: '>=8'}
+
   is-path-cwd@2.2.0:
     resolution: {integrity: sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==}
     engines: {node: '>=6'}
@@ -10016,6 +10031,9 @@ packages:
   is-typed-array@1.1.15:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
+
+  is-typedarray@1.0.0:
+    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
 
   is-unc-path@1.0.0:
     resolution: {integrity: sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==}
@@ -10267,6 +10285,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@7.0.3:
+    resolution: {integrity: sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -10682,6 +10703,10 @@ packages:
   make-dir@2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
     engines: {node: '>=6'}
+
+  make-dir@3.1.0:
+    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
+    engines: {node: '>=8'}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -11784,6 +11809,10 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  pkg-up@3.1.0:
+    resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
+    engines: {node: '>=8'}
 
   player.style@0.1.10:
     resolution: {integrity: sha512-Jxv7tlaQ3SFCddsN35jzoGnCHB3/xMTbJOgn4zcsmF0lcZvRPq5UkRRAD5tZm8CvzKndUvtoDlG6GSPL/N/SrA==}
@@ -13730,6 +13759,9 @@ packages:
   typedarray-dts@1.0.0:
     resolution: {integrity: sha512-Ka0DBegjuV9IPYFT1h0Qqk5U4pccebNIJCGl8C5uU7xtOs+jpJvKGAY4fHGK25hTmXZOEUl9Cnsg5cS6K/b5DA==}
 
+  typedarray-to-buffer@3.1.5:
+    resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
+
   typeid-js@0.3.0:
     resolution: {integrity: sha512-A1EmvIWG6xwYRfHuYUjPltHqteZ1EiDG+HOmbIYXeHUVztmnGrPIfU9KIK1QC30x59ko0r4JsMlwzsALCyiB3Q==}
 
@@ -14398,6 +14430,9 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  write-file-atomic@3.0.3:
+    resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==}
 
   write-file-atomic@4.0.2:
     resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
@@ -22155,6 +22190,16 @@ snapshots:
       tree-kill: 1.2.2
       yargs: 17.7.2
 
+  conf@5.0.0:
+    dependencies:
+      ajv: 6.15.0
+      dot-prop: 5.3.0
+      env-paths: 2.2.1
+      json-schema-typed: 7.0.3
+      make-dir: 3.1.0
+      pkg-up: 3.1.0
+      write-file-atomic: 3.0.3
+
   confbox@0.1.8: {}
 
   config-chain@1.1.13:
@@ -22585,6 +22630,10 @@ snapshots:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
+
+  dot-prop@5.3.0:
+    dependencies:
+      is-obj: 2.0.0
 
   dotenv@16.6.1: {}
 
@@ -24535,6 +24584,8 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-obj@2.0.0: {}
+
   is-path-cwd@2.2.0: {}
 
   is-path-cwd@3.0.0: {}
@@ -24606,6 +24657,8 @@ snapshots:
   is-typed-array@1.1.15:
     dependencies:
       which-typed-array: 1.1.19
+
+  is-typedarray@1.0.0: {}
 
   is-unc-path@1.0.0:
     dependencies:
@@ -24953,6 +25006,8 @@ snapshots:
 
   json-schema-traverse@1.0.0: {}
 
+  json-schema-typed@7.0.3: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json-stable-stringify@1.3.0:
@@ -25298,6 +25353,10 @@ snapshots:
     dependencies:
       pify: 4.0.1
       semver: 5.7.2
+
+  make-dir@3.1.0:
+    dependencies:
+      semver: 6.3.1
 
   make-dir@4.0.0:
     dependencies:
@@ -26773,6 +26832,10 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.0
       pathe: 2.0.3
+
+  pkg-up@3.1.0:
+    dependencies:
+      find-up: 3.0.0
 
   player.style@0.1.10(react@19.2.3):
     dependencies:
@@ -29217,6 +29280,10 @@ snapshots:
 
   typedarray-dts@1.0.0: {}
 
+  typedarray-to-buffer@3.1.5:
+    dependencies:
+      is-typedarray: 1.0.0
+
   typeid-js@0.3.0:
     dependencies:
       uuidv7: 0.4.4
@@ -30211,6 +30278,13 @@ snapshots:
       strip-ansi: 7.1.2
 
   wrappy@1.0.2: {}
+
+  write-file-atomic@3.0.3:
+    dependencies:
+      imurmurhash: 0.1.4
+      is-typedarray: 1.0.0
+      signal-exit: 3.0.7
+      typedarray-to-buffer: 3.1.5
 
   write-file-atomic@4.0.2:
     dependencies:


### PR DESCRIPTION
## Summary
- adds Next.js-precedent anonymous telemetry when `withGTConfig` is used by a local `next dev` server
- stores a local `anonymousId` and salt with `conf` under the `gt-next` namespace, using OS-native config paths and `.next/cache` in CI/container-like environments
- sends only `anonymousProjectHash` plus coarse usage fields to `/v2/telemetry/next-dev`

## Privacy
- does not read `GT_PROJECT_ID` for telemetry
- does not send any field named `projectId` or `anonymousProjectId`
- does not send API keys, org IDs, raw git remotes, cwd/path data, package names, usernames, hostnames, locale lists, logs, stack traces, serialized errors, or env var values
- computes `anonymousProjectHash` locally as a salted SHA-256 hash; the salt never leaves the machine

## Controls
- `devServerTelemetry: false` disables collection
- `devServerTelemetryUrl: null` disables network send
- `NEXT_TELEMETRY_DISABLED=1`, `GT_TELEMETRY_DISABLED=1`, and DNT disable collection
- `NEXT_TELEMETRY_DEBUG=1` or `GT_TELEMETRY_DEBUG=1` prints the payload to stderr and skips sending

## Verification
- `pnpm --filter gt-next test:js`
- `pnpm --filter gt-next build:no-swc-plugin`
- `pnpm --filter gt-next lint` (passes with existing warnings)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Adds anonymous, privacy-preserving dev-server telemetry to `withGTConfig`: a salted SHA-256 `anonymousProjectHash` (derived from git remote → `REPOSITORY_URL` → `cwd()`) and coarse feature flags are sent to `/v2/telemetry/next-dev`; raw paths, keys, and project IDs are never transmitted.
- Telemetry is disabled by any non-empty `NEXT_TELEMETRY_DISABLED`, `GT_TELEMETRY_DISABLED`, or `DO_NOT_TRACK` value (matching Next.js semantics after the 8104c875 fix), or by `devServerTelemetry: false` / `devServerTelemetryUrl: null`; a per-session in-memory dedupe key prevents duplicate sends.
- `conf@5.0.0` (exact pin) is added for cross-platform persistent storage; the intentionally old version preserves CJS compatibility in the Next.js plugin context.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; only a minor ordering nit with no practical impact under default configuration.

No P0/P1 issues found. All previously flagged concerns (DO_NOT_TRACK breadth, console.log in notify(), isCI duplication, NEXT_TELEMETRY_DISABLED strictness) have been resolved. The one remaining finding is a P2-level ordering edge-case between notify() and the endpoint guard that is unreachable under the documented API.

packages/next/src/telemetry/nextDevTelemetry.ts — minor notify()/endpoint guard ordering issue.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/telemetry/nextDevTelemetry.ts | Core telemetry orchestration: checks disabled state, deduplicates per bundler+cwd, builds and submits payload; notify() is called before the endpoint guard which means the opt-out notice fires even when endpoint is undefined |
| packages/next/src/telemetry/storage.ts | Wraps conf for persisting anonymousId/salt; uses process.stderr.write for opt-out notice; delegates CI/Docker detection to shared utils.ts |
| packages/next/src/telemetry/projectHash.ts | Derives a salted SHA-256 project hash from git remote → REPOSITORY_URL → cwd(); raw value never leaves the machine |
| packages/next/src/telemetry/postTelemetryPayload.ts | Thin fetch wrapper with 5s AbortSignal timeout; errors are silently swallowed, which is correct for fire-and-forget telemetry |
| packages/next/src/telemetry/utils.ts | Extracts shared isCI() helper (consolidating previously duplicated logic from storage.ts and nextDevTelemetry.ts) |
| packages/next/src/config.ts | Wires telemetry call sites: turbopack path fires on withGTConfig() when NODE_ENV=development, webpack path fires inside the dev webpack callback |
| packages/next/src/config-dir/props/defaultWithGTConfigProps.ts | Adds devServerTelemetry: true and devServerTelemetryUrl pointing to the production GT endpoint as safe defaults |
| packages/next/src/telemetry/__tests__/nextDevTelemetry.test.ts | Good test coverage: persisted ID/salt, hashing stability, dedupe, disabled-by-env cases (including yes/on values), debug mode, and payload privacy assertions |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant WGT as withGTConfig (config.ts)
    participant NDT as nextDevTelemetry
    participant ST as TelemetryStorage (conf)
    participant PH as projectHash
    participant Post as postTelemetryPayload
    participant API as GT API /v2/telemetry

    WGT->>NDT: recordNextDevTelemetry(options)
    NDT->>NDT: isTelemetryDisabled? / dedupe key?
    NDT->>ST: new TelemetryStorage()
    NDT-->>NDT: void submitNextDevTelemetry()
    NDT->>ST: get/create anonymousId + salt
    NDT->>PH: getAnonymousProjectHash(storage)
    PH->>PH: git remote → REPOSITORY_URL → cwd()
    PH->>ST: oneWayHash(rawInput)
    ST-->>NDT: anonymousProjectHash
    NDT->>NDT: build NextDevTelemetryPayload
    alt debug mode
        NDT->>NDT: console.error payload, return
    else normal mode
        NDT->>ST: notify() once per machine
        NDT->>Post: postTelemetryPayload(endpoint, payload)
        Post->>API: POST /v2/telemetry/next-dev
        API-->>Post: 200 OK (error silently ignored)
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/next/src/telemetry/nextDevTelemetry.ts:146-149
The opt-out notice is shown via `notify()` before the `!options.endpoint` guard. If `devServerTelemetryUrl` resolves to `undefined` (e.g. someone passes it explicitly as `undefined` in their config, distinct from `null`), the user sees the "we collect telemetry" notice on stderr but no payload is ever sent — a misleading experience. Moving the guard above `notify()` ensures the notice only fires when a send is actually about to happen.

```suggestion
  if (!options.endpoint) return;

  options.storage.notify();
  await postTelemetryPayload(options.endpoint, payload);
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(next): honor any telemetry disabled ..."](https://github.com/generaltranslation/gt/commit/8104c87506b323671ba2a3cb61969c1f0a959926) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30785495)</sub>

<!-- /greptile_comment -->