### PR TITLE
chore: use turbo tui for package builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "tests/apps/**/*"
   ],
   "scripts": {
-    "build": "turbo run build --filter='./packages/*'",
+    "build": "turbo run build --filter='./packages/*' --ui tui",
     "test": "turbo run test --filter='./packages/*'",
     "lint": "oxlint packages && oxfmt --check .",
     "lint:fix": "oxlint packages --fix && oxfmt .",


### PR DESCRIPTION
## Summary
- add `--ui tui` to the root `pnpm build` Turbo command

## Verification
- `pnpm turbo run build --filter='./packages/*' --ui tui --dry=json`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the `--ui tui` flag to the root `turbo run build` command in `package.json`, enabling Turbo's interactive Terminal User Interface during local package builds.

- The change affects only the `build` script; other turbo scripts (`test`, `transpile`, `build:clean`, `build:release`) are left unchanged, which is consistent with this being a local dev-experience improvement.
- Turbo v2 (currently `^2.5.3`) handles non-TTY environments (e.g., CI runners) gracefully when `--ui tui` is specified by falling back to stream output, so there is no risk to automated pipelines.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is limited to a single flag on a developer-facing build script with no runtime impact.

Only one line changes: appending `--ui tui` to the turbo build command. This only affects how build progress is rendered in the terminal; it does not alter build outputs, dependencies, or CI behavior.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Adds `--ui tui` flag to the root `pnpm build` turbo command for an interactive terminal UI during local package builds. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pnpm build] --> B["turbo run build\n--filter='./packages/*'\n--ui tui"]
    B --> C{TTY available?}
    C -- Yes --> D[Interactive TUI output]
    C -- No / CI --> E[Fallback: stream output]
    D --> F[Packages built]
    E --> F
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: use turbo tui for package builds"](https://github.com/generaltranslation/gt/commit/6ac4a4c4d68c59fb5238452ac284a3112f4dbb6f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31209662)</sub>

<!-- /greptile_comment -->