### PR TITLE
chore: reduce core and next explicit any usage

### DIFF
--- a/.changeset/tidy-core-next-any.md
+++ b/.changeset/tidy-core-next-any.md
@@ -1,0 +1,6 @@
+---
+'generaltranslation': patch
+'gt-next': patch
+---
+
+Reduce explicit any usage in core and Next.js types.

--- a/packages/core/src/derive/condenseVars.ts
+++ b/packages/core/src/derive/condenseVars.ts
@@ -26,7 +26,7 @@ export function condenseVars(icuString: string): string {
   // Replace with argument
   function visitor(child: GTIndexedSelectElement): void {
     (child as unknown as GTIndexedArgumentElement).type = TYPE.argument;
-    delete (child as any).options;
+    Reflect.deleteProperty(child, 'options');
   }
 
   const ast = traverseIcu({

--- a/packages/core/src/formatting/custom-formats/CutoffFormat/CutoffFormat.test.ts
+++ b/packages/core/src/formatting/custom-formats/CutoffFormat/CutoffFormat.test.ts
@@ -28,7 +28,8 @@ describe('CutoffFormatConstructor', () => {
 
     it('should throw error for invalid style', () => {
       expect(() => {
-        new CutoffFormatConstructor('en', { style: 'invalid' as any });
+        // @ts-expect-error testing runtime validation for invalid options
+        new CutoffFormatConstructor('en', { style: 'invalid' });
       }).toThrow();
     });
 

--- a/packages/core/src/formatting/format.ts
+++ b/packages/core/src/formatting/format.ts
@@ -179,7 +179,7 @@ export function _formatList({
   locales = [libraryDefaultLocale],
   options = {},
 }: {
-  value: Array<any>;
+  value: Array<string | number>;
   locales?: string | string[];
   options?: Intl.ListFormatOptions;
 }): string {
@@ -189,7 +189,7 @@ export function _formatList({
       style: 'long', // Default style, can be overridden via options
       ...options,
     })
-    .format(value);
+    .format(value.map(String));
 }
 
 /**

--- a/packages/core/src/locales/__tests__/resolveAliasLocale.test.ts
+++ b/packages/core/src/locales/__tests__/resolveAliasLocale.test.ts
@@ -89,8 +89,10 @@ describe('_resolveAliasLocale', () => {
 
   it('should ignore custom mapping entries with null or undefined values', () => {
     const customMapping: CustomMapping = {
-      'null-value': null as any,
-      'undefined-value': undefined as any,
+      // @ts-expect-error testing malformed runtime input
+      'null-value': null,
+      // @ts-expect-error testing malformed runtime input
+      'undefined-value': undefined,
       'valid-alias': {
         code: 'en-US',
         name: 'Valid Alias',
@@ -184,7 +186,8 @@ describe('_resolveAliasLocale', () => {
   it('should handle edge case with mixed data types in custom mapping', () => {
     const customMapping: CustomMapping = {
       'mixed-entry': {
-        code: 42 as any, // Invalid type
+        // @ts-expect-error testing malformed runtime input
+        code: 42, // Invalid type
         name: 'Mixed Types',
       },
       'valid-entry': {

--- a/packages/core/src/locales/getPluralForm.ts
+++ b/packages/core/src/locales/getPluralForm.ts
@@ -11,7 +11,7 @@ import { libraryDefaultLocale } from '../settings/settings';
  */
 export default function _getPluralForm(
   n: number,
-  forms: PluralType[] = pluralForms as any,
+  forms: readonly PluralType[] = pluralForms,
   locales: string[] = [libraryDefaultLocale]
 ): PluralType | '' {
   const pluralRules = intlCache.get('PluralRules', locales);

--- a/packages/core/src/logging/logger.ts
+++ b/packages/core/src/logging/logger.ts
@@ -5,12 +5,25 @@
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'off';
 
+export type LogMetadataValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | Date
+  | Error
+  | LogMetadataValue[]
+  | { [key: string]: LogMetadataValue };
+
+export type LogMetadata = Record<string, LogMetadataValue>;
+
 export interface LogEntry {
   level: LogLevel;
   message: string;
   timestamp: Date;
   context?: string;
-  metadata?: Record<string, any>;
+  metadata?: LogMetadata;
 }
 
 export interface LoggerConfig {
@@ -189,7 +202,7 @@ export class Logger {
     level: LogLevel,
     message: string,
     context?: string,
-    metadata?: Record<string, any>
+    metadata?: LogMetadata
   ): void {
     if (!this.shouldLog(level)) {
       return;
@@ -218,11 +231,7 @@ export class Logger {
    * Log a debug message
    * Used for detailed diagnostic information, typically of interest only when diagnosing problems
    */
-  debug(
-    message: string,
-    context?: string,
-    metadata?: Record<string, any>
-  ): void {
+  debug(message: string, context?: string, metadata?: LogMetadata): void {
     this.log('debug', message, context, metadata);
   }
 
@@ -230,11 +239,7 @@ export class Logger {
    * Log an info message
    * Used for general information about application operation.
    */
-  info(
-    message: string,
-    context?: string,
-    metadata?: Record<string, any>
-  ): void {
+  info(message: string, context?: string, metadata?: LogMetadata): void {
     this.log('info', message, context, metadata);
   }
 
@@ -242,11 +247,7 @@ export class Logger {
    * Log a warning message
    * Used for potentially problematic situations that don't prevent operation
    */
-  warn(
-    message: string,
-    context?: string,
-    metadata?: Record<string, any>
-  ): void {
+  warn(message: string, context?: string, metadata?: LogMetadata): void {
     this.log('warn', message, context, metadata);
   }
 
@@ -254,11 +255,7 @@ export class Logger {
    * Log an error message
    * Used for error events that might still allow the application to continue.
    */
-  error(
-    message: string,
-    context?: string,
-    metadata?: Record<string, any>
-  ): void {
+  error(message: string, context?: string, metadata?: LogMetadata): void {
     this.log('error', message, context, metadata);
   }
 
@@ -289,19 +286,19 @@ export class ContextLogger {
     this.context = context;
   }
 
-  debug(message: string, metadata?: Record<string, any>): void {
+  debug(message: string, metadata?: LogMetadata): void {
     this.logger.debug(message, this.context, metadata);
   }
 
-  info(message: string, metadata?: Record<string, any>): void {
+  info(message: string, metadata?: LogMetadata): void {
     this.logger.info(message, this.context, metadata);
   }
 
-  warn(message: string, metadata?: Record<string, any>): void {
+  warn(message: string, metadata?: LogMetadata): void {
     this.logger.warn(message, this.context, metadata);
   }
 
-  error(message: string, metadata?: Record<string, any>): void {
+  error(message: string, metadata?: LogMetadata): void {
     this.logger.error(message, this.context, metadata);
   }
 
@@ -322,25 +319,25 @@ export const defaultLogger = new Logger({
 export const debug = (
   message: string,
   context?: string,
-  metadata?: Record<string, any>
+  metadata?: LogMetadata
 ) => defaultLogger.debug(message, context, metadata);
 
 export const info = (
   message: string,
   context?: string,
-  metadata?: Record<string, any>
+  metadata?: LogMetadata
 ) => defaultLogger.info(message, context, metadata);
 
 export const warn = (
   message: string,
   context?: string,
-  metadata?: Record<string, any>
+  metadata?: LogMetadata
 ) => defaultLogger.warn(message, context, metadata);
 
 export const error = (
   message: string,
   context?: string,
-  metadata?: Record<string, any>
+  metadata?: LogMetadata
 ) => defaultLogger.error(message, context, metadata);
 
 // Create context-specific loggers for different parts of the system

--- a/packages/core/src/types-dir/api/fetchTranslations.ts
+++ b/packages/core/src/types-dir/api/fetchTranslations.ts
@@ -1,3 +1,5 @@
+import type { Content } from '../jsx/content';
+
 // Types for the fetchTranslations function
 export type FetchTranslationsOptions = {
   timeout?: number;
@@ -5,8 +7,9 @@ export type FetchTranslationsOptions = {
 
 export type RetrievedTranslation = {
   locale: string;
-  // TODO: explicitly define type from cloud
-  translation: any;
+  // Assumes the cloud API response matches the shared Content contract.
+  // This type is not runtime-validated at the response boundary.
+  translation: Content;
 };
 
 export type RetrievedTranslations = RetrievedTranslation[];

--- a/packages/core/src/types-dir/api/translationStatus.ts
+++ b/packages/core/src/types-dir/api/translationStatus.ts
@@ -2,7 +2,7 @@ export type TranslationStatusResult = {
   count: number;
   availableLocales: string[];
   locales: string[];
-  localesWaitingForApproval: any[];
+  localesWaitingForApproval: string[];
 };
 
 export type CheckTranslationStatusOptions = {

--- a/packages/core/src/utils/__tests__/base64.test.ts
+++ b/packages/core/src/utils/__tests__/base64.test.ts
@@ -114,19 +114,22 @@ Last line`;
   });
 
   describe('cross-platform compatibility', () => {
-    let originalBuffer: any;
+    const bufferGlobal = globalThis as typeof globalThis & {
+      Buffer?: typeof Buffer;
+    };
+    let originalBuffer: typeof Buffer | undefined;
 
     beforeEach(() => {
-      originalBuffer = global.Buffer;
+      originalBuffer = bufferGlobal.Buffer;
     });
 
     afterEach(() => {
-      global.Buffer = originalBuffer;
+      bufferGlobal.Buffer = originalBuffer;
     });
 
     it('should work consistently when Buffer is available (Node.js)', () => {
       // Ensure Buffer is available
-      global.Buffer = originalBuffer;
+      bufferGlobal.Buffer = originalBuffer;
 
       const testStrings = [
         'simple text',
@@ -144,7 +147,7 @@ Last line`;
 
     it('should work consistently when Buffer is not available (Browser)', () => {
       // Remove Buffer to simulate browser environment
-      global.Buffer = undefined as any;
+      bufferGlobal.Buffer = undefined;
 
       const testStrings = [
         'simple text',

--- a/packages/next/src/branches/Branch.tsx
+++ b/packages/next/src/branches/Branch.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react';
+
 /**
  * The `<Branch>` component dynamically renders a specified branch of content or a fallback child component.
  * It allows for flexible content switching based on the `branch` prop and an object of possible branches (`...branches`).
@@ -26,9 +28,9 @@ export function Branch({
   branch,
   ...branches
 }: {
-  children?: any;
+  children?: ReactNode;
   branch?: string | number | boolean;
-  [key: string]: any;
+  [key: string]: ReactNode;
 }): React.JSX.Element {
   branch = branch?.toString();
   // ignore data-* attributes

--- a/packages/next/src/branches/Plural.tsx
+++ b/packages/next/src/branches/Plural.tsx
@@ -1,4 +1,5 @@
 import { getPluralBranch } from 'gt-react/internal';
+import type { ReactNode } from 'react';
 import { getI18NConfig } from '../config-dir/getI18NConfig';
 import { useLocale } from '../request/getLocale';
 
@@ -32,10 +33,10 @@ export function Plural({
   locales = [useLocale(), getI18NConfig().getDefaultLocale()],
   ...branches
 }: {
-  children?: React.ReactNode;
+  children?: ReactNode;
   n?: number;
   locales?: string[];
-  [key: string]: any;
+  [key: string]: ReactNode;
 }) {
   return (
     <>

--- a/packages/next/src/config-dir/I18NConfiguration.ts
+++ b/packages/next/src/config-dir/I18NConfiguration.ts
@@ -43,8 +43,9 @@ type I18NConfigurationParams = {
   batchInterval: number;
   headersAndCookies: HeadersAndCookies;
   _usingPlugin: boolean;
+  _versionId?: string;
   customMapping?: CustomMapping | undefined;
-  [key: string]: any;
+  [key: string]: unknown;
 };
 
 type RuntimeTranslationParams = {

--- a/packages/next/src/config-dir/getI18NConfig.ts
+++ b/packages/next/src/config-dir/getI18NConfig.ts
@@ -7,9 +7,13 @@ import {
 } from '../errors/createErrors';
 import { getDefaultRenderSettings } from 'gt-react/internal';
 
+type GlobalWithI18NConfig = typeof globalThis & {
+  _GENERALTRANSLATION_I18N_CONFIG_INSTANCE?: I18NConfiguration;
+};
+
 export function getI18NConfig(): I18NConfiguration {
   // Return the singleton instance
-  const globalObj = globalThis as any;
+  const globalObj = globalThis as GlobalWithI18NConfig;
   if (globalObj._GENERALTRANSLATION_I18N_CONFIG_INSTANCE) {
     return globalObj._GENERALTRANSLATION_I18N_CONFIG_INSTANCE;
   }

--- a/packages/next/src/config-dir/loadTranslation.ts
+++ b/packages/next/src/config-dir/loadTranslation.ts
@@ -15,7 +15,7 @@ type RemoteLoadTranslationsInput = {
 
 let loadTranslationsFunction: (
   props: RemoteLoadTranslationsInput
-) => Promise<any>;
+) => Promise<Translations | undefined>;
 
 /**
  * Loads the translations for the user's current locale.
@@ -54,7 +54,7 @@ export async function loadTranslations(
     // Default translation loader: remote cache
     loadTranslationsFunction = async (
       _props: RemoteLoadTranslationsInput
-    ): Promise<any> => {
+    ): Promise<Translations | undefined> => {
       try {
         const gt = getI18NConfig().getGTClass();
         const targetLocale = gt.resolveCanonicalLocale(_props.targetLocale);

--- a/packages/next/src/index.types.ts
+++ b/packages/next/src/index.types.ts
@@ -548,7 +548,7 @@ export const useMessages: (
   _messages?: _Messages
 ) => <T extends string | null | undefined>(
   encodedMsg: T,
-  options?: Record<string, any>
+  options?: InlineTranslationOptions
 ) => T extends string ? string : T = () => {
   throw new Error(typesFileError);
 };

--- a/packages/next/src/middleware-dir/__tests__/middleware-latency.bench.ts
+++ b/packages/next/src/middleware-dir/__tests__/middleware-latency.bench.ts
@@ -4,12 +4,22 @@ import { vi } from 'vitest';
 import type { NextResponse } from 'next/server';
 import { RequestCookies } from 'next/dist/compiled/@edge-runtime/cookies';
 
+type MockResponseInit = ResponseInit & {
+  request?: {
+    headers?: Headers;
+  };
+};
+
+type ResponseWithCookies = Response & {
+  cookies: RequestCookies;
+};
+
 // Mock NextResponse (same pattern as Layer 1 tests)
 vi.mock('next/server', async (importActual) => {
-  const Actual = (await importActual()) as any;
-  function createResponse(init: any) {
-    const response = new Response(null, init);
-    (response as any).cookies = new RequestCookies(
+  const Actual = await importActual<typeof import('next/server')>();
+  function createResponse(init?: MockResponseInit) {
+    const response = new Response(null, init) as ResponseWithCookies;
+    response.cookies = new RequestCookies(
       init?.request?.headers || new Headers()
     );
     return response as NextResponse;
@@ -17,9 +27,13 @@ vi.mock('next/server', async (importActual) => {
   return {
     ...Actual,
     NextResponse: {
-      next: vi.fn((init?: any) => createResponse(init)),
-      rewrite: vi.fn((dest: any, init?: any) => createResponse(init)),
-      redirect: vi.fn((url: any, init?: any) => createResponse(init)),
+      next: vi.fn((init?: MockResponseInit) => createResponse(init)),
+      rewrite: vi.fn((_dest: string | URL, init?: MockResponseInit) =>
+        createResponse(init)
+      ),
+      redirect: vi.fn((_url: string | URL, init?: MockResponseInit) =>
+        createResponse(init)
+      ),
     },
   };
 });

--- a/packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { NextRequest } from 'next/server';
 import { createNextMiddleware } from '../createNextMiddleware';
 import type { PathConfig } from '../utils';
+import type { CustomMapping } from 'generaltranslation/types';
 
 // Mock gt-react/internal — only provides a constant, avoids deep react-core build chain
 vi.mock('gt-react/internal', () => ({
@@ -18,7 +19,14 @@ const LOCALE_HEADER = 'x-generaltranslation-locale';
 
 // ---- Helpers ----
 
-function setEnvConfig(overrides: Record<string, any> = {}) {
+type MiddlewareEnvOverrides = {
+  defaultLocale?: string;
+  locales?: string[];
+  customMapping?: CustomMapping;
+  headersAndCookies?: Record<string, string>;
+};
+
+function setEnvConfig(overrides: MiddlewareEnvOverrides = {}) {
   process.env._GENERALTRANSLATION_I18N_CONFIG_PARAMS = JSON.stringify({
     defaultLocale: 'en',
     locales: ['en', 'fr', 'es', 'de'],

--- a/packages/next/src/middleware-dir/createNextMiddleware.ts
+++ b/packages/next/src/middleware-dir/createNextMiddleware.ts
@@ -20,8 +20,17 @@ import {
   ResponseConfig,
 } from './utils';
 import { defaultLocaleHeaderName } from '../utils/headers';
+import type { CustomMapping } from 'generaltranslation/types';
+import type { HeadersAndCookies } from '../config-dir/props/withGTConfigProps';
 
 const NEXT_JS_SOURCE_MAP_PATH = '/__nextjs_source-map';
+
+type MiddlewareEnvConfig = {
+  customMapping?: CustomMapping;
+  defaultLocale?: string;
+  locales?: string[];
+  headersAndCookies?: HeadersAndCookies;
+};
 
 /**
  * Middleware factory to create a Next.js middleware for i18n routing and locale detection.
@@ -49,7 +58,7 @@ export function createNextMiddleware({
   pathConfig?: PathConfig;
 } = {}) {
   // i18n config
-  let envParams;
+  let envParams: MiddlewareEnvConfig | undefined;
   if (process.env._GENERALTRANSLATION_I18N_CONFIG_PARAMS) {
     try {
       envParams = JSON.parse(
@@ -75,11 +84,16 @@ export function createNextMiddleware({
   const locales: string[] = envParams?.locales || [defaultLocale];
 
   // add canonical locales
-  const canonicalLocales = Object.values(
-    (envParams?.customMapping || {}) as any
-  )
-    .filter((locale: any) => locale.code)
-    .map((locale: any) => locale.code);
+  const canonicalLocales = Object.values(envParams?.customMapping || {})
+    .filter(
+      (locale): locale is { code: string } =>
+        typeof locale === 'object' &&
+        locale !== null &&
+        'code' in locale &&
+        typeof locale.code === 'string' &&
+        locale.code.length > 0
+    )
+    .map((locale) => locale.code);
   locales.push(...canonicalLocales);
 
   // cookies and header names

--- a/packages/next/src/provider/GTProvider.tsx
+++ b/packages/next/src/provider/GTProvider.tsx
@@ -38,7 +38,7 @@ export async function GTProvider({
 
   const cachedTranslationsPromise: Promise<Translations> = translationRequired
     ? I18NConfig.getCachedTranslations(locale)
-    : ({} as any);
+    : Promise.resolve({});
 
   // ---------- PROCESS DICTIONARY ---------- //
   // (While waiting for cache...)

--- a/packages/next/src/request/utils/__mocks__/mockGetRequestFunction.ts
+++ b/packages/next/src/request/utils/__mocks__/mockGetRequestFunction.ts
@@ -14,6 +14,9 @@ import { vi } from 'vitest';
 export function setupModuleLoadPatching() {
   return vi.hoisted(() => {
     const Module = require('module');
+    type RequestFunctionMock = {
+      default: () => Promise<string>;
+    };
 
     // Save original _load if not already saved
     if (!Module._load_original) {
@@ -21,7 +24,7 @@ export function setupModuleLoadPatching() {
     }
 
     // Create mocks for all the require() calls in getRequestFunction
-    const mocks: Record<string, any> = {
+    const mocks: Record<string, RequestFunctionMock> = {
       'gt-next/internal/_getLocale': {
         default: () => Promise.resolve('en'),
       },
@@ -43,7 +46,7 @@ export function setupModuleLoadPatching() {
     };
 
     // Patch _load to intercept require() calls
-    Module._load = (uri: string, parent: any) => {
+    Module._load = (uri: string, parent: NodeModule | null) => {
       if (mocks[uri]) {
         return mocks[uri];
       }

--- a/packages/next/src/server-dir/buildtime/T.tsx
+++ b/packages/next/src/server-dir/buildtime/T.tsx
@@ -1,6 +1,6 @@
 import { getI18NConfig } from '../../config-dir/getI18NConfig';
 import { getLocale } from '../../request/getLocale';
-import { Suspense } from 'react';
+import { Suspense, type ReactNode } from 'react';
 import {
   addGTIdentifier,
   renderDefaultChildren,
@@ -11,6 +11,17 @@ import {
 } from 'gt-react/internal';
 import { renderVariable } from '../variables/renderVariable';
 import { hashSource } from 'generaltranslation/id';
+
+type TProps = {
+  children: ReactNode;
+  id?: string;
+  context?: string;
+  _hash?: string;
+  $id?: string;
+  $context?: string;
+  $maxChars?: number;
+  [key: string]: ReactNode;
+};
 
 /**
  * Build-time translation component that renders its children in the user's given locale.
@@ -47,13 +58,7 @@ export async function T({
   context,
   _hash,
   ...options
-}: {
-  children: any;
-  id?: string;
-  context?: string;
-  _hash?: string;
-  [key: string]: any;
-}): Promise<any> {
+}: TProps): Promise<ReactNode> {
   // ----- SET UP ----- //
 
   const I18NConfig = getI18NConfig();

--- a/packages/next/src/server-dir/buildtime/__tests__/getTranslations.test.ts
+++ b/packages/next/src/server-dir/buildtime/__tests__/getTranslations.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { setupGetRequestFunctionMocks } from '../../../request/utils/__mocks__/mockGetRequestFunction';
 import { VAR_IDENTIFIER } from 'generaltranslation/internal';
+import type { MockInstance } from 'vitest';
 
 // Set up comprehensive mocking for getRequestFunction and all its dependencies
 setupGetRequestFunctionMocks();
@@ -41,6 +42,22 @@ const mockInjectFallbacks = vi.fn();
 const mockInjectAndMerge = vi.fn();
 const mockMergeDictionaries = vi.fn();
 const mockSetDictionary = vi.fn();
+
+type GetTranslations = (typeof import('../getTranslations'))['getTranslations'];
+type UseTranslations = (typeof import('../getTranslations'))['useTranslations'];
+type MockFunction = ReturnType<typeof vi.fn>;
+type MockI18NConfig = {
+  getDefaultLocale: MockFunction;
+  requiresTranslation: MockFunction;
+  getDictionaryTranslations: MockFunction;
+  getCachedTranslations: MockFunction;
+  getCachedTranslationsStatus: MockFunction;
+  getRenderSettings: MockFunction;
+  isDevelopmentApiEnabled: MockFunction;
+  translate: MockFunction;
+  setDictionaryTranslations: MockFunction;
+  getGTClass: MockFunction;
+};
 
 vi.mock('../../dictionary/getDictionary', () => ({
   default: mockGetDictionary,
@@ -116,9 +133,9 @@ vi.mock('../../dictionary/setDictionary', () => ({
 }));
 
 describe('getTranslations', () => {
-  let mockI18NConfig: any;
-  let consoleWarnSpy: any;
-  let getTranslations: any;
+  let mockI18NConfig: MockI18NConfig;
+  let consoleWarnSpy: MockInstance;
+  let getTranslations: GetTranslations;
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -586,7 +603,7 @@ describe('getTranslations', () => {
 });
 
 describe('useTranslations', () => {
-  let useTranslations: any;
+  let useTranslations: UseTranslations;
 
   beforeEach(async () => {
     vi.clearAllMocks();

--- a/packages/next/src/server-dir/buildtime/getTranslationFunction.ts
+++ b/packages/next/src/server-dir/buildtime/getTranslationFunction.ts
@@ -23,14 +23,21 @@ import {
   VAR_IDENTIFIER,
   indexVars,
 } from 'generaltranslation/internal';
-import { StringFormat } from 'generaltranslation/types';
+import { FormatVariables, StringFormat } from 'generaltranslation/types';
 import { use } from '../../utils/use';
 
 type RenderFn = (msg: string, locales: string[], fallback?: string) => string;
 
+type GTStringOptions = InlineTranslationOptions & {
+  $context?: string;
+  $maxChars?: number;
+  $id?: string;
+  $_hash?: string;
+};
+
 type RenderMessageParams = {
   message: string;
-  variables: Record<string, any> | undefined;
+  variables: FormatVariables | undefined;
   locales: string[];
   fallback?: string;
   id?: string;
@@ -43,21 +50,13 @@ type InitResult = {
   context?: string;
   maxChars?: number;
   _hash?: string;
-  variables: Record<string, any>;
+  variables: FormatVariables;
   calculateHash: () => string;
   renderMessage: RenderFn;
 };
 
 type Translator = {
-  gt: (
-    message: string,
-    options?: InlineTranslationOptions & {
-      $id?: string;
-      $context?: string;
-      $maxChars?: number;
-      $_hash?: string;
-    }
-  ) => string;
+  gt: (message: string, options?: GTStringOptions) => string;
   m: <T extends string | null | undefined>(
     encodedMsg: T,
     options?: InlineTranslationOptions
@@ -148,12 +147,7 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
   }
   function initializeGT(
     message: string,
-    options: Record<string, any> & {
-      $context?: string;
-      $maxChars?: number;
-      $id?: string;
-      $_hash?: string;
-    } = {}
+    options: GTStringOptions = {}
   ): InitResult | null {
     if (!message || typeof message !== 'string') return null;
 
@@ -165,12 +159,13 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
       $format: format,
       ...variables
     } = options;
+    const formatVariables = variables as FormatVariables;
 
     const renderMessage: RenderFn = (msg, locales, fallback) => {
       return renderMessageHelper({
         message: msg,
         locales,
-        variables,
+        variables: formatVariables,
         id,
         fallback,
         maxChars,
@@ -192,7 +187,7 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
       context,
       maxChars,
       _hash,
-      variables,
+      variables: formatVariables,
       calculateHash,
       renderMessage,
     };
@@ -302,15 +297,7 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
 
   // ---------- gt() ---------- /
 
-  const gt = (
-    message: string,
-    options: Record<string, any> & {
-      $context?: string;
-      $maxChars?: number;
-      $id?: string;
-      $_hash?: string;
-    } = {}
-  ): string => {
+  const gt = (message: string, options: GTStringOptions = {}): string => {
     const init = initializeGT(message, options);
     if (!init) return '';
     const { id, context, maxChars, _hash, calculateHash, renderMessage } = init;
@@ -360,7 +347,7 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
   // ---------- m() ---------- //
   const m = <T extends string | null | undefined>(
     encodedMsg: T,
-    options?: Record<string, any>
+    options?: InlineTranslationOptions
   ): T extends string ? string : T => {
     if (!encodedMsg) return encodedMsg as T extends string ? string : T;
 
@@ -503,7 +490,7 @@ export async function getMessages(
 ): Promise<
   <T extends string | null | undefined>(
     encodedMsg: T,
-    options?: Record<string, any>
+    options?: InlineTranslationOptions
   ) => T extends string ? string : T
 > {
   const { m } = await createTranslator(_messages);
@@ -517,7 +504,7 @@ export function useMessages(
   _messages?: _Messages
 ): <T extends string | null | undefined>(
   encodedMsg: T,
-  options?: Record<string, any>
+  options?: InlineTranslationOptions
 ) => T extends string ? string : T {
   return use(getMessages(_messages));
 }

--- a/packages/next/src/server-dir/buildtime/getTranslations.tsx
+++ b/packages/next/src/server-dir/buildtime/getTranslations.tsx
@@ -59,7 +59,10 @@ import { StringFormat } from 'generaltranslation/types';
  */
 export async function getTranslations(id?: string): Promise<
   ((id: string, options?: DictionaryTranslationOptions) => string) & {
-    obj: (id: string, options?: Record<string, any>) => any | undefined;
+    obj: (
+      id: string,
+      options?: DictionaryTranslationOptions
+    ) => Dictionary | DictionaryEntry | string | undefined;
   }
 > {
   // ---------- SET UP ---------- //
@@ -105,7 +108,10 @@ export async function getTranslations(id?: string): Promise<
    * // Translates item in dictionary under greetings.greeting2 and replaces {name} with 'John'
    * t('greetings.greeting2', { variables: { name: 'John' } });
    */
-  const t = (id: string, options: Record<string, any> = {}): string => {
+  const t = (
+    id: string,
+    options: DictionaryTranslationOptions = {}
+  ): string => {
     // Get entry
     id = getId(id);
     const value = getDictionaryEntry(dictionary, id);
@@ -130,10 +136,8 @@ export async function getTranslations(id?: string): Promise<
     if (!entry || typeof entry !== 'string') return '';
 
     // Extract format from options
-    const { $format: format, ...variableOptions } = options as Record<
-      string,
-      any
-    > & { $format?: StringFormat };
+    const { $format: format, ...variableOptions } =
+      options as DictionaryTranslationOptions & { $format?: StringFormat };
 
     // Render method
     const renderContent = (
@@ -317,7 +321,7 @@ export async function getTranslations(id?: string): Promise<
    */
   t.obj = (
     id: string,
-    options: Record<string, any> = {}
+    options: DictionaryTranslationOptions = {}
   ): Dictionary | DictionaryEntry | string | undefined => {
     // (1) Get subtree
     const idWithParent = getId(id);

--- a/packages/next/src/server-dir/runtime/_Tx.tsx
+++ b/packages/next/src/server-dir/runtime/_Tx.tsx
@@ -39,14 +39,14 @@ async function Resolver({ children }: { children: React.ReactNode }) {
  *
  * @param {string} [context] - A context for the translation.
  * @param {string} [locale] - The locale to use for the translation.
- * @returns {Promise<any>} The translated content.
+ * @returns {Promise<React.ReactNode>} The translated content.
  */
 export async function Tx({
   children,
   context,
   locale,
   ...options
-}: TxProps): Promise<any> {
+}: TxProps): Promise<React.ReactNode> {
   // ----- SET UP ----- //
 
   // Compatibility with different options

--- a/packages/next/src/utils/types.ts
+++ b/packages/next/src/utils/types.ts
@@ -7,9 +7,12 @@ export type GTProviderProps = {
   region?: string | undefined;
 };
 
-export type TxProps = Record<string, any> & {
-  children: any;
+export type TxProps = Record<string, ReactNode> & {
+  children: ReactNode;
   context?: string;
   maxChars?: number;
   locale?: string;
+  $context?: string;
+  $maxChars?: number;
+  $locale?: string;
 };

--- a/packages/next/src/variables/Var.tsx
+++ b/packages/next/src/variables/Var.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { type ReactNode } from 'react';
 
 /**
  * The `<Var>` component renders a variable value, which can either be passed as `children` or a `value`.
@@ -17,7 +17,7 @@ import React from 'react';
 export function Var({
   children,
 }: {
-  children?: any;
+  children?: ReactNode;
   name?: string;
 }): React.JSX.Element | null {
   return <>{children}</>;


### PR DESCRIPTION
## Summary
- move remaining core no-explicit-any cleanup out of #1379
- move remaining gt-next runtime/test no-explicit-any cleanup out of #1379
- keep this as a mechanical cleanup PR after the behavior/type contract changes

## Verification
- pnpm --filter generaltranslation typecheck
- pnpm --filter generaltranslation test -- --runInBand
- pnpm --filter gt-next typecheck
- pnpm --filter gt-next test:js -- --runInBand
- pnpm lint
- git diff --check

Stack: 4/4. Stacked on #1386.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a mechanical cleanup that eliminates `explicit any` usage across `packages/core` and `packages/next`, replacing each occurrence with a precise type. It accompanies the behaviour-only changes in #1379 and #1386 without altering runtime logic.

- **Core**: Narrows `Array<any>` → `Array<string | number>` (with an explicit `.map(String)` for `Intl.ListFormat`), introduces `LogMetadata`/`LogMetadataValue` for the logger, types `RetrievedTranslation.translation` as `Content`, and replaces `delete (child as any).options` with `Reflect.deleteProperty`.
- **Next runtime/tests**: Replaces wide `Record<string, any>` and bare `any` props with `ReactNode`, `FormatVariables`, `InlineTranslationOptions`, proper `globalThis` augmentation types, and typed mock helpers; also fixes `GTProvider` to return a real `Promise.resolve({})` instead of the misleading `{} as any` non-Promise.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — purely a type-level cleanup with no behavioural changes except the correct fix of a non-Promise `{} as any` to `Promise.resolve({})` in GTProvider.

Every change is a mechanical narrowing of `any` to a precise type. The one runtime-observable change (`GTProvider` now assigns a real resolved Promise rather than `{} as any`) is strictly correct — JavaScript `await` on a non-thenable returns the value unchanged, so the old code happened to work, but the new code is unambiguously right. All other changes are compile-time only and the author reports passing typechecks and test runs.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/formatting/format.ts | Narrows `Array<any>` to `Array<string | number>` and adds `.map(String)` to satisfy `Intl.ListFormat` — correct and safe. |
| packages/core/src/logging/logger.ts | Introduces `LogMetadata`/`LogMetadataValue` recursive types to replace `Record<string, any>` across all logger methods — clean and non-breaking. |
| packages/next/src/provider/GTProvider.tsx | Replaces `{} as any` non-Promise with `Promise.resolve({})` — fixes a subtle type lie and ensures the variable is always a real Promise. |
| packages/next/src/middleware-dir/createNextMiddleware.ts | Replaces loose `as any` casts in `canonicalLocales` extraction with a runtime type-guard predicate; also introduces `MiddlewareEnvConfig` type for the parsed env params. |
| packages/next/src/server-dir/buildtime/getTranslationFunction.ts | Introduces `GTStringOptions` alias and replaces `Record<string, any>` with `FormatVariables`/`InlineTranslationOptions` throughout; `variables as FormatVariables` assertion is structurally sound after $ keys are destructured out. |
| packages/next/src/utils/types.ts | Tightens `TxProps` to `Record<string, ReactNode>` and adds `$context`/`$maxChars`/`$locale` named fields alongside the existing un-prefixed aliases. |
| packages/next/src/config-dir/I18NConfiguration.ts | Index signature narrowed from `any` to `unknown`; `_versionId` field surfaced explicitly — safe. |
| packages/next/src/branches/Branch.tsx | Index signature changed to `ReactNode`; `branch?: string | number | boolean` remains compatible since all three primitives are subtypes of `ReactNode`. |
| packages/next/src/branches/Plural.tsx | Index signature narrowed to `ReactNode`; `locales?: string[]` is assignable via `Iterable<ReactNode>` ⊆ ReactFragment — no conflict. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["chore: reduce core and next explicit any..."](https://github.com/generaltranslation/gt/commit/3ef23108a4096c18713c12e3358c7e1ddbffb038) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31269475)</sub>

<!-- /greptile_comment -->