### PR TITLE
fix: clean up package build outputs

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1060,7 +1060,6 @@
   https://generaltranslation.com/blog/generaltranslation_v8
 
   Please update the following packages to the latest version:
-
   - generaltranslation: `7.9.1` or later
   - gtx-cli: `2.4.15` or later
   - gt-sanity: `1.0.11` or later

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -281,7 +281,6 @@
   https://generaltranslation.com/blog/generaltranslation_v8
 
   Please update the following packages to the latest version:
-
   - generaltranslation: `7.9.1` or later
   - gtx-cli: `2.4.15` or later
   - gt-sanity: `1.0.11` or later

--- a/packages/sanity/CHANGELOG.md
+++ b/packages/sanity/CHANGELOG.md
@@ -340,7 +340,6 @@
   https://generaltranslation.com/blog/generaltranslation_v8
 
   Please update the following packages to the latest version:
-
   - generaltranslation: `7.9.1` or later
   - gtx-cli: `2.4.15` or later
   - gt-sanity: `1.0.11` or later

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -22,22 +22,35 @@
   "homepage": "https://generaltranslation.com/",
   "author": "General Translation, Inc.",
   "sideEffects": false,
-  "type": "commonjs",
+  "browserslist": "extends @sanity/browserslist-config",
+  "type": "module",
   "exports": {
     ".": {
       "source": "./src/index.ts",
-      "import": "./dist/index.mjs",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
       "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },
-  "main": "./dist/index.js",
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "import": "./dist/index.js",
+        "require": "./dist/index.cjs",
+        "default": "./dist/index.js"
+      },
+      "./package.json": "./package.json"
+    }
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
     "sanity.json",
     "src",
-    "v2-incompatible.js"
+    "v2-incompatible.cjs"
   ],
   "scripts": {
     "release": "pnpm run build && pnpm publish --access public",
@@ -69,6 +82,7 @@
   },
   "devDependencies": {
     "@portabletext/types": "^2.0.15",
+    "@sanity/browserslist-config": "^1.0.5",
     "@sanity/pkg-utils": "^10.4.13",
     "@sanity/plugin-kit": "^4.0.20",
     "@types/lodash.merge": "^4.6.9",

--- a/packages/sanity/sanity.json
+++ b/packages/sanity/sanity.json
@@ -2,7 +2,7 @@
   "parts": [
     {
       "implements": "part:@sanity/base/sanity-root",
-      "path": "./v2-incompatible.js"
+      "path": "./v2-incompatible.cjs"
     }
   ]
 }

--- a/packages/sanity/v2-incompatible.cjs
+++ b/packages/sanity/v2-incompatible.cjs
@@ -1,8 +1,8 @@
 const { showIncompatiblePluginDialog } = require('@sanity/incompatible-plugin');
 const { name, version, sanityExchangeUrl } = require('./package.json');
 
-export default showIncompatiblePluginDialog({
-  name: name,
+module.exports = showIncompatiblePluginDialog({
+  name,
   versions: {
     v3: version,
     v2: undefined,

--- a/packages/tanstack-start/package.json
+++ b/packages/tanstack-start/package.json
@@ -70,9 +70,7 @@
       "import": "./dist/index.esm.min.mjs"
     },
     "./types": {
-      "types": "./dist/types.d.ts",
-      "require": "./dist/types.cjs.min.cjs",
-      "import": "./dist/types.esm.min.mjs"
+      "types": "./dist/types.d.ts"
     }
   },
   "typesVersions": {

--- a/packages/tanstack-start/rollup.config.mjs
+++ b/packages/tanstack-start/rollup.config.mjs
@@ -63,31 +63,6 @@ export default [
     plugins: [dts()],
   },
 
-  // Bundling for the types module
-  {
-    input: 'src/types.ts',
-    output: [
-      {
-        file: 'dist/types.cjs.min.cjs',
-        format: 'cjs',
-        exports: 'auto',
-        sourcemap: true,
-      },
-      {
-        file: 'dist/types.esm.min.mjs',
-        format: 'es',
-        exports: 'named',
-        sourcemap: true,
-      },
-    ],
-    plugins: [
-      typescript({ tsconfig: './tsconfig.json' }),
-      commonjs(),
-      terser(),
-    ],
-    external,
-  },
-
   // TypeScript declarations for the types module
   {
     input: 'src/types.ts',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1533,6 +1533,9 @@ importers:
       '@portabletext/types':
         specifier: ^2.0.15
         version: 2.0.15
+      '@sanity/browserslist-config':
+        specifier: ^1.0.5
+        version: 1.0.5
       '@sanity/pkg-utils':
         specifier: ^10.4.13
         version: 10.4.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/babel__core@7.20.5)(@types/node@24.8.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(typescript@5.9.3)


### PR DESCRIPTION
## Summary
- update gt-sanity package metadata to match its ESM/CJS build outputs
- rename the Sanity v2 incompatible entry to .cjs so it remains CommonJS under type: module
- stop emitting runtime bundles for the type-only gt-tanstack-start/types export

## Verification
- pnpm --filter gt-sanity build
- pnpm --filter gt-tanstack-start build:clean
- pnpm --filter gt-sanity typecheck
- pnpm --filter gt-tanstack-start typecheck
- pnpm build

Note: pnpm build still reports the existing gt-sanity noCheck warning; that is intentionally left for a follow-up PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes build-output metadata mismatches in two packages: `gt-sanity` is updated to `type: module` with aligned dual ESM/CJS `exports`/`publishConfig` fields and a corrected CJS-only `v2-incompatible.cjs` file; `gt-tanstack-start` removes runtime bundles for its `./types` sub-path export, which is correct since `src/types.ts` only re-exports a TypeScript type.

- **`gt-sanity`**: Switched from `"type": "commonjs"` to `"type": "module"`, updated `main`/`module`/`exports`/`publishConfig` to point to the correct `.cjs`/`.js` artifacts, renamed the Sanity v2 shim to `.cjs`, and fixed its previously broken `export default` → `module.exports` mix.
- **`gt-tanstack-start`**: Dropped the redundant runtime CJS/ESM bundle targets for `src/types.ts` from both `rollup.config.mjs` and `package.json`; the `.d.ts` declaration step is retained.
- CHANGELOG whitespace cleanup across `cli`, `core`, and `sanity` packages.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are targeted metadata and build-config corrections with no logic changes.

Every change directly addresses a concrete build-output mismatch. The `v2-incompatible.cjs` fix corrects previously invalid mixed ESM/CJS syntax that would have failed at runtime in any environment. Removing the runtime bundles for `gt-tanstack-start/types` is safe because `src/types.ts` contains only `export type` re-exports — there is nothing to bundle at runtime. The `gt-sanity` metadata updates correctly reflect its dual-format build outputs.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/sanity/package.json | Changed `type` from `commonjs` to `module`, aligned `exports`/`publishConfig`/`main`/`module` fields to match dual ESM+CJS build outputs, added `@sanity/browserslist-config` dev dependency. |
| packages/sanity/v2-incompatible.cjs | Renamed from `.js` to `.cjs` and fixed broken mixed ESM/CJS syntax — replaced `export default` with `module.exports` so the file is valid CommonJS under `type: module`. |
| packages/tanstack-start/package.json | Removed runtime `require`/`import` entries from the `./types` sub-path export, leaving only the `types` key — correct because `src/types.ts` only re-exports TypeScript types, not runtime values. |
| packages/tanstack-start/rollup.config.mjs | Removed the runtime CJS and ESM bundle targets for `src/types.ts`; the `.d.ts` declaration step is kept, consistent with the `package.json` change. |
| packages/sanity/sanity.json | Updated the Sanity v2 entry path from `v2-incompatible.js` to `v2-incompatible.cjs` to match the renamed file. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph gt-sanity ["gt-sanity (type: module)"]
        SRC["src/index.ts"] --> ESMJS["dist/index.js (ESM)"]
        SRC --> CJS["dist/index.cjs (CJS)"]
        V2["v2-incompatible.cjs (CommonJS)"] -->|"Sanity v2 shim via sanity.json"| SANITYV2["Sanity v2 runtime"]
    end

    subgraph gt-tanstack-start ["gt-tanstack-start"]
        TSRC["src/index.ts"] --> TCJS["dist/index.cjs.min.cjs"]
        TSRC --> TMJS["dist/index.esm.min.mjs"]
        TYPES["src/types.ts"] -->|"dts only"| TYPESDTS["dist/types.d.ts"]
        TYPES -.->|"runtime bundles REMOVED"| REMOVED["(no .cjs/.mjs bundles)"]
    end

    PKG_ESM["import (ESM consumers)"] --> ESMJS
    PKG_CJS["require (CJS consumers)"] --> CJS
    PKG_TYPES["gt-tanstack-start/types (type-only)"] --> TYPESDTS
```
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: format release changelogs"](https://github.com/generaltranslation/gt/commit/ac59b493298ab42c625316a83e02bd69ef8dbac0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31245717)</sub>

<!-- /greptile_comment -->