### PR TITLE
docs(core): normalize comment punctuation

### DIFF
--- a/packages/core/src/backwards-compatability/oldHashJsxChildren.ts
+++ b/packages/core/src/backwards-compatability/oldHashJsxChildren.ts
@@ -10,7 +10,7 @@ import { bytesToHex, utf8ToBytes } from '@noble/hashes/utils.js';
  * Calculates a unique hash for a given string using sha256.
  *
  * @param {string} string - The string to be hashed.
- * @returns {string} - The resulting hash as a hexadecimal string.
+ * @returns {string} The resulting hash as a hexadecimal string.
  */
 export function oldHashString(string: string): string {
   return bytesToHex(sha256(utf8ToBytes(string)));
@@ -20,9 +20,9 @@ export function oldHashString(string: string): string {
  * Calculates a unique ID for the given children objects by hashing their sanitized JSON string representation.
  *
  * @param {any} childrenAsObjects - The children objects to be hashed.
- * @param {string} context - The context for the children
- * @param {string} id - The id for the JSX Children object
- * @param {function} hashFunction custom hash function
+ * @param {string} context - The context for the children.
+ * @param {string} id - The ID for the JSX children object.
+ * @param {function} hashFunction - Custom hash function.
  * @returns {string} - The unique has of the children.
  */
 export function oldHashJsxChildren(

--- a/packages/core/src/backwards-compatability/typeChecking.ts
+++ b/packages/core/src/backwards-compatability/typeChecking.ts
@@ -9,7 +9,7 @@ import { Variable as VariableObject } from '../types';
 
 /**
  * Checks if a JSX child is an old variable object format
- * @param child - The JSX child to check
+ * @param child - The JSX child to check.
  * @returns True if the child is an old variable object (has 'key' property)
  */
 export function isOldVariableObject(
@@ -20,7 +20,7 @@ export function isOldVariableObject(
 
 /**
  * Checks if a JSX child is a new variable object format
- * @param child - The JSX child to check
+ * @param child - The JSX child to check.
  * @returns True if the child is a new variable object (has 'k' property)
  */
 export function isNewVariableObject(
@@ -31,7 +31,7 @@ export function isNewVariableObject(
 
 /**
  * Checks if a JSX child is an old JSX element format
- * @param child - The JSX child to check
+ * @param child - The JSX child to check.
  * @returns True if the child is an old JSX element (has 'type' and 'props' properties)
  */
 function isOldJsxElement(
@@ -47,8 +47,8 @@ function isOldJsxElement(
 
 /**
  * Checks if a JSX child follows the old format (string, old variable object, or old JSX element)
- * @param child - The JSX child to check
- * @returns True if the child is in the old format
+ * @param child - The JSX child to check.
+ * @returns True if the child is in the old format.
  */
 function isOldJsxChild(child: OldJsxChild | JsxChild): child is OldJsxChild {
   // string
@@ -68,7 +68,7 @@ function isOldJsxChild(child: OldJsxChild | JsxChild): child is OldJsxChild {
 /**
  * Checks if JSX children follow the old format
  * @param children - The JSX children to check (can be string, array, or single child)
- * @returns True if all children are in the old format
+ * @returns True if all children are in the old format.
  */
 export function isOldJsxChildren(
   children: OldJsxChildren | JsxChildren

--- a/packages/core/src/cache/IntlCache.ts
+++ b/packages/core/src/cache/IntlCache.ts
@@ -26,7 +26,7 @@ const CustomIntl: CustomIntlType = {
 
 /**
  * Cache for Intl and custom format instances to avoid repeated instantiation
- * Uses a two-level structure: constructor name -> cache key -> instance
+ * Uses a two-level structure: constructor name -> cache key -> instance.
  */
 class IntlCache {
   private cache: IntlCacheObject;
@@ -36,8 +36,8 @@ class IntlCache {
   }
 
   /**
-   * Generates a consistent cache key from locales and options
-   * Handles all LocalesArgument types (string, Locale, array, undefined)
+   * Generates a consistent cache key from locales and options.
+   * Handles all LocalesArgument types (string, Locale, array, undefined).
    */
   private _generateKey(locales: Intl.LocalesArgument, options = {}) {
     // Normalize locales to string representation
@@ -56,9 +56,9 @@ class IntlCache {
 
   /**
    * Gets a cached Intl instance or creates a new one if not found
-   * @param constructor The name of the Intl constructor to use
-   * @param args Constructor arguments (locales, options)
-   * @returns Cached or newly created Intl instance
+   * @param constructor The name of the Intl constructor to use.
+   * @param args Constructor arguments (locales, options).
+   * @returns Cached or newly created Intl instance.
    */
   get<K extends keyof CustomIntlConstructors>(
     constructor: K,

--- a/packages/core/src/derive/declareVar.ts
+++ b/packages/core/src/derive/declareVar.ts
@@ -28,11 +28,11 @@ export function declareVar(
   variable: string | number | boolean | null | undefined,
   options?: { $name?: string }
 ): string {
-  // variable section
+  // Variable section.
   const sanitizedVariable = sanitizeVar(String(variable ?? ''));
   const variableSection = ` other {${sanitizedVariable}}`;
 
-  // name section
+  // Name section.
   let nameSection = '';
   if (options?.$name) {
     const sanitizedName = sanitizeVar(options.$name);

--- a/packages/core/src/derive/decodeVars.ts
+++ b/packages/core/src/derive/decodeVars.ts
@@ -36,7 +36,7 @@ export function decodeVars(icuString: string): string {
     });
   }
 
-  // Find all variable identifiers
+  // Find all variable identifiers.
   traverseIcu({
     icuString,
     shouldVisit: isGTUnindexedSelectElement,

--- a/packages/core/src/derive/indexVars.ts
+++ b/packages/core/src/derive/indexVars.ts
@@ -32,7 +32,7 @@ export function indexVars(icuString: IcuMessage): string {
     });
   }
 
-  // Find all variable identifiers
+  // Find all variable identifiers.
   traverseIcu({
     icuString,
     shouldVisit: isGTUnindexedSelectElement,
@@ -40,7 +40,7 @@ export function indexVars(icuString: IcuMessage): string {
     options: { recurseIntoVisited: false, captureLocation: true },
   });
 
-  // Index each variable and collapse the other option
+  // Index each variable and collapse the other option.
   const result = [];
   let current = 0;
   for (let i = 0; i < variableLocations.length; i++) {
@@ -50,7 +50,7 @@ export function indexVars(icuString: IcuMessage): string {
     // Replace the variable with the new identifier (+1 is for the curly brace)
     result.push(icuString.slice(start, start + VAR_IDENTIFIER.length + 1));
 
-    // Add the new identifier
+    // Add the new identifier.
     result.push(String(i + 1));
     // After the variable
     result.push(icuString.slice(start + VAR_IDENTIFIER.length + 1, otherStart));

--- a/packages/core/src/derive/utils/sanitizeVar.ts
+++ b/packages/core/src/derive/utils/sanitizeVar.ts
@@ -10,7 +10,7 @@
  * 3. Adding a single quote after the last special character ({}<>)
  */
 export function sanitizeVar(string: string): string {
-  // First, double all single quotes (both ASCII and Unicode)
+  // First, double all single quotes (both ASCII and Unicode).
   let result = string.replace(/'/g, "''");
 
   // Find first and last positions of special characters
@@ -18,7 +18,7 @@ export function sanitizeVar(string: string): string {
   const firstSpecialIndex = result.search(specialChars);
 
   if (firstSpecialIndex === -1) {
-    // No special characters, return with just doubled quotes
+    // No special characters; return with just doubled quotes.
     return result;
   }
 
@@ -31,7 +31,7 @@ export function sanitizeVar(string: string): string {
     }
   }
 
-  // Insert quotes around the special character region
+  // Insert quotes around the special character region.
   result =
     result.slice(0, firstSpecialIndex) +
     "'" +

--- a/packages/core/src/derive/utils/traverseIcu.ts
+++ b/packages/core/src/derive/utils/traverseIcu.ts
@@ -14,7 +14,7 @@ type TraverseIcuOptions = ParserOptions & {
  * @param icu - The ICU string to traverse
  * @param shouldVisit - A function that returns true if the element should be visited
  * @param visitor - A function that is called for each element that matches the type T
- * @returns The modified AST of the ICU string
+ * @returns The modified AST of the ICU string.
  *
  * @note This function is a heavy operation, use sparingly
  */

--- a/packages/core/src/formatting/custom-formats/CutoffFormat/CutoffFormat.ts
+++ b/packages/core/src/formatting/custom-formats/CutoffFormat/CutoffFormat.ts
@@ -69,7 +69,7 @@ export class CutoffFormatConstructor implements CutoffFormat {
       );
     }
 
-    // Resolve terminator options
+    // Resolve terminator options.
     let style: CutoffFormatStyle | undefined;
     let presetTerminatorOptions: ResolvedTerminatorOptions | undefined;
     if (options.maxChars !== undefined) {
@@ -159,13 +159,13 @@ export class CutoffFormatConstructor implements CutoffFormat {
       return [slicedValue];
     }
 
-    // Postpended cutoff
+    // Postpended cutoff.
     if (adjustedChars > 0) {
       return separator != null
         ? [slicedValue, separator, terminator]
         : [slicedValue, terminator];
     }
-    // Prepended cutoff
+    // Prepended cutoff.
     else {
       return separator != null
         ? [terminator, separator, slicedValue]

--- a/packages/core/src/formatting/custom-formats/CutoffFormat/types.ts
+++ b/packages/core/src/formatting/custom-formats/CutoffFormat/types.ts
@@ -3,9 +3,9 @@
 /** Type of terminator */
 export type CutoffFormatStyle = 'none' | 'ellipsis';
 
-/** Terminator options */
+/** Terminator options. */
 export interface TerminatorOptions {
-  /** The terminator to use */
+  /** The terminator to use. */
   terminator?: string;
   /** An optional separator between the terminator and the value */
   separator?: string;
@@ -13,7 +13,7 @@ export interface TerminatorOptions {
 
 /** Input formatting options (for constructor) */
 export interface CutoffFormatOptions extends TerminatorOptions {
-  /** Cutoff length */
+  /** Cutoff length. */
   maxChars?: number;
   /** Type of terminator */
   style?: CutoffFormatStyle;

--- a/packages/core/src/formatting/format.ts
+++ b/packages/core/src/formatting/format.ts
@@ -49,7 +49,7 @@ export function _formatCutoff({
  * @internal
  *
  * Will fallback to an empty string
- * TODO: add this to custom formats
+ * TODO: Add this to custom formats.
  */
 export function _formatMessageICU(
   message: string,
@@ -67,7 +67,7 @@ export function _formatMessageICU(
  * @returns {string} The original message, unchanged.
  * @internal
  *
- * TODO: add this to custom formats
+ * TODO: Add this to custom formats.
  */
 export function _formatMessageString(message: string): string {
   return message;

--- a/packages/core/src/id/hashSource.ts
+++ b/packages/core/src/id/hashSource.ts
@@ -14,7 +14,7 @@ import { HashMetadata } from './types';
  * First 16 characters of hash, hex encoded.
  *
  * @param {string} string - The string to be hashed.
- * @returns {string} - The resulting hash as a hexadecimal string.
+ * @returns {string} The resulting hash as a hexadecimal string.
  */
 export function hashString(string: string): string {
   return bytesToHex(sha256(utf8ToBytes(string))).slice(0, 16);
@@ -24,11 +24,11 @@ export function hashString(string: string): string {
  * Calculates a unique ID for the given children objects by hashing their sanitized JSON string representation.
  *
  * @param {any} childrenAsObjects - The children objects to be hashed.
- * @param {string} [context] - The context for the children
- * @param {string} [id] - The id for the JSX Children object
+ * @param {string} [context] - The context for the children.
+ * @param {string} [id] - The ID for the JSX children object.
  * @param {number} [maxChars] - The maxChars for the JSX Children object
- * @param {string} [dataFormat] - The data format of the sources
- * @param {function} [hashFunction] custom hash function
+ * @param {string} [dataFormat] - The data format of the sources.
+ * @param {function} [hashFunction] - Custom hash function.
  * @returns {string} - The unique has of the children.
  */
 export function hashSource(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -339,7 +339,7 @@ export class GT {
    * Queries branch information from the API.
    *
    * @param {BranchQuery} query - Object mapping the current branch and incoming branches
-   * @returns {Promise<BranchDataResult>} The branch information
+   * @returns {Promise<BranchDataResult>} The branch information.
    */
   async queryBranchData(query: BranchQuery): Promise<BranchDataResult> {
     this._validateAuth('queryBranchData');
@@ -350,7 +350,7 @@ export class GT {
    * Creates a new branch in the API. If the branch already exists, it will be returned.
    *
    * @param {CreateBranchQuery} query - Object mapping the branch name and default branch flag
-   * @returns {Promise<CreateBranchResult>} The created branch information
+   * @returns {Promise<CreateBranchResult>} The created branch information.
    */
   async createBranch(query: CreateBranchQuery): Promise<CreateBranchResult> {
     this._validateAuth('createBranch');
@@ -363,7 +363,7 @@ export class GT {
    *
    * @param {MoveMapping[]} moves - Array of move mappings (old fileId to new fileId)
    * @param {ProcessMovesOptions} options - Options including branchId and timeout
-   * @returns {Promise<ProcessMovesResponse>} The move processing results
+   * @returns {Promise<ProcessMovesResponse>} The move processing results.
    *
    * @example
    * const result = await gt.processFileMoves([
@@ -387,10 +387,10 @@ export class GT {
    * but whose fileIds are not in the provided list.
    * Used for move detection.
    *
-   * @param {string} branchId - The branch to check for orphaned files
+   * @param {string} branchId - The branch to check for orphaned files.
    * @param {string[]} fileIds - List of current file IDs (files that are NOT orphaned)
-   * @param {Object} options - Options including timeout
-   * @returns {Promise<GetOrphanedFilesResult>} The orphaned files
+   * @param {Object} options - Options including timeout.
+   * @returns {Promise<GetOrphanedFilesResult>} The orphaned files.
    *
    * @example
    * const result = await gt.getOrphanedFiles('branch-id', ['file-1', 'file-2']);
@@ -420,7 +420,7 @@ export class GT {
    * for processing and will generate a project setup based on the source files.
    *
    * @param {FileReference[]} files - Array of file references containing IDs of previously uploaded source files
-   * @param {SetupProjectOptions} [options] - Optional settings for target locales and timeout
+   * @param {SetupProjectOptions} [options] - Optional settings for target locales and timeout.
    * @returns {Promise<SetupProjectResult>} Object containing the jobId and status
    */
   async setupProject(
@@ -443,9 +443,9 @@ export class GT {
    * This method polls the API to determine whether one or more jobs are still running,
    * have completed successfully, or have failed. Jobs are created after calling either enqueueFiles or setupProject.
    *
-   * @param {string[]} jobIds - The unique identifiers of the jobs to check
-   * @param {number} [timeoutMs] - Optional timeout in milliseconds for the API request
-   * @returns {Promise<CheckJobStatusResult>} Object containing the job status
+   * @param {string[]} jobIds - The unique identifiers of the jobs to check.
+   * @param {number} [timeoutMs] - Optional timeout in milliseconds for the API request.
+   * @returns {Promise<CheckJobStatusResult>} Object containing the job status.
    *
    * @example
    * const result = await gt.checkJobStatus([
@@ -470,9 +470,9 @@ export class GT {
   /**
    * Polls job statuses until all jobs from enqueueFiles are finished or the timeout is reached.
    *
-   * @param {EnqueueFilesResult} enqueueResult - The result returned from enqueueFiles
-   * @param {AwaitJobsOptions} [options] - Polling configuration (interval, timeout)
-   * @returns {Promise<AwaitJobsResult>} The final status of all jobs and whether they all completed
+   * @param {EnqueueFilesResult} enqueueResult - The result returned from enqueueFiles.
+   * @param {AwaitJobsOptions} [options] - Polling configuration (interval, timeout).
+   * @returns {Promise<AwaitJobsResult>} The final status of all jobs and whether they all completed.
    */
   async awaitJobs(
     enqueueResult: EnqueueFilesResult,
@@ -496,8 +496,8 @@ export class GT {
    * generate translated content based on the source files and target locales provided.
    *
    * @param {FileReferenceIds[]} files - Array of file references containing IDs of previously uploaded source files
-   * @param {EnqueueOptions} options - Configuration options including source locale, target locales, and job settings
-   * @returns {Promise<EnqueueFilesResult>} Result containing job IDs, queue status, and processing information
+   * @param {EnqueueOptions} options - Configuration options including source locale, target locales, and job settings.
+   * @returns {Promise<EnqueueFilesResult>} Result containing job IDs, queue status, and processing information.
    */
   async enqueueFiles(
     files: FileReferenceIds[],
@@ -506,7 +506,7 @@ export class GT {
     // Validation
     this._validateAuth('enqueueFiles');
 
-    // Merge instance settings with options
+    // Merge instance settings with options.
     let mergedOptions: EnqueueOptions = {
       ...options,
       sourceLocale: options.sourceLocale ?? this.sourceLocale!,
@@ -550,7 +550,7 @@ export class GT {
    * with a user-defined tag ID and optional message.
    *
    * @param {CreateTagOptions} options - Tag creation options including tagId, sourceFileIds, and optional message
-   * @returns {Promise<CreateTagResult>} The created or updated tag
+   * @returns {Promise<CreateTagResult>} The created or updated tag.
    */
   async createTag(options: CreateTagOptions): Promise<CreateTagResult> {
     this._validateAuth('createTag');
@@ -578,7 +578,7 @@ export class GT {
     payload: SubmitUserEditDiffsPayload
   ): Promise<void> {
     this._validateAuth('submitUserEditDiffs');
-    // Normalize locales to canonical form before submission
+    // Normalize locales to canonical form before submission.
     const normalized: SubmitUserEditDiffsPayload = {
       ...payload,
       diffs: (payload.diffs || []).map((d) => ({
@@ -801,7 +801,7 @@ export class GT {
         : undefined,
     }));
 
-    // Request the batch download
+    // Request the batch download.
     const result = await _downloadFileBatch(
       requests,
       options,
@@ -865,7 +865,7 @@ export class GT {
       options?.sourceLocale || this.sourceLocale || libraryDefaultLocale
     );
 
-    // Request the translation
+    // Request the translation.
     const results = await _translateMany(
       [source],
       {
@@ -943,7 +943,7 @@ export class GT {
       options?.sourceLocale || this.sourceLocale || libraryDefaultLocale
     );
 
-    // Request the translation
+    // Request the translation.
     return await _translateMany(
       sources,
       {
@@ -965,8 +965,8 @@ export class GT {
    * translations through the translation workflow.
    *
    * @param {Array<{source: FileUpload}>} files - Array of objects containing source file data to upload
-   * @param {UploadFilesOptions} options - Configuration options including source locale and other upload settings
-   * @returns {Promise<UploadFilesResponse>} Upload result containing file IDs, version information, and upload status
+   * @param {UploadFilesOptions} options - Configuration options including source locale and other upload settings.
+   * @returns {Promise<UploadFilesResponse>} Upload result containing file IDs, version information, and upload status.
    */
   async uploadSourceFiles(
     files: { source: FileUpload }[],
@@ -975,7 +975,7 @@ export class GT {
     // Validation
     this._validateAuth('uploadSourceFiles');
 
-    // Merge instance settings with options
+    // Merge instance settings with options.
     const mergedOptions: UploadFilesOptions = {
       ...options,
       sourceLocale: this.resolveCanonicalLocale(
@@ -1015,10 +1015,10 @@ export class GT {
    * that you want to upload directly rather than generating them through the translation service.
    *
    * @param {Array<{source: FileUpload, translations: FileUpload[]}>} files - Array of file objects where:
-   *   - `source`: Reference to the existing source file (contains IDs but no content)
+   *   - `source`: Reference to the existing source file (contains IDs but no content).
    *   - `translations`: Array of translated files, each containing content, locale, and reference IDs
-   * @param {UploadFilesOptions} options - Configuration options including source locale and upload settings
-   * @returns {Promise<UploadFilesResponse>} Upload result containing translation IDs, status, and processing information
+   * @param {UploadFilesOptions} options - Configuration options including source locale and upload settings.
+   * @returns {Promise<UploadFilesResponse>} Upload result containing translation IDs, status, and processing information.
    */
   async uploadTranslations(
     files: {
@@ -1030,7 +1030,7 @@ export class GT {
     // Validation
     this._validateAuth('uploadTranslations');
 
-    // Merge instance settings with options
+    // Merge instance settings with options.
     const mergedOptions: UploadFilesOptions = {
       ...options,
       sourceLocale: options.sourceLocale ?? this.sourceLocale,
@@ -1135,11 +1135,11 @@ export class GT {
   /**
    * Formats a number according to the specified locales and options.
    *
-   * @param {number} number - The number to format
-   * @param {Object} [options] - Additional options for number formatting
-   * @param {string | string[]} [options.locales] - The locales to use for formatting
-   * @param {Intl.NumberFormatOptions} [options] - Additional Intl.NumberFormat options
-   * @returns {string} The formatted number
+   * @param {number} number - The number to format.
+   * @param {Object} [options] - Additional options for number formatting.
+   * @param {string | string[]} [options.locales] - The locales to use for formatting.
+   * @param {Intl.NumberFormatOptions} [options] - Additional Intl.NumberFormat options.
+   * @returns {string} The formatted number.
    *
    * @example
    * gt.formatNum(1234.56, { style: 'currency', currency: 'USD' });
@@ -1157,11 +1157,11 @@ export class GT {
   /**
    * Formats a date according to the specified locales and options.
    *
-   * @param {Date} date - The date to format
-   * @param {Object} [options] - Additional options for date formatting
-   * @param {string | string[]} [options.locales] - The locales to use for formatting
-   * @param {Intl.DateTimeFormatOptions} [options] - Additional Intl.DateTimeFormat options
-   * @returns {string} The formatted date
+   * @param {Date} date - The date to format.
+   * @param {Object} [options] - Additional options for date formatting.
+   * @param {string | string[]} [options.locales] - The locales to use for formatting.
+   * @param {Intl.DateTimeFormatOptions} [options] - Additional Intl.DateTimeFormat options.
+   * @returns {string} The formatted date.
    *
    * @example
    * gt.formatDateTime(new Date(), { dateStyle: 'full', timeStyle: 'long' });
@@ -1179,12 +1179,12 @@ export class GT {
   /**
    * Formats a currency value according to the specified locales and options.
    *
-   * @param {number} value - The currency value to format
+   * @param {number} value - The currency value to format.
    * @param {string} currency - The currency code (e.g., 'USD', 'EUR')
-   * @param {Object} [options] - Additional options for currency formatting
-   * @param {string | string[]} [options.locales] - The locales to use for formatting
-   * @param {Intl.NumberFormatOptions} [options] - Additional Intl.NumberFormat options
-   * @returns {string} The formatted currency value
+   * @param {Object} [options] - Additional options for currency formatting.
+   * @param {string | string[]} [options.locales] - The locales to use for formatting.
+   * @param {Intl.NumberFormatOptions} [options] - Additional Intl.NumberFormat options.
+   * @returns {string} The formatted currency value.
    *
    * @example
    * gt.formatCurrency(1234.56, 'USD', { style: 'currency' });
@@ -1208,11 +1208,11 @@ export class GT {
   /**
    * Formats a list of items according to the specified locales and options.
    *
-   * @param {Array<string | number>} array - The list of items to format
-   * @param {Object} [options] - Additional options for list formatting
-   * @param {string | string[]} [options.locales] - The locales to use for formatting
-   * @param {Intl.ListFormatOptions} [options] - Additional Intl.ListFormat options
-   * @returns {string} The formatted list
+   * @param {Array<string | number>} array - The list of items to format.
+   * @param {Object} [options] - Additional options for list formatting.
+   * @param {string | string[]} [options.locales] - The locales to use for formatting.
+   * @param {Intl.ListFormatOptions} [options] - Additional Intl.ListFormat options.
+   * @returns {string} The formatted list.
    *
    * @example
    * gt.formatList(['apple', 'banana', 'orange'], { type: 'conjunction' });
@@ -1229,11 +1229,11 @@ export class GT {
 
   /**
    * Formats a list of items according to the specified locales and options.
-   * @param {Array<T>} array - The list of items to format
-   * @param {Object} [options] - Additional options for list formatting
-   * @param {string | string[]} [options.locales] - The locales to use for formatting
-   * @param {Intl.ListFormatOptions} [options] - Additional Intl.ListFormat options
-   * @returns {Array<T | string>} The formatted list parts
+   * @param {Array<T>} array - The list of items to format.
+   * @param {Object} [options] - Additional options for list formatting.
+   * @param {string | string[]} [options.locales] - The locales to use for formatting.
+   * @param {Intl.ListFormatOptions} [options] - Additional Intl.ListFormat options.
+   * @returns {Array<T | string>} The formatted list parts.
    *
    * @example
    * gt.formatListToParts(['apple', 42, { foo: 'bar' }], { type: 'conjunction', style: 'short', locales: ['en'] });
@@ -1255,12 +1255,12 @@ export class GT {
   /**
    * Formats a relative time value according to the specified locales and options.
    *
-   * @param {number} value - The relative time value to format
+   * @param {number} value - The relative time value to format.
    * @param {Intl.RelativeTimeFormatUnit} unit - The unit of time (e.g., 'second', 'minute', 'hour', 'day', 'week', 'month', 'year')
-   * @param {Object} options - Additional options for relative time formatting
-   * @param {string | string[]} [options.locales] - The locales to use for formatting
-   * @param {Intl.RelativeTimeFormatOptions} [options] - Additional Intl.RelativeTimeFormat options
-   * @returns {string} The formatted relative time string
+   * @param {Object} options - Additional options for relative time formatting.
+   * @param {string | string[]} [options.locales] - The locales to use for formatting.
+   * @param {Intl.RelativeTimeFormatOptions} [options] - Additional Intl.RelativeTimeFormat options.
+   * @returns {string} The formatted relative time string.
    *
    * @example
    * gt.formatRelativeTime(-1, 'day', { locales: ['en-US'], numeric: 'auto' });
@@ -1284,9 +1284,9 @@ export class GT {
   /**
    * Formats a relative time string from a Date, automatically selecting the best unit.
    *
-   * @param {Date} date - The date to format relative to now
-   * @param {Object} [options] - Additional options for relative time formatting
-   * @param {string | string[]} [options.locales] - The locales to use for formatting
+   * @param {Date} date - The date to format relative to now.
+   * @param {Object} [options] - Additional options for relative time formatting.
+   * @param {string | string[]} [options.locales] - The locales to use for formatting.
    * @returns {string} The formatted relative time string (e.g., "2 hours ago", "in 3 days")
    *
    * @example
@@ -1312,9 +1312,9 @@ export class GT {
   /**
    * Retrieves the display name of a locale code using Intl.DisplayNames, returning an empty string if no name is found.
    *
-   * @param {string} [locale=this.targetLocale] - A BCP-47 locale code
-   * @returns {string} The display name corresponding to the code
-   * @throws {Error} If no target locale is provided
+   * @param {string} [locale=this.targetLocale] - A BCP-47 locale code.
+   * @returns {string} The display name corresponding to the code.
+   * @throws {Error} If no target locale is provided.
    *
    * @example
    * gt.getLocaleName('es-ES');
@@ -1330,8 +1330,8 @@ export class GT {
    * Uses the locale's region (if present) to select an emoji or falls back on default emojis.
    *
    * @param {string} [locale=this.targetLocale] - A BCP-47 locale code (e.g., 'en-US', 'fr-CA')
-   * @returns {string} The emoji representing the locale or its region
-   * @throws {Error} If no target locale is provided
+   * @returns {string} The emoji representing the locale or its region.
+   * @throws {Error} If no target locale is provided.
    *
    * @example
    * gt.getLocaleEmoji('es-ES');
@@ -1454,12 +1454,12 @@ export class GT {
   /**
    * Determines whether a translation is required based on the source and target locales.
    *
-   * @param {string} [sourceLocale=this.sourceLocale] - The locale code for the original content
-   * @param {string} [targetLocale=this.targetLocale] - The locale code to translate into
-   * @param {string[]} [approvedLocales=this.locales] - Optional array of approved target locales
+   * @param {string} [sourceLocale=this.sourceLocale] - The locale code for the original content.
+   * @param {string} [targetLocale=this.targetLocale] - The locale code to translate into.
+   * @param {string[]} [approvedLocales=this.locales] - Optional array of approved target locales.
    * @returns {boolean} True if translation is required, false otherwise
-   * @throws {Error} If no source locale is provided
-   * @throws {Error} If no target locale is provided
+   * @throws {Error} If no source locale is provided.
+   * @throws {Error} If no target locale is provided.
    *
    * @example
    * gt.requiresTranslation('en-US', 'es-ES');
@@ -1493,9 +1493,9 @@ export class GT {
   /**
    * Determines the best matching locale from the provided approved locales list.
    *
-   * @param {string | string[]} locales - A single locale or array of locales in preference order
-   * @param {string[]} [approvedLocales=this.locales] - Array of approved locales in preference order
-   * @returns {string | undefined} The best matching locale or undefined if no match is found
+   * @param {string | string[]} locales - A single locale or array of locales in preference order.
+   * @param {string[]} [approvedLocales=this.locales] - Array of approved locales in preference order.
+   * @returns {string | undefined} The best matching locale, or undefined if no match is found.
    *
    * @example
    * gt.determineLocale(['fr-CA', 'fr-FR'], ['en-US', 'fr-FR', 'es-ES']);
@@ -1515,9 +1515,9 @@ export class GT {
   /**
    * Gets the text direction for a given locale code.
    *
-   * @param {string} [locale=this.targetLocale] - A BCP-47 locale code
-   * @returns {'ltr' | 'rtl'} 'rtl' if the locale is right-to-left, otherwise 'ltr'
-   * @throws {Error} If no target locale is provided
+   * @param {string} [locale=this.targetLocale] - A BCP-47 locale code.
+   * @returns {'ltr' | 'rtl'} 'rtl' if the locale is right-to-left; otherwise 'ltr'.
+   * @throws {Error} If no target locale is provided.
    *
    * @example
    * gt.getLocaleDirection('ar-SA');
@@ -1532,10 +1532,10 @@ export class GT {
   /**
    * Checks if a given BCP 47 locale code is valid.
    *
-   * @param {string} [locale=this.targetLocale] - The BCP 47 locale code to validate
-   * @param {customMapping} [customMapping=this.customMapping] - The custom mapping to use for validation
+   * @param {string} [locale=this.targetLocale] - The BCP 47 locale code to validate.
+   * @param {CustomMapping} [customMapping=this.customMapping] - The custom mapping to use for validation.
    * @returns {boolean} True if the locale code is valid, false otherwise
-   * @throws {Error} If no target locale is provided
+   * @throws {Error} If no target locale is provided.
    *
    * @example
    * gt.isValidLocale('en-US');
@@ -1591,9 +1591,9 @@ export class GT {
   /**
    * Standardizes a BCP 47 locale code to ensure correct formatting.
    *
-   * @param {string} [locale=this.targetLocale] - The BCP 47 locale code to standardize
+   * @param {string} [locale=this.targetLocale] - The BCP 47 locale code to standardize.
    * @returns {string} The standardized locale code or empty string if invalid
-   * @throws {Error} If no target locale is provided
+   * @throws {Error} If no target locale is provided.
    *
    * @example
    * gt.standardizeLocale('en_us');
@@ -1608,7 +1608,7 @@ export class GT {
   /**
    * Checks if multiple BCP 47 locale codes represent the same dialect.
    *
-   * @param {...(string | string[])} locales - The BCP 47 locale codes to compare
+   * @param {...(string | string[])} locales - The BCP 47 locale codes to compare.
    * @returns {boolean} True if all codes represent the same dialect, false otherwise
    *
    * @example
@@ -1625,7 +1625,7 @@ export class GT {
   /**
    * Checks if multiple BCP 47 locale codes represent the same language.
    *
-   * @param {...(string | string[])} locales - The BCP 47 locale codes to compare
+   * @param {...(string | string[])} locales - The BCP 47 locale codes to compare.
    * @returns {boolean} True if all codes represent the same language, false otherwise
    *
    * @example
@@ -1750,11 +1750,11 @@ export function formatList(
 
 /**
  * Formats a list of items according to the specified locales and options.
- * @param {Array<T>} array - The list of items to format
- * @param {Object} [options] - Additional options for list formatting
- * @param {string | string[]} [options.locales] - The locales to use for formatting
- * @param {Intl.ListFormatOptions} [options] - Additional Intl.ListFormat options
- * @returns {Array<T | string>} The formatted list parts
+ * @param {Array<T>} array - The list of items to format.
+ * @param {Object} [options] - Additional options for list formatting.
+ * @param {string | string[]} [options.locales] - The locales to use for formatting.
+ * @param {Intl.ListFormatOptions} [options] - Additional Intl.ListFormat options.
+ * @returns {Array<T | string>} The formatted list parts.
  */
 export function formatListToParts<T>(
   array: Array<T>,
@@ -1981,7 +1981,7 @@ export function determineLocale(
  * Get the text direction for a given locale code using the Intl.Locale API.
  *
  * @param {string} locale - A BCP-47 locale code.
- * @returns {string} - 'rtl' if the locale is right-to-left, otherwise 'ltr'.
+ * @returns {string} 'rtl' if the locale is right-to-left; otherwise 'ltr'.
  */
 export function getLocaleDirection(locale: string): 'ltr' | 'rtl' {
   return _getLocaleDirection(locale);

--- a/packages/core/src/locales/getLocaleDirection.ts
+++ b/packages/core/src/locales/getLocaleDirection.ts
@@ -5,7 +5,7 @@ import _getLocaleProperties from './getLocaleProperties';
  * Get the text direction for a given locale code using the Intl.Locale API.
  *
  * @param {string} code - The locale code to check.
- * @returns {string} - 'rtl' if the language is right-to-left, otherwise 'ltr'.
+ * @returns {string} 'rtl' if the language is right-to-left; otherwise 'ltr'.
  * @internal
  */
 export function _getLocaleDirection(code: string): 'ltr' | 'rtl' {
@@ -68,7 +68,7 @@ const RTL_LANGUAGES = new Set([
 
 /**
  * Handles extracting direction via textInfo property
- * @param Locale - Intl.Locale object
+ * @param locale - Intl.Locale object.
  * @returns {'ltr' | 'rtl'} - The direction of the locale
  *
  * Intl.Locale.prototype.getTextInfo() / textInfo property incorporated in ES2024 Specification.

--- a/packages/core/src/logging/logger.ts
+++ b/packages/core/src/logging/logger.ts
@@ -1,6 +1,6 @@
 /**
- * Comprehensive logging system for the General Translation library
- * Provides structured logging with multiple levels and configurable output
+ * Comprehensive logging system for the General Translation library.
+ * Provides structured logging with multiple levels and configurable output.
  */
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'off';
@@ -14,17 +14,17 @@ export interface LogEntry {
 }
 
 export interface LoggerConfig {
-  /** Minimum log level to output */
+  /** Minimum log level to output. */
   level: LogLevel;
-  /** Whether to include timestamps in log output */
+  /** Whether to include timestamps in log output. */
   includeTimestamp: boolean;
-  /** Whether to include context information */
+  /** Whether to include context information. */
   includeContext: boolean;
-  /** Custom prefix for all log messages */
+  /** Custom prefix for all log messages. */
   prefix?: string;
   /** Whether to output to console (default: true) */
   enableConsole: boolean;
-  /** Custom log handlers */
+  /** Custom log handlers. */
   handlers?: LogHandler[];
 }
 
@@ -91,7 +91,7 @@ export class ConsoleLogHandler implements LogHandler {
       parts.push(`[${this.config.prefix}]`);
     }
 
-    // Add context if available and enabled
+    // Add context if available and enabled.
     if (this.config.includeContext && entry.context) {
       parts.push(`[${entry.context}]`);
     }
@@ -99,7 +99,7 @@ export class ConsoleLogHandler implements LogHandler {
     // Add the main message
     parts.push(entry.message);
 
-    // Format metadata if available
+    // Format metadata if available.
     if (entry.metadata && Object.keys(entry.metadata).length > 0) {
       parts.push(`\n  Metadata: ${JSON.stringify(entry.metadata, null, 2)}`);
     }
@@ -125,7 +125,7 @@ export class ConsoleLogHandler implements LogHandler {
 }
 
 /**
- * Main Logger class providing structured logging capabilities
+ * Main Logger class providing structured logging capabilities.
  */
 export class Logger {
   private config: LoggerConfig;
@@ -226,7 +226,7 @@ export class Logger {
 
   /**
    * Log an info message
-   * Used for general information about application operation
+   * Used for general information about application operation.
    */
   info(
     message: string,
@@ -250,7 +250,7 @@ export class Logger {
 
   /**
    * Log an error message
-   * Used for error events that might still allow the application to continue
+   * Used for error events that might still allow the application to continue.
    */
   error(
     message: string,
@@ -276,7 +276,7 @@ export class Logger {
 }
 
 /**
- * Context logger that automatically includes context information
+ * Context logger that automatically includes context information.
  */
 export class ContextLogger {
   private logger: Logger;
@@ -308,7 +308,7 @@ export class ContextLogger {
   }
 }
 
-// Default logger instance
+// Default logger instance.
 export const defaultLogger = new Logger({
   level: getConfiguredLogLevel(),
   includeTimestamp: true,
@@ -316,7 +316,7 @@ export const defaultLogger = new Logger({
   prefix: 'GT',
 });
 
-// Convenience functions using the default logger
+// Convenience functions using the default logger.
 export const debug = (
   message: string,
   context?: string,

--- a/packages/core/src/projects/getProjectData.ts
+++ b/packages/core/src/projects/getProjectData.ts
@@ -11,9 +11,9 @@ import { ProjectData } from '../types-dir/api/project';
  * @internal
  * Gets the project data for a given project ID.
  * @param projectId - The project ID to get the project data for
- * @param options - The options for the API call
- * @param config - The configuration for the request
- * @returns The project data for the given project ID
+ * @param options - The options for the API call.
+ * @param config - The configuration for the request.
+ * @returns The project data for the given project ID.
  */
 export default async function _getProjectData(
   projectId: string,

--- a/packages/core/src/translate/awaitJobs.ts
+++ b/packages/core/src/translate/awaitJobs.ts
@@ -24,10 +24,10 @@ export type AwaitJobsResult = {
 /**
  * @internal
  * Polls job statuses until all jobs are finished or the timeout is reached.
- * @param enqueueResult - The result from enqueueFiles
- * @param options - Polling configuration
- * @param config - API credentials and configuration
- * @returns The final status of all jobs
+ * @param enqueueResult - The result from enqueueFiles.
+ * @param options - Polling configuration.
+ * @param config - API credentials and configuration.
+ * @returns The final status of all jobs.
  */
 export default async function _awaitJobs(
   enqueueResult: EnqueueFilesResult,

--- a/packages/core/src/translate/checkJobStatus.ts
+++ b/packages/core/src/translate/checkJobStatus.ts
@@ -16,11 +16,11 @@ export type CheckJobStatusResult = {
 
 /**
  * @internal
- * Queries job statuses for a project
- * @param jobIds - Job IDs
- * @param config - The configuration for the API call
- * @param timeoutMS - The timeout in milliseconds
- * @returns The result of the API call
+ * Queries job statuses for a project.
+ * @param jobIds - Job IDs.
+ * @param config - The configuration for the API call.
+ * @param timeoutMs - The timeout in milliseconds.
+ * @returns The result of the API call.
  */
 export async function _checkJobStatus(
   jobIds: string[],

--- a/packages/core/src/translate/createBranch.ts
+++ b/packages/core/src/translate/createBranch.ts
@@ -14,8 +14,8 @@ export type CreateBranchResult = {
  * @internal
  * Creates a new branch in the API.
  * @param query - Object mapping the branch name and default branch flag
- * @param config - The configuration for the API call
- * @returns The created branch information
+ * @param config - The configuration for the API call.
+ * @returns The created branch information.
  */
 export default async function _createBranch(
   query: CreateBranchQuery,

--- a/packages/core/src/translate/createTag.ts
+++ b/packages/core/src/translate/createTag.ts
@@ -26,9 +26,9 @@ export type CreateTagResult = {
 /**
  * @internal
  * Creates or upserts a file tag in the General Translation API.
- * @param options - The tag creation options
- * @param config - The configuration for the API call
- * @returns The created or updated tag
+ * @param options - The tag creation options.
+ * @param config - The configuration for the API call.
+ * @returns The created or updated tag.
  */
 export default async function _createTag(
   options: CreateTagOptions,

--- a/packages/core/src/translate/downloadFileBatch.ts
+++ b/packages/core/src/translate/downloadFileBatch.ts
@@ -12,8 +12,8 @@ import { processBatches } from './utils/batch';
  * @internal
  * Downloads multiple translation files in batches.
  * @param files - Array of files to download
- * @param options - The options for the API call
- * @param config - The configuration for the request
+ * @param options - The options for the API call.
+ * @param config - The configuration for the request.
  * @returns Promise resolving to a BatchList with all downloaded files
  */
 export default async function _downloadFileBatch(

--- a/packages/core/src/translate/enqueueFiles.ts
+++ b/packages/core/src/translate/enqueueFiles.ts
@@ -17,9 +17,9 @@ export type EnqueueOptions = {
  * @internal
  * Enqueues files for translation in the General Translation API.
  * @param files - References of files to translate (file content already uploaded)
- * @param options - The options for the API call
- * @param config - The configuration for the API call
- * @returns The result of the API call
+ * @param options - The options for the API call.
+ * @param config - The configuration for the API call.
+ * @returns The result of the API call.
  */
 export default async function _enqueueFiles(
   files: FileReferenceIds[],

--- a/packages/core/src/translate/getOrphanedFiles.ts
+++ b/packages/core/src/translate/getOrphanedFiles.ts
@@ -62,7 +62,7 @@ export default async function _getOrphanedFiles(
     orphanedFileMap.set(orphan.fileId, orphan);
   }
 
-  // Intersect with each subsequent batch
+  // Intersect with each subsequent batch.
   for (let i = 1; i < batchResults.length; i++) {
     const batchOrphanIds = new Set(
       batchResults[i].orphanedFiles.map((f) => f.fileId)

--- a/packages/core/src/translate/processFileMoves.ts
+++ b/packages/core/src/translate/processFileMoves.ts
@@ -37,7 +37,7 @@ export type ProcessMovesOptions = {
  * Called when the CLI detects that files have been moved/renamed.
  * @param moves - Array of move mappings (old fileId to new fileId)
  * @param options - Options including branchId and timeout
- * @param config - The configuration for the API call
+ * @param config - The configuration for the API call.
  * @returns Promise resolving to the move results
  */
 export default async function _processFileMoves(

--- a/packages/core/src/translate/publishFiles.ts
+++ b/packages/core/src/translate/publishFiles.ts
@@ -24,8 +24,8 @@ export type PublishFilesResult = {
  * @internal
  * Publishes or unpublishes files on the CDN.
  * @param files - Array of file entries with publish flags
- * @param config - The configuration for the API call
- * @returns The result of the API call
+ * @param config - The configuration for the API call.
+ * @returns The result of the API call.
  */
 export default async function _publishFiles(
   files: PublishFileEntry[],

--- a/packages/core/src/translate/queryBranchData.ts
+++ b/packages/core/src/translate/queryBranchData.ts
@@ -10,8 +10,8 @@ export type BranchQuery = {
  * @internal
  * Queries branch information from the API.
  * @param query - Object mapping the current branch and incoming branches
- * @param config - The configuration for the API call
- * @returns The branch information
+ * @param config - The configuration for the API call.
+ * @returns The branch information.
  */
 export default async function _queryBranchData(
   query: BranchQuery,

--- a/packages/core/src/translate/queryFileData.ts
+++ b/packages/core/src/translate/queryFileData.ts
@@ -50,9 +50,9 @@ export type FileDataResult = {
  * @internal
  * Queries data about one or more source or translation files.
  * @param data - Object mapping source or translation file information
- * @param options - The options for the API call
- * @param config - The configuration for the API call
- * @returns The file data
+ * @param options - The options for the API call.
+ * @param config - The configuration for the API call.
+ * @returns The file data.
  */
 export default async function _queryFileData(
   data: FileDataQuery,

--- a/packages/core/src/translate/querySourceFile.ts
+++ b/packages/core/src/translate/querySourceFile.ts
@@ -10,8 +10,8 @@ import apiRequest from './utils/apiRequest';
  * @internal
  * Gets the source file and translation information for a given file ID and version ID.
  * @param query - The file ID and version ID to get the source file and translation information for
- * @param options - The options for the API call
- * @param config - The configuration for the request
+ * @param options - The options for the API call.
+ * @param config - The configuration for the request.
  * @returns The source file and translation information for the given file ID and version ID
  */
 export default async function _querySourceFile(

--- a/packages/core/src/translate/setupProject.ts
+++ b/packages/core/src/translate/setupProject.ts
@@ -16,9 +16,9 @@ export type SetupProjectOptions = {
  * @internal
  * Enqueues files for project setup the General Translation API.
  * @param files - References of files to translate (file content already uploaded)
- * @param config - The configuration for the API call
+ * @param config - The configuration for the API call.
  * @param timeoutMS - The timeout in milliseconds
- * @returns The result of the API call
+ * @returns The result of the API call.
  */
 export default async function _setupProject(
   files: FileReference[],

--- a/packages/core/src/translate/uploadSourceFiles.ts
+++ b/packages/core/src/translate/uploadSourceFiles.ts
@@ -12,9 +12,9 @@ import {
 /**
  * @internal
  * Uploads source files to the General Translation API in batches.
- * @param files - The files to upload
- * @param options - The options for the API call
- * @param config - The configuration for the API call
+ * @param files - The files to upload.
+ * @param options - The options for the API call.
+ * @param config - The configuration for the API call.
  * @returns Promise resolving to a BatchList with all uploaded files
  */
 export default async function _uploadSourceFiles(

--- a/packages/core/src/translate/uploadTranslations.ts
+++ b/packages/core/src/translate/uploadTranslations.ts
@@ -14,8 +14,8 @@ import { validateFileFormatTransforms } from './utils/validateFileFormatTransfor
  * @internal
  * Uploads multiple translations to the General Translation API in batches.
  * @param files - Translations to upload with their source
- * @param options - The options for the API call
- * @param config - The configuration for the API call
+ * @param options - The options for the API call.
+ * @param config - The configuration for the API call.
  * @returns Promise resolving to a BatchList with all uploaded files
  */
 export default async function _uploadTranslations(

--- a/packages/core/src/translate/utils/apiRequest.ts
+++ b/packages/core/src/translate/utils/apiRequest.ts
@@ -34,10 +34,10 @@ function getRetryDelay(policy: RetryPolicy, attempt: number): number {
  * Encapsulates URL construction, fetch with timeout, error handling,
  * response validation, and JSON parsing.
  *
- * @param config - The configuration for the API call
+ * @param config - The configuration for the API call.
  * @param endpoint - The API endpoint path (e.g. '/v2/project/jobs/info')
- * @param options - Optional request options
- * @returns The parsed JSON response
+ * @param options - Optional request options.
+ * @returns The parsed JSON response.
  */
 export default async function apiRequest<T>(
   config: TranslationRequestConfig,
@@ -75,7 +75,7 @@ export default async function apiRequest<T>(
       handleFetchError(error, timeout);
     }
 
-    // Retry on 5XX server errors
+    // Retry on 5XX server errors.
     if (response!.status >= 500 && attempt < maxRetries) {
       await sleep(getRetryDelay(retryPolicy, attempt));
       continue;

--- a/packages/core/src/translate/utils/batch.ts
+++ b/packages/core/src/translate/utils/batch.ts
@@ -1,8 +1,8 @@
 /**
  * Splits an array into batches of a specified size.
- * @param items - The array to split into batches
- * @param batchSize - The maximum size of each batch
- * @returns An array of batches
+ * @param items - The array to split into batches.
+ * @param batchSize - The maximum size of each batch.
+ * @returns An array of batches.
  */
 export function createBatches<T>(items: T[], batchSize: number): T[][] {
   const batches: T[][] = [];
@@ -13,7 +13,7 @@ export function createBatches<T>(items: T[], batchSize: number): T[][] {
 }
 
 /**
- * Result of processing batches
+ * Result of processing batches.
  */
 export interface BatchList<T> {
   /** The items successfully processed across all batches */
@@ -25,7 +25,7 @@ export interface BatchList<T> {
 }
 
 /**
- * Options for batch processing
+ * Options for batch processing.
  */
 export interface BatchProcessOptions {
   /** Maximum number of items per batch (default: 100) */
@@ -37,10 +37,10 @@ export interface BatchProcessOptions {
 /**
  * Processes items in batches using a provided processor function.
  *
- * @param items - The items to process
- * @param processor - Async function that processes a single batch and returns items
- * @param options - Optional configuration for batch processing
- * @returns Promise that resolves to a BatchList containing all processed items
+ * @param items - The items to process.
+ * @param processor - Async function that processes a single batch and returns items.
+ * @param options - Optional configuration for batch processing.
+ * @returns Promise that resolves to a BatchList containing all processed items.
  *
  * @example
  * ```typescript
@@ -77,7 +77,7 @@ export async function processBatches<TInput, TOutput>(
   const allItems: TOutput[] = [];
 
   if (parallel) {
-    // Process all batches in parallel
+    // Process all batches in parallel.
     const results = await Promise.all(batches.map((batch) => processor(batch)));
     for (const result of results) {
       if (result) {
@@ -85,7 +85,7 @@ export async function processBatches<TInput, TOutput>(
       }
     }
   } else {
-    // Process batches sequentially
+    // Process batches sequentially.
     for (const batch of batches) {
       const result = await processor(batch);
       if (result) {

--- a/packages/core/src/types-dir/api/enqueueFiles.ts
+++ b/packages/core/src/types-dir/api/enqueueFiles.ts
@@ -24,13 +24,13 @@ export type Updates = ({
 
 /**
  * Options for enqueueing files
- * @param requireApproval - Whether to require approval for the files
- * @param description - Optional description for the project
- * @param sourceLocale - The project's source locale
- * @param targetLocales - The locales to translate the files to
- * @param version - Optional custom version ID to specify
- * @param timeout - Optional timeout for the request
- * @param modelProvider - Optional model provider to use
+ * @param requireApproval - Whether to require approval for the files.
+ * @param description - Optional description for the project.
+ * @param sourceLocale - The project's source locale.
+ * @param targetLocales - The locales to translate the files to.
+ * @param version - Optional custom version ID to specify.
+ * @param timeout - Optional timeout for the request.
+ * @param modelProvider - Optional model provider to use.
  */
 export type EnqueueFilesOptions = {
   requireApproval?: boolean;

--- a/packages/core/src/types-dir/api/entry.ts
+++ b/packages/core/src/types-dir/api/entry.ts
@@ -11,7 +11,7 @@ export type ActionType = 'fast'; // TODO: Add standard action type when availabl
  * EntryMetadata is the metadata for a GTRequest.
  *
  * @param context - The context of the request.
- * @param id - The id of the request.
+ * @param id - The ID of the request.
  * @param maxChars - The maxChars of the request.
  * @param hash - The hash of the request.
  */

--- a/packages/core/src/types-dir/api/file.ts
+++ b/packages/core/src/types-dir/api/file.ts
@@ -16,18 +16,18 @@ export type FileFormat =
   | 'TWILIO_CONTENT_JSON';
 
 /**
- * Metadata for files or entries
+ * Metadata for files or entries.
  */
 type FormatMetadata = Record<string, any> | Updates[number]['metadata'];
 
 /**
- * File object structure for uploading files
+ * File object structure for uploading files.
  * @see {@link FileReferenceOptionalBranchId}
- * @property {string} content - Content of the file
+ * @property {string} content - Content of the file.
  * @property {string} locale - The locale of the file (e.g. 'en', 'de', 'es', etc.)
  * @property {FormatMetadata} [formatMetadata] - Optional metadata for the file, specific to the format of the file
- * @property {string} [incomingBranchId] - The ID of the incoming branch of the file
- * @property {string} [checkedOutBranchId] - The ID of the checked out branch of the file
+ * @property {string} [incomingBranchId] - The ID of the incoming branch of the file.
+ * @property {string} [checkedOutBranchId] - The ID of the checked-out branch of the file.
  */
 export type FileToUpload = Omit<FileReference, 'branchId'> & {
   content: string;
@@ -41,14 +41,14 @@ export type FileToUpload = Omit<FileReference, 'branchId'> & {
 };
 
 /**
- * File object structure for referencing files
- * @property {string} fileId - The ID of the file
+ * File object structure for referencing files.
+ * @property {string} fileId - The ID of the file.
  * @property {string} versionId - The ID of the version of the file
  * @property {string} branchId - The ID of the branch of the file
  * @property {string} locale - The locale of the file (e.g. 'en', 'de', 'es', etc.)
- * @property {string} fileName - The name of the file
- * @property {FileFormat} fileFormat - The format of the file (JSON, MDX, MD, etc.)
- * @property {DataFormat} [dataFormat] - Optional format of the data within the file
+ * @property {string} fileName - The name of the file.
+ * @property {FileFormat} fileFormat - The format of the file (JSON, MDX, MD, etc.).
+ * @property {DataFormat} [dataFormat] - Optional format of the data within the file.
  */
 export type FileReference = {
   fileId: string;
@@ -62,7 +62,7 @@ export type FileReference = {
 };
 
 /**
- * File reference object structure for referencing files
+ * File reference object structure for referencing files.
  * @see {@link FileReference}
  * @property {string} [branchId] - The ID of the branch of the file
  */

--- a/packages/core/src/types-dir/jsx/content.ts
+++ b/packages/core/src/types-dir/jsx/content.ts
@@ -43,36 +43,36 @@ export type JsxChild = string | JsxElement | Variable;
 export type StringFormat = 'ICU' | 'I18NEXT' | 'STRING';
 
 /**
- * The format of the content
+ * The format of the content.
  */
 export type DataFormat = 'JSX' | StringFormat;
 
 /**
- * String format content
+ * String format content.
  */
 export type StringContent = IcuMessage | StringMessage | I18nextMessage;
 
 /**
- * A content type representing JSX, ICU, and I18next messages
+ * A content type representing JSX, ICU, and I18next messages.
  */
 export type Content = JsxChildren | StringContent;
 
 /**
- * A content type representing JSX elements
+ * A content type representing JSX elements.
  */
 export type JsxChildren = JsxChild | JsxChild[];
 
 /**
- * A content type representing ICU messages
+ * A content type representing ICU messages.
  */
 export type IcuMessage = string;
 
 /**
- * A content type representing I18next messages
+ * A content type representing I18next messages.
  */
 export type I18nextMessage = string;
 
 /**
- * A content type representing plain strings
+ * A content type representing plain strings.
  */
 export type StringMessage = string;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -228,9 +228,9 @@ export type { CustomMapping } from './locales/customLocaleMapping';
 /**
  * TranslationRequestConfig is used to configure the translation request.
  *
- * @param projectId - The project id of the translation request.
- * @param baseUrl - The base url of the translation request.
- * @param apiKey - The api key of the translation request.
+ * @param projectId - The project ID of the translation request.
+ * @param baseUrl - The base URL of the translation request.
+ * @param apiKey - The API key of the translation request.
  */
 export type TranslationRequestConfig = {
   projectId: string;

--- a/packages/core/src/utils/base64.ts
+++ b/packages/core/src/utils/base64.ts
@@ -1,10 +1,10 @@
 // Encode a string to base64
 export function encode(data: string): string {
   if (typeof Buffer !== 'undefined') {
-    // Node.js path
+    // Node.js path.
     return Buffer.from(data, 'utf8').toString('base64');
   }
-  // Browser path
+  // Browser path.
   const bytes = new TextEncoder().encode(data);
   let binary = '';
   for (let i = 0; i < bytes.length; i++) {
@@ -16,10 +16,10 @@ export function encode(data: string): string {
 // Decode a base64 string to a string
 export function decode(base64: string): string {
   if (typeof Buffer !== 'undefined') {
-    // Node.js path
+    // Node.js path.
     return Buffer.from(base64, 'base64').toString('utf8');
   }
-  // Browser path
+  // Browser path.
   const binary = atob(base64);
   const bytes = new Uint8Array(binary.length);
   for (let i = 0; i < binary.length; i++) {

--- a/packages/core/src/utils/isSupportedFileFormatTransform.ts
+++ b/packages/core/src/utils/isSupportedFileFormatTransform.ts
@@ -18,8 +18,8 @@ const SUPPORTED_TRANSFORMATIONS = {
 
 /**
  * This function checks if a file format transformation is supported during translation
- * @param from - The source file format
- * @param to - The target file format
+ * @param from - The source file format.
+ * @param to - The target file format.
  * @returns True if the transformation is supported, false otherwise
  */
 export function isSupportedFileFormatTransform(


### PR DESCRIPTION
## Summary
- Normalize simple punctuation and capitalization in core comments/JSDoc
- Keep changes limited to comment-only mechanical edits

## Verification
- `git diff --check origin/main...HEAD`
- Verified changed line pairs are comment/JSDoc-only mechanical punctuation/casing edits

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR applies mechanical comment-only edits across 40 files in `packages/core`: trailing periods are added to JSDoc `@param`, `@returns`, and inline comment lines, and several abbreviations are capitalized consistently (`id` → `ID`, `url` → `URL`, `api` → `API`, `checked out` → `checked-out`). No logic, type definitions, or runtime behavior is changed.

- Trailing periods and capitalization fixes are applied to ~200 JSDoc tags across the `translate/`, `types-dir/`, `derive/`, and `formatting/` subdirectories.
- A small number of `@returns` tags (e.g. in `hashSource.ts`, `oldHashJsxChildren.ts`, `isSupportedFileFormatTransform.ts`) and several `@property` lines in `file.ts` were not updated, leaving those blocks internally inconsistent with the rest of the PR's changes.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

All 40 changed files are comment-only; no executable code, types, or exports are touched. Safe to merge.

The normalization is thorough across the majority of the diff, but a handful of @returns and @property tags in hashSource.ts, oldHashJsxChildren.ts, file.ts, and isSupportedFileFormatTransform.ts were not updated while adjacent tags in the same block were, leaving those blocks internally inconsistent.

packages/core/src/id/hashSource.ts, packages/core/src/backwards-compatability/oldHashJsxChildren.ts, packages/core/src/types-dir/api/file.ts, and packages/core/src/utils/isSupportedFileFormatTransform.ts have partially normalized JSDoc blocks.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/id/hashSource.ts | Comment-only: normalized @param periods and capitalization, but @param [maxChars] and @returns are inconsistently left without periods / still carry the old dash prefix. |
| packages/core/src/types-dir/api/file.ts | Comment-only: several @property tags in FileReference and FileReferenceOptionalBranchId blocks were not normalized while adjacent properties were. |
| packages/core/src/utils/isSupportedFileFormatTransform.ts | Comment-only: @param tags normalized but @returns tag left without a trailing period. |
| packages/core/src/index.ts | Comment-only: trailing periods added to @param/@returns tags and inline comments across all public GT class methods; no logic changes. |
| packages/core/src/translate/utils/batch.ts | Comment-only: trailing periods added to all JSDoc tags and interface descriptions consistently. |
| packages/core/src/types.ts | Comment-only: id → ID, url → URL, api → API capitalization fixes in TranslationRequestConfig JSDoc. |
| packages/core/src/backwards-compatability/oldHashJsxChildren.ts | Comment-only: @param punctuation normalized, but @returns still retains the old dash prefix that was removed from the sibling hashString function. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/core/src/id/hashSource.ts:27-34
**Partial normalization leaves inconsistency in `@returns` and `@param`**

The sibling `@param` tags for `[context]`, `[id]`, `[dataFormat]`, and `[hashFunction]` all received trailing periods in this PR, but `@param {number} [maxChars]` and `@returns {string}` were not updated. The `@returns` tag here also still carries the `- ` prefix that was removed from the equivalent tag in `hashString` above it. The same pattern appears in `oldHashJsxChildren.ts` — the `@returns {string} - The unique has of the children.` line was left with its dash prefix while the analogous line in `oldHashString` was normalized.

### Issue 2 of 3
packages/core/src/types-dir/api/file.ts:49-62
**Several `@property` tags missed in the same block**

Within the `FileReference` JSDoc block, `@property {string} versionId`, `@property {string} branchId`, and `@property {string} locale` did not receive trailing periods, while `@property {string} fileId`, `@property {string} fileName`, `@property {FileFormat} fileFormat`, and `@property {DataFormat} [dataFormat]` did. Likewise in `FileReferenceOptionalBranchId`, `@property {string} [branchId]` is missing its period. This leaves the two blocks internally inconsistent.

### Issue 3 of 3
packages/core/src/utils/isSupportedFileFormatTransform.ts:20-22
**`@returns` tag not normalized in this file**

The two `@param` tags received trailing periods, but `@returns True if the transformation is supported, false otherwise` was not updated to end with a period. The same pattern is visible in `typeChecking.ts`, where several `@returns` lines that lack `{type}` prefixes were also left without trailing periods.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(core): normalize comment punctuatio..."](https://github.com/generaltranslation/gt/commit/07f7d952c57b9946c55d1f8718146397eb63db96) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30872474)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->