### PR TITLE
fix: generate relative load translations imports

### DIFF
--- a/.changeset/cli-relative-load-paths.md
+++ b/.changeset/cli-relative-load-paths.md
@@ -1,0 +1,6 @@
+---
+'gt': patch
+---
+
+Generate explicit relative import paths in `loadTranslations.js` for local
+translation files.

--- a/packages/cli/src/fs/__tests__/createLoadTranslationsFile.test.ts
+++ b/packages/cli/src/fs/__tests__/createLoadTranslationsFile.test.ts
@@ -36,7 +36,7 @@ describe('createLoadTranslationsFile', () => {
 
     const content = fs.readFileSync(filePath, 'utf-8');
     expect(content).toContain('export default async function loadTranslations');
-    expect(content).toContain('../public/_gt/');
+    expect(content).toContain('import(`../public/_gt/${locale}.json`)');
   });
 
   it('creates loadTranslations.js at root when no src directory exists', async () => {
@@ -47,7 +47,7 @@ describe('createLoadTranslationsFile', () => {
 
     const content = fs.readFileSync(filePath, 'utf-8');
     expect(content).toContain('export default async function loadTranslations');
-    expect(content).toContain('public/_gt/');
+    expect(content).toContain('import(`./public/_gt/${locale}.json`)');
   });
 
   it('uses correct relative path for Vite translations dir (./src/_gt)', async () => {
@@ -61,9 +61,32 @@ describe('createLoadTranslationsFile', () => {
     expect(fs.existsSync(filePath)).toBe(true);
 
     const content = fs.readFileSync(filePath, 'utf-8');
-    // From src/loadTranslations.js to src/_gt/ the relative path is just _gt/
-    expect(content).toContain('_gt/');
+    expect(content).toContain('import(`./_gt/${locale}.json`)');
     expect(content).not.toContain('public/_gt');
+  });
+
+  it('prefixes nested Vite paths with ./ when loadTranslations.js is at the project root', async () => {
+    await createLoadTranslationsFile(tmpDir, DEFAULT_VITE_TRANSLATIONS_DIR, [
+      'es',
+    ]);
+
+    const filePath = path.join(tmpDir, 'loadTranslations.js');
+    expect(fs.existsSync(filePath)).toBe(true);
+
+    const content = fs.readFileSync(filePath, 'utf-8');
+    expect(content).toContain('import(`./src/_gt/${locale}.json`)');
+  });
+
+  it('prefixes hidden relative directories with ./', async () => {
+    fs.mkdirSync(path.join(tmpDir, 'src'), { recursive: true });
+
+    await createLoadTranslationsFile(tmpDir, './src/.gt', ['es']);
+
+    const filePath = path.join(tmpDir, 'src', 'loadTranslations.js');
+    expect(fs.existsSync(filePath)).toBe(true);
+
+    const content = fs.readFileSync(filePath, 'utf-8');
+    expect(content).toContain('import(`./.gt/${locale}.json`)');
   });
 
   it('creates locale JSON files in the translations directory', async () => {
@@ -130,6 +153,6 @@ describe('createLoadTranslationsFile', () => {
     expect(fs.existsSync(filePath)).toBe(true);
 
     const content = fs.readFileSync(filePath, 'utf-8');
-    expect(content).toContain('public/_gt/');
+    expect(content).toContain('import(`./public/_gt/${locale}.json`)');
   });
 });

--- a/packages/cli/src/fs/createLoadTranslationsFile.ts
+++ b/packages/cli/src/fs/createLoadTranslationsFile.ts
@@ -4,6 +4,25 @@ import { logger } from '../console/logger.js';
 import chalk from 'chalk';
 import { DEFAULT_TRANSLATIONS_DIR } from '../utils/constants.js';
 
+function toRelativeImportPath(relativePath: string) {
+  const normalizedPath = relativePath.split(path.sep).join(path.posix.sep);
+
+  if (!normalizedPath) {
+    return './';
+  }
+
+  // Dynamic imports must use explicit relative specifiers; values like
+  // "src/_gt" are otherwise treated as package names by Vite and Node.
+  const hasExplicitRelativePrefix =
+    normalizedPath === '..' ||
+    normalizedPath.startsWith('../') ||
+    normalizedPath.startsWith('./');
+
+  return hasExplicitRelativePrefix
+    ? `${normalizedPath}/`
+    : `./${normalizedPath}/`;
+}
+
 export async function createLoadTranslationsFile(
   appDirectory: string,
   translationsDir: string = DEFAULT_TRANSLATIONS_DIR,
@@ -11,7 +30,6 @@ export async function createLoadTranslationsFile(
 ) {
   const usingSrcDirectory = fs.existsSync(path.join(appDirectory, 'src'));
 
-  // Calculate the relative path from the loadTranslations.js location to the translations directory
   const loadTranslationsDir = usingSrcDirectory
     ? path.join(appDirectory, 'src')
     : appDirectory;
@@ -19,7 +37,7 @@ export async function createLoadTranslationsFile(
     loadTranslationsDir,
     path.resolve(appDirectory, translationsDir)
   );
-  const publicPath = relativePath ? `${relativePath}/` : './';
+  const publicPath = toRelativeImportPath(relativePath);
 
   const filePath = usingSrcDirectory
     ? path.join(appDirectory, 'src', 'loadTranslations.js')


### PR DESCRIPTION
## Summary
- Normalize generated `loadTranslations.js` dynamic import paths to explicit relative specifiers.
- Preserve parent-directory imports while prefixing same-directory and nested paths with `./`.
- Add regression coverage for Vite `src/_gt` paths and hidden relative directories.

## Verification
- `pnpm --filter gt test -- createLoadTranslationsFile`
- `pnpm --filter gt build`
- `pnpm exec prettier --check packages/cli/src/fs/createLoadTranslationsFile.ts packages/cli/src/fs/__tests__/createLoadTranslationsFile.test.ts .changeset/cli-relative-load-paths.md`
- Created `/Users/ernestmccarter/Documents/dev/playground/gt-load-path-vite-react` with Vite + React, ran `pnpm link /Users/ernestmccarter/Documents/dev/gt/packages/cli`, ran `pnpm gt init`, verified generated `src/loadTranslations.js` imports `./_gt/${locale}.json`, and ran `pnpm build`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1338"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where generated `loadTranslations.js` dynamic import paths could be treated as bare package specifiers by Vite/Node (e.g. `src/_gt`) instead of local file paths. The fix adds a `toRelativeImportPath` helper that normalises the output of `path.relative` into an explicit relative specifier by prepending `./` when the path doesn't already begin with `./` or `../`, and tests are updated to assert on the full import expression.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is correct, well-scoped, and fully covered by new regression tests.

All edge cases produced by `path.relative` (empty string, `..`, `../…`, bare segment, hidden dot-directory) are handled correctly by `toRelativeImportPath`. The path normalisation for Windows separators is also in place. No custom rules are violated and no existing behaviour is regressed.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/fs/createLoadTranslationsFile.ts | Introduces `toRelativeImportPath` helper to normalize `path.relative` output into explicit ES-module relative specifiers, replacing the inline ternary. Logic is correct for all cases produced by `path.relative` (empty, `..`, `../…`, bare segments). |
| packages/cli/src/fs/__tests__/createLoadTranslationsFile.test.ts | Tightens existing assertions to full import expression strings and adds two new regression tests: root-level Vite paths and hidden dot-directories. Coverage is thorough for the changed behaviour. |
| .changeset/cli-relative-load-paths.md | Adds a `patch` changeset entry for the `gt` package describing the fix; no issues. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["createLoadTranslationsFile(appDir, translationsDir, locales)"] --> B{src/ exists?}
    B -- Yes --> C["loadTranslationsDir = appDir/src"]
    B -- No --> D["loadTranslationsDir = appDir"]
    C & D --> E["relativePath = path.relative(loadTranslationsDir, resolve(appDir, translationsDir))"]
    E --> F["toRelativeImportPath(relativePath)"]
    F --> G{normalizedPath empty?}
    G -- Yes --> H["return './'"]
    G -- No --> I{starts with './' or '../' or equals '..'?}
    I -- Yes --> J["return normalizedPath + '/'"]
    I -- No --> K["return './' + normalizedPath + '/'"]
    H & J & K --> L["publicPath"]
    L --> M["Write loadTranslations.js with import(\`\${publicPath}\${locale}.json\`)"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: generate relative load translations..."](https://github.com/generaltranslation/gt/commit/3772cb2512d0b7b1591e557529134cb4839caea0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30864887)</sub>

<!-- /greptile_comment -->