### PR TITLE
fix: tighten metadata api types

### DIFF
--- a/.changeset/quiet-types-rest.md
+++ b/.changeset/quiet-types-rest.md
@@ -1,0 +1,6 @@
+---
+'generaltranslation': patch
+'gt': patch
+---
+
+Tighten public and API metadata types, and handle metadata entries without hashes in the CLI.

--- a/packages/cli/src/cli/inline.ts
+++ b/packages/cli/src/cli/inline.ts
@@ -124,7 +124,7 @@ export class InlineCLI extends BaseCLI {
       const { hash, id } = metadata;
       if (id) {
         newData[id] = source;
-      } else {
+      } else if (hash) {
         newData[hash] = source;
       }
     }

--- a/packages/cli/src/formats/files/collectFiles.ts
+++ b/packages/cli/src/formats/files/collectFiles.ts
@@ -48,7 +48,7 @@ export async function collectFiles(
         if (id) {
           fileData[id] = source;
           fileMetadata[id] = metadata;
-        } else {
+        } else if (hash) {
           fileData[hash] = source;
           fileMetadata[hash] = metadata;
         }

--- a/packages/cli/src/translation/parse.ts
+++ b/packages/cli/src/translation/parse.ts
@@ -93,26 +93,29 @@ export async function createUpdates(
   const duplicateIds = new Set<string>();
 
   updates = updates.map((update) => {
-    if (!update.metadata.id) return update;
-    const existingHash = idHashMap.get(update.metadata.id);
-    if (existingHash) {
-      if (existingHash !== update.metadata.hash) {
+    const { id, hash } = update.metadata;
+    if (!id || !hash) return update;
+    const existingHash = idHashMap.get(id);
+    if (existingHash !== undefined) {
+      if (existingHash !== hash) {
         errors.push(
           `Hashes don't match on two components with the same id: ${chalk.blue(
-            update.metadata.id
+            id
           )}. Check your ${chalk.green(
             '<T>'
           )} tags and dictionary entries and make sure you're not accidentally duplicating IDs.`
         );
-        duplicateIds.add(update.metadata.id);
+        duplicateIds.add(id);
       }
     } else {
-      idHashMap.set(update.metadata.id, update.metadata.hash);
+      idHashMap.set(id, hash);
     }
     return update;
   });
 
   // Filter out updates with duplicate IDs
-  updates = updates.filter((update) => !duplicateIds.has(update.metadata.id));
+  updates = updates.filter(
+    (update) => !update.metadata.id || !duplicateIds.has(update.metadata.id)
+  );
   return { updates, errors, warnings };
 }

--- a/packages/core/src/types-dir/api/downloadFileBatch.ts
+++ b/packages/core/src/types-dir/api/downloadFileBatch.ts
@@ -1,4 +1,5 @@
 import { FileFormat } from './file';
+import type { JsonObject } from './json';
 // Types for the downloadFileBatch function
 
 export type DownloadFileBatchRequest = {
@@ -30,7 +31,7 @@ export type DownloadedFile = {
   locale?: string;
   fileName?: string; // Only present for source files (if locale is not present)
   data: string;
-  metadata: Record<string, any>;
+  metadata: JsonObject;
   fileFormat: FileFormat;
 };
 

--- a/packages/core/src/types-dir/api/enqueueFiles.ts
+++ b/packages/core/src/types-dir/api/enqueueFiles.ts
@@ -1,8 +1,24 @@
-import { JsxChildren } from '../jsx/content';
+import { DataFormat, JsxChildren } from '../jsx/content';
+
+type UpdateMetadata = {
+  id?: string;
+  hash?: string;
+  context?: string;
+  maxChars?: number;
+  dataFormat?: DataFormat;
+  actionType?: 'standard' | 'fast' | string;
+  staticId?: string;
+  format?: string;
+  filePaths?: string[];
+  sourceCode?: unknown;
+  contextDeriveExpr?: unknown;
+  _contextDeriveExpr?: unknown;
+  [key: string]: unknown;
+};
 
 // Types for the enqueueTranslationEntries function
 export type Updates = ({
-  metadata: Record<string, any> & { staticId?: string };
+  metadata: UpdateMetadata;
 } & (
   | {
       dataFormat: 'JSX';

--- a/packages/core/src/types-dir/api/file.ts
+++ b/packages/core/src/types-dir/api/file.ts
@@ -1,5 +1,6 @@
 import { DataFormat } from '../jsx/content';
 import { Updates } from './enqueueFiles';
+import type { JsonObject } from './json';
 
 export type FileFormat =
   | 'GTJSON'
@@ -18,7 +19,7 @@ export type FileFormat =
 /**
  * Metadata for files or entries.
  */
-type FormatMetadata = Record<string, any> | Updates[number]['metadata'];
+export type FormatMetadata = JsonObject | Updates[number]['metadata'];
 
 /**
  * File object structure for uploading files.

--- a/packages/core/src/types-dir/api/json.ts
+++ b/packages/core/src/types-dir/api/json.ts
@@ -1,0 +1,7 @@
+export type JsonPrimitive = string | number | boolean | null;
+
+export type JsonValue = JsonPrimitive | JsonValue[] | JsonObject;
+
+export type JsonObject = {
+  [key: string]: JsonValue;
+};

--- a/packages/core/src/types-dir/api/uploadFiles.ts
+++ b/packages/core/src/types-dir/api/uploadFiles.ts
@@ -1,5 +1,5 @@
 import { DataFormat } from '../jsx/content';
-import { FileFormat, FileReference } from './file';
+import { FileFormat, FileReference, type FormatMetadata } from './file';
 
 /**
  * Metadata stored alongside GTJSON file entries.
@@ -33,7 +33,7 @@ export type FileUpload = {
   transformFormat?: FileFormat;
   dataFormat?: DataFormat;
   locale: string;
-  formatMetadata?: GTJsonFormatMetadata;
+  formatMetadata?: GTJsonFormatMetadata | FormatMetadata;
   versionId?: string; // Optional versionId. Only use this if you know what you are doing.
   fileId?: string; // Optional fileId. Only use this if you know what you are doing.
 };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -25,6 +25,11 @@ import type {
 } from './types-dir/api/entry';
 import type { HashMetadata } from './id/types';
 export type { TranslationStatusResult } from './types-dir/api/translationStatus';
+export type {
+  JsonObject,
+  JsonPrimitive,
+  JsonValue,
+} from './types-dir/api/json';
 
 export {
   IcuMessage,
@@ -132,10 +137,13 @@ export type Metadata = {
   maxChars?: number;
   context?: string;
   id?: string;
+  hash?: string;
+  format?: string;
+  dataFormat?: DataFormat;
   sourceLocale?: string;
   actionType?: 'standard' | 'fast' | string;
   filePaths?: string[];
-  [key: string]: any;
+  [key: string]: unknown;
 };
 
 export type FormatVariables = Record<


### PR DESCRIPTION
## Summary
- tighten core metadata/API types used by source and file uploads
- add reusable JSON value/object types for file metadata
- keep this PR scoped to generaltranslation core types

## Verification
- pnpm --filter generaltranslation typecheck
- pnpm --filter generaltranslation test -- --runInBand
- pnpm lint
- git diff --check

Stack: 1/4. Next: #1385.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens the public and internal metadata/API types in `generaltranslation` core, replacing loose `Record<string, any>` shapes with a new `JsonObject`/`JsonValue`/`JsonPrimitive` hierarchy and an explicit `UpdateMetadata` type. CLI behaviour is adjusted so that entries missing both `id` and `hash` are no longer stored under the string `"undefined"` as a key.

- **New `json.ts`**: introduces reusable, recursive `JsonPrimitive → JsonValue → JsonObject` types that replace `Record<string, any>` in `DownloadedFile.metadata` and the `FormatMetadata` union.
- **`UpdateMetadata`**: replaces the `Record<string, any> & { staticId?: string }` inline type with a named, field-by-field interface whose index signature is `unknown` instead of `any`.
- **CLI guard (`else if (hash)`)**: prevents spurious `"undefined"` dictionary keys when an entry has neither `id` nor `hash`; same guard applied in `inline.ts`, `collectFiles.ts`, and `parse.ts`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all changes are additive type narrowing with well-scoped CLI behavioural fixes for edge-case entries.

The diff is purely type tightening and a guard against missing-hash entries in the CLI. No data paths are altered for the common case, and the edge-case changes (dropping entries that previously produced a literal "undefined" dictionary key) are improvements. No regressions or correctness issues were found.

No files require special attention; the remaining looseness in collectFiles.ts is a minor inconsistency rather than a bug.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/types-dir/api/json.ts | New file introducing standard JsonPrimitive / JsonValue / JsonObject types; clean recursive definition with no issues. |
| packages/core/src/types-dir/api/enqueueFiles.ts | Replaces Record with explicit UpdateMetadata type; well-formed with catch-all index signature typed as unknown instead of any. |
| packages/core/src/types-dir/api/file.ts | FormatMetadata changed from Record<string, any> to JsonObject | UpdateMetadata and exported; union is correct but consumers cannot narrow it without a runtime type guard. |
| packages/core/src/types-dir/api/uploadFiles.ts | formatMetadata broadened to GTJsonFormatMetadata | FormatMetadata; intentional and type-safe widening. |
| packages/core/src/types-dir/api/downloadFileBatch.ts | DownloadedFile.metadata tightened from Record<string, any> to JsonObject; clean improvement. |
| packages/core/src/types.ts | Public Metadata type gains hash, format, dataFormat fields and changes index signature from any to unknown; new JSON types re-exported. |
| packages/cli/src/translation/parse.ts | Duplicate-ID detection now skips entries that lack either id or hash; filter corrected to pass through no-id entries; logic is sound and type-safe. |
| packages/cli/src/formats/files/collectFiles.ts | Drops entries that have neither id nor hash silently; fileMetadata is still typed as Record<string, any>. |
| packages/cli/src/cli/inline.ts | Same else-if-hash guard as collectFiles; entries without id and without hash are silently discarded. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[update entry] --> B{has id?}
    B -- yes --> C[use id as lookup\ntrack in idHashMap]
    B -- no --> D{has hash?}
    D -- yes --> E[use hash as lookup]
    D -- no --> F[silently dropped]

    C --> G{duplicate id\nwith different hash?}
    G -- yes --> H[record error\nadd to duplicateIds]
    G -- no --> I[register in idHashMap]

    H --> J[filter duplicates out]
    I --> J
    E --> J
    F --> J

    J --> K[FileToUpload formatMetadata]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/cli/src/formats/files/collectFiles.ts:42
The `fileMetadata` accumulator is still typed as `Record<string, any>` even though all values inserted into it are `UpdateMetadata` objects (the tightened type introduced by this PR). This is inconsistent with the stated goal of the PR and means `formatMetadata: fileMetadata` on the `FileToUpload` satisfies-check is relying on `any` assignability rather than actual type safety.

```suggestion
      const fileMetadata: Record<string, unknown> = {};
```

### Issue 2 of 2
packages/cli/src/formats/files/collectFiles.ts:47-54
**Silent discard of hash-less, id-less entries**

When an update carries neither an `id` nor a `hash`, it is now silently skipped — no warning is emitted to the caller and the entry simply vanishes from the upload. The changeset explicitly notes that hash-less entries can occur in practice, so users could lose translation content with no indication of what happened. Emitting a `logger.warn` (or equivalent) here would make this edge case observable without blocking the upload.

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix: tighten metadata api types"](https://github.com/generaltranslation/gt/commit/e3cfa002701388c4d185be0acdfcfc6dac696121) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31265528)</sub>

<!-- /greptile_comment -->