### PR TITLE
fix: enable sourcemaps for rollup builds

### DIFF
--- a/packages/react-core/rollup.base.config.mjs
+++ b/packages/react-core/rollup.base.config.mjs
@@ -24,7 +24,7 @@ export default {
     typescript({
       // Compiles TypeScript files
       tsconfig: './tsconfig.json',
-      sourceMap: false,
+      sourceMap: true,
       outputToFilesystem: true, // supress warning about outputToFilesystem
     }),
     postcss(), // Process CSS files

--- a/packages/react-core/tsconfig.json
+++ b/packages/react-core/tsconfig.json
@@ -10,7 +10,7 @@
     "rootDir": "./src",
     "resolveJsonModule": true,
     "moduleResolution": "Node",
-    "sourceMap": false,
+    "sourceMap": true,
     "declaration": true,
     "declarationDir": "./dist",
     "declarationMap": true,

--- a/packages/react/rollup.base.config.mjs
+++ b/packages/react/rollup.base.config.mjs
@@ -24,7 +24,7 @@ export default {
     typescript({
       // Compiles TypeScript files
       tsconfig: './tsconfig.json',
-      sourceMap: false,
+      sourceMap: true,
       outputToFilesystem: true, // supress warning about outputToFilesystem
     }),
     postcss(), // Process CSS files

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -10,7 +10,7 @@
     "rootDir": "./src",
     "resolveJsonModule": true,
     "moduleResolution": "Node",
-    "sourceMap": false,
+    "sourceMap": true,
     "declaration": true,
     "declarationDir": "./dist",
     "declarationMap": true,

--- a/packages/tanstack-start/tsconfig.json
+++ b/packages/tanstack-start/tsconfig.json
@@ -10,7 +10,7 @@
     "rootDir": "./src",
     "resolveJsonModule": true,
     "moduleResolution": "Bundler",
-    "sourceMap": false,
+    "sourceMap": true,
     "declaration": true,
     "declarationDir": "./dist",
     "declarationMap": true,


### PR DESCRIPTION
## Summary
- enable TypeScript source maps for React, React Core, and TanStack Start builds
- align the TypeScript plugin config with Rollup outputs that already request sourcemaps

## Verification
- `pnpm --filter @generaltranslation/react-core --filter gt-react --filter gt-tanstack-start build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a mismatch between Rollup output configuration and the TypeScript plugin configuration across three packages. The Rollup output objects already declared `sourcemap: true`, but the TypeScript plugin was explicitly suppressing source map generation with `sourceMap: false`, causing Rollup to emit warnings and produce incomplete source maps.

- **react-core & gt-react**: `sourceMap` flipped to `true` in both `rollup.base.config.mjs` (TypeScript plugin) and `tsconfig.json`, bringing the plugin in line with the outputs that already requested source maps.
- **tanstack-start**: Only `tsconfig.json` needed updating since its `rollup.config.mjs` passes the tsconfig directly to the TypeScript plugin without an explicit `sourceMap` override.
- The generated `.map` files will land in `dist/` and be published via the existing `"files": ["dist"]` entry in each package's `package.json`, which is the intended behavior.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change only enables source map generation and has no effect on runtime behavior.

All three packages already had sourcemap:true in their Rollup output configs; this PR simply makes the TypeScript plugin agree with those outputs. No logic, API surface, or runtime code is modified.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/rollup.base.config.mjs | Enables sourceMap in the TypeScript plugin, aligning it with the output-level sourcemap:true already set in rollup.config.mjs. |
| packages/react-core/tsconfig.json | Turns on sourceMap emission in the TypeScript compiler config to match the now-enabled plugin setting. |
| packages/react/rollup.base.config.mjs | Same alignment fix as react-core — TypeScript plugin sourceMap now matches the output-level sourcemap:true. |
| packages/react/tsconfig.json | Enables sourceMap in the TypeScript compiler config to match the rollup base config change. |
| packages/tanstack-start/tsconfig.json | Enables sourceMap; the TypeScript plugin in rollup.config.mjs reads tsconfig directly (no explicit override), so this is the only change needed for this package. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[TypeScript Source .ts/.tsx] --> B[TypeScript Plugin\ntsconfig sourceMap: true\nplugin sourceMap: true]
    B --> C[Rollup Transform]
    C --> D{Output Config\nsourcemap: true}
    D --> E[dist/index.esm.min.mjs]
    D --> F[dist/index.cjs.min.cjs]
    D --> G[dist/index.esm.min.mjs.map]
    D --> H[dist/index.cjs.min.cjs.map]
    
    style B fill:#90EE90
    style G fill:#90EE90
    style H fill:#90EE90
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: enable sourcemaps for rollup builds"](https://github.com/generaltranslation/gt/commit/936499e1d6c0e605a502b8ac7596c594953370c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31209621)</sub>

<!-- /greptile_comment -->