### PR TITLE
chore: clear no-console lint warnings

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -23,7 +23,12 @@
     "tests/seeds/**/*"
   ],
   "rules": {
-    "no-console": "warn",
+    "no-console": [
+      "warn",
+      {
+        "allow": ["warn", "error"]
+      }
+    ],
     "prefer-const": "warn",
     "no-unused-vars": [
       "warn",

--- a/packages/cli/src/console/logging.ts
+++ b/packages/cli/src/console/logging.ts
@@ -42,6 +42,7 @@ export function displayHeader(introString?: string) {
 }
 
 function displayAsciiTitle() {
+  // eslint-disable-next-line no-console
   console.log(
     chalk.cyan(
       `\n  ,ad8888ba,  888888888888  
@@ -58,6 +59,7 @@ Y8,        88      88
 
 function displayInitializingText() {
   const version = getCLIVersion();
+  // eslint-disable-next-line no-console
   console.log(
     `\n${chalk.bold.blue('General Translation, Inc.')}
 ${chalk.dim('https://generaltranslation.com/docs')}

--- a/packages/cli/src/utils/__tests__/gitDiff.test.ts
+++ b/packages/cli/src/utils/__tests__/gitDiff.test.ts
@@ -287,12 +287,6 @@ describe('getGitUnifiedDiff', () => {
 
     const diff = await getGitUnifiedDiff(oldFile, newFile);
 
-    // Log the complete diff for inspection
-    console.log('Complete diff output:');
-    console.log('='.repeat(50));
-    console.log(diff);
-    console.log('='.repeat(50));
-
     // Basic structure checks
     expect(diff).toContain('---');
     expect(diff).toContain('+++');

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -177,6 +177,7 @@ const gtUnplugin = createUnplugin<GTUnpluginOptions | undefined>(
           );
           const manifest = Object.fromEntries(debugManifest);
           fs.writeFileSync(outPath, JSON.stringify(manifest, null, 2));
+          // eslint-disable-next-line no-console
           console.log(
             `[gt-compiler] Debug hash manifest written to ${outPath} (${debugManifest.size} entries)`
           );

--- a/packages/core/src/logging/logger.ts
+++ b/packages/core/src/logging/logger.ts
@@ -109,9 +109,11 @@ export class ConsoleLogHandler implements LogHandler {
     // Output to appropriate console method based on level
     switch (entry.level) {
       case 'debug':
+        // eslint-disable-next-line no-console
         console.debug(formattedMessage);
         break;
       case 'info':
+        // eslint-disable-next-line no-console
         console.info(formattedMessage);
         break;
       case 'warn':

--- a/packages/i18n/src/logs/logger.ts
+++ b/packages/i18n/src/logs/logger.ts
@@ -8,10 +8,12 @@ export default {
   },
 
   info(message: string) {
+    // eslint-disable-next-line no-console
     console.info(message);
   },
 
   debug(message: string) {
+    // eslint-disable-next-line no-console
     console.debug(message);
   },
 };

--- a/packages/sanity/src/translation/initProject.ts
+++ b/packages/sanity/src/translation/initProject.ts
@@ -48,8 +48,10 @@ export async function initProject(
     }
 
     if (setupCompleted) {
+      // eslint-disable-next-line no-console
       console.log('Setup successfully completed');
     } else {
+      // eslint-disable-next-line no-console
       console.log(
         `Setup ${setupFailedMessage ? 'failed' : 'timed out'} — proceeding without setup${
           setupFailedMessage ? ` (${setupFailedMessage})` : ''


### PR DESCRIPTION
## Summary

- allow intentional `console.warn` and `console.error` usage in the oxlint `no-console` rule
- add targeted disables for intentional stdout/debug logger implementations
- remove debug `console.log` output from the git diff test

## Validation

- `pnpm lint` passes with 847 warnings remaining, all `typescript-eslint(no-explicit-any)`
- `git diff --check`
- `pnpm --filter gt test -- src/utils/__tests__/gitDiff.test.ts`
- `pnpm --filter generaltranslation test`
- `pnpm --filter gt-sanity test`
- `pnpm --filter gt-i18n test`
- `pnpm --filter @generaltranslation/compiler test`

## Stack

- Built after #1337, which has merged into `main`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR cleans up `no-console` lint warnings by tightening the oxlint rule to allow `console.warn`/`console.error` globally, adding targeted `eslint-disable-next-line` comments where `console.log`/`console.debug`/`console.info` are genuinely intentional (logger implementations, CLI header output, compiler debug manifest, Sanity setup messages), and removing leftover debug `console.log` calls from a test.

- **`.oxlintrc.json`**: The `no-console` rule now uses the `allow` option to permit `warn` and `error` project-wide, which is consistent with the codebase's accepted pattern for error reporting.
- **Logger files (`core`, `i18n`)**: `eslint-disable` comments are added inside `ConsoleLogHandler` and the i18n logger shim — the correct layer for deliberate console delegation.
- **Test cleanup**: Five debug `console.log` lines that were left in `gitDiff.test.ts` from a prior investigation are removed; test assertions are untouched.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are lint housekeeping with no runtime behaviour changes.

Every changed line either tightens a lint rule, adds a targeted disable comment above an already-existing console call, or removes a leftover debug log from a test file. No logic is modified, no new console calls are introduced, and the test cleanup is strictly an improvement.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .oxlintrc.json | Upgrades the `no-console` rule from a plain warn to an options object that allows `console.warn` and `console.error`, reducing noise while keeping `log`/`debug`/`info` warned. |
| packages/cli/src/console/logging.ts | Adds targeted `eslint-disable-next-line no-console` for intentional ASCII-title and version-header stdout output. |
| packages/cli/src/utils/__tests__/gitDiff.test.ts | Removes five debug `console.log` calls left in from a previous investigation; test assertions are unaffected. |
| packages/compiler/src/index.ts | Adds a single `eslint-disable-next-line no-console` before an intentional debug-manifest notification that only fires when `debugManifest` is populated. |
| packages/core/src/logging/logger.ts | Adds `eslint-disable` comments for `console.debug` and `console.info` inside `ConsoleLogHandler`, the canonical place for intentional console delegation. |
| packages/i18n/src/logs/logger.ts | Adds `eslint-disable` comments for `console.info` and `console.debug` in the i18n logger shim — same pattern as the core logger. |
| packages/sanity/src/translation/initProject.ts | Adds targeted `eslint-disable` comments for two `console.log` calls that surface user-visible setup success/failure messages in the Sanity plugin. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: clear no-console lint warnings"](https://github.com/generaltranslation/gt/commit/ed4c59198a62ab6b552390acaf354957268e91ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30869799)</sub>

**Context used:**

- Rule used - Remove console.log statements and debug logging fr... ([source](https://app.greptile.com/review/custom-context?memory=ea076fa4-7856-4d31-9266-35f86e49f4b6))

**Learned From**
[generaltranslation/gt-cloud#1266](https://github.com/generaltranslation/gt-cloud/pull/1266)
[generaltranslation/gt-cloud#1240](https://github.com/generaltranslation/gt-cloud/pull/1240)
- Rule used - Using console.error() is acceptable in dashboard c... ([source](https://app.greptile.com/review/custom-context?memory=871e50c6-4344-4574-9bc8-358b76298084))

**Learned From**
[generaltranslation/gt-cloud#1276](https://github.com/generaltranslation/gt-cloud/pull/1276)

<!-- /greptile_comment -->