### PR TITLE
chore: ignore oxfmt formatting commit in blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Format repository with oxfmt (#1347)
+1cf570c05e51f3f8ccf49916c893232cea064184


### PR DESCRIPTION
## Summary
- add .git-blame-ignore-revs
- ignore the PR #1347 oxfmt formatting squash commit in git blame

## Validation
- git diff --check
- git blame --ignore-revs-file .git-blame-ignore-revs -- package.json >/dev/null

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `.git-blame-ignore-revs` file to exclude the large `oxfmt` formatting commit (PR #1347) from `git blame` output. The referenced SHA `1cf570c05e51f3f8ccf49916c893232cea064184` is verified to exist in the repository history.

- Adds `.git-blame-ignore-revs` with a single entry pointing to the `oxfmt` formatting squash commit, following the standard Git convention for this file.
- Developers who want this to apply automatically without passing `--ignore-revs-file` on every invocation can run `git config blame.ignoreRevsFile .git-blame-ignore-revs` locally (or set it in `.gitconfig`); this is optional and not required for the file to be useful.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — adds a single-entry `.git-blame-ignore-revs` file with a verified commit SHA.

The change is a one-line config file that tells `git blame` to skip a specific formatting commit. The referenced SHA exists in the repository history, the file format is correct, and there are no code changes.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .git-blame-ignore-revs | Adds a new `.git-blame-ignore-revs` file listing the oxfmt formatting squash commit (SHA verified to exist in repo history) so `git blame` skips it by default. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Git as git blame
    participant File as .git-blame-ignore-revs

    Dev->>Git: "git blame <file>"
    Git->>File: read ignore-revs list
    File-->>Git: 1cf570c0... (oxfmt formatting commit)
    Git->>Git: skip lines last touched by 1cf570c0
    Git-->>Dev: blame output (without formatting noise)
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: ignore oxfmt formatting commit in..."](https://github.com/generaltranslation/gt/commit/585a111991799c44feab826291cb087dcf6a8a3d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31086083)</sub>

<!-- /greptile_comment -->