### PR TITLE
docs(core): correct locale helper comments

### DIFF
--- a/packages/core/src/backwards-compatability/dataConversion.ts
+++ b/packages/core/src/backwards-compatability/dataConversion.ts
@@ -135,7 +135,7 @@ export function getNewGTProp(dataGT: OldGTProp): GTProp {
 }
 
 /**
- * Convert response data from old format to new format
+ * Convert response data from current format to old format
  */
 
 export function getOldJsxChild(child: JsxChild): OldJsxChild {

--- a/packages/core/src/backwards-compatability/oldHashJsxChildren.ts
+++ b/packages/core/src/backwards-compatability/oldHashJsxChildren.ts
@@ -7,7 +7,7 @@ import { bytesToHex, utf8ToBytes } from '@noble/hashes/utils.js';
 
 // ----- FUNCTIONS ----- //
 /**
- * Calculates a unique hash for a given string using sha256.
+ * Calculates a unique hash for a given string using SHA-256.
  *
  * @param {string} string - The string to be hashed.
  * @returns {string} The resulting hash as a hexadecimal string.
@@ -23,7 +23,7 @@ export function oldHashString(string: string): string {
  * @param {string} context - The context for the children.
  * @param {string} id - The ID for the JSX children object.
  * @param {function} hashFunction - Custom hash function.
- * @returns {string} - The unique has of the children.
+ * @returns {string} - The unique hash of the children.
  */
 export function oldHashJsxChildren(
   {

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -133,7 +133,7 @@ export function isValidLocale(locale: string, customMapping?: CustomMapping) {
  *
  * @param {string} locale - The locale to resolve the canonical locale for.
  * @param {CustomMapping} [customMapping] - The custom mapping to use for resolving the canonical locale.
- * @returns {string} The canonical locale.
+ * @returns {string} The canonical locale, or the input locale when no canonical mapping exists.
  *
  * @example
  * resolveCanonicalLocale('en-US');
@@ -154,7 +154,7 @@ export function resolveCanonicalLocale(
  * Standardizes a BCP 47 locale code to ensure correct formatting.
  *
  * @param {string} locale - The BCP 47 locale code to standardize.
- * @returns {string} The standardized BCP 47 locale code or an empty string if it is an invalid code.
+ * @returns {string} The standardized BCP 47 locale code, or the input string if it cannot be standardized.
  *
  * @example
  * standardizeLocale('en-us');
@@ -162,7 +162,7 @@ export function resolveCanonicalLocale(
  *
  * @example
  * standardizeLocale('not a locale');
- * // Returns: ''
+ * // Returns: 'not a locale'
  */
 export function standardizeLocale(locale: string) {
   return _standardizeLocale(locale);

--- a/packages/core/src/formatting/custom-formats/CutoffFormat/CutoffFormat.ts
+++ b/packages/core/src/formatting/custom-formats/CutoffFormat/CutoffFormat.ts
@@ -21,16 +21,16 @@ export class CutoffFormatConstructor implements CutoffFormat {
   private additionLength: number;
   /**
    * Constructor
-   * @param {string | string[]} locales - The locales to use for formatting.
+   * @param {Intl.LocalesArgument} locales - The locales to use for formatting.
    * @param {CutoffFormatOptions} options - The options for formatting.
-   * @param {number} [option.maxChars] - The maximum number of characters to display.
+   * @param {number} [options.maxChars] - The maximum number of characters to display.
    * - Undefined values are treated as no cutoff.
    * - Negative values follow .slice() behavior and terminator will be added before the value.
    * - 0 will result in an empty string.
    * - If cutoff results in an empty string, no terminator is added.
-   * @param {CutoffFormatStyle} [option.style='ellipsis'] - The style of the terminator.
-   * @param {string} [option.terminator] - Optional override the terminator to use.
-   * @param {string} [option.separator] - Optional override the separator to use between the terminator and the value.
+   * @param {CutoffFormatStyle} [options.style='ellipsis'] - The style of the terminator.
+   * @param {string} [options.terminator] - Optional override the terminator to use.
+   * @param {string} [options.separator] - Optional override the separator to use between the terminator and the value.
    * - If no terminator is provided, then separator is ignored.
    *
    * @example

--- a/packages/core/src/formatting/format.ts
+++ b/packages/core/src/formatting/format.ts
@@ -24,8 +24,6 @@ import { CutoffFormatOptions } from './custom-formats/CutoffFormat/types';
  *
  * @example
  * _formatCutoff({ value: 'Hello, world!', options: { maxChars: 8 } }); // Returns 'Hello, w...'
- *
- * Will fallback to an empty string if formatting fails.
  */
 export function _formatCutoff({
   value,
@@ -48,7 +46,7 @@ export function _formatCutoff({
  * @returns {string} The formatted message.
  * @internal
  *
- * Will fallback to an empty string
+ * Returns an empty string if IntlMessageFormat produces no output.
  * TODO: Add this to custom formats.
  */
 export function _formatMessageICU(

--- a/packages/core/src/id/hashSource.ts
+++ b/packages/core/src/id/hashSource.ts
@@ -9,7 +9,7 @@ import { HashMetadata } from './types';
 
 // ----- FUNCTIONS ----- //
 /**
- * Calculates a unique hash for a given string using sha256.
+ * Calculates a unique hash for a given string using SHA-256.
  *
  * First 16 characters of hash, hex encoded.
  *
@@ -26,10 +26,10 @@ export function hashString(string: string): string {
  * @param {any} childrenAsObjects - The children objects to be hashed.
  * @param {string} [context] - The context for the children.
  * @param {string} [id] - The ID for the JSX children object.
- * @param {number} [maxChars] - The maxChars for the JSX Children object
+ * @param {number} [maxChars] - The maxChars limit for the JSX children object.
  * @param {string} [dataFormat] - The data format of the sources.
  * @param {function} [hashFunction] - Custom hash function.
- * @returns {string} - The unique has of the children.
+ * @returns {string} - The unique hash of the children.
  */
 export function hashSource(
   {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1556,7 +1556,7 @@ export class GT {
    * Resolves the canonical locale for a given locale.
    * @param locale - The locale to resolve the canonical locale for
    * @param customMapping - The custom mapping to use for resolving the canonical locale
-   * @returns The canonical locale
+   * @returns The canonical locale, or the input locale when no canonical mapping exists.
    */
   resolveCanonicalLocale(
     locale: string | undefined = this.targetLocale,
@@ -1574,7 +1574,7 @@ export class GT {
    * Resolves the alias locale for a given locale.
    * @param locale - The locale to resolve the alias locale for
    * @param customMapping - The custom mapping to use for resolving the alias locale
-   * @returns The alias locale
+   * @returns The configured alias for a canonical locale, or the input locale when already an alias or no alias mapping exists.
    */
   resolveAliasLocale(
     locale: string,
@@ -1592,7 +1592,7 @@ export class GT {
    * Standardizes a BCP 47 locale code to ensure correct formatting.
    *
    * @param {string} [locale=this.targetLocale] - The BCP 47 locale code to standardize.
-   * @returns {string} The standardized locale code or empty string if invalid
+   * @returns {string} The standardized locale code, or the input string if it cannot be standardized.
    * @throws {Error} If no target locale is provided.
    *
    * @example

--- a/packages/core/src/locales/getPluralForm.ts
+++ b/packages/core/src/locales/getPluralForm.ts
@@ -6,7 +6,7 @@ import { libraryDefaultLocale } from '../settings/settings';
  * Given a number and a list of allowed plural forms, return the plural form that best fits the number.
  *
  * @param {number} n - The number to determine the plural form for.
- * @param {locales[]} forms - The allowed plural forms.
+ * @param {PluralType[]} forms - The allowed plural forms.
  * @returns {PluralType} The determined plural form, or an empty string if none fit.
  */
 export default function _getPluralForm(

--- a/packages/core/src/locales/isValidLocale.ts
+++ b/packages/core/src/locales/isValidLocale.ts
@@ -87,7 +87,7 @@ export const _isValidLocale = (
 /**
  * Standardizes a BCP 47 locale to ensure correct formatting.
  * @param {string} locale - The BCP 47 locale to standardize.
- * @returns {string} The standardized BCP 47 locale, or an empty string if invalid.
+ * @returns {string} The standardized BCP 47 locale, or the input string if it cannot be standardized.
  * @internal
  */
 export const _standardizeLocale = (locale: string): string => {

--- a/packages/core/src/locales/resolveAliasLocale.ts
+++ b/packages/core/src/locales/resolveAliasLocale.ts
@@ -4,7 +4,7 @@ import { CustomMapping } from './customLocaleMapping';
  * Resolves the alias locale for a given locale.
  * @param locale - The locale to resolve the alias locale for
  * @param customMapping - The custom mapping to use for resolving the alias locale
- * @returns The alias locale
+ * @returns The configured alias for a canonical locale, or the input locale when already an alias or no alias mapping exists.
  */
 export function _resolveAliasLocale(
   locale: string,

--- a/packages/core/src/locales/resolveCanonicalLocale.ts
+++ b/packages/core/src/locales/resolveCanonicalLocale.ts
@@ -5,7 +5,7 @@ import { CustomMapping } from './customLocaleMapping';
  * Resolves the canonical locale for a given locale.
  * @param locale - The locale to resolve the canonical locale for
  * @param customMapping - The custom mapping to use for resolving the canonical locale
- * @returns The canonical locale
+ * @returns The canonical locale, or the input locale when no canonical mapping exists.
  */
 export function _resolveCanonicalLocale(
   locale: string,


### PR DESCRIPTION
## Summary
- Correct docs for locale standardization and canonical/alias locale resolution
- Fix factual JSDoc issues in plural-form and cutoff formatter helpers
- Correct the old/current JSX conversion direction comment

## Notes
- Based on latest `origin/main` after #1340
- Intentionally avoids broad comment cleanup and keeps confusing-function examples/comments in place

## Verification
- `pnpm exec prettier --check packages/core/src/core.ts packages/core/src/locales/isValidLocale.ts packages/core/src/locales/resolveCanonicalLocale.ts packages/core/src/locales/resolveAliasLocale.ts packages/core/src/locales/getPluralForm.ts packages/core/src/formatting/format.ts packages/core/src/formatting/custom-formats/CutoffFormat/CutoffFormat.ts packages/core/src/backwards-compatability/dataConversion.ts`
- `git diff --check origin/main...HEAD`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1341"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Documentation-only corrections across 8 files in `packages/core/src`. Every changed line was verified against the live implementation and is factually accurate.

- **`standardizeLocale` / `_standardizeLocale`**: `@returns` and the inline example now correctly state the input string is returned on failure (not `''`), matching the `catch { return locale; }` branch.
- **`CutoffFormat` constructor**: Four `option.` → `options.` typo fixes and the locales type corrected to `Intl.LocalesArgument` (matching the actual parameter type); the stale \"fallback to empty string\" note removed from `_formatCutoff`.
- **Alias / canonical locale helpers**: Terse `@returns` tags expanded to describe pass-through behavior; `_getPluralForm`'s `forms` param type corrected from `locales[]` to `PluralType[]`; `dataConversion` comment direction reversed to current→old.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

All changes are documentation only; no runtime behaviour is modified.

Every corrected doc string was cross-checked against the live implementation: _standardizeLocale returns the input string on failure (not ''), the locale resolver helpers pass through when no mapping exists, the CutoffFormat constructor really does accept Intl.LocalesArgument, and _formatCutoff has no empty-string fallback. No logic, types, or exports were touched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/backwards-compatability/dataConversion.ts | Corrected comment direction: the functions below (getOldJsxChild etc.) convert current→old, not old→new. Change is accurate. |
| packages/core/src/core.ts | Updated @returns for resolveCanonicalLocale (pass-through when no mapping) and standardizeLocale (returns input string on failure, not ''). Both match the actual implementations. |
| packages/core/src/formatting/custom-formats/CutoffFormat/CutoffFormat.ts | Fixed four option. → options. typos in JSDoc param names and corrected the locales type annotation from string | string[] to Intl.LocalesArgument, matching the actual constructor signature. |
| packages/core/src/formatting/format.ts | Removed the inaccurate 'Will fallback to an empty string if formatting fails' note from _formatCutoff, which has no such fallback. |
| packages/core/src/locales/getPluralForm.ts | Corrected @param type for forms from the nonsensical locales[] to the correct PluralType[], matching the actual function signature. |
| packages/core/src/locales/isValidLocale.ts | Updated @returns for _standardizeLocale to reflect that it returns the original input string (not '') on failure; matches the catch { return locale; } block. |
| packages/core/src/locales/resolveAliasLocale.ts | Expanded terse @returns to describe the pass-through behavior; matches reverseCustomMapping?.[locale] || locale in the implementation. |
| packages/core/src/locales/resolveCanonicalLocale.ts | Expanded terse @returns to note the pass-through when no canonical mapping exists; matches return locale fall-through in the implementation. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["standardizeLocale(locale)"] --> B{"Intl.getCanonicalLocales throws?"}
    B -- No --> C["return canonicalized locale"]
    B -- Yes --> D["return locale (input string)"]

    E["resolveCanonicalLocale(locale, mapping?)"] --> F{"mapping exists & should use canonical?"}
    F -- Yes --> G["return mapping[locale].code"]
    F -- No --> H["return locale (input string)"]

    I["resolveAliasLocale(locale, mapping?)"] --> J{"reverseMapping exists for locale?"}
    J -- Yes --> K["return alias key"]
    J -- No --> L["return locale (input string)"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(core): correct locale helper commen..."](https://github.com/generaltranslation/gt/commit/1f4035889e9afe9e615e7bdcaebe79ed261ebc08) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30875107)</sub>

<!-- /greptile_comment -->