### PR TITLE
feat: update cli setup flow

### DIFF
--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -65,6 +65,7 @@ import {
   getFrameworkDisplayName,
   getReactFrameworkLibrary,
 } from '../setup/frameworkUtils.js';
+import { promptSetupMode } from '../setup/setupMode.js';
 import { INLINE_LIBRARIES } from '../types/libraries.js';
 import { handleEnqueue } from './commands/enqueue.js';
 import { splitMintlifyLanguageRefs } from '../utils/splitMintlifyLanguageRefs.js';
@@ -395,34 +396,20 @@ export class BaseCLI {
         findFilepath(['gt.config.json'])
       )
       .action(async (options: SetupOptions) => {
-        const settings = await generateSettings(options);
         displayHeader('Running setup wizard...');
+        const settings = await generateSettings(options);
 
         const framework = await detectFramework();
+        const setupMode = await promptSetupMode(framework);
 
-        const useAgent = await (async () => {
-          let useAgentMessage;
-          if (framework.name === 'mintlify') {
-            useAgentMessage = `Mintlify project detected. Would you like to connect to GitHub so that the Locadex AI Agent can translate your project automatically?`;
-          }
-          if (framework.name === 'next-app') {
-            useAgentMessage = `Next.js App Router detected. Would you like to connect to GitHub so that the Locadex AI Agent can set up your project automatically?`;
-          }
-          if (useAgentMessage) {
-            return await promptConfirm({
-              message: useAgentMessage,
-              defaultValue: false,
-            });
-          }
-          return false;
-        })();
-
-        if (useAgent) {
+        if (setupMode === 'agent') {
           await setupLocadex(settings);
           logger.endCommand(
-            'Once installed, Locadex will open a PR to your repository. See the docs for more information: https://generaltranslation.com/docs/locadex'
+            'Continue in your browser to finish Locadex setup. Docs: https://generaltranslation.com/docs/locadex'
           );
         } else {
+          logger.step('Manual setup selected');
+
           // Get framework display info for the defaults message
           const frameworkDisplayName =
             framework.type === 'react'

--- a/packages/cli/src/console/logger.ts
+++ b/packages/cli/src/console/logger.ts
@@ -39,11 +39,28 @@ class MockSpinner implements SpinnerResult {
     this.currentMessage = '';
   }
 
+  cancel(message?: string): void {
+    this.isCancelled = true;
+    const msg = message || this.currentMessage || 'Canceled';
+    this.logger.info(`[Spinner] ${msg}`);
+    this.currentMessage = '';
+  }
+
+  error(message?: string): void {
+    const msg = message || this.currentMessage || 'Something went wrong';
+    this.logger.error(`[Spinner] ${msg}`);
+    this.currentMessage = '';
+  }
+
   message(message?: string): void {
     if (message) {
       this.currentMessage = message;
       this.logger.info(`[Spinner] ${message}`);
     }
+  }
+
+  clear(): void {
+    this.currentMessage = '';
   }
 }
 
@@ -69,6 +86,17 @@ class MockProgress implements ProgressResult {
     this.logger.info(`[Progress] ${msg} (${this.current}/${this.max})`);
   }
 
+  cancel(message?: string): void {
+    this.isCancelled = true;
+    const msg = message || 'Canceled';
+    this.logger.info(`[Progress] ${msg} (${this.current}/${this.max})`);
+  }
+
+  error(message?: string): void {
+    const msg = message || 'Something went wrong';
+    this.logger.error(`[Progress] ${msg} (${this.current}/${this.max})`);
+  }
+
   message(message?: string): void {
     if (message) {
       this.logger.info(`[Progress] ${message} (${this.current}/${this.max})`);
@@ -79,6 +107,10 @@ class MockProgress implements ProgressResult {
     this.current += amount;
     const msg = message || 'Progress';
     this.logger.info(`[Progress] ${msg} (${this.current}/${this.max})`);
+  }
+
+  clear(): void {
+    this.current = 0;
   }
 }
 

--- a/packages/cli/src/locadex/setupFlow.ts
+++ b/packages/cli/src/locadex/setupFlow.ts
@@ -4,6 +4,9 @@ import chalk from 'chalk';
 
 export async function setupLocadex(settings: Settings): Promise<void> {
   const urlToOpen = `${settings.dashboardUrl}/api/integrations/github/start?returnTo=%2Fproject%2Flocadex`;
+
+  logger.step('Opening Locadex setup in your browser...');
+
   await import('open').then((open) =>
     open.default(urlToOpen, {
       wait: false,
@@ -12,7 +15,7 @@ export async function setupLocadex(settings: Settings): Promise<void> {
 
   logger.message(
     `${chalk.dim(
-      `If the browser window didn't open automatically, open the following link:`
+      `Sign in or create an account, finish company info, connect GitHub, and configure Locadex. If the browser window didn't open automatically, open the following link:`
     )}\n\n${chalk.cyan(urlToOpen)}`
   );
 }

--- a/packages/cli/src/setup/setupMode.ts
+++ b/packages/cli/src/setup/setupMode.ts
@@ -1,0 +1,38 @@
+import chalk from 'chalk';
+import { promptSelect } from '../console/logging.js';
+import { getFrameworkDisplayName } from './frameworkUtils.js';
+import type { FrameworkObject } from '../types/index.js';
+
+export type SetupMode = 'agent' | 'manual';
+
+type DetectedFramework = FrameworkObject | { name: undefined };
+
+export async function promptSetupMode(
+  framework: DetectedFramework
+): Promise<SetupMode> {
+  const detectedFramework = framework.name
+    ? getFrameworkDisplayName(framework)
+    : 'no supported framework detected';
+
+  const defaultValue: SetupMode =
+    framework.name === 'mintlify' || framework.name === 'next-app'
+      ? 'agent'
+      : 'manual';
+
+  return await promptSelect<SetupMode>({
+    message: `How would you like to set up General Translation? ${chalk.dim(`(${detectedFramework})`)}`,
+    options: [
+      {
+        value: 'agent',
+        label: 'Use Locadex AI Agent',
+        hint: 'Connect GitHub and configure automation in your browser',
+      },
+      {
+        value: 'manual',
+        label: 'Configure manually',
+        hint: 'Choose framework, languages, and API keys step by step',
+      },
+    ],
+    defaultValue,
+  });
+}

--- a/packages/cli/src/utils/credentials.ts
+++ b/packages/cli/src/utils/credentials.ts
@@ -36,7 +36,7 @@ export async function retrieveCredentials(
 
   logger.message(
     `${chalk.dim(
-      `If the browser window didn't open automatically, please open the following link:`
+      `Sign in or create an account, finish company info, and create your project credentials. If the browser window didn't open automatically, please open the following link:`
     )}\n\n${chalk.cyan(urlToOpen)}`
   );
 
@@ -77,7 +77,7 @@ export async function retrieveCredentials(
       1000 * 60 * 60
     );
   });
-  spinner.stop('Received credentials');
+  spinner.stop('Received project credentials');
   return credentials;
 }
 


### PR DESCRIPTION
## Summary
- add an explicit manual vs Locadex AI Agent setup choice to the CLI wizard
- route the agent path to browser-based Locadex setup with clearer handoff copy
- keep the manual path on the existing framework, language, config, and credential flow
- update JSON-mode mock spinner/progress compatibility methods

## Verification
- pnpm --filter gt lint
- pnpm --filter gt exec tsc --noEmit --pretty false | rg "src/(setup/setupMode|cli/base|console/logger|locadex/setupFlow|utils/credentials)" || true

Note: full tsc still fails in this worktree because dependent workspace packages such as generaltranslation, gt-remark, and @generaltranslation/python-extractor do not have resolvable built type outputs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1353"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->