### PR TITLE
fix(i18n): fall back for dictionary translations

### DIFF
--- a/.changeset/steady-slate-path.md
+++ b/.changeset/steady-slate-path.md
@@ -1,0 +1,5 @@
+---
+'gt-i18n': patch
+---
+
+Fix dictionary getTranslations fallback to use loaded translations when a target dictionary entry is missing.

--- a/packages/i18n/src/translation-functions/internal/__tests__/locale-defaults.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/locale-defaults.test.ts
@@ -95,6 +95,30 @@ describe('translation function locale defaults', () => {
     expect(t('greeting', { name: 'Alice' })).toBe('Hello Alice!');
   });
 
+  it('getTranslations falls back to translations with source dictionary options', async () => {
+    const message = 'Hello {name}!';
+    const lookupOptions = { $format: 'ICU', $context: 'homepage' } as const;
+    const loadTranslations = vi.fn().mockResolvedValue({
+      [hashMessage(message, lookupOptions)]: 'Bonjour {name} !',
+    });
+    const manager = new I18nManager({
+      defaultLocale: 'en',
+      locales: ['en', 'fr'],
+      dictionary: {
+        greeting: [message, { context: 'homepage' }],
+      },
+      loadDictionary: vi.fn().mockResolvedValue({}),
+      loadTranslations,
+    });
+    setI18nManager(manager);
+    setConditionStore({ getLocale: () => 'fr' });
+
+    const t = await getTranslations();
+
+    expect(t('greeting', { name: 'Alice' })).toBe('Bonjour Alice !');
+    expect(loadTranslations).toHaveBeenCalledWith('fr');
+  });
+
   it('getTranslations throws when the source dictionary entry is missing', async () => {
     const manager = new I18nManager({
       defaultLocale: 'en',
@@ -169,6 +193,47 @@ describe('translation function locale defaults', () => {
       greeting: 'Bonjour {name} !',
       title: 'Title',
     });
+  });
+
+  it('getTranslations obj falls back to translations for missing target leaves', async () => {
+    const title = 'Title';
+    const titleOptions = {
+      $format: 'ICU',
+      $context: 'profile title',
+    } as const;
+    const loadTranslations = vi.fn().mockResolvedValue({
+      [hashMessage(title, titleOptions)]: 'Titre',
+    });
+    const manager = new I18nManager({
+      defaultLocale: 'en',
+      locales: ['en', 'fr'],
+      dictionary: {
+        user: {
+          profile: {
+            name: 'Name',
+            title: [title, { context: 'profile title' }],
+          },
+        },
+      },
+      loadDictionary: vi.fn().mockResolvedValue({
+        user: {
+          profile: {
+            name: 'Nom',
+          },
+        },
+      }),
+      loadTranslations,
+    });
+    setI18nManager(manager);
+    setConditionStore({ getLocale: () => 'fr' });
+
+    const t = await getTranslations();
+
+    expect(t.obj('user.profile')).toEqual({
+      name: 'Nom',
+      title: 'Titre',
+    });
+    expect(loadTranslations).toHaveBeenCalledWith('fr');
   });
 
   it('getMessages uses the current locale without accepting a locale parameter', async () => {

--- a/packages/i18n/src/translation-functions/internal/getTranslations.ts
+++ b/packages/i18n/src/translation-functions/internal/getTranslations.ts
@@ -31,7 +31,10 @@ import type { DictionaryObjectTranslation } from '../types/functions';
 export async function getTranslations(): Promise<TFunctionType> {
   const i18nManager = getI18nManager();
   const locale = getCurrentLocale();
-  await i18nManager.loadDictionary(locale);
+  await Promise.all([
+    i18nManager.loadDictionary(locale),
+    i18nManager.loadTranslations(locale),
+  ]);
   const sourceLocale = i18nManager.getDefaultLocale();
 
   /**
@@ -59,11 +62,22 @@ export async function getTranslations(): Promise<TFunctionType> {
       throw new Error(`Dictionary entry ${id} cannot be found`);
     }
     const targetEntry = i18nManager.lookupDictionary(locale, id);
+    const dictionaryOptions = resolveDictionaryLookupOptions(
+      sourceEntry.options
+    );
+    const target =
+      targetEntry?.entry ??
+      i18nManager.lookupTranslation(
+        locale,
+        sourceEntry.entry,
+        dictionaryOptions
+      );
     return renderEntry({
       sourceLocale,
       targetLocale: locale,
       sourceEntry,
-      targetEntry,
+      target,
+      dictionaryOptions,
       options,
     });
   }) as TFunctionType;
@@ -77,6 +91,93 @@ export async function getTranslations(): Promise<TFunctionType> {
     return renderObject({ sourceObject, targetObject });
   };
 
+  function renderObject({
+    sourceObject,
+    targetObject,
+  }: {
+    sourceObject: DictionaryValue | undefined;
+    targetObject: DictionaryValue | undefined;
+  }): DictionaryObjectTranslation {
+    const targetEntry = getDictionaryEntry(targetObject);
+    if (targetEntry !== undefined) {
+      return targetEntry.entry;
+    }
+
+    if (isDictionaryValue(targetObject)) {
+      if (!isDictionaryValue(sourceObject)) {
+        return renderObject({
+          sourceObject: targetObject,
+          targetObject: undefined,
+        });
+      }
+
+      return renderDictionaryObject({
+        sourceObject,
+        targetObject,
+      });
+    }
+
+    const sourceEntry = getDictionaryEntry(sourceObject);
+    if (sourceEntry !== undefined) {
+      // Fallback to translations cache
+      const dictionaryOptions = resolveDictionaryLookupOptions(
+        sourceEntry.options
+      );
+
+      const target = i18nManager.lookupTranslation(
+        locale,
+        sourceEntry.entry,
+        dictionaryOptions
+      );
+      if (target !== undefined) {
+        return target;
+      }
+
+      // Fallback to source entry
+      return sourceEntry.entry;
+    }
+
+    if (isDictionaryValue(sourceObject)) {
+      return renderDictionaryObject({
+        sourceObject,
+        targetObject: undefined,
+      });
+    }
+
+    throw new Error('Dictionary object cannot be rendered');
+  }
+
+  function renderDictionaryObject({
+    sourceObject,
+    targetObject,
+  }: {
+    sourceObject: DictionaryValue;
+    targetObject: DictionaryValue | undefined;
+  }): DictionaryObjectTranslation {
+    if (!isDictionaryValue(sourceObject)) {
+      return renderObject({ sourceObject, targetObject });
+    }
+    const result: Record<string, DictionaryObjectTranslation> = {};
+    const keys = new Set([
+      ...Object.keys(sourceObject),
+      ...(isDictionaryValue(targetObject) ? Object.keys(targetObject) : []),
+    ]);
+
+    for (const key of Array.from(keys)) {
+      const renderedChild = renderObject({
+        sourceObject: sourceObject[key],
+        targetObject: isDictionaryValue(targetObject)
+          ? targetObject[key]
+          : undefined,
+      });
+      if (renderedChild !== undefined) {
+        result[key] = renderedChild;
+      }
+    }
+
+    return result;
+  }
+
   return t;
 }
 
@@ -84,16 +185,17 @@ function renderEntry({
   sourceLocale,
   targetLocale,
   sourceEntry,
-  targetEntry,
+  target,
+  dictionaryOptions,
   options = {},
 }: {
   sourceLocale: string;
   targetLocale: string;
   sourceEntry: DictionaryEntry;
-  targetEntry: DictionaryEntry | undefined;
+  target: string | undefined;
+  dictionaryOptions: ReturnType<typeof resolveDictionaryLookupOptions>;
   options?: DictionaryTranslationOptions;
 }): string {
-  const dictionaryOptions = resolveDictionaryLookupOptions(sourceEntry.options);
   const interpolationOptions = extractVariables(options);
   const lookupOptions = createLookupOptions<StringFormat>(
     targetLocale,
@@ -106,80 +208,8 @@ function renderEntry({
 
   return interpolateMessage({
     source: sourceEntry.entry,
-    target: targetEntry?.entry,
+    target,
     options: lookupOptions,
     sourceLocale,
   });
-}
-
-function renderObject({
-  sourceObject,
-  targetObject,
-}: {
-  sourceObject: DictionaryValue | undefined;
-  targetObject: DictionaryValue | undefined;
-}): DictionaryObjectTranslation {
-  const targetEntry = getDictionaryEntry(targetObject);
-  if (targetEntry !== undefined) {
-    return targetEntry.entry;
-  }
-
-  if (isDictionaryValue(targetObject)) {
-    if (!isDictionaryValue(sourceObject)) {
-      return renderObject({
-        sourceObject: targetObject,
-        targetObject: undefined,
-      });
-    }
-
-    return renderDictionaryObject({
-      sourceObject,
-      targetObject,
-    });
-  }
-
-  const sourceEntry = getDictionaryEntry(sourceObject);
-  if (sourceEntry !== undefined) {
-    return sourceEntry.entry;
-  }
-
-  if (isDictionaryValue(sourceObject)) {
-    return renderDictionaryObject({
-      sourceObject,
-      targetObject: undefined,
-    });
-  }
-
-  throw new Error('Dictionary object cannot be rendered');
-}
-
-function renderDictionaryObject({
-  sourceObject,
-  targetObject,
-}: {
-  sourceObject: DictionaryValue;
-  targetObject: DictionaryValue | undefined;
-}): DictionaryObjectTranslation {
-  if (!isDictionaryValue(sourceObject)) {
-    return renderObject({ sourceObject, targetObject });
-  }
-  const result: Record<string, DictionaryObjectTranslation> = {};
-  const keys = new Set([
-    ...Object.keys(sourceObject),
-    ...(isDictionaryValue(targetObject) ? Object.keys(targetObject) : []),
-  ]);
-
-  for (const key of keys) {
-    const renderedChild = renderObject({
-      sourceObject: sourceObject[key],
-      targetObject: isDictionaryValue(targetObject)
-        ? targetObject[key]
-        : undefined,
-    });
-    if (renderedChild !== undefined) {
-      result[key] = renderedChild;
-    }
-  }
-
-  return result;
 }


### PR DESCRIPTION
## Summary

Fix dictionary-backed `getTranslations()` fallback behavior in `gt-i18n`.

When `t()` cannot find a target dictionary entry, it now falls back to the loaded translations cache via `lookupTranslation()`, using lookup options resolved from the source dictionary entry metadata through `resolveDictionaryLookupOptions()`. This keeps dictionary metadata such as `context`, `$context`, `$format`, and `$maxChars` aligned with how dictionary runtime fallback hashes entries.

This also extends the same fallback behavior to `t.obj()` for missing translated dictionary leaves.

## Notes

The translated dictionary is expected to follow the same structure as the source dictionary. When a node is missing from the translated dictionary, `t.obj()` falls back to the corresponding source dictionary node. Target-only dictionary nodes are not part of the intended contract; the fallback behavior is designed around source-shaped dictionaries.

## Changes

- Preload both dictionary and translations caches in `getTranslations()`.
- Fall back from missing target dictionary entries to `lookupTranslation()`.
- Use `resolveDictionaryLookupOptions()` for dictionary lookup metadata.
- Preserve interpolation behavior for `t()` by applying caller variables only during render.
- Add regression coverage for `t()` and `t.obj()` translation-cache fallback when target dictionary entries are missing.
- Add a patch changeset for `gt-i18n`.

## Testing

- `pnpm exec vitest run --config=./vitest.config.ts src/translation-functions/internal/__tests__/locale-defaults.test.ts`
- `pnpm typecheck`
- Targeted `oxfmt --check`
- Earlier full `pnpm test` in `packages/i18n`
- Earlier root `pnpm build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the fallback behavior in `getTranslations()` for dictionary-backed translations. When a target dictionary entry is missing, `t()` and `t.obj()` now fall back to the loaded translations cache using the source entry's metadata (context, format, maxChars) before falling back to the source string.

- `getTranslations()` now preloads both the dictionary and translations caches in parallel via `Promise.all`, enabling the synchronous `lookupTranslation` call inside `t()` and `t.obj()`.
- `renderObject`/`renderDictionaryObject` are moved inside the `getTranslations` closure to capture `locale` and `i18nManager`, and the translation-cache lookup is inserted as a new fallback step before the source-string fallback.
- Two regression tests are added covering both `t()` and `t.obj()` translation-cache fallback paths when target dictionary entries are absent.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the fallback chain is logically correct and the hashMessage function ignores the deprecated lowercase context field, so the translation cache lookup hash aligns with what was loaded.

The two main behavioral changes — preloading translations in parallel and inserting a lookupTranslation call before the source-string fallback — are both well-tested and consistent with the rest of the codebase conventions. Calling loadTranslations unconditionally in getTranslations() is a deliberate trade-off; dictionary-only configurations without a translations loader will trigger an extra no-op call, but I18nManager.loadTranslations handles that case gracefully. The only nit is an unnecessary Array.from(keys) wrapping a Set.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/translation-functions/internal/getTranslations.ts | Core logic change: adds translation-cache fallback for missing target dictionary entries in both t() and t.obj(); moves renderObject/renderDictionaryObject into closure and adds unnecessary Array.from(keys) call. |
| packages/i18n/src/translation-functions/internal/__tests__/locale-defaults.test.ts | Adds two regression tests that correctly validate the new t() and t.obj() translation-cache fallback paths, including hash-option alignment via resolveDictionaryLookupOptions. |
| .changeset/steady-slate-path.md | Patch-level changeset entry for gt-i18n describing the dictionary fallback fix. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["getTranslations()"] --> B["Promise.all(loadDictionary, loadTranslations)"]
    B --> C["t(id, options)"]
    B --> D["t.obj(id)"]

    C --> E["lookupDictionary(sourceLocale, id)"]
    E -->|missing| F["throw Error"]
    E -->|found| G["lookupDictionary(locale, id)"]
    G -->|targetEntry found| H["target = targetEntry.entry"]
    G -->|targetEntry missing| I["lookupTranslation(locale, sourceEntry.entry, dictionaryOptions)"]
    I -->|found| H
    I -->|missing| J["target = undefined"]
    H --> K["renderEntry → interpolateMessage"]
    J --> K

    D --> L["lookupDictionaryObj(sourceLocale, id)"]
    L -->|missing| M["throw Error"]
    L -->|found| N["lookupDictionaryObj(locale, id)"]
    N --> O["renderObject(sourceObject, targetObject)"]

    O --> P{targetObject is leaf?}
    P -->|yes| Q["return targetEntry.entry"]
    P -->|no: is dict| R["renderDictionaryObject (recurse)"]
    P -->|no: sourceObject is leaf| S["lookupTranslation fallback"]
    S -->|found| T["return translation"]
    S -->|missing| U["return sourceEntry.entry"]
    R --> O
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/i18n/src/translation-functions/internal/getTranslations.ts:166
`Array.from(keys)` is not needed here — `Set` is directly iterable with `for...of`. The old standalone version of this function iterated `keys` directly.

```suggestion
    for (const key of keys) {
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(i18n): fall back for dictionary tran..."](https://github.com/generaltranslation/gt/commit/dad08195858bd4d4f04e13515f750ba3675c5434) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31249098)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->