### PR TITLE
fix(cli): warn on duplicate hashless ids

### DIFF
--- a/.changeset/metal-hash-guards.md
+++ b/.changeset/metal-hash-guards.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Warn when duplicate source update IDs include hashless entries.

--- a/packages/cli/src/translation/parse.ts
+++ b/packages/cli/src/translation/parse.ts
@@ -90,11 +90,35 @@ export async function createUpdates(
 
   // Metadata addition and validation
   const idHashMap = new Map<string, string>();
+  const hashlessIds = new Set<string>();
+  const warnedHashlessDuplicateIds = new Set<string>();
   const duplicateIds = new Set<string>();
+
+  const warnHashlessDuplicateId = (id: string) => {
+    if (warnedHashlessDuplicateIds.has(id)) return;
+    warnings.push(
+      `Duplicate id ${chalk.blue(
+        id
+      )} includes at least one entry without a hash. Hashless duplicate IDs cannot be compared, and later entries may overwrite earlier entries.`
+    );
+    warnedHashlessDuplicateIds.add(id);
+  };
 
   updates = updates.map((update) => {
     const { id, hash } = update.metadata;
-    if (!id || !hash) return update;
+    if (!id) return update;
+    if (!hash) {
+      if (hashlessIds.has(id) || idHashMap.has(id)) {
+        warnHashlessDuplicateId(id);
+      }
+      hashlessIds.add(id);
+      return update;
+    }
+
+    if (hashlessIds.has(id)) {
+      warnHashlessDuplicateId(id);
+    }
+
     const existingHash = idHashMap.get(id);
     if (existingHash !== undefined) {
       if (existingHash !== hash) {


### PR DESCRIPTION
## Summary
- skip hash-keyed source data writes when update metadata has no hash
- make duplicate-ID checks explicit for hashless entries
- add a gt changeset for the CLI behavior adjustment

## Verification
- pnpm --filter gt typecheck
- pnpm exec oxlint packages/cli/src/cli/inline.ts packages/cli/src/formats/files/collectFiles.ts packages/cli/src/translation/parse.ts
- pnpm lint
- git diff --check

Stack: 2/4. Stacked on #1379.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds explicit duplicate-ID detection and user-visible warnings for entries that share an `id` but lack a `hash` in the CLI parse step. Previously, such entries silently passed through with no diagnostic output.

- **`parse.ts`**: Introduces a `hashlessIds` Set alongside the existing `idHashMap` to track IDs that appear without a hash, and a `warnedHashlessDuplicateIds` guard Set to emit each warning at most once per ID. Four interaction patterns are now covered: hashless→hashless, hashless→hashed, hashed→hashless, and hashed (any hash)→hashless.
- **`.changeset/metal-hash-guards.md`**: Adds a `patch` changeset entry for the `gt` package documenting the new warning behaviour.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change adds observable warnings for a previously silent edge case without altering how updates are filtered or written downstream.

The logic correctly handles all four ordering permutations of hashless/hashed duplicate IDs, the one-warning-per-id guard (warnedHashlessDuplicateIds) prevents log spam, and no existing filtering or error paths are altered.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/translation/parse.ts | Adds hashlessIds / warnedHashlessDuplicateIds tracking and a warnHashlessDuplicateId helper to surface duplicate-ID warnings for hashless entries; logic is correct across all four ordering permutations. |
| .changeset/metal-hash-guards.md | Standard patch changeset entry describing the new CLI warning behaviour; no issues. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[update.metadata] --> B{id present?}
    B -- No --> Z[return update as-is]
    B -- Yes --> C{hash present?}

    C -- No/hashless --> D{hashlessIds has id\nOR idHashMap has id?}
    D -- Yes --> E[warnHashlessDuplicateId\nonce per id]
    D -- No --> F[hashlessIds.add id]
    E --> F
    F --> Z

    C -- Yes/hashed --> G{hashlessIds has id?}
    G -- Yes --> H[warnHashlessDuplicateId\nonce per id]
    G -- No --> I[idHashMap lookup]
    H --> I
    I --> J{existing hash found?}
    J -- No --> K[idHashMap.set id hash]
    K --> Z
    J -- Yes --> L{hashes match?}
    L -- Yes --> Z
    L -- No --> M[errors.push\nduplicateIds.add id]
    M --> Z

    Z --> N[filter: remove duplicateIds entries]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(cli): warn on duplicate hashless ids"](https://github.com/generaltranslation/gt/commit/20b7a1c5d3056a4fbf7eadab80d0a9a8c65cb20e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31269461)</sub>

<!-- /greptile_comment -->