### PR TITLE
chore: enable pnpm global virtual store

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -31,9 +31,9 @@ Turbo tasks: `build`, `test`, `lint`, `lint:fix`, `format`, `format:fix`, `trans
 
 ## pnpm Worktrees
 
-- pnpm's global virtual store is enabled via `enableGlobalVirtualStore: true` in `pnpm-workspace.yaml` so git worktrees share the pnpm store while keeping isolated `node_modules`.
+- pnpm's global virtual store is enabled via `enableGlobalVirtualStore: true` in `pnpm-workspace.yaml` so git worktrees share the pnpm store while keeping isolated `node_modules`. Hoisting is disabled with `hoist: false` because pnpm's hoisted dependency workaround relies on `NODE_PATH`, which does not work for ESM.
 - After creating a new worktree, run `pnpm install` inside it.
-- If pnpm prompts to recreate `node_modules` in a non-interactive shell, use `CI=true pnpm install`.
+- If pnpm prompts to recreate `node_modules` in a non-interactive shell, use `pnpm install --force`. Do not use `CI=true` for this because pnpm disables the global virtual store in CI mode.
 
 ## Key Packages
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -29,6 +29,12 @@ Per-package commands: `pnpm --filter <pkg> <script>` (e.g., `pnpm --filter gt te
 
 Turbo tasks: `build`, `test`, `lint`, `lint:fix`, `format`, `format:fix`, `transpile`, `build:clean`, `build:release`, `bench`.
 
+## pnpm Worktrees
+
+- pnpm's global virtual store is enabled via `enableGlobalVirtualStore: true` in `pnpm-workspace.yaml` so git worktrees share the pnpm store while keeping isolated `node_modules`.
+- After creating a new worktree, run `pnpm install` inside it.
+- If pnpm prompts to recreate `node_modules` in a non-interactive shell, use `CI=true pnpm install`.
+
 ## Key Packages
 
 | Package                                 | Path                         | Description                                                       |

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -34,6 +34,7 @@ Turbo tasks: `build`, `test`, `lint`, `lint:fix`, `format`, `format:fix`, `trans
 - pnpm's global virtual store is enabled via `enableGlobalVirtualStore: true` in `pnpm-workspace.yaml` so git worktrees share the pnpm store while keeping isolated `node_modules`. Hoisting is disabled with `hoist: false` because pnpm's hoisted dependency workaround relies on `NODE_PATH`, which does not work for ESM.
 - After creating a new worktree, run `pnpm install` inside it.
 - If pnpm prompts to recreate `node_modules` in a non-interactive shell, use `pnpm install --force`. Do not use `CI=true` for this because pnpm disables the global virtual store in CI mode.
+- Treat missing module/type errors after install as real missing direct dependencies. Add the dependency to the package that imports or uses it, not to a sibling package or the workspace root just to make hoisting work.
 
 ## Key Packages
 

--- a/packages/gtx-cli/package.json
+++ b/packages/gtx-cli/package.json
@@ -67,6 +67,7 @@
     "dotenv": "^16.4.5"
   },
   "devDependencies": {
+    "@types/node": "^22.5.1",
     "typescript": "^5.5.4",
     "vitest": "^2.0.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -423,12 +423,15 @@ importers:
         specifier: workspace:*
         version: link:../cli
     devDependencies:
+      '@types/node':
+        specifier: ^22.5.1
+        version: 22.13.10
       typescript:
         specifier: ^5.5.4
         version: 5.9.2
       vitest:
         specifier: ^2.0.0
-        version: 2.1.9(@edge-runtime/vm@4.0.4)(@types/node@24.8.0)(jsdom@29.0.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.44.0)
+        version: 2.1.9(@edge-runtime/vm@4.0.4)(@types/node@22.13.10)(jsdom@29.0.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.44.0)
 
   packages/i18n:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,8 @@ packages:
   - examples/next-ssg
   - examples/react-native
 
+enableGlobalVirtualStore: true
+
 minimumReleaseAge: 1440
 
 minimumReleaseAgeExclude:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ packages:
   - examples/react-native
 
 enableGlobalVirtualStore: true
+hoist: false
 
 minimumReleaseAge: 1440
 

--- a/turbo.json
+++ b/turbo.json
@@ -19,6 +19,7 @@
       "cache": false
     },
     "test": {
+      "dependsOn": ["^build"],
       "cache": false,
       "env": ["VITE_CI_TEST_GT_PROJECT_ID", "VITE_CI_TEST_GT_API_KEY"]
     },


### PR DESCRIPTION
## Summary
- Enable pnpm's global virtual store for shared dependency storage across git worktrees
- Document the per-worktree install workflow in the repo agent instructions

## Testing
- Verified with pnpm 10.20.0: `pnpm config get enable-global-virtual-store` returns `true`
- Ran `CI=true pnpm install` successfully

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enables pnpm's global virtual store (`enableGlobalVirtualStore: true`) so git worktrees share a single pnpm store without duplicating packages, while disabling hoisting (`hoist: false`) to avoid the known ESM/`NODE_PATH` incompatibility. Documentation in `CLAUDE.md` is updated to guide developers through the per-worktree install workflow and explicitly warn against `CI=true`, which would silently disable the feature.

- **`pnpm-workspace.yaml`**: Adds `enableGlobalVirtualStore: true` and `hoist: false`; the combination correctly side-steps the hoisted-`NODE_PATH` workaround that breaks ESM modules.
- **`.claude/CLAUDE.md`**: New "pnpm Worktrees" section accurately explains the rationale and recommends `pnpm install --force` over `CI=true` for non-interactive environments.
- **`packages/gtx-cli/package.json`**: Adds `@types/node@^22.5.1` as a devDependency, pinning gtx-cli to the `22.x` range while most other packages in the monorepo use `24.x`; this is cosmetically inconsistent but has no runtime impact.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — only pnpm workspace configuration, agent documentation, and a devDependency are changed; no production code is touched.

The two concerns raised in the previous review cycle (ESM incompatibility with hoisting and the CI=true footgun) are both directly addressed: hoist: false prevents the broken NODE_PATH workaround for ESM packages, and the updated documentation explicitly tells developers to use --force instead of CI=true. The change is entirely in build tooling and developer docs with no impact on shipped code.

No files require special attention. packages/gtx-cli/package.json introduces a minor @types/node version skew (22.x vs 24.x elsewhere in the monorepo), but this is a devDependency with no runtime effect.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pnpm-workspace.yaml | Adds `enableGlobalVirtualStore: true` and `hoist: false` to share the pnpm store across git worktrees while avoiding the ESM/NODE_PATH incompatibility that hoisting would introduce. |
| .claude/CLAUDE.md | Documents the worktree install workflow, correctly warns against `CI=true` (which disables the global virtual store), and explains why `hoist: false` is required for ESM packages. |
| packages/gtx-cli/package.json | Adds `@types/node@^22.5.1` as a devDependency; resolves to `22.13.10`, pinning gtx-cli to an older major than the `24.x` used by other packages in the monorepo — a minor version skew across devDependencies. |
| pnpm-lock.yaml | Lock file updated to reflect the new `@types/node@22.13.10` devDependency for gtx-cli and the corresponding vitest peer resolution. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[git worktree A\nworktrees/feature-x] -->|pnpm install| B[local node_modules\n.strict symlinks]
    C[git worktree B\nworktrees/fix-y] -->|pnpm install| D[local node_modules\n.strict symlinks]
    E[main worktree\n/repo] -->|pnpm install| F[local node_modules\n.strict symlinks]
    B --> G[(Global Virtual Store\n~/.pnpm-store)]
    D --> G
    F --> G
    A --> G
    G -->|hard-links package content| B
    G -->|hard-links package content| D
    G -->|hard-links package content| F
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: disable hoisting with global virtua..."](https://github.com/generaltranslation/gt/commit/66eb9b7b09975b397cd2398689eb28c410365498) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31069566)</sub>

<!-- /greptile_comment -->