### PR TITLE
fix(compiler): auto-load gt config

### DIFF
--- a/.changeset/bright-config-loader.md
+++ b/.changeset/bright-config-loader.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/compiler': patch
+---
+
+Auto-load gt.config.json for compiler plugins when no gtConfig option is passed.

--- a/packages/compiler/src/__tests__/index.test.ts
+++ b/packages/compiler/src/__tests__/index.test.ts
@@ -149,12 +149,45 @@ describe('gtUnplugin config loading', () => {
     }
   });
 
-  it('preserves default behavior when auto-loaded gt.config.json has no parsingFlags', async () => {
+  it('preserves default behavior when auto-loaded gt.config.json has ordinary project settings', async () => {
     const cwd = createTempDir();
     writeGTConfig(cwd, {
       projectId: 'test-project',
+      _versionId: 'test-version',
       defaultLocale: 'en',
       locales: ['en', 'es'],
+      files: {
+        gt: {
+          output: 'src/_gt/[locale].json',
+        },
+      },
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const output = await transformWithPlugin(undefined, cwd);
+
+      expect(output).toBeNull();
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('preserves default behavior when auto-loaded parsingFlags are explicitly disabled', async () => {
+    const cwd = createTempDir();
+    writeGTConfig(cwd, {
+      locales: ['en', 'es'],
+      files: {
+        gt: {
+          output: 'src/_gt/[locale].json',
+          parsingFlags: {
+            enableAutoJsxInjection: false,
+            autoderive: false,
+            devHotReload: false,
+          },
+        },
+      },
     });
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 

--- a/packages/compiler/src/__tests__/index.test.ts
+++ b/packages/compiler/src/__tests__/index.test.ts
@@ -1,0 +1,174 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  TransformResult,
+  UnpluginBuildContext,
+  UnpluginContext,
+} from 'unplugin';
+import gtUnplugin from '../index';
+import type { GTUnpluginOptions } from '../index';
+
+const MISSING_GT_CONFIG_WARNING =
+  '[@generaltranslation/compiler] No gtConfig found. Auto JSX injection and parsingFlags features require a gt.config.json. See https://generaltranslation.com/en/docs/react/concepts/compiler.';
+
+const JSX_RUNTIME_CODE = `
+  import { jsx, jsxs } from 'react/jsx-runtime';
+  export function App() {
+    return jsxs("div", { children: ["Hello ", name] });
+  }
+`;
+
+function createTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'gt-compiler-'));
+}
+
+function writeGTConfig(cwd: string, config: unknown): void {
+  fs.writeFileSync(
+    path.join(cwd, 'gt.config.json'),
+    JSON.stringify(config, null, 2)
+  );
+}
+
+async function transformWithPlugin(
+  options: GTUnpluginOptions | undefined,
+  cwd: string
+): Promise<string | null> {
+  const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(cwd);
+  const plugin = (() => {
+    try {
+      return gtUnplugin.raw(options, { framework: 'vite' });
+    } finally {
+      cwdSpy.mockRestore();
+    }
+  })();
+
+  const transform = plugin.transform;
+  if (typeof transform !== 'function') {
+    throw new Error('Expected transform hook to be a function');
+  }
+
+  const context = {
+    addWatchFile() {},
+    emitFile() {},
+    getWatchFiles() {
+      return [];
+    },
+    parse() {
+      throw new Error('parse is not implemented in this test context');
+    },
+    warn() {},
+    error(message: unknown) {
+      throw new Error(String(message));
+    },
+  } as UnpluginBuildContext & UnpluginContext;
+
+  const result: TransformResult = await transform.call(
+    context,
+    JSX_RUNTIME_CODE,
+    path.join(cwd, 'App.tsx')
+  );
+  if (!result) {
+    return null;
+  }
+  return typeof result === 'string' ? result : result.code;
+}
+
+describe('gtUnplugin config loading', () => {
+  it('auto-loads gt.config.json from process.cwd() when gtConfig is omitted', async () => {
+    const cwd = createTempDir();
+    writeGTConfig(cwd, {
+      files: {
+        gt: {
+          parsingFlags: {
+            enableAutoJsxInjection: true,
+          },
+        },
+      },
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const output = await transformWithPlugin(undefined, cwd);
+
+      expect(output).toContain('GtInternalTranslateJsx');
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('does not auto-load gt.config.json when gtConfig is provided', async () => {
+    const cwd = createTempDir();
+    writeGTConfig(cwd, {
+      files: {
+        gt: {
+          parsingFlags: {
+            enableAutoJsxInjection: true,
+          },
+        },
+      },
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const output = await transformWithPlugin(
+        {
+          gtConfig: {
+            files: {
+              gt: {
+                parsingFlags: {
+                  enableAutoJsxInjection: false,
+                },
+              },
+            },
+          },
+        },
+        cwd
+      );
+
+      expect(output).toBeNull();
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('warns once per plugin instance when gtConfig cannot be loaded', async () => {
+    const cwd = createTempDir();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(cwd);
+      const plugin = (() => {
+        try {
+          return gtUnplugin.raw(undefined, { framework: 'vite' });
+        } finally {
+          cwdSpy.mockRestore();
+        }
+      })();
+      const transform = plugin.transform;
+      if (typeof transform !== 'function') {
+        throw new Error('Expected transform hook to be a function');
+      }
+      const context = {} as UnpluginBuildContext & UnpluginContext;
+
+      await transform.call(
+        context,
+        JSX_RUNTIME_CODE,
+        path.join(cwd, 'One.tsx')
+      );
+      await transform.call(
+        context,
+        JSX_RUNTIME_CODE,
+        path.join(cwd, 'Two.tsx')
+      );
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(MISSING_GT_CONFIG_WARNING);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});

--- a/packages/compiler/src/__tests__/index.test.ts
+++ b/packages/compiler/src/__tests__/index.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type {
   TransformResult,
   UnpluginBuildContext,
@@ -20,8 +20,29 @@ const JSX_RUNTIME_CODE = `
   }
 `;
 
+const tempDirs: string[] = [];
+
 function createTempDir(): string {
-  return fs.mkdtempSync(path.join(os.tmpdir(), 'gt-compiler-'));
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gt-compiler-'));
+  tempDirs.push(tempDir);
+  return tempDir;
+}
+
+function createTestContext(): UnpluginBuildContext & UnpluginContext {
+  return {
+    addWatchFile() {},
+    emitFile() {},
+    getWatchFiles() {
+      return [];
+    },
+    parse() {
+      throw new Error('parse is not implemented in this test context');
+    },
+    warn() {},
+    error(message: unknown) {
+      throw new Error(String(message));
+    },
+  } as UnpluginBuildContext & UnpluginContext;
 }
 
 function writeGTConfig(cwd: string, config: unknown): void {
@@ -49,20 +70,7 @@ async function transformWithPlugin(
     throw new Error('Expected transform hook to be a function');
   }
 
-  const context = {
-    addWatchFile() {},
-    emitFile() {},
-    getWatchFiles() {
-      return [];
-    },
-    parse() {
-      throw new Error('parse is not implemented in this test context');
-    },
-    warn() {},
-    error(message: unknown) {
-      throw new Error(String(message));
-    },
-  } as UnpluginBuildContext & UnpluginContext;
+  const context = createTestContext();
 
   const result: TransformResult = await transform.call(
     context,
@@ -76,6 +84,12 @@ async function transformWithPlugin(
 }
 
 describe('gtUnplugin config loading', () => {
+  afterEach(() => {
+    for (const tempDir of tempDirs.splice(0)) {
+      fs.rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+
   it('auto-loads gt.config.json from process.cwd() when gtConfig is omitted', async () => {
     const cwd = createTempDir();
     writeGTConfig(cwd, {
@@ -135,6 +149,25 @@ describe('gtUnplugin config loading', () => {
     }
   });
 
+  it('preserves default behavior when auto-loaded gt.config.json has no parsingFlags', async () => {
+    const cwd = createTempDir();
+    writeGTConfig(cwd, {
+      projectId: 'test-project',
+      defaultLocale: 'en',
+      locales: ['en', 'es'],
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const output = await transformWithPlugin(undefined, cwd);
+
+      expect(output).toBeNull();
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it('warns once per plugin instance when gtConfig cannot be loaded', async () => {
     const cwd = createTempDir();
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -152,7 +185,7 @@ describe('gtUnplugin config loading', () => {
       if (typeof transform !== 'function') {
         throw new Error('Expected transform hook to be a function');
       }
-      const context = {} as UnpluginBuildContext & UnpluginContext;
+      const context = createTestContext();
 
       await transform.call(
         context,

--- a/packages/compiler/src/__tests__/index.test.ts
+++ b/packages/compiler/src/__tests__/index.test.ts
@@ -7,11 +7,10 @@ import type {
   UnpluginBuildContext,
   UnpluginContext,
 } from 'unplugin';
-import gtUnplugin from '../index';
+import gtUnplugin, {
+  MISSING_GT_CONFIG_WARNING,
+} from '../index';
 import type { GTUnpluginOptions } from '../index';
-
-const MISSING_GT_CONFIG_WARNING =
-  '[@generaltranslation/compiler] No gtConfig found. Auto JSX injection and parsingFlags features require a gt.config.json. See https://generaltranslation.com/en/docs/react/concepts/compiler.';
 
 const JSX_RUNTIME_CODE = `
   import { jsx, jsxs } from 'react/jsx-runtime';
@@ -50,6 +49,12 @@ function writeGTConfig(cwd: string, config: unknown): void {
     path.join(cwd, 'gt.config.json'),
     JSON.stringify(config, null, 2)
   );
+}
+
+function writeInvalidGTConfig(cwd: string): string {
+  const configPath = path.join(cwd, 'gt.config.json');
+  fs.writeFileSync(configPath, '{ invalid json');
+  return configPath;
 }
 
 async function transformWithPlugin(
@@ -233,6 +238,27 @@ describe('gtUnplugin config loading', () => {
 
       expect(warnSpy).toHaveBeenCalledTimes(1);
       expect(warnSpy).toHaveBeenCalledWith(MISSING_GT_CONFIG_WARNING);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('warns that gt.config.json is invalid when the config file cannot be parsed', async () => {
+    const cwd = createTempDir();
+    const configPath = writeInvalidGTConfig(cwd);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const output = await transformWithPlugin(undefined, cwd);
+
+      expect(output).toBeNull();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const warning = warnSpy.mock.calls[0]?.[0];
+      expect(warning).toContain(
+        `[@generaltranslation/compiler] Failed to load gt.config.json at ${configPath}.`
+      );
+      expect(warning).toContain('valid gt.config.json');
+      expect(warning).not.toBe(MISSING_GT_CONFIG_WARNING);
     } finally {
       warnSpy.mockRestore();
     }

--- a/packages/compiler/src/__tests__/index.test.ts
+++ b/packages/compiler/src/__tests__/index.test.ts
@@ -7,9 +7,7 @@ import type {
   UnpluginBuildContext,
   UnpluginContext,
 } from 'unplugin';
-import gtUnplugin, {
-  MISSING_GT_CONFIG_WARNING,
-} from '../index';
+import gtUnplugin, { MISSING_GT_CONFIG_WARNING } from '../index';
 import type { GTUnpluginOptions } from '../index';
 
 const JSX_RUNTIME_CODE = `

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -1,4 +1,6 @@
 import { createUnplugin } from 'unplugin';
+import fs from 'node:fs';
+import path from 'node:path';
 import * as parser from '@babel/parser';
 import generate from '@babel/generator';
 import traverse from '@babel/traverse';
@@ -64,6 +66,28 @@ export interface GTUnpluginOptions extends PluginConfig {
   // Inherits from PluginConfig
 }
 
+const MISSING_GT_CONFIG_WARNING =
+  '[@generaltranslation/compiler] No gtConfig found. Auto JSX injection and parsingFlags features require a gt.config.json. See https://generaltranslation.com/en/docs/react/concepts/compiler.';
+
+function shouldWarn(logLevel: PluginConfig['logLevel']): boolean {
+  return logLevel !== 'silent' && logLevel !== 'error';
+}
+
+function loadGTConfigFromCwd(): PluginConfig['gtConfig'] | undefined {
+  const configPath = path.join(process.cwd(), 'gt.config.json');
+  if (!fs.existsSync(configPath)) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(fs.readFileSync(configPath, 'utf-8')) as NonNullable<
+      PluginConfig['gtConfig']
+    >;
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * GT Universal Plugin - Main entry point
  *
@@ -72,8 +96,18 @@ export interface GTUnpluginOptions extends PluginConfig {
  */
 const gtUnplugin = createUnplugin<GTUnpluginOptions | undefined>(
   (options = {}) => {
+    const loadedGTConfig = options.gtConfig ?? loadGTConfigFromCwd();
+    const resolvedOptions: GTUnpluginOptions = {
+      ...options,
+      ...(loadedGTConfig ? { gtConfig: loadedGTConfig } : {}),
+    };
+
+    if (!loadedGTConfig && shouldWarn(options.logLevel)) {
+      console.warn(MISSING_GT_CONFIG_WARNING);
+    }
+
     // Debug manifest: accumulates hash → jsxChildren across all files
-    const debugManifest = options._debugHashManifest
+    const debugManifest = resolvedOptions._debugHashManifest
       ? new Map<string, unknown>()
       : undefined;
 
@@ -90,7 +124,7 @@ const gtUnplugin = createUnplugin<GTUnpluginOptions | undefined>(
       },
       transform(code: string, id: string) {
         // Initialize processing state
-        const state = initializeState(options, id);
+        const state = initializeState(resolvedOptions, id);
         if (debugManifest) state.debugManifest = debugManifest;
         try {
           // Skip transformation if not needed

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -66,25 +66,50 @@ export interface GTUnpluginOptions extends PluginConfig {
   // Inherits from PluginConfig
 }
 
-const MISSING_GT_CONFIG_WARNING =
+export const MISSING_GT_CONFIG_WARNING =
   '[@generaltranslation/compiler] No gtConfig found. Auto JSX injection and parsingFlags features require a gt.config.json. See https://generaltranslation.com/en/docs/react/concepts/compiler.';
+
+export const createInvalidGTConfigWarning = (
+  configPath: string,
+  error: unknown
+) =>
+  `[@generaltranslation/compiler] Failed to load gt.config.json at ${configPath}. ` +
+  `Auto JSX injection and parsingFlags features require a valid gt.config.json. ` +
+  `${error instanceof Error ? error.message : String(error)}`;
 
 function shouldWarn(logLevel: PluginConfig['logLevel']): boolean {
   return logLevel !== 'silent' && logLevel !== 'error';
 }
 
-function loadGTConfigFromCwd(): PluginConfig['gtConfig'] | undefined {
+type GTConfigLoadResult =
+  | {
+      gtConfig: NonNullable<PluginConfig['gtConfig']>;
+      status: 'loaded';
+    }
+  | {
+      status: 'missing';
+    }
+  | {
+      configPath: string;
+      error: unknown;
+      status: 'invalid';
+    };
+
+function loadGTConfigFromCwd(): GTConfigLoadResult {
   const configPath = path.join(process.cwd(), 'gt.config.json');
   if (!fs.existsSync(configPath)) {
-    return undefined;
+    return { status: 'missing' };
   }
 
   try {
-    return JSON.parse(fs.readFileSync(configPath, 'utf-8')) as NonNullable<
-      PluginConfig['gtConfig']
-    >;
-  } catch {
-    return undefined;
+    return {
+      gtConfig: JSON.parse(fs.readFileSync(configPath, 'utf-8')) as NonNullable<
+        PluginConfig['gtConfig']
+      >,
+      status: 'loaded',
+    };
+  } catch (error) {
+    return { configPath, error, status: 'invalid' };
   }
 }
 
@@ -96,14 +121,29 @@ function loadGTConfigFromCwd(): PluginConfig['gtConfig'] | undefined {
  */
 const gtUnplugin = createUnplugin<GTUnpluginOptions | undefined>(
   (options = {}) => {
-    const loadedGTConfig = options.gtConfig ?? loadGTConfigFromCwd();
+    const gtConfigLoadResult = options.gtConfig
+      ? ({ gtConfig: options.gtConfig, status: 'loaded' } as const)
+      : loadGTConfigFromCwd();
+    const loadedGTConfig =
+      gtConfigLoadResult.status === 'loaded'
+        ? gtConfigLoadResult.gtConfig
+        : undefined;
     const resolvedOptions: GTUnpluginOptions = {
       ...options,
       ...(loadedGTConfig ? { gtConfig: loadedGTConfig } : {}),
     };
 
-    if (!loadedGTConfig && shouldWarn(options.logLevel)) {
-      console.warn(MISSING_GT_CONFIG_WARNING);
+    if (shouldWarn(options.logLevel)) {
+      if (gtConfigLoadResult.status === 'missing') {
+        console.warn(MISSING_GT_CONFIG_WARNING);
+      } else if (gtConfigLoadResult.status === 'invalid') {
+        console.warn(
+          createInvalidGTConfigWarning(
+            gtConfigLoadResult.configPath,
+            gtConfigLoadResult.error
+          )
+        );
+      }
     }
 
     // Debug manifest: accumulates hash → jsxChildren across all files


### PR DESCRIPTION
## Summary
- auto-load `gt.config.json` from `process.cwd()` when `gtConfig` is omitted
- warn once per plugin instance when no config can be loaded
- add coverage for auto-load, explicit config precedence, and warning behavior

## Checks
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm --filter generaltranslation build`
- `pnpm --filter @generaltranslation/compiler test -- src/__tests__/index.test.ts`

## Notes
- Fresh worktree install emitted existing bin-link warnings for unbuilt CLI packages, but completed successfully.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1342"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds automatic `gt.config.json` discovery to the compiler plugin: when no `gtConfig` option is passed, the plugin now reads `process.cwd()/gt.config.json` at construction time and emits a one-time `console.warn` if the file is missing or unparseable. Explicit `gtConfig` options continue to take precedence over the auto-loaded file.

- **Auto-load logic** (`loadGTConfigFromCwd`): resolves the config path from `process.cwd()` once at plugin instantiation, returning a typed discriminated-union result (`loaded` / `missing` / `invalid`) that drives both config merging and warning emission.
- **Warning behavior**: `MISSING_GT_CONFIG_WARNING` and `createInvalidGTConfigWarning` are exported constants so tests can assert against exact strings; `shouldWarn` gates output on the plugin's own `logLevel`.
- **Test coverage**: six new integration tests exercise auto-load, explicit-config precedence, invalid JSON, and the once-per-instance warning guarantee, using `vi.spyOn(process, 'cwd')` to isolate each test in its own temp directory that is cleaned up via `afterEach`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrowly scoped to plugin construction, does not touch the transform hot path, and is fully covered by new tests.

Config resolution and warning emission happen once at construction, isolated from the transform pipeline. The discriminated-union design makes all three states explicit and exhaustive. Tests cover every branch including invalid JSON, missing file, explicit-option precedence, and the once-per-instance warning guarantee. No existing behavior is altered when gtConfig is provided.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/compiler/src/index.ts | Adds loadGTConfigFromCwd, MISSING_GT_CONFIG_WARNING, createInvalidGTConfigWarning, and shouldWarn helpers; plugin factory now resolves and merges config before constructing state. Logic is correct and well-scoped. |
| packages/compiler/src/__tests__/index.test.ts | New test file covering auto-load, explicit-config precedence, warning suppression, invalid JSON, and once-per-instance warning; temp dirs are properly cleaned via afterEach. |
| .changeset/bright-config-loader.md | Patch-level changeset entry for @generaltranslation/compiler; description accurately reflects the auto-load feature. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Plugin factory called\ngtUnplugin.raw options] --> B{options.gtConfig\nprovided?}
    B -- Yes --> C[status: loaded\nuse options.gtConfig]
    B -- No --> D[loadGTConfigFromCwd\nprocess.cwd + gt.config.json]
    D --> E{File exists?}
    E -- No --> F[status: missing]
    E -- Yes --> G{JSON.parse\nsucceeds?}
    G -- Yes --> H[status: loaded\nuse parsed config]
    G -- No --> I[status: invalid\ncapture error + path]
    C --> J[Build resolvedOptions\nmerge gtConfig]
    H --> J
    F --> K{shouldWarn\nlogLevel?}
    I --> K
    K -- Yes + missing --> L[console.warn\nMISSING_GT_CONFIG_WARNING]
    K -- Yes + invalid --> M[console.warn\ncreateInvalidGTConfigWarning]
    K -- No --> N[Silent]
    J --> O[Return plugin object\nwith transform hook]
    L --> O
    M --> O
    N --> O
    O --> P[transform called\nper file]
    P --> Q[initializeState\nresolvedOptions]
```
</details>

<sub>Reviews (5): Last reviewed commit: ["chore(compiler): format config loading t..."](https://github.com/generaltranslation/gt/commit/48f7ac8f5406ac2441779932ea89422878eff701) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30876002)</sub>

<!-- /greptile_comment -->