### PR TITLE
chore(gt-i18n): add a jsdoc comment for t.obj() function

### DIFF
--- a/.changeset/fresh-snails-follow.md
+++ b/.changeset/fresh-snails-follow.md
@@ -1,0 +1,5 @@
+---
+'gt-i18n': patch
+---
+
+chore(gt-i18n): add comment documentation for t.obj()

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.14.32';
+export const PACKAGE_VERSION = '2.14.33';

--- a/packages/i18n/src/translation-functions/internal/getTranslations.ts
+++ b/packages/i18n/src/translation-functions/internal/getTranslations.ts
@@ -68,6 +68,17 @@ export async function getTranslations(): Promise<TFunctionType> {
     });
   }) as TFunctionType;
 
+  /**
+   * Returns a subtree of the dictionary object translation based on its id.
+   * @param {string} id - The id of the translation to translate.
+   * @returns The translated object.
+   *
+   * @example
+   * const t = await getTranslations();
+   * const user = t('greetings');
+   * console.log(user);
+   * // { greeting1: 'Hello', greeting2: 'Hi' }
+   */
   t.obj = (id: string): DictionaryObjectTranslation => {
     const sourceObject = i18nManager.lookupDictionaryObj(sourceLocale, id);
     if (sourceObject === undefined) {

--- a/packages/i18n/src/translation-functions/internal/getTranslations.ts
+++ b/packages/i18n/src/translation-functions/internal/getTranslations.ts
@@ -75,8 +75,8 @@ export async function getTranslations(): Promise<TFunctionType> {
    *
    * @example
    * const t = await getTranslations();
-   * const user = t('greetings');
-   * console.log(user);
+   * const greetings = t.obj('greetings');
+   * console.log(greetings);
    * // { greeting1: 'Hello', greeting2: 'Hi' }
    */
   t.obj = (id: string): DictionaryObjectTranslation => {


### PR DESCRIPTION
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a JSDoc comment to the `t.obj()` function in `getTranslations.ts` to document its purpose, parameter, return value, and usage example, along with the corresponding changeset and auto-generated version bump.

- The JSDoc description, `@param`, and `@returns` tags are accurate and match the function signature.
- The `@example` block contains a bug: it calls `t('greetings')` (the base string function) instead of `t.obj('greetings')`, and names the variable `user` despite using a `'greetings'` key — both should be corrected before merging.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after fixing the incorrect function call in the @example block.

The only functional change is a JSDoc comment. The example code calls `t('greetings')` instead of `t.obj('greetings')`, which would mislead anyone following the documentation and cause them to get a string rather than the advertised object. Fixing this one-line mistake is all that's needed before the PR is ready.

packages/i18n/src/translation-functions/internal/getTranslations.ts — the @example block needs to be corrected.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/translation-functions/internal/getTranslations.ts | JSDoc comment added for t.obj() — the @example block incorrectly calls t() instead of t.obj(), and the variable is named `user` while the key is 'greetings'. |
| .changeset/fresh-snails-follow.md | Standard patch-level changeset entry for gt-i18n; no issues. |
| packages/cli/src/generated/version.ts | Auto-generated version bump from 2.14.32 → 2.14.33; no issues. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["getTranslations()"] --> B["Create t() function\n(string lookup)"]
    B --> C["Attach t.obj(id)"]
    C --> D["lookupDictionaryObj(sourceLocale, id)"]
    D -->|"undefined"| E["throw Error"]
    D -->|"found"| F["lookupDictionaryObj(locale, id)"]
    F --> G["renderObject(sourceObject, targetObject)"]
    G --> H["Return DictionaryObjectTranslation"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/i18n/src/translation-functions/internal/getTranslations.ts:76-80
The `@example` block calls `t('greetings')` (the base string function) instead of `t.obj('greetings')`, so the example does not actually demonstrate the method being documented. A reader following this example would get a `string` back, not the object shown in the comment output.

```suggestion
   * @example
   * const t = await getTranslations();
   * const greetings = t.obj('greetings');
   * console.log(greetings);
   * // { greeting1: 'Hello', greeting2: 'Hi' }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(gt-i18n): add a jsdoc comment for ..."](https://github.com/generaltranslation/gt/commit/d5d0a0e0cdb965594e150e921c11f9e1531a723d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31249072)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->