### PR TITLE
docs: document compiler setup

### DIFF
--- a/docs/en-US/cli/features/auto-jsx-injection.mdx
+++ b/docs/en-US/cli/features/auto-jsx-injection.mdx
@@ -1,0 +1,188 @@
+---
+title: Auto JSX Injection
+description: Automatically wrap React JSX text for translation
+---
+
+## Overview
+
+Auto JSX injection lets the GT compiler wrap plain React JSX text with
+translation components during your build. It is useful for SPA React apps where
+you want to keep authoring normal JSX while still extracting and translating
+user-facing copy.
+
+```tsx title="src/App.tsx"
+export function App() {
+  return <h1>Welcome back</h1>;
+}
+```
+
+With auto JSX injection enabled, the compiler treats that text as translatable
+content and injects the GT translation wrapper for you.
+
+<Callout type='info'>
+  This guide is for React apps that use `gt-react` with Vite, webpack, Rollup,
+  or esbuild. Next.js apps should use the compiler options in
+  [`withGTConfig()`](/docs/next/api/config/withGTConfig).
+</Callout>
+
+## Complete Setup
+
+### 1. Install the compiler
+
+Install `@generaltranslation/compiler` as a development dependency.
+
+<Tabs items={['npm', 'yarn', 'bun', 'pnpm']}>
+  <Tab value="npm">
+
+```bash
+npm i -D @generaltranslation/compiler
+```
+
+  </Tab>
+  <Tab value="yarn">
+
+```bash
+yarn add -D @generaltranslation/compiler
+```
+
+  </Tab>
+  <Tab value="bun">
+
+```bash
+bun add -d @generaltranslation/compiler
+```
+
+  </Tab>
+  <Tab value="pnpm">
+
+```bash
+pnpm add -D @generaltranslation/compiler
+```
+
+  </Tab>
+</Tabs>
+
+### 2. Add the bundler plugin
+
+Add the GT compiler plugin to your bundler config and pass `{ gtConfig }`. The
+`gtConfig` option lets the compiler read `files.gt.parsingFlags` from the same
+`gt.config.json` file used by the CLI.
+
+```ts title="vite.config.ts"
+import fs from 'node:fs';
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { vite as gtCompiler } from '@generaltranslation/compiler';
+
+const gtConfig = JSON.parse(fs.readFileSync('./gt.config.json', 'utf-8'));
+
+export default defineConfig({
+  plugins: [react(), gtCompiler({ gtConfig })],
+});
+```
+
+For webpack, Rollup, and esbuild examples, see the
+[React compiler guide](/docs/react/concepts/compiler).
+
+### 3. Enable auto JSX injection
+
+Enable `files.gt.parsingFlags.enableAutoJsxInjection` in `gt.config.json`.
+
+```json title="gt.config.json"
+{
+  "defaultLocale": "en",
+  "locales": ["es", "fr"],
+  "files": {
+    "gt": {
+      "output": "public/_gt/[locale].json",
+      "parsingFlags": {
+        "enableAutoJsxInjection": true
+      }
+    }
+  }
+}
+```
+
+### 4. Build your app
+
+Run your normal build command. The compiler runs as part of the bundler build.
+
+<Tabs items={['npm', 'yarn', 'bun', 'pnpm']}>
+  <Tab value="npm">
+
+```bash
+npm run build
+```
+
+  </Tab>
+  <Tab value="yarn">
+
+```bash
+yarn build
+```
+
+  </Tab>
+  <Tab value="bun">
+
+```bash
+bun run build
+```
+
+  </Tab>
+  <Tab value="pnpm">
+
+```bash
+pnpm build
+```
+
+  </Tab>
+</Tabs>
+
+## React Setup
+
+Your app still needs `GTProvider` from `gt-react` at the root so translated
+content can render with the active locale.
+
+```tsx title="src/App.tsx"
+import { GTProvider, LocaleSelector } from 'gt-react';
+
+function Home() {
+  return (
+    <main>
+      <LocaleSelector />
+      <h1>Welcome back</h1>
+      <p>Your dashboard is ready.</p>
+    </main>
+  );
+}
+
+export default function App() {
+  return (
+    <GTProvider>
+      <Home />
+    </GTProvider>
+  );
+}
+```
+
+Auto JSX injection handles static JSX text. Continue to use explicit
+[`<T>`](/docs/react/api/components/t), [`<Var>`](/docs/react/api/components/var),
+and [`useGT()`](/docs/react/api/strings/useGT) calls when you need precise
+control over variables, attributes, or translation context.
+
+## How It Works
+
+During the bundler build, the compiler scans JSX and injects GT translation
+wrappers around plain text. When you also run the CLI translate command, the CLI
+uses the same `enableAutoJsxInjection` flag to extract matching text from your
+source files.
+
+Passing `{ gtConfig }` keeps those two steps aligned:
+
+- the build compiler knows auto JSX injection is enabled
+- the CLI knows to extract text that will be wrapped automatically
+
+## Next Steps
+
+Use the [React compiler guide](/docs/react/concepts/compiler) for bundler
+setup details, including compile-time hashing and build checks.

--- a/docs/en-US/next/api/config/withGTConfig.mdx
+++ b/docs/en-US/next/api/config/withGTConfig.mdx
@@ -1,0 +1,238 @@
+---
+title: withGTConfig()
+description: API reference for configuring gt-next
+---
+
+## Overview
+
+`withGTConfig()` wraps your Next.js config and enables `gt-next`.
+
+```js title="next.config.mjs"
+import { withGTConfig } from 'gt-next/config';
+
+const nextConfig = {
+  // Your existing Next.js config
+};
+
+export default withGTConfig(nextConfig, {
+  defaultLocale: 'en',
+  locales: ['es', 'fr'],
+});
+```
+
+By default, `withGTConfig()` also reads `gt.config.json` from the same directory
+as your `next.config.js` or `next.config.mjs` file and merges it with the
+options passed directly to `withGTConfig()`.
+
+<Callout type='info'>
+  Use `gt.config.json` as the source of truth for settings that also need to be
+  read by the CLI.
+</Callout>
+
+## Required Props
+
+<TypeTable
+  type={{
+    nextConfig: {
+      type: 'NextConfig',
+      optional: false,
+    },
+  }}
+/>
+
+## Recommended Props
+
+<TypeTable
+  type={{
+    'defaultLocale?': {
+      type: 'string',
+      optional: true,
+      default: '"en"',
+    },
+    'locales?': {
+      type: 'string[]',
+      optional: true,
+      default: '[]',
+    },
+    'description?': {
+      type: 'string',
+      optional: true,
+    },
+  }}
+/>
+
+| Prop            | Description                                                                 |
+| --------------- | --------------------------------------------------------------------------- |
+| `defaultLocale` | The locale your source content is written in.                               |
+| `locales`       | The locales your application supports.                                      |
+| `description`   | Natural-language project context that can help produce better translations. |
+
+## Advanced Props
+
+<TypeTable
+  type={{
+    'projectId?': {
+      type: 'string',
+      optional: true,
+    },
+    'apiKey?': {
+      type: 'string',
+      optional: true,
+    },
+    'devApiKey?': {
+      type: 'string',
+      optional: true,
+    },
+    'runtimeUrl?': {
+      type: 'string | null',
+      optional: true,
+    },
+    'cacheUrl?': {
+      type: 'string | null',
+      optional: true,
+    },
+    'cacheExpiryTime?': {
+      type: 'number',
+      optional: true,
+      default: '60000',
+    },
+    'renderSettings?': {
+      type: 'RenderSettings',
+      optional: true,
+    },
+    'maxConcurrentRequests?': {
+      type: 'number',
+      optional: true,
+      default: '100',
+    },
+    'maxBatchSize?': {
+      type: 'number',
+      optional: true,
+      default: '25',
+    },
+    'batchInterval?': {
+      type: 'number',
+      optional: true,
+      default: '50',
+    },
+    'dictionary?': {
+      type: 'string',
+      optional: true,
+    },
+    'experimentalCompilerOptions?': {
+      type: 'CompilerOptions',
+      optional: true,
+    },
+  }}
+/>
+
+| Prop                          | Description                                                                |
+| ----------------------------- | -------------------------------------------------------------------------- |
+| `projectId`                   | Project ID for the General Translation platform.                           |
+| `apiKey`                      | Production API key. Prefer `GT_API_KEY` in your environment.               |
+| `devApiKey`                   | Development API key. Prefer `GT_DEV_API_KEY` in your environment.          |
+| `runtimeUrl`                  | Base URL for runtime translations. Set to `null` to disable.               |
+| `cacheUrl`                    | Base URL for cached translations. Set to `null` to disable.                |
+| `cacheExpiryTime`             | Time in milliseconds before remote cached translations expire.             |
+| `renderSettings`              | Loading behavior for runtime translations.                                 |
+| `maxConcurrentRequests`       | Maximum number of concurrent translation requests.                         |
+| `maxBatchSize`                | Maximum number of translations per request batch.                          |
+| `batchInterval`               | Time in milliseconds between batched translation requests.                 |
+| `dictionary`                  | Path to a local dictionary file.                                           |
+| `experimentalCompilerOptions` | Compiler plugin settings for build checks and compile-time hash injection. |
+
+## `experimentalCompilerOptions`
+
+`experimentalCompilerOptions` controls the compiler that `gt-next` wires into
+your Next.js build.
+
+```js title="next.config.mjs"
+import { withGTConfig } from 'gt-next/config';
+
+const nextConfig = {};
+
+export default withGTConfig(nextConfig, {
+  experimentalCompilerOptions: {
+    type: 'swc',
+    logLevel: 'warn',
+    compileTimeHash: true,
+    disableBuildChecks: false,
+  },
+});
+```
+
+<TypeTable
+  type={{
+    type: {
+      type: '"swc" | "babel" | "none"',
+      optional: false,
+      default: '"none"',
+    },
+    'logLevel?': {
+      type: '"silent" | "error" | "warn" | "info" | "debug"',
+      optional: true,
+      default: '"warn"',
+    },
+    'disableBuildChecks?': {
+      type: 'boolean',
+      optional: true,
+      default: 'false',
+    },
+    'compileTimeHash?': {
+      type: 'boolean',
+      optional: true,
+      default: 'true',
+    },
+  }}
+/>
+
+| Option               | Description                                                                                                    |
+| -------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `type`               | Selects `swc`, `babel`, or `none` for compiler integration.                                                    |
+| `logLevel`           | Controls compiler output. Use `silent`, `error`, `warn`, `info`, or `debug`.                                   |
+| `disableBuildChecks` | Disables compiler validation for dynamic JSX content and translation function usage.                           |
+| `compileTimeHash`    | Adds translation hashes at build time so the runtime does not need to calculate them in the browser or server. |
+
+<Callout type='warn'>
+  `babel` does not work with Turbopack, which is the default bundler in Next.js
+  16 and newer. The `swc` compiler option requires Next.js 16.1 or newer.
+</Callout>
+
+If `type` is `none`, the compiler does not run. Other compiler options only
+apply when `type` is `swc` or `babel`.
+
+## Render Settings
+
+`renderSettings` controls how runtime translations are displayed while they are
+loading.
+
+<TypeTable
+  type={{
+    method: {
+      type: '"skeleton" | "replace" | "default"',
+      optional: false,
+      default: '"default"',
+    },
+    'timeout?': {
+      type: 'number',
+      optional: true,
+      default: '8000',
+    },
+  }}
+/>
+
+| Prop      | Description                                                         |
+| --------- | ------------------------------------------------------------------- |
+| `method`  | Loading behavior. Options are `skeleton`, `replace`, and `default`. |
+| `timeout` | Time in milliseconds before the loading behavior times out.         |
+
+## Returns
+
+`withGTConfig()` returns a `NextConfig` object with GT settings, aliases,
+environment values, and optional compiler integration applied.
+
+## Exceptions
+
+`withGTConfig()` can throw when required project configuration is missing,
+local translation or dictionary files cannot be resolved, or configuration in
+`gt.config.json` conflicts with values passed directly to `withGTConfig()`.

--- a/docs/en-US/react/concepts/compiler.mdx
+++ b/docs/en-US/react/concepts/compiler.mdx
@@ -1,0 +1,167 @@
+---
+title: Compiler
+description: Use the GT compiler with React apps that are not using Next.js
+---
+
+## Overview
+
+The GT compiler is an optional build plugin for React apps that use Vite,
+webpack, Rollup, or esbuild. Next.js users should configure the compiler through
+[`withGTConfig()`](/docs/next/api/config/withGTConfig) instead.
+
+The compiler can:
+
+- add compile-time hashes to translated JSX and strings
+- run build checks for common translation mistakes
+- automatically wrap plain JSX text for translation when auto JSX injection is enabled
+
+<Callout type='info'>
+  Auto JSX injection is configured through `gt.config.json`. See the [auto JSX
+  injection guide](/docs/cli/features/auto-jsx-injection) for the full setup.
+</Callout>
+
+## Install
+
+Install the compiler as a development dependency.
+
+<Tabs items={['npm', 'yarn', 'bun', 'pnpm']}>
+  <Tab value="npm">
+
+```bash
+npm i -D @generaltranslation/compiler
+```
+
+  </Tab>
+  <Tab value="yarn">
+
+```bash
+yarn add -D @generaltranslation/compiler
+```
+
+  </Tab>
+  <Tab value="bun">
+
+```bash
+bun add -d @generaltranslation/compiler
+```
+
+  </Tab>
+  <Tab value="pnpm">
+
+```bash
+pnpm add -D @generaltranslation/compiler
+```
+
+  </Tab>
+</Tabs>
+
+## Setup
+
+Pass your parsed `gt.config.json` as `{ gtConfig }` so compiler features that
+read `files.gt.parsingFlags`, including auto JSX injection and autoderive, use
+the same configuration as the CLI.
+
+### Vite
+
+```ts title="vite.config.ts"
+import fs from 'node:fs';
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { vite as gtCompiler } from '@generaltranslation/compiler';
+
+const gtConfig = JSON.parse(fs.readFileSync('./gt.config.json', 'utf-8'));
+
+export default defineConfig({
+  plugins: [react(), gtCompiler({ gtConfig })],
+});
+```
+
+### webpack
+
+```js title="webpack.config.js"
+const fs = require('node:fs');
+const { webpack: gtCompiler } = require('@generaltranslation/compiler');
+
+const gtConfig = JSON.parse(fs.readFileSync('./gt.config.json', 'utf-8'));
+
+module.exports = {
+  plugins: [gtCompiler({ gtConfig })],
+};
+```
+
+### Rollup
+
+```js title="rollup.config.mjs"
+import fs from 'node:fs';
+import { rollup as gtCompiler } from '@generaltranslation/compiler';
+
+const gtConfig = JSON.parse(fs.readFileSync('./gt.config.json', 'utf-8'));
+
+export default {
+  plugins: [gtCompiler({ gtConfig })],
+};
+```
+
+### esbuild
+
+```js title="build.mjs"
+import fs from 'node:fs';
+import { build } from 'esbuild';
+import { esbuild as gtCompiler } from '@generaltranslation/compiler';
+
+const gtConfig = JSON.parse(fs.readFileSync('./gt.config.json', 'utf-8'));
+
+await build({
+  entryPoints: ['src/main.tsx'],
+  bundle: true,
+  outdir: 'dist',
+  plugins: [gtCompiler({ gtConfig })],
+});
+```
+
+## Options
+
+You can pass compiler options next to `gtConfig`.
+
+```ts
+gtCompiler({
+  gtConfig,
+  logLevel: 'warn',
+  compileTimeHash: true,
+  disableBuildChecks: false,
+});
+```
+
+- `gtConfig`: parsed `gt.config.json`. When omitted, the compiler tries to
+  load `./gt.config.json` from the current working directory.
+- `logLevel`: one of `silent`, `error`, `warn`, `info`, or `debug`. Defaults
+  to `warn`.
+- `compileTimeHash`: boolean. Defaults to `false`.
+- `disableBuildChecks`: boolean. Defaults to `false`.
+
+## Enable Parsing Flags
+
+Compiler features that are shared with the CLI live under
+`files.gt.parsingFlags` in `gt.config.json`.
+
+```json title="gt.config.json"
+{
+  "defaultLocale": "en",
+  "locales": ["es", "fr"],
+  "files": {
+    "gt": {
+      "output": "public/_gt/[locale].json",
+      "parsingFlags": {
+        "enableAutoJsxInjection": true,
+        "autoderive": {
+          "jsx": true,
+          "strings": true
+        }
+      }
+    }
+  }
+}
+```
+
+With `{ gtConfig }` passed to the plugin, the compiler reads these flags during
+your bundler build.

--- a/docs/en-US/react/tutorials/quickstart.mdx
+++ b/docs/en-US/react/tutorials/quickstart.mdx
@@ -1,0 +1,150 @@
+---
+title: React Quickstart
+description: Get started with gt-react
+---
+
+## Step 1: Install
+
+Install `gt-react` and the CLI.
+
+<Tabs items={['npm', 'yarn', 'bun', 'pnpm']}>
+  <Tab value="npm">
+
+```bash
+npm i gt-react
+npm i -D gtx-cli
+```
+
+  </Tab>
+  <Tab value="yarn">
+
+```bash
+yarn add gt-react
+yarn add -D gtx-cli
+```
+
+  </Tab>
+  <Tab value="bun">
+
+```bash
+bun add gt-react
+bun add -d gtx-cli
+```
+
+  </Tab>
+  <Tab value="pnpm">
+
+```bash
+pnpm add gt-react
+pnpm add -D gtx-cli
+```
+
+  </Tab>
+</Tabs>
+
+## Step 2: Add `GTProvider`
+
+Wrap your React app with `GTProvider`.
+
+```tsx title="src/App.tsx"
+import { GTProvider } from 'gt-react';
+
+export default function App() {
+  return (
+    <GTProvider>
+      <YourApp />
+    </GTProvider>
+  );
+}
+```
+
+## Step 3: Configure locales
+
+Create `gt.config.json` in your project root.
+
+```json title="gt.config.json"
+{
+  "defaultLocale": "en",
+  "locales": ["es", "fr"]
+}
+```
+
+## Step 4: Add environment variables
+
+For development hot reloading, expose your development key and project ID using
+the prefix required by your React framework.
+
+```bash title=".env.local"
+VITE_GT_API_KEY="your-dev-api-key"
+VITE_GT_PROJECT_ID="your-project-id"
+```
+
+<Callout type='warn'>
+  Development keys can be exposed to the browser. Production API keys should
+  stay server-side and should not use a public client-side prefix.
+</Callout>
+
+## Step 5: Translate JSX
+
+Wrap JSX content with [`<T>`](/docs/react/api/components/t).
+
+```tsx
+import { T } from 'gt-react';
+
+function Welcome() {
+  return (
+    <T>
+      <h1>Welcome to our app!</h1>
+    </T>
+  );
+}
+```
+
+<Callout type='info'>
+  Want this done automatically? Install `@generaltranslation/compiler` and
+  enable auto JSX injection. See the [auto JSX injection
+  guide](/docs/cli/features/auto-jsx-injection).
+</Callout>
+
+For dynamic values, use [`<Var>`](/docs/react/api/components/var).
+
+```tsx
+import { T, Var } from 'gt-react';
+
+function Greeting({ user }) {
+  return (
+    <T>
+      <p>
+        Hello, <Var>{user.name}</Var>!
+      </p>
+    </T>
+  );
+}
+```
+
+## Step 6: Translate strings
+
+Use [`useGT()`](/docs/react/api/strings/useGT) for attributes, labels, and
+plain strings.
+
+```tsx
+import { useGT } from 'gt-react';
+
+function ContactForm() {
+  const t = useGT();
+
+  return <input placeholder={t('Enter your email')} />;
+}
+```
+
+## Step 7: Build for production
+
+Run the translate command before your production build.
+
+```bash
+npx gtx-cli translate
+```
+
+For Vite apps, the optional
+[`@generaltranslation/compiler`](/docs/react/concepts/compiler) plugin can also
+add compile-time hashes and run build checks as part of your bundler build.


### PR DESCRIPTION
## Summary
- document `experimentalCompilerOptions` in the `withGTConfig()` API reference
- add a React compiler guide for Vite, webpack, Rollup, and esbuild users
- update auto JSX injection docs with compiler installation, `gtConfig` setup, and `gt-react` examples
- add a React quickstart callout for optional compiler/auto JSX injection setup

## Checks
- `pnpm exec prettier --check docs/en-US/**/*.mdx`

## Notes
- This checkout does not include a docs app/nav build target, so I verified formatting only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds four new documentation pages covering the `@generaltranslation/compiler` plugin and `withGTConfig()` API reference for React and Next.js users. The content is well-structured and cross-references between pages are consistent, but two pages disagree on the default value of `compileTimeHash` — a discrepancy that will give developers incorrect expectations about build behavior depending on which page they read.

- **`withGTConfig.mdx`**: New full API reference for the Next.js config wrapper, including a new `experimentalCompilerOptions` section; documents `compileTimeHash` as defaulting to `true` and marks the `type` field as `optional: false` despite having a `\"none\"` default.
- **`compiler.mdx`**: New bundler plugin guide for Vite, webpack, Rollup, and esbuild; documents `compileTimeHash` as defaulting to `false`, directly contradicting `withGTConfig.mdx`.
- **`auto-jsx-injection.mdx` / `quickstart.mdx`**: New guides for auto JSX injection and the React getting-started flow; both appear accurate and internally consistent.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Documentation-only change, but the conflicting compileTimeHash defaults between the two new pages will mislead developers about actual build behavior until one is corrected.

The two core reference pages give opposite answers for the compileTimeHash default (true vs. false). A developer following one page will get different build output than one following the other, with no indication the pages disagree. Additionally, the type field is simultaneously marked non-optional and given a default in withGTConfig.mdx, which is internally contradictory.

docs/en-US/next/api/config/withGTConfig.mdx and docs/en-US/react/concepts/compiler.mdx need the compileTimeHash default reconciled against the actual implementation default.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/en-US/next/api/config/withGTConfig.mdx | New API reference for withGTConfig(); contains a conflicting compileTimeHash default (true here vs. false in compiler.mdx) and a required/optional contradiction on the `type` field |
| docs/en-US/react/concepts/compiler.mdx | New bundler plugin guide for Vite/webpack/Rollup/esbuild; documents compileTimeHash as defaulting to false, conflicting with withGTConfig.mdx which says true |
| docs/en-US/cli/features/auto-jsx-injection.mdx | New guide for auto JSX injection with install, bundler config, and gt.config.json setup; content and cross-references appear consistent |
| docs/en-US/react/tutorials/quickstart.mdx | New React quickstart tutorial; clear step-by-step guide with appropriate callouts and cross-references; no issues found |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Developer adds gt-react] --> B{Framework?}
    B -->|Next.js| C[withGTConfig in next.config.mjs]
    B -->|Vite / webpack / Rollup / esbuild| D[Install @generaltranslation/compiler]
    C --> E[experimentalCompilerOptions type: swc or babel or none]
    D --> F[Add bundler plugin with gt.config.json]
    E --> G[Compiler runs in Next.js build]
    F --> G
    G --> H{enableAutoJsxInjection?}
    H -->|Yes| I[Compiler wraps plain JSX text automatically]
    H -->|No| J[Explicit T / Var / useGT calls only]
    I --> K[npx gtx-cli translate]
    J --> K
    K --> L[Production build with translated content]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
docs/en-US/next/api/config/withGTConfig.mdx:176-184
**`compileTimeHash` default conflicts with `compiler.mdx`**

`withGTConfig.mdx` documents `compileTimeHash` as defaulting to `true`, but `compiler.mdx` (the bundler plugin reference for Vite/webpack/Rollup/esbuild) states: *"Defaults to `false`."* A reader configuring the standalone compiler plugin will get a different default than the Next.js wrapper docs suggest, or one of these docs is simply wrong. This needs to be reconciled so both documents agree on the actual runtime default.

### Issue 2 of 4
docs/en-US/next/api/config/withGTConfig.mdx:160-165
**`type` marked `optional: false` but has a default value**

The TypeTable entry for `type` sets `optional: false` alongside `default: '"none"'`. A field with a runtime default is by definition optional at call sites — marking it required will mislead users who omit it expecting the `"none"` default to apply. If `type` truly must be supplied explicitly, the default entry should be removed; if it is genuinely optional, `optional` should be `true`.

### Issue 3 of 4
docs/en-US/next/api/config/withGTConfig.mdx:222-226
**Turbopack-as-default version may be off by one**

The callout states Turbopack is "the default bundler in Next.js 16 and newer." Turbopack became the default for `next dev` in Next.js 15, so the warning under-covers Next.js 15 users who pick `babel` and hit the same incompatibility. If the claim is intentional (e.g. Turbopack became the production-build default only in 16), a brief clarifying note distinguishing `next dev` vs. `next build` would prevent confusion.

### Issue 4 of 4
docs/en-US/react/concepts/compiler.mdx:153-157
**`compileTimeHash` default conflicts with `withGTConfig.mdx`**

This file documents `compileTimeHash` as defaulting to `false`, while `withGTConfig.mdx` documents it as defaulting to `true`. Developers using the standalone bundler plugin will expect different behavior than the Next.js integration docs suggest. The actual default should be verified against the implementation and both pages updated to match.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: document compiler setup"](https://github.com/generaltranslation/gt/commit/72db37cbc0051eca16a1b3013648fd6a2fa9af8f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30876044)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->