### PR TITLE
chore(cli): stop tracking generated version file

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -91,7 +91,7 @@ Load only the relevant file for the area being changed:
 - **Exports:** Most packages use conditional exports (`package.json` `exports` field) with separate paths for different entry points (e.g., `gt-next` has `/client`, `/server`, `/middleware`, `/config`).
 - **Internal subpaths:** Packages expose `/internal` subpaths for cross-package use. These are not part of the public API.
 - **React i18n-context:** `packages/react/src/i18n-context/` has restricted imports from `gt-i18n` (only `/types`, `/internal`, `/internal/types`). This is enforced by ESLint.
-- **CLI version generation:** `packages/cli` has a pre-commit hook that runs `node scripts/generate-version.js` to keep `src/generated/version.ts` in sync.
+- **CLI version generation:** `packages/cli/src/generated/version.ts` is ignored and generated from `packages/cli/package.json` by `node scripts/generate-version.js`; do not edit or track it manually.
 - **gt-react / gt-react-native parity:** These two packages are fixed-version siblings (released together via changesets). When a feature is added to one, the equivalent should be added to the other unless it's platform-specific (e.g., DOM-only UI components). Compare their `index.ts`/`index.tsx` exports to verify parity.
 
 ## MCP Server

--- a/.claude/rules/cli.md
+++ b/.claude/rules/cli.md
@@ -9,6 +9,6 @@ paths:
 - The `gt` CLI (`packages/cli`) is the primary command-line tool. `gtx-cli` is a thin wrapper.
 - CLI entry point is `src/main.ts`. Library entry point is `src/index.ts`.
 - Uses `commander` for argument parsing and `chalk` for terminal output.
-- The CLI has a pre-commit hook that generates `src/generated/version.ts` — never edit this file manually.
+- `src/generated/version.ts` is ignored and generated from `package.json` by `node scripts/generate-version.js` — never edit or track it manually.
 - Test with `pnpm --filter gt test`. Type-check with `pnpm --filter gt typecheck`.
 - When adding new CLI commands, follow the existing pattern in `src/cli/`.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -5,5 +5,5 @@ pre-commit:
       glob: '**/*.{js,ts,jsx,tsx,mjs}'
     - run: pnpm exec oxfmt --no-error-on-unmatched-pattern {staged_files}
       glob: '**/*.{js,ts,jsx,tsx,mjs,json,md,yml,yaml,html,css,toml}'
-    - run: node scripts/generate-version.js && git add src/generated/version.ts
+    - run: node scripts/generate-version.js
       root: packages/cli

--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -3,3 +3,4 @@ package-lock.json
 **.tgz
 binaries
 .rollup.cache
+src/generated/version.ts

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,10 +11,11 @@
   ],
   "type": "module",
   "scripts": {
-    "build": "node scripts/generate-version.js && tsc && rm -rf dist/setup/instructions && cp -r src/setup/instructions dist/setup/instructions",
+    "generate-version": "node scripts/generate-version.js",
+    "build": "pnpm run generate-version && tsc && rm -rf dist/setup/instructions && cp -r src/setup/instructions dist/setup/instructions",
     "build:clean": "sh ../../scripts/clean.sh && pnpm bin:restore && rm -rf binaries && pnpm run build",
     "build:release": "pnpm run build:clean",
-    "build:bin": "node scripts/generate-version.js && tsc && rm -rf dist/setup/instructions && cp -r src/setup/instructions dist/setup/instructions && sh scripts/build-exe.sh all",
+    "build:bin": "pnpm run generate-version && tsc && rm -rf dist/setup/instructions && cp -r src/setup/instructions dist/setup/instructions && sh scripts/build-exe.sh all",
     "build:bin:clean": "sh ../../scripts/clean.sh && rm -rf binaries && pnpm run build:bin",
     "build:bin:release": "pnpm run build:bin:clean && pnpm run build:bin",
     "build:bin:darwin-x64": "sh scripts/build-exe.sh darwin-x64",
@@ -22,8 +23,8 @@
     "build:bin:linux-x64": "sh scripts/build-exe.sh linux-x64",
     "build:bin:linux-arm64": "sh scripts/build-exe.sh linux-arm64",
     "build:bin:windows-x64": "sh scripts/build-exe.sh windows-x64",
-    "test": "vitest run --config=./vitest.config.ts",
-    "test:watch": "vitest --config=./vitest.config.ts",
+    "test": "pnpm run generate-version && vitest run --config=./vitest.config.ts",
+    "test:watch": "pnpm run generate-version && vitest --config=./vitest.config.ts",
     "release": "pnpm run release:normal && pnpm run release:bin",
     "release:normal": "pnpm run build:clean && pnpm publish",
     "release:bin": "pnpm run bin:prep && pnpm run build:bin:clean && pnpm publish --tag bin --no-git-checks && pnpm run bin:restore && pnpm run build:clean",
@@ -32,7 +33,7 @@
     "release:latest": "pnpm run build:clean && pnpm publish --tag latest",
     "bin:restore": "node scripts/restore-package-json.js",
     "bin:prep": "node scripts/prepare-binary-release.js",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "pnpm run generate-version && tsc --noEmit"
   },
   "exports": {
     ".": {

--- a/packages/cli/scripts/generate-version.js
+++ b/packages/cli/scripts/generate-version.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { readFileSync, writeFileSync } from 'fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 
@@ -18,4 +18,5 @@ export const PACKAGE_VERSION = '${packageJson.version}';
 
 // Write to src/generated/version.ts
 const outputPath = join(__dirname, '..', 'src', 'generated', 'version.ts');
+mkdirSync(dirname(outputPath), { recursive: true });
 writeFileSync(outputPath, tsContent, 'utf8');

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,0 @@
-// This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.14.32';


### PR DESCRIPTION
## Summary
- stop tracking and ignore packages/cli/src/generated/version.ts
- ensure version generation creates src/generated and runs before build, typecheck, and tests
- keep pre-commit generation without staging the generated file

## Verification
- pnpm --filter gt typecheck
- pnpm --filter gt test
- pnpm --filter gt build
- pnpm exec oxfmt --check .claude/CLAUDE.md .claude/rules/cli.md lefthook.yml packages/cli/.gitignore packages/cli/package.json packages/cli/scripts/generate-version.js
- pnpm exec oxlint packages/cli/scripts/generate-version.js

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR stops tracking `packages/cli/src/generated/version.ts` in git by adding it to `.gitignore` and deleting it from the repository. All scripts that invoke TypeScript tooling (`build`, `typecheck`, `test`, `test:watch`) now call `generate-version` first, and `generate-version.js` creates the `src/generated/` directory if it doesn't exist — making fresh checkouts work without any manual steps.

- `packages/cli/scripts/generate-version.js` adds `mkdirSync` with `recursive: true` so the output directory is created automatically on a clean clone.
- `packages/cli/package.json` extracts version generation into a dedicated `generate-version` script and prepends it to every script that feeds into the TypeScript compiler.
- `lefthook.yml` removes the `git add src/generated/version.ts` step from the pre-commit hook since the file is now gitignored; the generation step itself is kept so the file exists locally for any immediate tooling use after committing.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all entry points for TypeScript tooling now generate the file first, and fresh checkouts create the directory automatically.

The change is a clean infrastructure improvement: every script that needs version.ts generates it beforehand, mkdirSync handles missing directories, and the gitignore prevents the file from ever drifting in the repository again. No logic changes, no new runtime paths.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/scripts/generate-version.js | Added mkdirSync with recursive:true to ensure src/generated/ directory is created before writing version.ts on fresh checkouts. |
| packages/cli/package.json | Extracted generate-version as a named script and prepended it to build, build:bin, test, test:watch, and typecheck to guarantee the file exists before any TypeScript tooling runs. |
| lefthook.yml | Removed the git add of version.ts from the pre-commit hook; generation still runs to keep the local file fresh, but the gitignored file is no longer staged. |
| packages/cli/.gitignore | Added src/generated/version.ts to gitignore so the auto-generated file is never accidentally tracked. |
| packages/cli/src/generated/version.ts | Deleted from the repository; will be generated on-demand by generate-version.js. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Developer runs script or commits] --> B{Which trigger?}

    B --> |pnpm run build / typecheck / test| C[generate-version script]
    B --> |git commit - pre-commit hook| D[lefthook: node scripts/generate-version.js]

    C --> E[mkdirSync src/generated/ - recursive]
    D --> E

    E --> F[Write src/generated/version.ts]
    F --> G{gitignored - never staged}

    C --> H[tsc / vitest]
    H --> I[Reads src/generated/version.ts]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(cli): stop tracking generated vers..."](https://github.com/generaltranslation/gt/commit/1d236732730abad16eca8132d0f38178d7e86ea0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31251863)</sub>

<!-- /greptile_comment -->