### PR TITLE
fix(next): clarify babel compiler compatibility warnings

### DIFF
--- a/packages/next/src/__tests__/config.test.ts
+++ b/packages/next/src/__tests__/config.test.ts
@@ -11,12 +11,14 @@ vi.mock('fs', () => ({
   },
 }));
 
-vi.mock('../plugin/getStableNextVersionInfo', () => ({
+const mockVersionInfo = vi.hoisted(() => ({
   rootParamStability: 'experimental',
   turboConfigStable: true,
   swcPluginCompatible: true,
   babelPluginCompatible: true,
 }));
+
+vi.mock('../plugin/getStableNextVersionInfo', () => mockVersionInfo);
 
 // ---- Helpers ---- //
 
@@ -49,6 +51,10 @@ beforeEach(() => {
   delete process.env.TURBOPACK;
   process.env.NODE_ENV = 'development';
   vi.clearAllMocks();
+  mockVersionInfo.rootParamStability = 'experimental';
+  mockVersionInfo.turboConfigStable = true;
+  mockVersionInfo.swcPluginCompatible = true;
+  mockVersionInfo.babelPluginCompatible = true;
   vi.mocked(fs.existsSync).mockReturnValue(false);
   vi.mocked(fs.readFileSync).mockReturnValue('{}');
 });
@@ -1146,9 +1152,122 @@ describe('withGTConfig', () => {
   });
 
   // ==============================
-  // 13. Webpack function
+  // 13. Compiler configuration
   // ==============================
-  describe('13. Webpack function', () => {
+  describe('13. Compiler configuration', () => {
+    it('logs when the SWC compiler is enabled', async () => {
+      const withGTConfig = await getWithGTConfig();
+      const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+      const result = withGTConfig(
+        {},
+        { experimentalCompilerOptions: { type: 'swc' } as any }
+      );
+
+      expect(result.experimental!.swcPlugins).toHaveLength(1);
+      expect(infoSpy).toHaveBeenCalledWith('gt-next: SWC compiler enabled');
+      infoSpy.mockRestore();
+    });
+
+    it('emits debug compiler details when SWC logLevel is debug', async () => {
+      const withGTConfig = await getWithGTConfig();
+      const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+      const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+
+      withGTConfig(
+        {},
+        {
+          experimentalCompilerOptions: {
+            type: 'swc',
+            logLevel: 'debug',
+            disableBuildChecks: false,
+          } as any,
+        }
+      );
+
+      expect(infoSpy).toHaveBeenCalledWith('gt-next: SWC compiler enabled');
+      expect(debugSpy).toHaveBeenCalledWith(
+        expect.stringContaining('gt-next: SWC compiler debug config')
+      );
+      infoSpy.mockRestore();
+      debugSpy.mockRestore();
+    });
+
+    it('does not log SWC startup messages when logLevel is silent', async () => {
+      const withGTConfig = await getWithGTConfig();
+      const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+      const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+
+      withGTConfig(
+        {},
+        {
+          experimentalCompilerOptions: {
+            type: 'swc',
+            logLevel: 'silent',
+          } as any,
+        }
+      );
+
+      expect(infoSpy).not.toHaveBeenCalled();
+      expect(debugSpy).not.toHaveBeenCalled();
+      infoSpy.mockRestore();
+      debugSpy.mockRestore();
+    });
+
+    it('uses a Turbopack-specific babel compiler warning', async () => {
+      const withGTConfig = await getWithGTConfig();
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      process.env.TURBOPACK = '1';
+
+      const result = withGTConfig(
+        {},
+        { experimentalCompilerOptions: { type: 'babel' } as any }
+      );
+      const params = parseConfigParams(result);
+
+      expect(params.experimentalCompilerOptions.type).toBe('none');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'The GT babel compiler is not compatible with Turbopack'
+        )
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("experimentalCompilerOptions: { type: 'swc' }")
+      );
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('compatible with turbopack or < react')
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('uses a React-version-specific babel compiler warning', async () => {
+      const withGTConfig = await getWithGTConfig();
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      mockVersionInfo.babelPluginCompatible = false;
+
+      const result = withGTConfig(
+        {},
+        { experimentalCompilerOptions: { type: 'babel' } as any }
+      );
+      const params = parseConfigParams(result);
+
+      expect(params.experimentalCompilerOptions.type).toBe('none');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'The GT babel compiler requires react@17.0.0 or newer'
+        )
+      );
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('compatible with turbopack or < react')
+      );
+      warnSpy.mockRestore();
+    });
+  });
+
+  // ==============================
+  // 14. Webpack function
+  // ==============================
+  describe('14. Webpack function', () => {
     it('returns webpack config object', async () => {
       const withGTConfig = await getWithGTConfig();
       const result = withGTConfig();
@@ -1217,9 +1336,9 @@ describe('withGTConfig', () => {
   });
 
   // ==============================
-  // 14. Turbopack configuration
+  // 15. Turbopack configuration
   // ==============================
-  describe('14. Turbopack configuration', () => {
+  describe('15. Turbopack configuration', () => {
     it('when TURBOPACK=1 + turboConfigStable=true (no legacy turbo config): aliases in result.turbopack.resolveAlias', async () => {
       const withGTConfig = await getWithGTConfig();
       process.env.TURBOPACK = '1';
@@ -1257,9 +1376,9 @@ describe('withGTConfig', () => {
   });
 
   // ==============================
-  // 15. Headers/cookies merging
+  // 16. Headers/cookies merging
   // ==============================
-  describe('15. Headers/cookies merging', () => {
+  describe('16. Headers/cookies merging', () => {
     it('default values used when none provided', async () => {
       const withGTConfig = await getWithGTConfig();
       const result = withGTConfig();
@@ -1312,9 +1431,9 @@ describe('withGTConfig', () => {
   });
 
   // ==============================
-  // 16. nextConfig passthrough
+  // 17. nextConfig passthrough
   // ==============================
-  describe('16. nextConfig passthrough', () => {
+  describe('17. nextConfig passthrough', () => {
     it('preserves all existing nextConfig properties', async () => {
       const withGTConfig = await getWithGTConfig();
       const result = withGTConfig({
@@ -1350,9 +1469,9 @@ describe('withGTConfig', () => {
   });
 
   // ==============================
-  // 17. initGT backward compatibility
+  // 18. initGT backward compatibility
   // ==============================
-  describe('17. initGT backward compatibility', () => {
+  describe('18. initGT backward compatibility', () => {
     it('initGT(props) returns a function (nextConfig) => NextConfig', async () => {
       const initGT = await getInitGT();
       const configFn = initGT({ defaultLocale: 'es' });

--- a/packages/next/src/config-dir/props/withGTConfigProps.ts
+++ b/packages/next/src/config-dir/props/withGTConfigProps.ts
@@ -12,7 +12,7 @@ export type HeadersAndCookies = {
 export type CompilerOptions = {
   /**
    * Which compiler plugin to use: babel, swc, or none
-   * @default 'babel'
+   * @default 'none'
    */
   type: 'babel' | 'swc' | 'none';
   /**

--- a/packages/next/src/config-dir/utils/validateCompiler.ts
+++ b/packages/next/src/config-dir/utils/validateCompiler.ts
@@ -1,6 +1,7 @@
 import { type withGTConfigProps } from '../props/withGTConfigProps';
 import { babelPluginCompatible } from '../../plugin/getStableNextVersionInfo';
 import {
+  babelCompilerTurbopackUnavailableWarning,
   createGTCompilerUnavailableWarning,
   disablingCompileTimeHashWarning,
   swcPluginCompatibilityChangeWarning,
@@ -20,9 +21,16 @@ export function validateCompiler(mergedConfig: withGTConfigProps) {
     console.warn(createGTCompilerUnavailableWarning('swc'));
     console.warn(swcPluginCompatibilityChangeWarning);
     mergedConfig.experimentalCompilerOptions.type = 'none';
-  } else if (type === 'babel' && (!babelPluginCompatible || turboPackEnabled)) {
-    console.warn(createGTCompilerUnavailableWarning('babel'));
-    mergedConfig.experimentalCompilerOptions.type = 'none';
+  } else if (type === 'babel') {
+    if (turboPackEnabled) {
+      console.warn(babelCompilerTurbopackUnavailableWarning);
+    }
+    if (!babelPluginCompatible) {
+      console.warn(createGTCompilerUnavailableWarning('babel'));
+    }
+    if (turboPackEnabled || !babelPluginCompatible) {
+      mergedConfig.experimentalCompilerOptions.type = 'none';
+    }
   }
   // Backwards compatibility, remove this condition in the future
   if (mergedConfig.experimentalCompilerOptions.compileTimeHash === false) {

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -5,7 +5,10 @@ import {
   defaultWithGTConfigProps,
   defaultCacheExpiryTime,
 } from './config-dir/props/defaultWithGTConfigProps';
-import { type withGTConfigProps } from './config-dir/props/withGTConfigProps';
+import {
+  type CompilerOptions,
+  type withGTConfigProps,
+} from './config-dir/props/withGTConfigProps';
 import {
   APIKeyMissingWarn,
   conflictingConfigurationBuildError,
@@ -525,8 +528,10 @@ export function withGTConfig(
   // ---------- STORE CONFIGURATIONS ---------- //
   const I18NConfigParams = JSON.stringify(mergedConfig);
 
+  const resolvedExperimentalCompilerOptions: CompilerOptions =
+    mergedConfig.experimentalCompilerOptions ?? { type: 'none' };
   const { type: _type, ...compilerOptions } =
-    mergedConfig.experimentalCompilerOptions || {};
+    resolvedExperimentalCompilerOptions;
 
   // Read autoderive from parsingFlags (single source of truth shared with CLI)
   const rawAutoderive: boolean | { jsx?: boolean; strings?: boolean } =
@@ -549,6 +554,21 @@ export function withGTConfig(
           { ...compilerOptions, autoderiveJsx, autoderiveStrings },
         ]
       : null;
+
+  if (swcPluginEntry && compilerOptions.logLevel !== 'silent') {
+    console.info('gt-next: SWC compiler enabled');
+    if (compilerOptions.logLevel === 'debug') {
+      console.debug(
+        `gt-next: SWC compiler debug config ${JSON.stringify({
+          wasm: resolvedWasmFilePath,
+          compileTimeHash: compilerOptions.compileTimeHash,
+          disableBuildChecks: compilerOptions.disableBuildChecks,
+          autoderiveJsx,
+          autoderiveStrings,
+        })}`
+      );
+    }
+  }
 
   const turboAliases = {
     'gt-next/_dictionary': resolvedDictionaryFilePath || '',

--- a/packages/next/src/errors/createErrors.ts
+++ b/packages/next/src/errors/createErrors.ts
@@ -172,7 +172,11 @@ export const createGTCompilerUnresolvedWarning = (type: 'babel' | 'swc') =>
 export const createGTCompilerUnavailableWarning = (type: 'babel' | 'swc') =>
   type === 'swc'
     ? `gt-next (plugin): The GT swc compiler is compatible with < next@${SWC_PLUGIN_SUPPORT}. Skipping compiler optimizations.`
-    : `gt-next (plugin): The GT babel compiler is compatible with turbopack or < react@${BABEL_PLUGIN_SUPPORT}. Skipping compiler optimizations.`;
+    : `gt-next (plugin): The GT babel compiler requires react@${BABEL_PLUGIN_SUPPORT} or newer. Skipping compiler optimizations.`;
+
+export const babelCompilerTurbopackUnavailableWarning =
+  `gt-next (plugin): The GT babel compiler is not compatible with Turbopack. ` +
+  `To use compiler optimizations with Turbopack, set experimentalCompilerOptions: { type: 'swc' }.`;
 
 export const disablingCompileTimeHashWarning = `gt-next (plugin): Compile-time hash is disabled. Compiler optimizations are inactive.`;
 

--- a/packages/next/src/request/headers/__tests__/getNextLocale.test.ts
+++ b/packages/next/src/request/headers/__tests__/getNextLocale.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { cookies, headers } from 'next/headers';
+import { getI18NConfig } from '../../../config-dir/getI18NConfig';
+
+const mockNextHeaders = vi.hoisted(() => ({
+  headers: vi.fn(),
+  cookies: vi.fn(),
+}));
+
+const mockConfig = vi.hoisted(() => ({
+  getI18NConfig: vi.fn(),
+}));
+
+vi.mock('next/headers', () => mockNextHeaders);
+
+vi.mock('../../../config-dir/getI18NConfig', () => mockConfig);
+
+const determineLocale = vi.fn();
+
+function mockHeaders(values: Record<string, string | undefined> = {}) {
+  return {
+    get: vi.fn((key: string) => values[key]),
+  };
+}
+
+function mockCookies(values: Record<string, string | undefined> = {}) {
+  return {
+    get: vi.fn((key: string) => {
+      const value = values[key];
+      return value ? { value } : undefined;
+    }),
+  };
+}
+
+describe('getNextLocale', () => {
+  let savedEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    savedEnv = { ...process.env };
+    process.env._GENERALTRANSLATION_IGNORE_BROWSER_LOCALES = 'false';
+    vi.resetModules();
+    vi.clearAllMocks();
+    determineLocale.mockReturnValue('en');
+    vi.mocked(getI18NConfig).mockReturnValue({
+      getDefaultLocale: () => 'en',
+      getLocales: () => ['en', 'fr'],
+      getLocaleHeaderName: () => 'x-generaltranslation-locale',
+      getLocaleCookieName: () => 'generaltranslation.locale',
+      getGTClass: () => ({
+        determineLocale,
+      }),
+    } as any);
+  });
+
+  afterEach(() => {
+    process.env = savedEnv;
+  });
+
+  it('does not warn when locale resolution succeeds with the default locale', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.mocked(headers).mockResolvedValue(mockHeaders() as any);
+    vi.mocked(cookies).mockResolvedValue(mockCookies() as any);
+
+    const { getNextLocale } = await import('../getNextLocale');
+
+    await expect(getNextLocale()).resolves.toBe('en');
+
+    expect(determineLocale).toHaveBeenCalledWith(['en'], ['en', 'fr']);
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('warns at most once for the same unresolved headers object', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const headersList = mockHeaders();
+    vi.mocked(headers).mockResolvedValue(headersList as any);
+    vi.mocked(cookies).mockResolvedValue(mockCookies() as any);
+    determineLocale.mockReturnValue(undefined);
+
+    const { getNextLocale } = await import('../getNextLocale');
+
+    await getNextLocale();
+    await getNextLocale();
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
+});

--- a/packages/next/src/request/headers/getNextLocale.ts
+++ b/packages/next/src/request/headers/getNextLocale.ts
@@ -3,6 +3,14 @@ import { getI18NConfig } from '../../config-dir/getI18NConfig';
 import { noLocalesCouldBeDeterminedWarning } from '../../errors/ssg';
 import { RequestFunctionReturnType } from '../types';
 
+const warnedNoLocaleHeaders = new WeakSet<object>();
+
+function warnNoLocalesCouldBeDeterminedOnce(headersList: object) {
+  if (warnedNoLocaleHeaders.has(headersList)) return;
+  warnedNoLocaleHeaders.add(headersList);
+  console.warn(noLocalesCouldBeDeterminedWarning);
+}
+
 /**
  * Retrieves the 'accept-language' header from the headers list.
  * If the 'next/headers' module is not available, it attempts to load it. If the
@@ -41,17 +49,21 @@ export async function getNextLocale(): Promise<RequestFunctionReturnType> {
     if (acceptedLocales) preferredLocales.push(...acceptedLocales);
   }
 
-  // Give an error here
-  if (
-    preferredLocales.length === 0 &&
-    process.env._GENERALTRANSLATION_IGNORE_BROWSER_LOCALES === 'false'
-  ) {
-    console.warn(noLocalesCouldBeDeterminedWarning);
-  }
+  const hadRequestLocales = preferredLocales.length > 0;
 
   // add defaultLocale just in case there are no matches
   preferredLocales.push(defaultLocale);
 
   const gt = getI18NConfig().getGTClass();
-  return gt.determineLocale(preferredLocales, locales);
+  const locale = gt.determineLocale(preferredLocales, locales);
+
+  if (
+    !locale &&
+    !hadRequestLocales &&
+    process.env._GENERALTRANSLATION_IGNORE_BROWSER_LOCALES === 'false'
+  ) {
+    warnNoLocalesCouldBeDeterminedOnce(headersList);
+  }
+
+  return locale;
 }

--- a/packages/next/src/server-dir/buildtime/getTranslationFunction.ts
+++ b/packages/next/src/server-dir/buildtime/getTranslationFunction.ts
@@ -227,7 +227,7 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
   }) {
     const { source, context, maxChars, id, hash, renderMessage } = args;
     try {
-      I18NConfig.translate({
+      void I18NConfig.translate({
         source: indexVars(source),
         targetLocale: locale,
         options: {
@@ -237,20 +237,24 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
           $_hash: hash,
           $format: 'ICU',
         },
-      }).then((result) => {
-        // eslint-disable-next-line no-console
-        console.warn(
-          createTranslationLoadingWarning({
-            ...(id && { id }),
-            source: renderMessage(source, [defaultLocale]),
-            translation: renderMessage(
-              result as string,
-              [locale, defaultLocale],
-              source
-            ),
-          })
-        );
-      });
+      })
+        .then((result) => {
+          // eslint-disable-next-line no-console
+          console.warn(
+            createTranslationLoadingWarning({
+              ...(id && { id }),
+              source: renderMessage(source, [defaultLocale]),
+              translation: renderMessage(
+                result as string,
+                [locale, defaultLocale],
+                source
+              ),
+            })
+          );
+        })
+        .catch((error) => {
+          console.warn(error);
+        });
     } catch (error) {
       console.warn(error);
     }

--- a/packages/next/src/server-dir/buildtime/getTranslations.tsx
+++ b/packages/next/src/server-dir/buildtime/getTranslations.tsx
@@ -273,7 +273,7 @@ export async function getTranslations(id?: string): Promise<
 
     try {
       // Translate on demand
-      I18NConfig.translate({
+      void I18NConfig.translate({
         source: indexVars(entry),
         targetLocale: locale,
         options: {
@@ -285,23 +285,32 @@ export async function getTranslations(id?: string): Promise<
           $_hash: getHash(),
           $format: 'ICU',
         },
-      }).then((result) => {
-        // Log the translation result for debugging purposes
-        // eslint-disable-next-line no-console
-        console.warn(
-          createTranslationLoadingWarning({
-            ...(id && { id }),
-            source: renderContent(entry, [defaultLocale]),
-            translation: renderContent(result as string, [
-              locale,
-              defaultLocale,
-            ]),
-          })
-        );
+      })
+        .then((result) => {
+          // Log the translation result for debugging purposes
+          // eslint-disable-next-line no-console
+          console.warn(
+            createTranslationLoadingWarning({
+              ...(id && { id }),
+              source: renderContent(entry, [defaultLocale]),
+              translation: renderContent(result as string, [
+                locale,
+                defaultLocale,
+              ]),
+            })
+          );
 
-        // inject
-        injectEntry(result as string, dictionaryTranslations!, id, dictionary);
-      });
+          // inject
+          injectEntry(
+            result as string,
+            dictionaryTranslations!,
+            id,
+            dictionary
+          );
+        })
+        .catch((error) => {
+          console.warn(error);
+        });
     } catch (error) {
       console.warn(error);
     }

--- a/packages/next/swc-plugin/src/lib.rs
+++ b/packages/next/swc-plugin/src/lib.rs
@@ -1,6 +1,7 @@
 use crate::visitor::TransformVisitor;
 use crate::{
   config::PluginConfig,
+  logging::Logger,
   visitor::{
     analysis::{is_translation_function_callback, is_translation_function_name},
     errors::create_dynamic_content_warning,
@@ -144,9 +145,15 @@ impl VisitMut for TransformVisitor {
   /// Process JSX expression containers to detect unwrapped dynamic content
   fn visit_mut_jsx_expr_container(&mut self, expr_container: &mut JSXExprContainer) {
     // Only check for violations if we're in a translation component and NOT in a JSX attribute
-    if self.traversal_state.in_translation_component && !self.traversal_state.in_jsx_attribute {
+    if self.traversal_state.in_translation_component
+      && !self.traversal_state.in_variable_component
+      && !self.traversal_state.in_jsx_attribute
+    {
       // Check if the expression is allowed dynamic content
-      if !self.settings.disable_build_checks && !self.settings.autoderive_jsx && !is_allowed_dynamic_content(&expr_container.expr) {
+      if !self.settings.disable_build_checks
+        && !self.settings.autoderive_jsx
+        && !is_allowed_dynamic_content(&expr_container.expr)
+      {
         self.statistics.dynamic_content_violations += 1;
         let warning = create_dynamic_content_warning(self.settings.filename.as_deref(), "T");
         self.logger.log_error(&warning);
@@ -174,8 +181,10 @@ impl VisitMut for TransformVisitor {
     // Update component tracking state
     let (is_translation_component, is_variable_component, _) =
       self.determine_component_type(element);
-    self.traversal_state.in_translation_component = is_translation_component;
-    self.traversal_state.in_variable_component = is_variable_component;
+    self.traversal_state.in_translation_component =
+      was_in_translation || is_translation_component;
+    self.traversal_state.in_variable_component =
+      was_in_variable || is_variable_component;
 
     // Calculate and record hash for translation components
     if self.settings.compile_time_hash
@@ -327,8 +336,10 @@ impl Fold for TransformVisitor {
 
     // Determine context
     let (is_translation, is_variable, _) = self.determine_component_type(&element);
-    self.traversal_state.in_translation_component = is_translation;
-    self.traversal_state.in_variable_component = is_variable;
+    self.traversal_state.in_translation_component =
+      was_in_translation || is_translation;
+    self.traversal_state.in_variable_component =
+      was_in_variable || is_variable;
 
     // Inject hash attributes on translation components
     let element = if self.settings.compile_time_hash
@@ -365,6 +376,16 @@ pub fn process_transform(program: Program, metadata: TransformPluginProgramMetad
   let filename = metadata
     .get_context(&TransformPluginMetadataContextKind::Filename)
     .map(|f| f.to_string());
+
+  let logger = Logger::new(config.log_level.clone());
+  let debug_message = format!(
+    "gt-next: SWC compiler transform started{}",
+    filename
+      .as_ref()
+      .map(|filename| format!(" for {filename}"))
+      .unwrap_or_default()
+  );
+  logger.log_debug(debug_message.as_str());
 
   // Create StringCollector for the two-pass system
   let string_collector = crate::ast::StringCollector::new();

--- a/packages/next/swc-plugin/src/visitor/transform.rs
+++ b/packages/next/swc-plugin/src/visitor/transform.rs
@@ -767,6 +767,7 @@ mod tests {
   use super::*;
   use swc_core::common::{SyntaxContext, DUMMY_SP};
   use swc_core::ecma::atoms::Atom;
+  use swc_core::ecma::visit::VisitMutWith;
 
   // Helper to create a test visitor with specific imports
   fn create_visitor_with_imports() -> TransformVisitor {
@@ -2143,6 +2144,104 @@ mod tests {
       visitor.visit_mut_jsx_expr_container(&mut expr_container);
 
       assert_eq!(visitor.statistics.dynamic_content_violations, 1);
+    }
+
+    #[test]
+    fn autoderive_off_rejects_raw_variable_child_in_t_component() {
+      let mut visitor = create_visitor_with_imports();
+      let mut element = create_jsx_element("T", vec![]);
+      element.children.push(JSXElementChild::JSXExprContainer(
+        JSXExprContainer {
+          span: DUMMY_SP,
+          expr: JSXExpr::Expr(Box::new(Expr::Ident(Ident {
+            span: DUMMY_SP,
+            sym: Atom::new("username"),
+            optional: false,
+            ctxt: SyntaxContext::empty(),
+          }))),
+        },
+      ));
+
+      element.visit_mut_with(&mut visitor);
+
+      assert_eq!(visitor.statistics.dynamic_content_violations, 1);
+    }
+
+    #[test]
+    fn autoderive_off_rejects_nested_raw_variable_in_t_component() {
+      let mut visitor = create_visitor_with_imports();
+      let mut element = create_jsx_element("T", vec![]);
+      let mut nested = create_jsx_element("strong", vec![]);
+      nested.children.push(JSXElementChild::JSXExprContainer(
+        JSXExprContainer {
+          span: DUMMY_SP,
+          expr: JSXExpr::Expr(Box::new(Expr::Ident(Ident {
+            span: DUMMY_SP,
+            sym: Atom::new("username"),
+            optional: false,
+            ctxt: SyntaxContext::empty(),
+          }))),
+        },
+      ));
+      element
+        .children
+        .push(JSXElementChild::JSXElement(Box::new(nested)));
+
+      element.visit_mut_with(&mut visitor);
+
+      assert_eq!(visitor.statistics.dynamic_content_violations, 1);
+    }
+
+    #[test]
+    fn autoderive_off_allows_var_child_in_t_component() {
+      let mut visitor = create_visitor_with_imports();
+      let mut element = create_jsx_element("T", vec![]);
+      let mut var = create_jsx_element("Var", vec![]);
+      var.children.push(JSXElementChild::JSXExprContainer(
+        JSXExprContainer {
+          span: DUMMY_SP,
+          expr: JSXExpr::Expr(Box::new(Expr::Ident(Ident {
+            span: DUMMY_SP,
+            sym: Atom::new("username"),
+            optional: false,
+            ctxt: SyntaxContext::empty(),
+          }))),
+        },
+      ));
+      element
+        .children
+        .push(JSXElementChild::JSXElement(Box::new(var)));
+
+      element.visit_mut_with(&mut visitor);
+
+      assert_eq!(visitor.statistics.dynamic_content_violations, 0);
+    }
+
+    #[test]
+    fn autoderive_off_allows_nested_jsx_inside_var_child() {
+      let mut visitor = create_visitor_with_imports();
+      let mut element = create_jsx_element("T", vec![]);
+      let mut var = create_jsx_element("Var", vec![]);
+      let mut nested = create_jsx_element("span", vec![]);
+      nested.children.push(JSXElementChild::JSXExprContainer(
+        JSXExprContainer {
+          span: DUMMY_SP,
+          expr: JSXExpr::Expr(Box::new(Expr::Ident(Ident {
+            span: DUMMY_SP,
+            sym: Atom::new("username"),
+            optional: false,
+            ctxt: SyntaxContext::empty(),
+          }))),
+        },
+      ));
+      var.children.push(JSXElementChild::JSXElement(Box::new(nested)));
+      element
+        .children
+        .push(JSXElementChild::JSXElement(Box::new(var)));
+
+      element.visit_mut_with(&mut visitor);
+
+      assert_eq!(visitor.statistics.dynamic_content_violations, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- split the Babel compiler incompatibility warning into separate Turbopack and React-version messages
- keep both warnings when both incompatibilities apply
- add focused withGTConfig coverage for the compatibility warning behavior

## Checks
- `pnpm --dir packages/next exec vitest run src/__tests__/config.test.ts`

## Notes
- Rewritten after review feedback to focus only on compiler compatibility logging.