### PR TITLE
fix(sanity): separate release typecheck from build

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -40,14 +40,15 @@
     "v2-incompatible.js"
   ],
   "scripts": {
-    "release": "pnpm run build && pnpm publish --access public",
-    "release:alpha": "pnpm run build && pnpm publish --access public --tag alpha",
-    "release:beta": "pnpm run build && pnpm publish --access public --tag beta",
-    "release:latest": "pnpm run build && pnpm publish --access public --tag latest",
+    "release": "pnpm publish --access public",
+    "release:alpha": "pnpm publish --access public --tag alpha",
+    "release:beta": "pnpm publish --access public --tag beta",
+    "release:latest": "pnpm publish --access public --tag latest",
     "build": "plugin-kit verify-package --silent && pkg-utils build --strict --check --clean",
+    "build:release": "pnpm run typecheck && pnpm run build",
     "format": "oxfmt .",
     "link-watch": "plugin-kit link-watch",
-    "prepublishOnly": "pnpm run build",
+    "prepublishOnly": "pnpm run build:release",
     "test": "vitest run",
     "watch": "pkg-utils watch --strict",
     "typecheck": "tsc --noEmit"

--- a/packages/sanity/tsconfig.dist.json
+++ b/packages/sanity/tsconfig.dist.json
@@ -1,5 +1,8 @@
 {
   "extends": "./tsconfig.settings",
+  "compilerOptions": {
+    "noCheck": true
+  },
   "include": ["./src"],
   "exclude": [
     "./src/**/__fixtures__",


### PR DESCRIPTION
## Summary
- set noCheck for gt-sanity dist declaration generation to remove the pkg-utils noCheck build warning
- add a gt-sanity build:release script that runs typecheck before build
- route prepublishOnly through build:release so publish still typechecks

## Verification
- pnpm --filter gt-sanity typecheck
- pnpm --filter gt-sanity build:release
- git diff --check

Note: because this PR is based directly on main, gt-sanity still reports the older package metadata warnings that are addressed separately in #1372.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR separates type checking from declaration-file generation for the `gt-sanity` package, addressing a `pkg-utils` `noCheck` build warning and eliminating a double-build during publish.

- Adds `"noCheck": true` to `tsconfig.dist.json` so `pkg-utils` generates declarations without re-running type checking, silencing the warning.
- Introduces a `build:release` script that chains `typecheck` then `build`, and routes `prepublishOnly` through it so publish still type-checks.
- Strips `pnpm run build` from the individual `release` / `release:*` scripts, which previously caused the full build to run twice (once explicitly, once via `prepublishOnly`).

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a focused build-script reorganisation with no runtime code affected.

Both changed files are build/tooling configuration only. The publish lifecycle remains intact: `pnpm publish` triggers `prepublishOnly` → `build:release` → typecheck + build, so type safety is preserved. The `noCheck` flag in `tsconfig.dist.json` is intentional and scoped exclusively to declaration-file generation; the standalone `typecheck` script still runs `tsc --noEmit` against the full source. The previous double-build issue is now resolved.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/sanity/package.json | Release scripts now delegate entirely to `prepublishOnly` via `pnpm publish`; new `build:release` chains typecheck → build; eliminates the previous double-build. |
| packages/sanity/tsconfig.dist.json | Adds `"noCheck": true` so `pkg-utils` skips type checking during declaration generation; type checking is now handled exclusively by the `typecheck` script. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["pnpm run release / release:alpha / release:beta / release:latest"] --> B["pnpm publish"]
    B --> C["prepublishOnly"]
    C --> D["build:release"]
    D --> E["typecheck\n(tsc --noEmit)"]
    E --> F["build\n(plugin-kit verify-package && pkg-utils build)"]
    F --> G["pkg-utils uses tsconfig.dist.json\nnoCheck: true — skips type re-check\ngenerates declarations only"]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/sanity/package.json`, line 43-46 ([link](https://github.com/generaltranslation/gt/blob/f8883365b3237d204d73b24f763105f2b4dcea9f/packages/sanity/package.json#L43-L46)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> The `release`, `release:alpha`, `release:beta`, and `release:latest` scripts still invoke `pnpm run build` directly. When `pnpm publish` runs afterward, the `prepublishOnly` lifecycle hook fires and executes `build:release` (typecheck + build) a second time, so `build` ends up running twice per release. Routing these scripts through `build:release` instead would keep the type-checking guarantee while avoiding the redundant build.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/sanity/package.json
   Line: 43-46

   Comment:
   The `release`, `release:alpha`, `release:beta`, and `release:latest` scripts still invoke `pnpm run build` directly. When `pnpm publish` runs afterward, the `prepublishOnly` lifecycle hook fires and executes `build:release` (typecheck + build) a second time, so `build` ends up running twice per release. Routing these scripts through `build:release` instead would keep the type-checking guarantee while avoiding the redundant build.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix(sanity): separate release typecheck ..."](https://github.com/generaltranslation/gt/commit/6189f05e33f3318add93264869f9323e174f49ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31248230)</sub>

<!-- /greptile_comment -->