### PR TITLE
refactor: centralize i18n manager event names

### DIFF
--- a/.changeset/quiet-event-names.md
+++ b/.changeset/quiet-event-names.md
@@ -1,0 +1,5 @@
+---
+'gt-i18n': patch
+---
+
+Export i18n manager cache-miss event-name constants from `gt-i18n/internal` so downstream packages such as `@generaltranslation/react-core` can consume one shared source of truth.

--- a/packages/i18n/src/i18n-manager/I18nManager.ts
+++ b/packages/i18n/src/i18n-manager/I18nManager.ts
@@ -31,7 +31,8 @@ import { DictionarySourceNotFoundError } from './translations-manager/utils/Dict
 import { createLifecycleCallbacks } from './lifecycle-hooks/createLifecycleCallbacks';
 import { EventEmitter } from './event-subscription/EventEmitter';
 import { subscribeLifecycleCallbacks } from './lifecycle-hooks/subscribeLifecycleCallbacks';
-import { I18nEvents } from './event-subscription/types';
+import { TRANSLATIONS_CACHE_MISS_EVENT_NAME } from './event-subscription/types';
+import type { I18nEvents } from './event-subscription/types';
 
 /**
  * Default translation timeout in milliseconds for a runtime translation request
@@ -164,12 +165,12 @@ class I18nManager<
    */
   subscribeToTranslationsCacheMiss(
     listener: (
-      event: I18nEvents<TranslationValue>['translations-cache-miss']
+      event: I18nEvents<TranslationValue>[typeof TRANSLATIONS_CACHE_MISS_EVENT_NAME]
     ) => void,
     locale: Locale,
     hash: Hash
   ) {
-    return this.subscribe('translations-cache-miss', (event) => {
+    return this.subscribe(TRANSLATIONS_CACHE_MISS_EVENT_NAME, (event) => {
       if (event.locale !== locale || event.hash !== hash) {
         return;
       }

--- a/packages/i18n/src/i18n-manager/event-subscription/types.ts
+++ b/packages/i18n/src/i18n-manager/event-subscription/types.ts
@@ -21,6 +21,12 @@ export type ListenerStore<Events extends BaseEvent> = Partial<{
   [EventName in keyof Events]: Set<Listener<Events, EventName>>;
 }>;
 
+export const LOCALES_CACHE_MISS_EVENT_NAME = 'locales-cache-miss';
+export const TRANSLATIONS_CACHE_MISS_EVENT_NAME = 'translations-cache-miss';
+export const LOCALES_DICTIONARY_CACHE_MISS_EVENT_NAME =
+  'locales-dictionary-cache-miss';
+export const DICTIONARY_CACHE_MISS_EVENT_NAME = 'dictionary-cache-miss';
+
 /**
  * A base event for the I18nManagers
  * @prop {locales-cache-hit} - Emitted when a locale cache hit occurs
@@ -38,7 +44,7 @@ export type I18nEvents<TranslationValue extends Translation> = BaseEvent & {
     locale: Locale;
     translations: Record<Hash, TranslationValue>;
   };
-  'locales-cache-miss': {
+  [LOCALES_CACHE_MISS_EVENT_NAME]: {
     locale: Locale;
     translations: Record<Hash, TranslationValue>;
   };
@@ -47,7 +53,7 @@ export type I18nEvents<TranslationValue extends Translation> = BaseEvent & {
     hash: Hash;
     translation: TranslationValue;
   };
-  'translations-cache-miss': {
+  [TRANSLATIONS_CACHE_MISS_EVENT_NAME]: {
     locale: Locale;
     hash: Hash;
     translation: TranslationValue;
@@ -56,7 +62,7 @@ export type I18nEvents<TranslationValue extends Translation> = BaseEvent & {
     locale: Locale;
     dictionary: Dictionary;
   };
-  'locales-dictionary-cache-miss': {
+  [LOCALES_DICTIONARY_CACHE_MISS_EVENT_NAME]: {
     locale: Locale;
     dictionary: Dictionary;
   };
@@ -65,7 +71,7 @@ export type I18nEvents<TranslationValue extends Translation> = BaseEvent & {
     id: DictionaryPath;
     dictionaryEntry: DictionaryEntry;
   };
-  'dictionary-cache-miss': {
+  [DICTIONARY_CACHE_MISS_EVENT_NAME]: {
     locale: Locale;
     id: DictionaryPath;
     dictionaryEntry: DictionaryEntry;

--- a/packages/i18n/src/i18n-manager/index.ts
+++ b/packages/i18n/src/i18n-manager/index.ts
@@ -8,6 +8,14 @@ export {
 } from './condition-store/localeResolver';
 export type { LocaleCandidates } from './condition-store/localeResolver';
 
+// Events
+export {
+  DICTIONARY_CACHE_MISS_EVENT_NAME,
+  LOCALES_CACHE_MISS_EVENT_NAME,
+  LOCALES_DICTIONARY_CACHE_MISS_EVENT_NAME,
+  TRANSLATIONS_CACHE_MISS_EVENT_NAME,
+} from './event-subscription/types';
+
 // Functions
 export {
   getCurrentLocale,

--- a/packages/i18n/src/i18n-manager/lifecycle-hooks/createLifecycleCallbacks.ts
+++ b/packages/i18n/src/i18n-manager/lifecycle-hooks/createLifecycleCallbacks.ts
@@ -1,4 +1,10 @@
 import { EventEmitter } from '../event-subscription/EventEmitter';
+import {
+  DICTIONARY_CACHE_MISS_EVENT_NAME,
+  LOCALES_CACHE_MISS_EVENT_NAME,
+  LOCALES_DICTIONARY_CACHE_MISS_EVENT_NAME,
+  TRANSLATIONS_CACHE_MISS_EVENT_NAME,
+} from '../event-subscription/types';
 import type { Translation } from '../translations-manager/utils/types/translation-data';
 import type { I18nManagerCacheLifecycleCallbacks } from './types';
 import type { I18nEvents } from '../event-subscription/types';
@@ -20,7 +26,7 @@ export function createLifecycleCallbacks<TranslationValue extends Translation>(
       });
     },
     onLocalesCacheMiss: (params) => {
-      emit('locales-cache-miss', {
+      emit(LOCALES_CACHE_MISS_EVENT_NAME, {
         locale: params.inputKey,
         translations: params.outputValue.getInternalCache(),
       });
@@ -33,7 +39,7 @@ export function createLifecycleCallbacks<TranslationValue extends Translation>(
       });
     },
     onTranslationsCacheMiss: (params) => {
-      emit('translations-cache-miss', {
+      emit(TRANSLATIONS_CACHE_MISS_EVENT_NAME, {
         locale: params.locale,
         hash: params.cacheKey,
         translation: params.outputValue,
@@ -46,7 +52,7 @@ export function createLifecycleCallbacks<TranslationValue extends Translation>(
       });
     },
     onLocalesDictionaryCacheMiss: (params) => {
-      emit('locales-dictionary-cache-miss', {
+      emit(LOCALES_DICTIONARY_CACHE_MISS_EVENT_NAME, {
         locale: params.inputKey,
         dictionary: params.outputValue.getInternalCache(),
       });
@@ -59,7 +65,7 @@ export function createLifecycleCallbacks<TranslationValue extends Translation>(
       });
     },
     onDictionaryCacheMiss: (params) => {
-      emit('dictionary-cache-miss', {
+      emit(DICTIONARY_CACHE_MISS_EVENT_NAME, {
         locale: params.locale,
         id: params.cacheKey,
         dictionaryEntry: params.outputValue,

--- a/packages/i18n/src/i18n-manager/lifecycle-hooks/subscribeLifecycleCallbacks.ts
+++ b/packages/i18n/src/i18n-manager/lifecycle-hooks/subscribeLifecycleCallbacks.ts
@@ -1,4 +1,10 @@
 import { EventEmitter } from '../event-subscription/EventEmitter';
+import {
+  DICTIONARY_CACHE_MISS_EVENT_NAME,
+  LOCALES_CACHE_MISS_EVENT_NAME,
+  LOCALES_DICTIONARY_CACHE_MISS_EVENT_NAME,
+  TRANSLATIONS_CACHE_MISS_EVENT_NAME,
+} from '../event-subscription/types';
 import type { Translation } from '../translations-manager/utils/types/translation-data';
 import type { LifecycleCallbacks } from './types';
 import type { I18nEvents } from '../event-subscription/types';
@@ -35,7 +41,7 @@ export function subscribeLifecycleCallbacks<
     });
   }
   if (onLocalesCacheMiss) {
-    subscribe('locales-cache-miss', (event) => {
+    subscribe(LOCALES_CACHE_MISS_EVENT_NAME, (event) => {
       onLocalesCacheMiss({
         ...event,
         value: event.translations,
@@ -51,7 +57,7 @@ export function subscribeLifecycleCallbacks<
     });
   }
   if (onTranslationsCacheMiss) {
-    subscribe('translations-cache-miss', (event) => {
+    subscribe(TRANSLATIONS_CACHE_MISS_EVENT_NAME, (event) => {
       onTranslationsCacheMiss({
         ...event,
         value: event.translation,
@@ -64,7 +70,7 @@ export function subscribeLifecycleCallbacks<
     });
   }
   if (onLocalesDictionaryCacheMiss) {
-    subscribe('locales-dictionary-cache-miss', (event) => {
+    subscribe(LOCALES_DICTIONARY_CACHE_MISS_EVENT_NAME, (event) => {
       onLocalesDictionaryCacheMiss(event);
     });
   }
@@ -74,7 +80,7 @@ export function subscribeLifecycleCallbacks<
     });
   }
   if (onDictionaryCacheMiss) {
-    subscribe('dictionary-cache-miss', (event) => {
+    subscribe(DICTIONARY_CACHE_MISS_EVENT_NAME, (event) => {
       onDictionaryCacheMiss(event);
     });
   }


### PR DESCRIPTION
## Summary
- Added i18n manager cache-miss event-name constants next to the existing event type definitions in `packages/i18n/src/i18n-manager/event-subscription/types.ts`.
- Exported those constants through the existing `gt-i18n/internal` path via `packages/i18n/src/i18n-manager/index.ts`.
- Replaced current `gt-i18n` cache-miss emit/subscribe literals in `I18nManager`, `createLifecycleCallbacks`, and `subscribeLifecycleCallbacks` with the shared constants.
- Added a `gt-i18n` patch changeset documenting that the event-name constants are now exported from `gt-i18n/internal` for downstream consumers such as `@generaltranslation/react-core`.

## Validation
- `pnpm --filter gt-i18n test` - passed (23 files, 191 tests)
- `pnpm --filter @generaltranslation/react-core test` - passed (15 files, 289 tests)
- `pnpm --filter @generaltranslation/react-core typecheck` - passed
- `pnpm --filter gt-i18n typecheck` - passed
- `pnpm exec oxfmt --check ...` on touched files - passed
- Literal search confirmed no remaining occurrences of the four event strings outside the new constant definitions, documentation comments, and existing public event-name tests.

## Notes
- `packages/react-core/src/provider/i18n-store/managerEvents.ts` was not present in this checkout or on `origin/main`, so no react-core source file needed removal. It remains absent/unused.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralizes the four cache-miss event-name strings (`locales-cache-miss`, `translations-cache-miss`, `locales-dictionary-cache-miss`, `dictionary-cache-miss`) into named constants colocated with the `I18nEvents` type definitions, then exports them from `gt-i18n/internal` so downstream packages can subscribe using the same source of truth.

- **`types.ts`**: Declares `LOCALES_CACHE_MISS_EVENT_NAME`, `TRANSLATIONS_CACHE_MISS_EVENT_NAME`, `LOCALES_DICTIONARY_CACHE_MISS_EVENT_NAME`, and `DICTIONARY_CACHE_MISS_EVENT_NAME` as `const` string literals; converts the matching `I18nEvents` type keys from inline literals to computed property keys — cache-hit keys are intentionally left as literals.
- **`I18nManager.ts`, `createLifecycleCallbacks.ts`, `subscribeLifecycleCallbacks.ts`**: All inline emit/subscribe string literals replaced with the new constants; no behavioural change.
- **`index.ts` + changeset**: Re-exports the constants through `gt-i18n/internal` as a patch-level addition.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — this is a purely mechanical refactor replacing string literals with named constants; no runtime behaviour changes.

Every emit and subscribe site now uses the same constant that defines the type key, so there is no way for a typo to silently decouple the emitter from the subscriber. The cache-hit keys are intentionally left as literals, and the new exports are strictly additive. Tests and typechecks passed.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/i18n-manager/event-subscription/types.ts | Adds four cache-miss event-name string constants and converts the corresponding I18nEvents type keys from inline literals to computed property keys; cache-hit keys remain as literals. |
| packages/i18n/src/i18n-manager/I18nManager.ts | Swaps the 'translations-cache-miss' string literal for TRANSLATIONS_CACHE_MISS_EVENT_NAME in both the subscribe call and the event-type lookup; import is correctly split into a value import and a type import. |
| packages/i18n/src/i18n-manager/index.ts | Adds a new Events export block re-exporting all four cache-miss event-name constants through the existing gt-i18n/internal barrel. |
| packages/i18n/src/i18n-manager/lifecycle-hooks/createLifecycleCallbacks.ts | Replaces four inline emit(...) string literals with the shared constants; logic is unchanged. |
| packages/i18n/src/i18n-manager/lifecycle-hooks/subscribeLifecycleCallbacks.ts | Replaces four inline subscribe(...) string literals with the shared constants; logic is unchanged. |
| .changeset/quiet-event-names.md | Patch-level changeset documenting that cache-miss event-name constants are now exported from gt-i18n/internal. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["types.ts\n(defines constants + I18nEvents type)"]
    B["createLifecycleCallbacks.ts\nemit(CONSTANT, payload)"]
    C["subscribeLifecycleCallbacks.ts\nsubscribe(CONSTANT, handler)"]
    D["I18nManager.ts\nsubscribe(CONSTANT, handler)"]
    E["index.ts\n(re-exports constants via gt-i18n/internal)"]
    F["Downstream consumers\ne.g. @generaltranslation/react-core"]

    A -->|"imports constants"| B
    A -->|"imports constants"| C
    A -->|"imports constants"| D
    A --> E
    E -->|"gt-i18n/internal"| F
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: centralize i18n manager event ..."](https://github.com/generaltranslation/gt/commit/6c558c2040ae728e1e0db779b993617ee66f8fe5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31265876)</sub>

<!-- /greptile_comment -->