### PR TITLE
test(python-extractor): remove type-only runtime tests

### DIFF
--- a/packages/python-extractor/src/__tests__/index.test.ts
+++ b/packages/python-extractor/src/__tests__/index.test.ts
@@ -12,7 +12,6 @@ import {
   PYTHON_DECLARE_VAR,
   PYTHON_METADATA_KWARGS,
 } from '../index.js';
-import type { ExtractionResult, ExtractionMetadata } from '../types.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const fixture = (name: string) =>
@@ -1372,34 +1371,6 @@ t(f"{declare_static(None)}")`;
           ],
         })
       ).toEqual(['same']);
-    });
-  });
-
-  describe('types', () => {
-    it('ExtractionResult type is usable', () => {
-      const result: ExtractionResult = {
-        dataFormat: 'ICU',
-        source: 'Hello',
-        metadata: { id: 'greeting' },
-      };
-      expect(result.dataFormat).toBe('ICU');
-      expect(result.source).toBe('Hello');
-      expect(result.metadata.id).toBe('greeting');
-    });
-
-    it('ExtractionMetadata supports all optional fields', () => {
-      const metadata: ExtractionMetadata = {
-        id: 'test',
-        context: 'casual',
-        maxChars: 100,
-        filePaths: ['file.py'],
-        staticId: 'static-1',
-      };
-      expect(metadata.id).toBe('test');
-      expect(metadata.context).toBe('casual');
-      expect(metadata.maxChars).toBe(100);
-      expect(metadata.filePaths).toEqual(['file.py']);
-      expect(metadata.staticId).toBe('static-1');
     });
   });
 


### PR DESCRIPTION
## Summary
- remove runtime tests that only verify TypeScript type assignments compile
- leave behavior and public constants tests in place

## Verification
- `pnpm --filter @generaltranslation/python-extractor exec vitest run src/__tests__/index.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1390"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->