### PR TITLE
fix(gt-next): preserve wrapped config types

### DIFF
--- a/.changeset/green-next-wrapper.md
+++ b/.changeset/green-next-wrapper.md
@@ -1,0 +1,5 @@
+---
+'gt-next': patch
+---
+
+Preserve user Next config types when wrapping with GT config.

--- a/packages/next/src/__tests__/config.test.ts
+++ b/packages/next/src/__tests__/config.test.ts
@@ -36,8 +36,16 @@ function makeWebpackConfig() {
   };
 }
 
+type WebpackConfig = ReturnType<typeof makeWebpackConfig>;
+type WebpackConfigArg = Parameters<NonNullable<NextConfig['webpack']>>[0];
+type WebpackOptions = Parameters<NonNullable<NextConfig['webpack']>>[1];
+
 function makeWebpackOptions() {
-  return { isServer: true } as any;
+  return { isServer: true } as WebpackOptions;
+}
+
+function runWebpack(result: NextConfig, config: WebpackConfig) {
+  return result.webpack!(config as WebpackConfigArg, makeWebpackOptions());
 }
 
 // ---- Setup ---- //
@@ -587,10 +595,12 @@ describe('withGTConfig', () => {
       try {
         withGTConfig({}, { defaultLocale: 'de' });
         expect.fail('Should have thrown');
-      } catch (e: any) {
-        expect(e.message).toContain('defaultLocale');
-        expect(e.message).toContain('fr');
-        expect(e.message).toContain('de');
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error);
+        const message = error instanceof Error ? error.message : '';
+        expect(message).toContain('defaultLocale');
+        expect(message).toContain('fr');
+        expect(message).toContain('de');
       }
     });
   });
@@ -1163,7 +1173,7 @@ describe('withGTConfig', () => {
 
       const result = withGTConfig(
         {},
-        { experimentalCompilerOptions: { type: 'babel' } as any }
+        { experimentalCompilerOptions: { type: 'babel' } }
       );
       const params = parseConfigParams(result);
 
@@ -1189,7 +1199,7 @@ describe('withGTConfig', () => {
 
       const result = withGTConfig(
         {},
-        { experimentalCompilerOptions: { type: 'babel' } as any }
+        { experimentalCompilerOptions: { type: 'babel' } }
       );
       const params = parseConfigParams(result);
 
@@ -1213,7 +1223,7 @@ describe('withGTConfig', () => {
 
       const result = withGTConfig(
         {},
-        { experimentalCompilerOptions: { type: 'babel' } as any }
+        { experimentalCompilerOptions: { type: 'babel' } }
       );
       const params = parseConfigParams(result);
 
@@ -1243,10 +1253,7 @@ describe('withGTConfig', () => {
       const withGTConfig = await getWithGTConfig();
       const result = withGTConfig();
 
-      const webpackResult = result.webpack!(
-        makeWebpackConfig() as any,
-        makeWebpackOptions()
-      );
+      const webpackResult = runWebpack(result, makeWebpackConfig());
 
       expect(webpackResult).toBeDefined();
       expect(webpackResult).toHaveProperty('resolve');
@@ -1254,17 +1261,14 @@ describe('withGTConfig', () => {
 
     it('calls original nextConfig.webpack if present', async () => {
       const withGTConfig = await getWithGTConfig();
-      const originalWebpack = vi.fn((config: any) => ({
+      const originalWebpack = vi.fn((config: WebpackConfig) => ({
         ...config,
         customProp: true,
       }));
 
       const result = withGTConfig({ webpack: originalWebpack });
 
-      const webpackResult = result.webpack!(
-        makeWebpackConfig() as any,
-        makeWebpackOptions()
-      );
+      const webpackResult = runWebpack(result, makeWebpackConfig());
 
       expect(originalWebpack).toHaveBeenCalled();
       expect(webpackResult).toHaveProperty('customProp', true);
@@ -1276,7 +1280,7 @@ describe('withGTConfig', () => {
       const result = withGTConfig({}, { dictionary: './my-dict.json' });
 
       const wc = makeWebpackConfig();
-      result.webpack!(wc as any, makeWebpackOptions());
+      runWebpack(result, wc);
 
       expect(wc.resolve.alias).toHaveProperty('gt-next/_dictionary');
     });
@@ -1288,7 +1292,7 @@ describe('withGTConfig', () => {
       const result = withGTConfig({}, { dictionary: './my-dict.json' });
 
       const wc = makeWebpackConfig();
-      result.webpack!(wc as any, makeWebpackOptions());
+      runWebpack(result, wc);
 
       expect(wc.resolve.alias).not.toHaveProperty('gt-next/_dictionary');
     });
@@ -1300,7 +1304,7 @@ describe('withGTConfig', () => {
       const result = withGTConfig();
 
       const wc = makeWebpackConfig();
-      result.webpack!(wc as any, makeWebpackOptions());
+      runWebpack(result, wc);
 
       expect(wc.cache).toBe(false);
     });
@@ -1332,7 +1336,7 @@ describe('withGTConfig', () => {
           turbopack: {
             resolveAlias: { 'existing-alias': '/some/path' },
           },
-        } as any,
+        },
         { dictionary: './my-dict.json' }
       );
 
@@ -1411,13 +1415,13 @@ describe('withGTConfig', () => {
         images: { domains: ['example.com'] },
         reactStrictMode: true,
         compress: false,
-      } as any);
+      });
 
-      expect((result as any).images).toEqual({
+      expect(result.images).toEqual({
         domains: ['example.com'],
       });
-      expect((result as any).reactStrictMode).toBe(true);
-      expect((result as any).compress).toBe(false);
+      expect(result.reactStrictMode).toBe(true);
+      expect(result.compress).toBe(false);
     });
 
     it('handles empty {} nextConfig', async () => {

--- a/packages/next/src/config-dir/props/withGTConfigProps.ts
+++ b/packages/next/src/config-dir/props/withGTConfigProps.ts
@@ -46,6 +46,8 @@ export const REQUEST_FUNCTION_TO_CONFIG_KEY = {
 } as const;
 
 export type withGTConfigProps = {
+  // Additional top-level keys are forwarded as runtime translation metadata.
+  [key: string]: unknown;
   // Request scoped filepath
   dictionary?: string;
   config?: string;
@@ -104,5 +106,4 @@ export type withGTConfigProps = {
   getStaticRegionPath?: string;
   /** @deprecated use getDomainPath instead */
   getStaticDomainPath?: string;
-  [key: string]: any;
 };

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import fs from 'fs';
-import { NextConfig } from 'next';
+import type { NextConfig } from 'next';
 import {
   defaultWithGTConfigProps,
   defaultCacheExpiryTime,
@@ -39,14 +39,42 @@ import { resolveConfigFilepath } from './config-dir/utils/resolveConfigFilepath'
 import { ssgChecks } from './plugin/checks/ssgChecks';
 import { cacheComponentsChecks } from './plugin/checks/cacheComponentsChecks';
 
+type AutoderiveConfig = boolean | { jsx?: boolean; strings?: boolean };
+
+type ConfigFileShape = {
+  files?: {
+    gt?: {
+      parsingFlags?: {
+        autoderive?: AutoderiveConfig;
+        autoDerive?: AutoderiveConfig;
+      };
+    };
+  };
+};
+
+type InternalGTConfigProps = withGTConfigProps &
+  ConfigFileShape & {
+    devApiKey?: string;
+    loadDictionaryEnabled?: boolean;
+    loadTranslationsType?: 'remote' | 'custom' | 'disabled';
+    _dictionaryFileType?: string;
+  };
+
+type WithGTConfigResult<TNextConfig extends object> = TNextConfig & NextConfig;
+
 /**
  * Initializes General Translation settings for a Next.js application.
  *
  * Use it in `next.config.js` to enable GT translation functionality as a plugin.
  *
  * @example
- * // In next.config.mjs
+ * // In next.config.ts
  * import { withGTConfig } from 'gt-next/config';
+ * import type { NextConfig } from 'next';
+ *
+ * const nextConfig = {
+ *   reactStrictMode: true,
+ * } satisfies NextConfig;
  *
  * export default withGTConfig(nextConfig, {
  *   projectId: 'abc-123',
@@ -83,19 +111,21 @@ import { cacheComponentsChecks } from './plugin/checks/cacheComponentsChecks';
  * @param {string|undefined} [experimentalLocaleResolutionParam=defaultWithGTConfigProps.experimentalLocaleResolutionParam] - The parameter to use for experimental locale resolution.
  * @param {object} metadata - Additional metadata that can be passed for extended configuration.
  *
- * @param {NextConfig} nextConfig - The Next.js configuration object to extend
+ * @param {object} nextConfig - The Next.js configuration object to extend
  * @param {withGTConfigProps} props - General Translation configuration properties
  * @returns {NextConfig} - An updated Next.js config with GT settings applied
  *
  * @throws {Error} If the project ID is missing and default URLs are used, or if the API key is required and missing.
  */
-export function withGTConfig(
-  nextConfig: any = {},
+export function withGTConfig<TNextConfig extends object = NextConfig>(
+  nextConfig?: TNextConfig,
   props: withGTConfigProps = {}
-) {
+): WithGTConfigResult<TNextConfig> {
+  const internalNextConfig = (nextConfig ?? {}) as unknown as NextConfig;
+
   // ---------- LOAD GT CONFIG FILE ---------- //
 
-  let loadedConfig: Partial<withGTConfigProps> = {};
+  let loadedConfig: Partial<InternalGTConfigProps> = {};
   try {
     let configPath: string | undefined;
     if (props.config) {
@@ -138,7 +168,7 @@ export function withGTConfig(
   }
 
   // conditionally add environment variables to config
-  const envConfig: Partial<withGTConfigProps> = {
+  const envConfig: Partial<InternalGTConfigProps> = {
     ...(projectId ? { projectId } : {}),
     ...(apiKey ? { apiKey } : {}),
     ...(devApiKey ? { devApiKey } : {}),
@@ -147,12 +177,13 @@ export function withGTConfig(
   // ---------- CHECK FOR CONFIG CONFLICTS ---------- //
 
   // Check for conflicts between config and params
+  const propsRecord = props as Record<string, unknown>;
   const conflicts = Object.entries(loadedConfig)
     .filter(([key, value]) => {
       // Skip if key doesn't exist in props
       if (!(key in props)) return false;
 
-      const propValue = props[key];
+      const propValue = propsRecord[key];
 
       // Handle null/undefined values
       if (value == null || propValue == null) {
@@ -173,20 +204,22 @@ export function withGTConfig(
 
       // Handle objects
       if (typeof value === 'object' && typeof propValue === 'object') {
-        const valueKeys = Object.keys(value);
-        const propKeys = Object.keys(propValue);
+        const valueRecord = value as Record<string, unknown>;
+        const propRecord = propValue as Record<string, unknown>;
+        const valueKeys = Object.keys(valueRecord);
+        const propKeys = Object.keys(propRecord);
         const keys = new Set([...valueKeys, ...propKeys]);
 
         // Objects must match exactly (no need to go deeper)
         if (valueKeys.length !== propKeys.length) return true;
-        return !Array.from(keys).every((k) => value[k] === propValue[k]);
+        return !Array.from(keys).every((k) => valueRecord[k] === propRecord[k]);
       }
 
       return false;
     })
     .map(
       ([key, value]) =>
-        `- Key: ${key} Next Config: ${JSON.stringify(props[key])} does not match GT Config: ${JSON.stringify(value)}`
+        `- Key: ${key} Next Config: ${JSON.stringify(propsRecord[key])} does not match GT Config: ${JSON.stringify(value)}`
     );
 
   if (conflicts.length) {
@@ -209,7 +242,7 @@ export function withGTConfig(
   };
 
   // precedence: input > env > config file > defaults
-  const mergedConfig: withGTConfigProps = {
+  const mergedConfig: InternalGTConfigProps = {
     ...defaultWithGTConfigProps,
     ...loadedConfig,
     ...envConfig,
@@ -403,7 +436,7 @@ export function withGTConfig(
   // Run cache component checks
   cacheComponentsChecks({
     mergedConfig,
-    nextConfig,
+    nextConfig: internalNextConfig,
     requestFunctionPaths,
     localTranslationsEnabled: !!customLoadTranslationsPath,
     localDictionaryEnabled: !!customLoadDictionaryPath,
@@ -542,12 +575,15 @@ export function withGTConfig(
       ? rawAutoderive
       : (rawAutoderive.strings ?? false);
 
-  const swcPluginEntry =
+  const swcPluginOptions: Record<string, unknown> = {
+    ...compilerOptions,
+    autoderiveJsx,
+    autoderiveStrings,
+  };
+
+  const swcPluginEntry: [string, Record<string, unknown>] | null =
     mergedConfig.experimentalCompilerOptions?.type === 'swc'
-      ? [
-          resolvedWasmFilePath,
-          { ...compilerOptions, autoderiveJsx, autoderiveStrings },
-        ]
+      ? [resolvedWasmFilePath, swcPluginOptions]
       : null;
 
   const turboAliases = {
@@ -571,13 +607,14 @@ export function withGTConfig(
   // Yet, if there are other resolveAlias fields, we don't want to be ignored either.
   const experimentalTurbopack = !(
     turboConfigStable &&
-    (!nextConfig.experimental?.turbo || nextConfig.turbopack?.resolveAlias)
+    (!internalNextConfig.experimental?.turbo ||
+      internalNextConfig.turbopack?.resolveAlias)
   );
 
   const config: NextConfig = {
-    ...nextConfig,
+    ...internalNextConfig,
     env: {
-      ...nextConfig.env,
+      ...internalNextConfig.env,
       _GENERALTRANSLATION_I18N_CONFIG_PARAMS: I18NConfigParams,
       ...(resolvedDictionaryFilePathType && {
         _GENERALTRANSLATION_DICTIONARY_FILE_TYPE:
@@ -622,28 +659,28 @@ export function withGTConfig(
     ...(turboPackEnabled &&
       !experimentalTurbopack && {
         turbopack: {
-          ...nextConfig.turbopack,
+          ...internalNextConfig.turbopack,
           resolveAlias: {
-            ...nextConfig.turbopack?.resolveAlias,
+            ...internalNextConfig.turbopack?.resolveAlias,
             ...turboAliases,
           },
         },
       }),
     experimental: {
-      ...nextConfig.experimental,
+      ...internalNextConfig.experimental,
       ...(rootParamStability === 'experimental' && {
         rootParams: true,
       }),
       swcPlugins: [
-        ...(nextConfig.experimental?.swcPlugins || []),
+        ...(internalNextConfig.experimental?.swcPlugins || []),
         ...(swcPluginEntry ? [swcPluginEntry] : []),
       ],
       ...(turboPackEnabled &&
         experimentalTurbopack && {
           turbo: {
-            ...nextConfig.experimental?.turbo,
+            ...internalNextConfig.experimental?.turbo,
             resolveAlias: {
-              ...nextConfig.experimental?.turbo?.resolveAlias,
+              ...internalNextConfig.experimental?.turbo?.resolveAlias,
               ...turboAliases,
             },
           },
@@ -706,15 +743,17 @@ export function withGTConfig(
           );
         }
       }
-      if (typeof nextConfig?.webpack === 'function') {
-        return nextConfig.webpack(webpackConfig, options);
+      if (typeof internalNextConfig?.webpack === 'function') {
+        return internalNextConfig.webpack(webpackConfig, options);
       }
       return webpackConfig;
     },
   };
-  return config;
+  return config as WithGTConfigResult<TNextConfig>;
 }
 
 // Keep initGT for backward compatibility
-export const initGT = (props: withGTConfigProps) => (nextConfig: any) =>
-  withGTConfig(nextConfig, props);
+export const initGT =
+  (props: withGTConfigProps) =>
+  <TNextConfig extends object = NextConfig>(nextConfig?: TNextConfig) =>
+    withGTConfig(nextConfig, props);


### PR DESCRIPTION
## Summary
- make withGTConfig generic over the caller's Next config object
- keep wrapper internals typed against NextConfig without exposing package-local Next types to users
- preserve top-level GT metadata props as unknown instead of any

## Verification
- pnpm --filter gt-next typecheck
- pnpm --filter gt-next test:js -- --runInBand
- pnpm lint
- git diff --check

Stack: 3/4. Stacked on #1385.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes `withGTConfig` generic over the caller's Next.js config object, preserving user-defined config types in the return value and tightening the index signature on `withGTConfigProps`.

- `withGTConfig` now accepts an optional generic parameter `TNextConfig extends object` and returns the intersection of `TNextConfig` and `NextConfig`, so callers get their own properties typed correctly without casting.
- The `withGTConfigProps` extra-key index signature is narrowed from `any` to `unknown`, reducing accidental unsound access on extra metadata keys.
- Test helpers (`runWebpack`, typed webpack argument aliases) replace scattered `as any` casts throughout the test file.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is purely additive type-level work with no runtime logic altered.

All runtime behavior is unchanged. The generic parameter and updated return type are correctly bounded, the optional parameter is normalised to an empty object internally, and the `as unknown as NextConfig` double cast is the standard safe pattern for this kind of wrapper. No new execution paths are introduced.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/config.ts | Core change: `withGTConfig` is now generic over `TNextConfig`, with correct optional parameter, `internalNextConfig` alias for all internal access, and final cast `config as WithGTConfigResult<TNextConfig>`. `initGT` backward-compatibility wrapper is also updated to propagate the generic. No runtime logic changed. |
| packages/next/src/config-dir/props/withGTConfigProps.ts | Index signature narrowed from any to unknown and relocated to the top of the type. All named properties remain compatible. Reduces unsound access on extra metadata keys. |
| packages/next/src/__tests__/config.test.ts | Test cleanup: introduces `runWebpack` helper and proper type aliases for webpack arguments, replacing scattered `as any` casts. Error handling in catch blocks also tightened. No test logic changed. |
| .changeset/green-next-wrapper.md | Changeset entry correctly categorizes this as a patch release for `gt-next`. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["withGTConfig(nextConfig?, props)"] --> B{nextConfig provided?}
    B -- No --> C["internalNextConfig = {} as NextConfig"]
    B -- Yes --> D["internalNextConfig = nextConfig as NextConfig"]
    C --> E[Load GT config file]
    D --> E
    E --> F[Merge env + file + prop configs]
    F --> G[Build NextConfig object using internalNextConfig spreads]
    G --> H["Return config as TNextConfig & NextConfig"]
    style H fill:#22c55e,color:#fff
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(gt-next): preserve wrapped config ty..."](https://github.com/generaltranslation/gt/commit/0378098820586dfc086f91a7d082a13f745550de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31269465)</sub>

<!-- /greptile_comment -->