### PR TITLE
test(compiler): skip empty jsx seed cases

### DIFF
--- a/packages/compiler/src/transform/jsx-children/__tests__/constructJsxChildren.test.ts
+++ b/packages/compiler/src/transform/jsx-children/__tests__/constructJsxChildren.test.ts
@@ -49,9 +49,7 @@ function createTest(dirPath: string) {
     const statePath = path.join(dirPath, 'state.json');
     const stateSeed = JSON.parse(fs.readFileSync(statePath, 'utf8'));
     if (!stateSeed || Object.keys(stateSeed).length === 0) {
-      test(testName, () => {
-        expect(true).toBe(true);
-      });
+      test.skip(testName, () => {});
       return;
     }
     const expectedPath = path.join(dirPath, 'expected.json');
@@ -59,9 +57,7 @@ function createTest(dirPath: string) {
 
     // Skip static tests
     if (expected && expected['static'] === true) {
-      test(testName, () => {
-        expect(true).toBe(true);
-      });
+      test.skip(testName, () => {});
       return;
     }
 


### PR DESCRIPTION
## Summary
- skip empty/static JSX seed cases instead of registering no-op passing tests
- preserve coverage for all non-empty seed cases

## Verification
- `pnpm --filter @generaltranslation/compiler exec vitest run src/transform/jsx-children/__tests__/constructJsxChildren.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces two no-op passing tests (`expect(true).toBe(true)`) with `test.skip` calls for empty/static JSX seed cases in `constructJsxChildren.test.ts`.

- Empty `state.json` seeds and seeds whose `expected.json` marks `static: true` are now explicitly skipped rather than silently passing, making the test report more honest about what is and isn't exercised.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — only test scaffolding is touched, no production or core test logic is changed.

The only change is swapping two always-passing no-op tests for explicit skips. All real seed cases continue to run and assert as before.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/compiler/src/transform/jsx-children/__tests__/constructJsxChildren.test.ts | Replaced two no-op always-passing tests with test.skip for empty and static seed cases; no logic changes to the real test path. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[createTest called] --> B{state.json empty?}
    B -- Yes --> C["test.skip(testName, () => {})"]
    B -- No --> D[Read expected.json]
    D --> E{expected.static === true?}
    E -- Yes --> F["test.skip(testName, () => {})"]
    E -- No --> G[Register real test with assertions]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test(compiler): skip empty jsx seed case..."](https://github.com/generaltranslation/gt/commit/dcad1eb75fb5a82ecdc38cf7578b26160d2bff85) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31371898)</sub>

<!-- /greptile_comment -->