### PR TITLE
test(cli): remove wall-clock json assertion

### DIFF
--- a/packages/cli/src/formats/json/__tests__/parseJson.test.ts
+++ b/packages/cli/src/formats/json/__tests__/parseJson.test.ts
@@ -1134,7 +1134,6 @@ describe('parseJson', () => {
       }
       const json = JSON.stringify({ data: largeObject });
 
-      const start = Date.now();
       const result = parseJson(
         json,
         path.join(__dirname, '../__mocks__', 'test.json'),
@@ -1147,9 +1146,7 @@ describe('parseJson', () => {
         },
         'en'
       );
-      const end = Date.now();
 
-      expect(end - start).toBeLessThan(1000); // Should complete in under 1 second
       const parsed = JSON.parse(result);
       expect(parsed['/data/key0']).toBe('value0');
       expect(parsed['/data/key999']).toBe('value999');


### PR DESCRIPTION
## Summary
- keep the large JSON parse correctness assertions
- remove the wall-clock timing assertion from the unit test

## Verification
- `pnpm --filter gt exec vitest run src/formats/json/__tests__/parseJson.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes a wall-clock timing assertion from the `parseJson` unit test that checked large JSON parsing completes under 1 second. The functional correctness assertions — verifying that `key0` and `key999` are correctly parsed — are preserved.

- Eliminates the flaky `expect(end - start).toBeLessThan(1000)` guard that could cause spurious CI failures on slow or resource-constrained runners.
- All correctness checks for the large-JSON path remain intact, so the test still validates the actual parsing behaviour.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Removing a wall-clock assertion from a test is safe to merge; no production code is touched and all correctness checks remain.

The change is limited to a single test file, deletes three lines, and leaves every correctness assertion intact. The removed timing check was prone to flaking on slow runners and carried no functional guarantee value.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/formats/json/__tests__/parseJson.test.ts | Removes the flaky wall-clock timing assertion (`expect(end - start).toBeLessThan(1000)`) from the large-JSON efficiency test while keeping the correctness assertions for key0 and key999. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Test: large JSON 1000 keys] --> B[Call parseJson]
    B --> C[JSON.parse result]
    C --> D{Assert key0 == 'value0'}
    C --> E{Assert key999 == 'value999'}
    D --> F[Pass]
    E --> F

    style F fill:#4caf50,color:#fff
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test(cli): remove wall-clock json assert..."](https://github.com/generaltranslation/gt/commit/cbfe12b27e2bd5bc1a0aeeda6c0f5ebd2e5c0057) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31371922)</sub>

<!-- /greptile_comment -->