### PR TITLE
fix: quiet sanity package build warnings

### DIFF
--- a/packages/sanity/package.config.mts
+++ b/packages/sanity/package.config.mts
@@ -6,10 +6,14 @@ export default defineConfig({
 
   // Remove this block to enable strict export validation
   extract: {
+    checkTypes: false,
     rules: {
       'ae-incompatible-release-tags': 'off',
       'ae-internal-missing-underscore': 'off',
       'ae-missing-release-tag': 'off',
     },
+  },
+  strictOptions: {
+    preferModuleType: 'off',
   },
 });

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -23,6 +23,7 @@
   "author": "General Translation, Inc.",
   "sideEffects": false,
   "type": "commonjs",
+  "browserslist": "extends @sanity/browserslist-config",
   "exports": {
     ".": {
       "source": "./src/index.ts",
@@ -39,6 +40,15 @@
     "src",
     "v2-incompatible.js"
   ],
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "import": "./dist/index.mjs",
+        "default": "./dist/index.js"
+      },
+      "./package.json": "./package.json"
+    }
+  },
   "scripts": {
     "release": "pnpm run build && pnpm publish --access public",
     "release:alpha": "pnpm run build && pnpm publish --access public --tag alpha",
@@ -68,6 +78,7 @@
   },
   "devDependencies": {
     "@portabletext/types": "^2.0.15",
+    "@sanity/browserslist-config": "^1.0.5",
     "@sanity/pkg-utils": "^10.4.13",
     "@sanity/plugin-kit": "^4.0.20",
     "@types/lodash.merge": "^4.6.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1004,6 +1004,9 @@ importers:
       '@portabletext/types':
         specifier: ^2.0.15
         version: 2.0.15
+      '@sanity/browserslist-config':
+        specifier: ^1.0.5
+        version: 1.0.5
       '@sanity/pkg-utils':
         specifier: ^10.4.13
         version: 10.4.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/babel__core@7.20.5)(@types/node@24.8.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(typescript@5.9.3)


### PR DESCRIPTION
## Summary
- add explicit browserslist and publishConfig exports for gt-sanity
- disable slow declaration type checking during pkg-utils extraction
- suppress the package type migration warning without changing gt-sanity runtime semantics

## Verification
- `pnpm --filter generaltranslation build`
- `pnpm --filter gt-sanity build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->