### PR TITLE
fix(next): clarify babel compiler compatibility warnings

### DIFF
--- a/.changeset/fair-babel-warnings.md
+++ b/.changeset/fair-babel-warnings.md
@@ -1,0 +1,5 @@
+---
+'gt-next': patch
+---
+
+Clarify Babel compiler compatibility warnings for Turbopack and unsupported React versions.

--- a/packages/next/src/__tests__/config.test.ts
+++ b/packages/next/src/__tests__/config.test.ts
@@ -11,12 +11,14 @@ vi.mock('fs', () => ({
   },
 }));
 
-vi.mock('../plugin/getStableNextVersionInfo', () => ({
+const mockVersionInfo = vi.hoisted(() => ({
   rootParamStability: 'experimental',
   turboConfigStable: true,
   swcPluginCompatible: true,
   babelPluginCompatible: true,
 }));
+
+vi.mock('../plugin/getStableNextVersionInfo', () => mockVersionInfo);
 
 // ---- Helpers ---- //
 
@@ -49,6 +51,10 @@ beforeEach(() => {
   delete process.env.TURBOPACK;
   process.env.NODE_ENV = 'development';
   vi.clearAllMocks();
+  mockVersionInfo.rootParamStability = 'experimental';
+  mockVersionInfo.turboConfigStable = true;
+  mockVersionInfo.swcPluginCompatible = true;
+  mockVersionInfo.babelPluginCompatible = true;
   vi.mocked(fs.existsSync).mockReturnValue(false);
   vi.mocked(fs.readFileSync).mockReturnValue('{}');
 });
@@ -1146,9 +1152,92 @@ describe('withGTConfig', () => {
   });
 
   // ==============================
-  // 13. Webpack function
+  // 13. Compiler configuration
   // ==============================
-  describe('13. Webpack function', () => {
+  describe('13. Compiler configuration', () => {
+    it('uses a Turbopack-specific babel compiler warning', async () => {
+      const withGTConfig = await getWithGTConfig();
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      process.env.TURBOPACK = '1';
+
+      const result = withGTConfig(
+        {},
+        { experimentalCompilerOptions: { type: 'babel' } as any }
+      );
+      const params = parseConfigParams(result);
+
+      expect(params.experimentalCompilerOptions.type).toBe('none');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'The GT babel compiler is not compatible with Turbopack'
+        )
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("experimentalCompilerOptions: { type: 'swc' }")
+      );
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('compatible with turbopack or < react')
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('uses a React-version-specific babel compiler warning', async () => {
+      const withGTConfig = await getWithGTConfig();
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      mockVersionInfo.babelPluginCompatible = false;
+
+      const result = withGTConfig(
+        {},
+        { experimentalCompilerOptions: { type: 'babel' } as any }
+      );
+      const params = parseConfigParams(result);
+
+      expect(params.experimentalCompilerOptions.type).toBe('none');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'The GT babel compiler requires react@17.0.0 or newer'
+        )
+      );
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('compatible with turbopack or < react')
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('warns for both babel compiler incompatibilities when both apply', async () => {
+      const withGTConfig = await getWithGTConfig();
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      process.env.TURBOPACK = '1';
+      mockVersionInfo.babelPluginCompatible = false;
+
+      const result = withGTConfig(
+        {},
+        { experimentalCompilerOptions: { type: 'babel' } as any }
+      );
+      const params = parseConfigParams(result);
+
+      expect(params.experimentalCompilerOptions.type).toBe('none');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'The GT babel compiler is not compatible with Turbopack'
+        )
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'The GT babel compiler requires react@17.0.0 or newer'
+        )
+      );
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('compatible with turbopack or < react')
+      );
+      warnSpy.mockRestore();
+    });
+  });
+
+  // ==============================
+  // 14. Webpack function
+  // ==============================
+  describe('14. Webpack function', () => {
     it('returns webpack config object', async () => {
       const withGTConfig = await getWithGTConfig();
       const result = withGTConfig();
@@ -1217,9 +1306,9 @@ describe('withGTConfig', () => {
   });
 
   // ==============================
-  // 14. Turbopack configuration
+  // 15. Turbopack configuration
   // ==============================
-  describe('14. Turbopack configuration', () => {
+  describe('15. Turbopack configuration', () => {
     it('when TURBOPACK=1 + turboConfigStable=true (no legacy turbo config): aliases in result.turbopack.resolveAlias', async () => {
       const withGTConfig = await getWithGTConfig();
       process.env.TURBOPACK = '1';
@@ -1257,9 +1346,9 @@ describe('withGTConfig', () => {
   });
 
   // ==============================
-  // 15. Headers/cookies merging
+  // 16. Headers/cookies merging
   // ==============================
-  describe('15. Headers/cookies merging', () => {
+  describe('16. Headers/cookies merging', () => {
     it('default values used when none provided', async () => {
       const withGTConfig = await getWithGTConfig();
       const result = withGTConfig();
@@ -1312,9 +1401,9 @@ describe('withGTConfig', () => {
   });
 
   // ==============================
-  // 16. nextConfig passthrough
+  // 17. nextConfig passthrough
   // ==============================
-  describe('16. nextConfig passthrough', () => {
+  describe('17. nextConfig passthrough', () => {
     it('preserves all existing nextConfig properties', async () => {
       const withGTConfig = await getWithGTConfig();
       const result = withGTConfig({
@@ -1350,9 +1439,9 @@ describe('withGTConfig', () => {
   });
 
   // ==============================
-  // 17. initGT backward compatibility
+  // 18. initGT backward compatibility
   // ==============================
-  describe('17. initGT backward compatibility', () => {
+  describe('18. initGT backward compatibility', () => {
     it('initGT(props) returns a function (nextConfig) => NextConfig', async () => {
       const initGT = await getInitGT();
       const configFn = initGT({ defaultLocale: 'es' });

--- a/packages/next/src/__tests__/config.test.ts
+++ b/packages/next/src/__tests__/config.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'fs';
 import type { NextConfig } from 'next';
+import { BABEL_PLUGIN_SUPPORT } from '../plugin/constants';
 
 // ---- Mocks ---- //
 
@@ -1195,7 +1196,7 @@ describe('withGTConfig', () => {
       expect(params.experimentalCompilerOptions.type).toBe('none');
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining(
-          'The GT babel compiler requires react@17.0.0 or newer'
+          `The GT babel compiler requires react@${BABEL_PLUGIN_SUPPORT} or newer`
         )
       );
       expect(warnSpy).not.toHaveBeenCalledWith(
@@ -1224,7 +1225,7 @@ describe('withGTConfig', () => {
       );
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining(
-          'The GT babel compiler requires react@17.0.0 or newer'
+          `The GT babel compiler requires react@${BABEL_PLUGIN_SUPPORT} or newer`
         )
       );
       expect(warnSpy).not.toHaveBeenCalledWith(

--- a/packages/next/src/config-dir/utils/validateCompiler.ts
+++ b/packages/next/src/config-dir/utils/validateCompiler.ts
@@ -1,6 +1,7 @@
 import { type withGTConfigProps } from '../props/withGTConfigProps';
 import { babelPluginCompatible } from '../../plugin/getStableNextVersionInfo';
 import {
+  babelCompilerTurbopackUnavailableWarning,
   createGTCompilerUnavailableWarning,
   disablingCompileTimeHashWarning,
   swcPluginCompatibilityChangeWarning,
@@ -20,9 +21,16 @@ export function validateCompiler(mergedConfig: withGTConfigProps) {
     console.warn(createGTCompilerUnavailableWarning('swc'));
     console.warn(swcPluginCompatibilityChangeWarning);
     mergedConfig.experimentalCompilerOptions.type = 'none';
-  } else if (type === 'babel' && (!babelPluginCompatible || turboPackEnabled)) {
-    console.warn(createGTCompilerUnavailableWarning('babel'));
-    mergedConfig.experimentalCompilerOptions.type = 'none';
+  } else if (type === 'babel') {
+    if (turboPackEnabled) {
+      console.warn(babelCompilerTurbopackUnavailableWarning);
+    }
+    if (!babelPluginCompatible) {
+      console.warn(createGTCompilerUnavailableWarning('babel'));
+    }
+    if (turboPackEnabled || !babelPluginCompatible) {
+      mergedConfig.experimentalCompilerOptions.type = 'none';
+    }
   }
   // Backwards compatibility, remove this condition in the future
   if (mergedConfig.experimentalCompilerOptions.compileTimeHash === false) {

--- a/packages/next/src/errors/createErrors.ts
+++ b/packages/next/src/errors/createErrors.ts
@@ -172,7 +172,11 @@ export const createGTCompilerUnresolvedWarning = (type: 'babel' | 'swc') =>
 export const createGTCompilerUnavailableWarning = (type: 'babel' | 'swc') =>
   type === 'swc'
     ? `gt-next (plugin): The GT swc compiler is compatible with < next@${SWC_PLUGIN_SUPPORT}. Skipping compiler optimizations.`
-    : `gt-next (plugin): The GT babel compiler is compatible with turbopack or < react@${BABEL_PLUGIN_SUPPORT}. Skipping compiler optimizations.`;
+    : `gt-next (plugin): The GT babel compiler requires react@${BABEL_PLUGIN_SUPPORT} or newer. Skipping compiler optimizations.`;
+
+export const babelCompilerTurbopackUnavailableWarning =
+  `gt-next (plugin): The GT babel compiler is not compatible with Turbopack. ` +
+  `To use compiler optimizations with Turbopack, set experimentalCompilerOptions: { type: 'swc' }.`;
 
 export const disablingCompileTimeHashWarning = `gt-next (plugin): Compile-time hash is disabled. Compiler optimizations are inactive.`;
 


### PR DESCRIPTION
## Summary
- split the Babel compiler incompatibility warning into separate Turbopack and React-version messages
- keep both warnings when both incompatibilities apply
- add focused withGTConfig coverage for the compatibility warning behavior

## Checks
- `pnpm --dir packages/next exec vitest run src/__tests__/config.test.ts`

## Notes
- Replacement for #1343, rewritten after review feedback to focus only on compiler compatibility logging.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR splits the combined Babel compiler incompatibility warning (Turbopack + React version) into two focused, separate messages and adds dedicated test coverage for each case.

- **`validateCompiler.ts`**: The single `else if` guard is replaced by two independent `if` checks, each emitting its own warning, with `type = 'none'` set when either condition is met.
- **`createErrors.ts`**: Adds a new `babelCompilerTurbopackUnavailableWarning` constant (with an actionable SWC suggestion) and updates the existing babel warning to only describe the React version requirement.
- **`config.test.ts`**: Converts the static module mock to a mutable `vi.hoisted` object (reset in `beforeEach`), then adds three targeted tests covering the Turbopack-only, React-version-only, and both-at-once scenarios.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is limited to warning message formatting and test infrastructure, with no behavioral changes to compilation output or runtime logic.

The logic changes are minimal and well-covered: the only behavioral difference is that users now see two distinct, actionable warnings instead of one combined message. The type = 'none' fallback path is preserved for all existing incompatibility combinations. The mock refactor correctly uses vi.hoisted with a beforeEach reset, so test isolation is maintained.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/config-dir/utils/validateCompiler.ts | Splits the combined babel incompatibility check into two independent guards; logic and fallthrough to 'none' are correct for all combinations. |
| packages/next/src/errors/createErrors.ts | Adds new Turbopack-specific warning constant with actionable SWC suggestion; updates babel warning to only reference React version requirement. |
| packages/next/src/__tests__/config.test.ts | Converts static mock to mutable vi.hoisted object (reset in beforeEach), adds three focused compiler tests. BABEL_PLUGIN_SUPPORT constant is used instead of hardcoded version strings. |
| .changeset/fair-babel-warnings.md | Patch-level changeset entry for gt-next, accurately describes the warning clarification. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["test(next): reference babel support cons..."](https://github.com/generaltranslation/gt/commit/cc4a451b36d3f9dd44e8eddc23b79e902076437c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30892980)</sub>

<!-- /greptile_comment -->