### PR TITLE
J/Improve Derive Component Comments

### DIFF
--- a/.changeset/nice-bottles-joke.md
+++ b/.changeset/nice-bottles-joke.md
@@ -1,0 +1,8 @@
+---
+'@generaltranslation/react-core': patch
+'gt-react': patch
+'generaltranslation': patch
+'gt-next': patch
+---
+
+Update Derive docs comments

--- a/packages/core/src/derive/derive.ts
+++ b/packages/core/src/derive/derive.ts
@@ -1,7 +1,17 @@
 /**
- * derive() is a powerful but dangerous function which marks its argument as derivable (statically analyzable) for the compiler and CLI tool.
+ * Marks content as derivable by the GT compiler and CLI.
  *
- * This function is dangerous because it can cause the compiler and CLI tool to throw an error if the argument is not derivable.
+ * Use `derive()` when a translation string or context needs content that is
+ * computed from source code, but should still be discovered during extraction
+ * instead of treated as a runtime interpolation variable. The CLI attempts to
+ * resolve the derivable expression into every possible static value and
+ * includes those values in the source content that gets translated.
+ *
+ * `derive()` returns its argument unchanged at runtime.
+ *
+ * Run `gt validate` after adding or changing `derive()` calls to verify that
+ * each derivable expression can be resolved by the CLI before translating or
+ * building.
  *
  * @example
  * ```jsx
@@ -12,8 +22,8 @@
  * gt(`My name is ${derive(getSubject())}`);
  * ```
  *
- * @param {T extends string | boolean | number | null | undefined} content - Content to mark as derivable.
- * @returns content
+ * @param {T extends string | boolean | number | null | undefined} content - Content to derive for translation extraction.
+ * @returns {T} The same content, unchanged at runtime.
  */
 export function derive<T extends string | boolean | number | null | undefined>(
   content: T
@@ -24,9 +34,14 @@ export function derive<T extends string | boolean | number | null | undefined>(
 /**
  * @deprecated Use derive() instead.
  *
- * declareStatic() is a powerful but dangerous function which marks its argument as derivable (statically analyzable) for the compiler and CLI tool.
+ * Marks content as derivable by the GT compiler and CLI.
  *
- * This function is dangerous because it can cause the compiler and CLI tool to throw an error if the argument is not derivable.
+ * Use `derive()` instead of `declareStatic()` for new code. This alias is kept
+ * for backwards compatibility and returns its argument unchanged at runtime.
+ *
+ * Run `gt validate` after adding or changing derived content to verify that
+ * each derivable expression can be resolved by the CLI before translating or
+ * building.
  *
  * @example
  * ```jsx
@@ -37,7 +52,7 @@ export function derive<T extends string | boolean | number | null | undefined>(
  * gt(`My name is ${declareStatic(getSubject())}`);
  * ```
  *
- * @param {T extends string | boolean | number | null | undefined} content - Content to mark as derivable.
- * @returns content
+ * @param {T extends string | boolean | number | null | undefined} content - Content to derive for translation extraction.
+ * @returns {T} The same content, unchanged at runtime.
  */
 export const declareStatic = derive;

--- a/packages/next/src/index.types.ts
+++ b/packages/next/src/index.types.ts
@@ -199,9 +199,19 @@ export const Var: typeof _Var = () => {
 Var._gtt = 'variable-variable';
 
 /**
- * `<Derive>` is a powerful but dangerous component which marks its children as statically analyzable for the compiler and CLI tool.
+ * Marks JSX children as derivable by the GT compiler and CLI.
  *
- * This component is dangerous because it can cause the compiler and CLI tool to throw an error if children are not statically analyzable.
+ * Use `<Derive>` inside translated JSX when child content is computed from
+ * source code, but should still be discovered during extraction instead of
+ * treated as a runtime interpolation variable. The CLI attempts to resolve the
+ * derivable children into every possible static value and includes those values
+ * in the source content that gets translated.
+ *
+ * `<Derive>` renders its children unchanged at runtime.
+ *
+ * Run `gt validate` after adding or changing `<Derive>` usage to verify that
+ * each derivable expression can be resolved by the CLI before translating or
+ * building.
  *
  * @example
  * ```jsx
@@ -217,8 +227,8 @@ Var._gtt = 'variable-variable';
  * </T>
  * ```
  *
- * @param {T extends React.ReactNode} children - Derived content to render.
- * @returns {T} The result of the function invocation.
+ * @param {T extends React.ReactNode} children - JSX content to derive for translation extraction.
+ * @returns {T} The same children, unchanged at runtime.
  */
 export const Derive: typeof _Derive = () => {
   throw new Error(typesFileError);
@@ -229,9 +239,14 @@ Derive._gtt = 'derive';
 /**
  * @deprecated Use `<Derive>` instead.
  *
- * `<Static>` is a powerful but dangerous component which marks its children as statically analyzable for the compiler and CLI tool.
+ * Marks JSX children as derivable by the GT compiler and CLI.
  *
- * This component is dangerous because it can cause the compiler and CLI tool to throw an error if children are not statically analyzable.
+ * Use `<Derive>` instead of `<Static>` for new code. This alias is kept for
+ * backwards compatibility and renders its children unchanged at runtime.
+ *
+ * Run `gt validate` after adding or changing derived JSX content to verify that
+ * each derivable expression can be resolved by the CLI before translating or
+ * building.
  *
  * @example
  * ```jsx
@@ -247,8 +262,8 @@ Derive._gtt = 'derive';
  * </T>
  * ```
  *
- * @param {T extends React.ReactNode} children - Derived content to render.
- * @returns {T} The result of the function invocation.
+ * @param {T extends React.ReactNode} children - JSX content to derive for translation extraction.
+ * @returns {T} The same children, unchanged at runtime.
  */
 export const Static: typeof _Static = () => {
   throw new Error(typesFileError);

--- a/packages/react-core/src/variables/Derive.tsx
+++ b/packages/react-core/src/variables/Derive.tsx
@@ -1,9 +1,19 @@
 import React from 'react';
 
 /**
- * `<Derive>` is a powerful but dangerous component which marks its children as statically analyzable for the compiler and CLI tool.
+ * Marks JSX children as derivable by the GT compiler and CLI.
  *
- * This component is dangerous because it can cause the compiler and CLI tool to throw an error if children are not statically analyzable.
+ * Use `<Derive>` inside translated JSX when child content is computed from
+ * source code, but should still be discovered during extraction instead of
+ * treated as a runtime interpolation variable. The CLI attempts to resolve the
+ * derivable children into every possible static value and includes those values
+ * in the source content that gets translated.
+ *
+ * `<Derive>` renders its children unchanged at runtime.
+ *
+ * Run `gt validate` after adding or changing `<Derive>` usage to verify that
+ * each derivable expression can be resolved by the CLI before translating or
+ * building.
  *
  * @example
  * ```jsx
@@ -19,8 +29,8 @@ import React from 'react';
  * </T>
  * ```
  *
- * @param {T extends React.ReactNode} children - Derived content to render.
- * @returns {T} The result of the function invocation.
+ * @param {T extends React.ReactNode} children - JSX content to derive for translation extraction.
+ * @returns {T} The same children, unchanged at runtime.
  */
 function Derive<T extends React.ReactNode>({ children }: { children: T }): T {
   return children;
@@ -29,9 +39,14 @@ function Derive<T extends React.ReactNode>({ children }: { children: T }): T {
 /**
  * @deprecated Use `<Derive>` instead.
  *
- * `<Static>` is a powerful but dangerous component which marks its children as statically analyzable for the compiler and CLI tool.
+ * Marks JSX children as derivable by the GT compiler and CLI.
  *
- * This component is dangerous because it can cause the compiler and CLI tool to throw an error if children are not statically analyzable.
+ * Use `<Derive>` instead of `<Static>` for new code. This alias is kept for
+ * backwards compatibility and renders its children unchanged at runtime.
+ *
+ * Run `gt validate` after adding or changing derived JSX content to verify that
+ * each derivable expression can be resolved by the CLI before translating or
+ * building.
  *
  * @example
  * ```jsx
@@ -47,8 +62,8 @@ function Derive<T extends React.ReactNode>({ children }: { children: T }): T {
  * </T>
  * ```
  *
- * @param {T extends React.ReactNode} children - Derived content to render.
- * @returns {T} The result of the function invocation.
+ * @param {T extends React.ReactNode} children - JSX content to derive for translation extraction.
+ * @returns {T} The same children, unchanged at runtime.
  */
 function Static<T extends React.ReactNode>(props: { children: T }): T {
   return Derive(props);

--- a/packages/react/src/i18n-context/functions/derivation/GtInternalDerive.ts
+++ b/packages/react/src/i18n-context/functions/derivation/GtInternalDerive.ts
@@ -1,9 +1,17 @@
 import { ReactNode } from 'react';
 
 /**
- * `<Derive>` marks its children as statically analyzable for the compiler and CLI tool.
+ * Marks JSX children as derivable by the GT compiler and CLI.
  *
- * This is the i18n-context version — does not use React Context.
+ * Use `<Derive>` inside translated JSX when child content is computed from
+ * source code, but should still be discovered during extraction instead of
+ * treated as a runtime interpolation variable. It renders its children
+ * unchanged at runtime.
+ *
+ * Run `gt validate` after adding or changing `<Derive>` usage to verify that
+ * each derivable expression can be resolved by the CLI.
+ *
+ * This is the i18n-context version and does not use React Context.
  */
 function Derive<T extends ReactNode>({ children }: { children: T }): T {
   return children;


### PR DESCRIPTION
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR rewrites the JSDoc comments for `derive()` and its deprecated alias `declareStatic()` in `packages/core/src/derive/derive.ts`. The original comments described the function as "powerful but dangerous" without explaining the actual semantics; the new comments explain the extraction workflow, CLI resolution behavior, and the `gt validate` step.

- The `derive()` JSDoc now describes when to use the function (computed content that should still be extracted as static values), what the CLI does with it, and that it is a no-op at runtime.
- The `declareStatic()` JSDoc now clearly states it is a backwards-compatible alias and directs users to `derive()` for new code.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — no functional code is changed, only JSDoc comments are updated.

All changes are confined to JSDoc comment text. The runtime implementation of derive() and the declareStatic alias are untouched, so there is no risk of behavioral regression.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/derive/derive.ts | Documentation-only update: rewrites JSDoc for derive() and declareStatic() to clarify purpose, usage guidance, and runtime behavior. No logic changes. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["derive(content) called"] --> B["Returns content unchanged\nat runtime"]
    C["GT CLI / compiler"] --> D["Resolves derivable expression\ninto all possible static values"]
    D --> E["Includes values in source\ncontent for translation"]
    F["gt validate"] --> G{"Each derive() expression\nresolvable?"}
    G -- Yes --> H["Safe to translate / build"]
    G -- No --> I["Error thrown by CLI"]
    B -.->|"same value"| J["Caller receives original content"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["J/Improve Derive Component Comments"](https://github.com/generaltranslation/gt/commit/9a275cddda03cd4ce81a1ec4224a4af2090ff5b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31093594)</sub>

<!-- /greptile_comment -->