### PR TITLE
fix(cli): type JSON runtime helpers

### DIFF
--- a/packages/cli/src/api/__tests__/collectUserEditDiffs.test.ts
+++ b/packages/cli/src/api/__tests__/collectUserEditDiffs.test.ts
@@ -12,6 +12,7 @@ import {
   DownloadedVersionsV1,
 } from '../../fs/config/downloadedVersions.js';
 import { createFileMapping } from '../../formats/files/fileMapping.js';
+import type { FileReference } from 'generaltranslation/types';
 
 vi.mock('../../utils/gt.js', () => ({
   gt: {
@@ -92,7 +93,7 @@ describe('collectAndSendUserEditDiffs', () => {
       },
     });
 
-    const files = [
+    const files: FileReference[] = [
       {
         fileName: 'docs/doc.md',
         fileFormat: 'MD',
@@ -106,7 +107,7 @@ describe('collectAndSendUserEditDiffs', () => {
     const entry = entryMap.get('file1');
     expect(entry?.translations?.ja?.postProcessHash).toBeDefined();
 
-    await collectAndSendUserEditDiffs(files as any, settings);
+    await collectAndSendUserEditDiffs(files, settings);
 
     expect(gt.queryFileData).not.toHaveBeenCalled();
     expect(gt.downloadFileBatch).not.toHaveBeenCalled();
@@ -146,7 +147,7 @@ describe('collectAndSendUserEditDiffs', () => {
       },
     });
 
-    (gt.queryFileData as any).mockResolvedValue({
+    vi.mocked(gt.queryFileData).mockResolvedValue({
       translatedFiles: [
         {
           branchId: 'branch1',
@@ -158,7 +159,7 @@ describe('collectAndSendUserEditDiffs', () => {
       ],
     });
 
-    (gt.downloadFileBatch as any).mockResolvedValue({
+    vi.mocked(gt.downloadFileBatch).mockResolvedValue({
       files: [
         {
           branchId: 'branch1',
@@ -170,9 +171,9 @@ describe('collectAndSendUserEditDiffs', () => {
       ],
     });
 
-    (getGitUnifiedDiff as any).mockResolvedValue('mock-diff');
+    vi.mocked(getGitUnifiedDiff).mockResolvedValue('mock-diff');
 
-    const files = [
+    const files: FileReference[] = [
       {
         fileName: 'docs/doc.md',
         fileFormat: 'MD',
@@ -182,7 +183,7 @@ describe('collectAndSendUserEditDiffs', () => {
       },
     ];
 
-    await collectAndSendUserEditDiffs(files as any, settings);
+    await collectAndSendUserEditDiffs(files, settings);
 
     expect(gt.queryFileData).toHaveBeenCalledTimes(1);
     expect(gt.downloadFileBatch).toHaveBeenCalledTimes(1);
@@ -213,7 +214,7 @@ describe('collectAndSendUserEditDiffs', () => {
       },
     });
 
-    (gt.queryFileData as any).mockResolvedValue({
+    vi.mocked(gt.queryFileData).mockResolvedValue({
       translatedFiles: [
         {
           branchId: 'branch1',
@@ -225,7 +226,7 @@ describe('collectAndSendUserEditDiffs', () => {
       ],
     });
 
-    (gt.downloadFileBatch as any).mockResolvedValue({
+    vi.mocked(gt.downloadFileBatch).mockResolvedValue({
       files: [
         {
           branchId: 'branch1',
@@ -237,9 +238,9 @@ describe('collectAndSendUserEditDiffs', () => {
       ],
     });
 
-    (getGitUnifiedDiff as any).mockResolvedValue('mock-diff');
+    vi.mocked(getGitUnifiedDiff).mockResolvedValue('mock-diff');
 
-    const files = [
+    const files: FileReference[] = [
       {
         fileName: 'docs/doc.md',
         fileFormat: 'MD',
@@ -249,11 +250,11 @@ describe('collectAndSendUserEditDiffs', () => {
       },
     ];
 
-    await collectAndSendUserEditDiffs(files as any, settings);
+    await collectAndSendUserEditDiffs(files, settings);
 
     expect(gt.queryFileData).toHaveBeenCalledTimes(1);
     expect(
-      (gt.queryFileData as any).mock.calls[0][0].translatedFiles[0].versionId
+      vi.mocked(gt.queryFileData).mock.calls[0][0].translatedFiles[0].versionId
     ).toBe('version1');
     expect(gt.downloadFileBatch).toHaveBeenCalledTimes(1);
     expect(gt.submitUserEditDiffs).toHaveBeenCalledTimes(1);

--- a/packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts
+++ b/packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts
@@ -7,6 +7,10 @@ import parseYaml from '../../yaml/parseYaml.js';
 import sanitizeFileContent from '../../../utils/sanitizeFileContent.js';
 import { determineLibrary } from '../../../fs/determineFramework/index.js';
 import { isValidMdx } from '../../../utils/validateMdx.js';
+import type { Settings } from '../../../types/index.js';
+
+const aggregateTestFiles = (settings: Partial<Settings>) =>
+  aggregateFiles(settings as Settings);
 
 vi.mock('../../../console/logger.js', () => ({
   logger: {
@@ -88,7 +92,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         .mockReturnValueOnce('') // empty file
         .mockReturnValueOnce('{"key": "value"}'); // valid file
 
-      const { files: result } = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateTestFiles(settings);
 
       expect(mockLogWarning).toHaveBeenCalledWith(
         'Skipping empty.json: JSON file is not parsable'
@@ -113,7 +117,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         .mockReturnValueOnce('   \n\t  ') // whitespace only
         .mockReturnValueOnce('{"key": "value"}'); // valid file
 
-      const { files: result } = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateTestFiles(settings);
 
       expect(mockLogWarning).toHaveBeenCalledWith(
         'Skipping whitespace.json: JSON file is not parsable'
@@ -140,36 +144,11 @@ describe('aggregateFiles - Empty File Handling', () => {
 
       mockReadFile.mockReturnValueOnce('{ invalid json');
 
-      const { files: result } = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateTestFiles(settings);
 
       expect(mockLogWarning).not.toHaveBeenCalled();
       expect(result).toHaveLength(1);
       expect(result[0].fileName).toBe('invalid.json');
-    });
-
-    it('should skip JSON files that return null content and log warning', async () => {
-      const settings = {
-        files: {
-          resolvedPaths: {
-            json: ['/full/path/null.json', '/full/path/valid.json'],
-          },
-          placeholderPaths: {},
-        },
-        options: {},
-        defaultLocale: 'en',
-      };
-
-      mockReadFile
-        .mockReturnValueOnce(null as any) // null content
-        .mockReturnValueOnce('{"key": "value"}'); // valid file
-
-      const { files: result } = await aggregateFiles(settings as any);
-
-      expect(mockLogWarning).toHaveBeenCalledWith(
-        'Skipping null.json: JSON file is empty'
-      );
-      expect(result).toHaveLength(1);
-      expect(result[0].fileName).toBe('valid.json');
     });
   });
 
@@ -189,7 +168,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         .mockReturnValueOnce('') // empty file
         .mockReturnValueOnce('key: value'); // valid file
 
-      const { files: result } = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateTestFiles(settings);
 
       expect(mockLogWarning).toHaveBeenCalledWith(
         'Skipping empty.yaml: YAML file is empty'
@@ -213,7 +192,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         .mockReturnValueOnce('   \n\t  ') // whitespace only
         .mockReturnValueOnce('key: value'); // valid file
 
-      const { files: result } = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateTestFiles(settings);
 
       expect(mockLogWarning).toHaveBeenCalledWith(
         'Skipping whitespace.yml: YAML file is empty'
@@ -239,7 +218,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         .mockReturnValueOnce('') // empty file
         .mockReturnValueOnce('# Valid MDX'); // valid file
 
-      const { files: result } = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateTestFiles(settings);
 
       expect(mockLogWarning).toHaveBeenCalledWith(
         'Skipping empty.mdx: File is empty after sanitization'
@@ -269,7 +248,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         error: 'bad',
       });
 
-      const { files: result } = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateTestFiles(settings);
 
       expect(mockIsValidMdx).not.toHaveBeenCalled();
       expect(mockLogWarning).not.toHaveBeenCalled();
@@ -295,7 +274,7 @@ describe('aggregateFiles - Empty File Handling', () => {
 
       mockReadFile.mockReturnValueOnce('msgid "Hello"');
 
-      const { files: result } = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateTestFiles(settings);
 
       expect(result).toHaveLength(1);
       expect(result[0]).toMatchObject({
@@ -326,7 +305,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         '---\nsummary: "Hello"\n---\n\n# Content'
       );
 
-      const { files: result } = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateTestFiles(settings);
 
       expect(result).toHaveLength(1);
       expect(result[0].content).toMatch(/title:\s*"?My File"?/);
@@ -358,7 +337,7 @@ describe('aggregateFiles - Empty File Handling', () => {
 
       mockReadFile.mockReturnValueOnce(content);
 
-      const { files: result } = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateTestFiles(settings);
 
       expect(result).toHaveLength(1);
       expect(result[0].content).toBe(content);
@@ -385,7 +364,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         '---\nsummary: "Hello"\n---\n\n# Content'
       );
 
-      const { files: result } = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateTestFiles(settings);
 
       expect(result).toHaveLength(1);
       expect(result[0].content).toMatch(/title:\s*"?Getting Started"?/);
@@ -412,7 +391,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         '---\nsummary: "Hello"\n---\n\n# Content'
       );
 
-      const { files: result } = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateTestFiles(settings);
 
       expect(result).toHaveLength(1);
       expect(result[0].content).toMatch(/title:\s*"?Index"?/);
@@ -437,7 +416,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         .mockReturnValueOnce('') // empty after sanitization
         .mockReturnValueOnce('# Valid content'); // valid after sanitization
 
-      const { files: result } = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateTestFiles(settings);
 
       expect(mockLogWarning).toHaveBeenCalledWith(
         'Skipping sanitized-empty.md: File is empty after sanitization'
@@ -468,7 +447,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         .mockReturnValueOnce('   \n\t  ') // whitespace only after sanitization
         .mockReturnValueOnce('export const Component = () => "Hello"'); // valid after sanitization
 
-      const { files: result } = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateTestFiles(settings);
 
       expect(mockLogWarning).toHaveBeenCalledWith(
         'Skipping whitespace-after-sanitization.ts: File is empty after sanitization'
@@ -493,7 +472,7 @@ describe('aggregateFiles - Empty File Handling', () => {
 
       mockReadFile.mockReturnValueOnce('{"key": "value"}');
 
-      const { files: result } = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateTestFiles(settings);
 
       expect(result).toHaveLength(1);
       expect(result[0].fileFormat).toBe('TWILIO_CONTENT_JSON');
@@ -520,7 +499,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         .mockReturnValueOnce('') // empty file
         .mockReturnValueOnce('{"key": "value"}'); // valid file
 
-      const { files: result } = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateTestFiles(settings);
 
       expect(mockLogWarning).toHaveBeenCalledWith(
         'Skipping empty.json: JSON file is not parsable'
@@ -543,7 +522,7 @@ describe('aggregateFiles - Empty File Handling', () => {
 
       mockReadFile.mockReturnValueOnce('{ invalid json');
 
-      const { files: result } = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateTestFiles(settings);
 
       expect(mockLogWarning).toHaveBeenCalledWith(
         'Skipping invalid.json: JSON file is not parsable'
@@ -569,7 +548,7 @@ describe('aggregateFiles - Empty File Handling', () => {
 
       mockReadFile.mockReturnValueOnce('{ invalid json');
 
-      const { files: result } = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateTestFiles(settings);
 
       expect(mockLogWarning).not.toHaveBeenCalled();
       expect(result).toHaveLength(1);
@@ -600,7 +579,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         .mockReturnValueOnce('{"twilio": "content"}') // valid Twilio Content JSON
         .mockReturnValueOnce('# Valid markdown'); // valid MD
 
-      const { files: result } = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateTestFiles(settings);
 
       // Check that warnings were logged for empty files
       expect(mockLogWarning).toHaveBeenCalledWith(
@@ -644,7 +623,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         .mockReturnValueOnce('') // empty file 2 - will return null from map
         .mockReturnValueOnce('{"key": "value"}'); // valid file
 
-      const { files: result } = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateTestFiles(settings);
 
       expect(mockLogWarning).toHaveBeenCalledWith(
         'Skipping empty1.json: JSON file is not parsable'
@@ -679,7 +658,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         .mockReturnValueOnce('') // empty after parsing - gets filtered out
         .mockReturnValueOnce('parsed content'); // valid after parsing
 
-      const { files: result } = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateTestFiles(settings);
 
       expect(result).toHaveLength(1);
       expect(result[0].fileName).toBe('valid.json');

--- a/packages/cli/src/formats/json/__tests__/extractJson.test.ts
+++ b/packages/cli/src/formats/json/__tests__/extractJson.test.ts
@@ -776,7 +776,7 @@ describe('extractJson', () => {
         'en'
       );
 
-      gt.setConfig({ sourceLocale: 'en', customMapping: undefined as any });
+      gt.setConfig({ sourceLocale: 'en' });
 
       expect(result).not.toBeNull();
       const parsed = JSON.parse(result!);

--- a/packages/cli/src/formats/json/__tests__/mergeJson.test.ts
+++ b/packages/cli/src/formats/json/__tests__/mergeJson.test.ts
@@ -15,6 +15,18 @@ const mockExit = vi.mocked(exitSync).mockImplementation(() => {
   throw new Error('Process exit called');
 });
 
+type LocaleEntry = { locale: string };
+type NestedLocaleEntry = { meta: { locale: string } };
+type LanguageEntry = { language: string };
+
+const hasLocale = (locale: string) => (item: LocaleEntry) =>
+  item.locale === locale;
+const hasNestedLocale = (locale: string) => (item: NestedLocaleEntry) =>
+  item.meta.locale === locale;
+const hasLanguage = (language: string) => (item: LanguageEntry) =>
+  item.language === language;
+const getLanguage = (item: LanguageEntry) => item.language;
+
 describe('mergeJson', () => {
   beforeEach(() => {
     mockLogError.mockClear();
@@ -259,21 +271,17 @@ describe('mergeJson', () => {
       expect(parsed.items).toHaveLength(3);
 
       // English item should be unchanged
-      const englishItem = parsed.items.find(
-        (item: any) => item.locale === 'en'
-      );
+      const englishItem = parsed.items.find(hasLocale('en'));
       expect(englishItem.title).toBe('English Title');
       expect(englishItem.desc).toBe('English Description');
 
       // Spanish item should remain unchanged
-      const spanishItem = parsed.items.find(
-        (item: any) => item.locale === 'es'
-      );
+      const spanishItem = parsed.items.find(hasLocale('es'));
       expect(spanishItem.title).toBe('Título Español');
       expect(spanishItem.desc).toBe('Descripción Española');
 
       // French item should be updated with French translations
-      const frenchItem = parsed.items.find((item: any) => item.locale === 'fr');
+      const frenchItem = parsed.items.find(hasLocale('fr'));
       expect(frenchItem.title).toBe('Nouveau Titre');
       expect(frenchItem.desc).toBe('Nouvelle Description');
     });
@@ -320,7 +328,7 @@ describe('mergeJson', () => {
       );
 
       const parsed = JSON.parse(result[0]);
-      const frenchItem = parsed.items.find((item: any) => item.locale === 'fr');
+      const frenchItem = parsed.items.find(hasLocale('fr'));
       expect(frenchItem.title).toBe('Titre Français Traduit');
     });
 
@@ -371,9 +379,7 @@ describe('mergeJson', () => {
       );
 
       const parsed = JSON.parse(result[0]);
-      const frenchItems = parsed.items.filter(
-        (item: any) => item.locale === 'fr'
-      );
+      const frenchItems = parsed.items.filter(hasLocale('fr'));
       expect(frenchItems).toHaveLength(2);
       expect(frenchItems[0].title).toBe('Titre Français Traduit');
       expect(frenchItems[1].title).toBe('Titre Français Phrase2');
@@ -421,15 +427,9 @@ describe('mergeJson', () => {
       );
 
       const parsed = JSON.parse(result[0]);
-      const englishItem = parsed.items.find(
-        (item: any) => item.meta.locale === 'en'
-      );
-      const spanishItem = parsed.items.find(
-        (item: any) => item.meta.locale === 'es'
-      );
-      const frenchItem = parsed.items.find(
-        (item: any) => item.meta.locale === 'fr'
-      );
+      const englishItem = parsed.items.find(hasNestedLocale('en'));
+      const spanishItem = parsed.items.find(hasNestedLocale('es'));
+      const frenchItem = parsed.items.find(hasNestedLocale('fr'));
       expect(englishItem.title).toBe('English Title');
       expect(spanishItem.title).toBe('Título Español');
       expect(frenchItem.title).toBe('Titre Français');
@@ -1147,9 +1147,7 @@ describe('mergeJson', () => {
 
       // The valid /0 translation should be applied
       const parsed = JSON.parse(result[0]);
-      const spanishItem = parsed.items.find(
-        (item: any) => item.locale === 'es'
-      );
+      const spanishItem = parsed.items.find(hasLocale('es'));
       expect(spanishItem.title).toBe('Título Español');
 
       // The invalid /1 key should produce a warning
@@ -1309,9 +1307,7 @@ describe('mergeJson', () => {
 
       const parsed = JSON.parse(result[0]);
       // Should have remapped /1 to /0 and applied the translation
-      const spanishItem = parsed.items.find(
-        (item: any) => item.locale === 'es'
-      );
+      const spanishItem = parsed.items.find(hasLocale('es'));
       expect(spanishItem).toBeDefined();
       expect(spanishItem.title).toBe('Hola');
     });
@@ -1412,12 +1408,8 @@ describe('mergeJson', () => {
       );
 
       const parsed = JSON.parse(result[0]);
-      const englishNav = parsed.navigation.languages.find(
-        (lang: any) => lang.language === 'en'
-      );
-      const spanishNav = parsed.navigation.languages.find(
-        (lang: any) => lang.language === 'es'
-      );
+      const englishNav = parsed.navigation.languages.find(hasLanguage('en'));
+      const spanishNav = parsed.navigation.languages.find(hasLanguage('es'));
 
       expect(englishNav.global.anchors[0].anchor).toBe('Announcements');
       expect(englishNav.global.anchors[1].anchor).toBe('Status');
@@ -1496,10 +1488,8 @@ describe('mergeJson', () => {
       expect(result).toHaveLength(1); // Composite returns single merged result
 
       const parsed = JSON.parse(result[0]);
-      const englishItem = parsed.items.find(
-        (item: any) => item.locale === 'en'
-      );
-      const germanItem = parsed.items.find((item: any) => item.locale === 'de');
+      const englishItem = parsed.items.find(hasLocale('en'));
+      const germanItem = parsed.items.find(hasLocale('de'));
 
       expect(englishItem.title).toBe('English Title');
       expect(englishItem.desc).toBe('English Description');
@@ -1561,18 +1551,14 @@ describe('mergeJson', () => {
         ['fr-ca']
       );
 
-      gt.setConfig({ sourceLocale: 'en', customMapping: undefined as any });
+      gt.setConfig({ sourceLocale: 'en' });
 
       const parsed = JSON.parse(result[0]);
-      const frenchNav = parsed.navigation.languages.find(
-        (lang: any) => lang.language === 'fr-CA'
-      );
+      const frenchNav = parsed.navigation.languages.find(hasLanguage('fr-CA'));
 
       expect(frenchNav).toBeDefined();
       expect(
-        parsed.navigation.languages.find(
-          (lang: any) => lang.language === 'fr-ca'
-        )
+        parsed.navigation.languages.find(hasLanguage('fr-ca'))
       ).toBeUndefined();
       expect(frenchNav.tabs[0].tab).toBe('Accueil');
       expect(frenchNav.tabs[0].pages[0]).toBe('docs/fr-ca/index');
@@ -1625,14 +1611,8 @@ describe('mergeJson', () => {
 
       const parsed = JSON.parse(result[0]);
       const languages = parsed.navigation.languages;
-      expect(languages.map((lang: any) => lang.language)).toEqual([
-        'en',
-        'es',
-        'ja',
-      ]);
-      const spanishEntry = languages.find(
-        (lang: any) => lang.language === 'es'
-      );
+      expect(languages.map(getLanguage)).toEqual(['en', 'es', 'ja']);
+      const spanishEntry = languages.find(hasLanguage('es'));
       expect(spanishEntry.tab).toBe('Inicio');
     });
 
@@ -1683,11 +1663,7 @@ describe('mergeJson', () => {
 
       const parsed = JSON.parse(result[0]);
       const languages = parsed.navigation.languages;
-      expect(languages.map((lang: any) => lang.language)).toEqual([
-        'en',
-        'es',
-        'ja',
-      ]);
+      expect(languages.map(getLanguage)).toEqual(['en', 'es', 'ja']);
     });
 
     it('should order locales alphabetically with default locale first', () => {
@@ -1737,11 +1713,7 @@ describe('mergeJson', () => {
 
       const parsed = JSON.parse(result[0]);
       const languages = parsed.navigation.languages;
-      expect(languages.map((lang: any) => lang.language)).toEqual([
-        'ja',
-        'de',
-        'en',
-      ]);
+      expect(languages.map(getLanguage)).toEqual(['ja', 'de', 'en']);
     });
 
     it('should preserve non-translatable fields during merge', () => {
@@ -2458,7 +2430,7 @@ describe('mergeJson', () => {
   describe('Edge Cases', () => {
     it('should handle empty targets array', () => {
       const originalContent = JSON.stringify({ test: 'value' });
-      const targets: any[] = [];
+      const targets: Parameters<typeof mergeJson>[3] = [];
 
       const result = mergeJson(
         originalContent,
@@ -2876,10 +2848,10 @@ describe('mergeJson', () => {
         sourceItem,
         {
           '$.title': {
-            replace: null as any,
+            replace: null as unknown as string,
           },
           '$.count': {
-            replace: 100 as any,
+            replace: 100 as unknown as string,
           },
         },
         'es',

--- a/packages/cli/src/formats/json/__tests__/structuralTransform.test.ts
+++ b/packages/cli/src/formats/json/__tests__/structuralTransform.test.ts
@@ -94,7 +94,7 @@ describe('structuralTransform', () => {
       // no "label" field exists
       applyStructuralTransforms(json, transforms, compositeConfig);
 
-      expect((json.item_a.i18n as any).en).toBeUndefined();
+      expect(json.item_a.i18n).not.toHaveProperty('en');
     });
 
     it('should handle multiple transforms', () => {
@@ -138,8 +138,8 @@ describe('structuralTransform', () => {
       expect(json.btn_save.i18n.en).toBe('Save changes');
 
       unapplyStructuralTransforms(json, transforms, compositeConfig);
-      expect((json.btn_save.i18n as any).en).toBeUndefined();
-      expect((json.btn_cancel.i18n as any).en).toBeUndefined();
+      expect(json.btn_save.i18n).not.toHaveProperty('en');
+      expect(json.btn_cancel.i18n).not.toHaveProperty('en');
     });
 
     it('should leave sourcePointer value intact', () => {

--- a/packages/cli/src/formats/json/extractJson.ts
+++ b/packages/cli/src/formats/json/extractJson.ts
@@ -9,6 +9,7 @@ import {
 import { flattenJsonWithStringFilter } from './flattenJson.js';
 import { gt } from '../../utils/gt.js';
 import { applyStructuralTransforms } from './transformJson.js';
+import type { JSONObject, JSONValue } from '../../types/data/json.js';
 
 /**
  * Extracts translated values from a full JSON file back into composite JSON format.
@@ -36,7 +37,7 @@ export function extractJson(
     return null;
   }
 
-  let localJson: any;
+  let localJson: JSONValue;
   try {
     localJson = JSON.parse(localContent);
   } catch {
@@ -76,7 +77,7 @@ export function extractJson(
   }
 
   // Handle composite schemas
-  const compositeResult: Record<string, any> = {};
+  const compositeResult: Record<string, JSONValue> = {};
 
   // Generate source object pointers from the local JSON
   const sourceObjectPointers = generateSourceObjectPointers(
@@ -139,7 +140,8 @@ export function extractJson(
         // Use default locale key
         const outputKey =
           i < defaultKeys.length ? defaultKeys[i] : targetEntries[i][0];
-        compositeResult[sourceObjectPointer][outputKey] = extractedValues;
+        (compositeResult[sourceObjectPointer] as JSONObject)[outputKey] =
+          extractedValues;
       }
     } else {
       // Object type
@@ -149,13 +151,14 @@ export function extractJson(
         );
         continue;
       }
+      const sourceObjectRecord = sourceObjectValue as JSONObject;
 
       // Find the matching item for the target locale
       const matchingTargetItem = findMatchingItemObject(
         canonicalTargetLocale,
         sourceObjectPointer,
         sourceObjectOptions,
-        sourceObjectValue
+        sourceObjectRecord
       );
 
       if (!matchingTargetItem.sourceItem) {
@@ -173,7 +176,7 @@ export function extractJson(
 
       // Extract values at the include paths
       const extractedValues = flattenJsonWithStringFilter(
-        matchingTargetItem.sourceItem,
+        matchingTargetItem.sourceItem as JSONObject,
         sourceObjectOptions.include
       );
 

--- a/packages/cli/src/formats/json/flattenJson.ts
+++ b/packages/cli/src/formats/json/flattenJson.ts
@@ -1,5 +1,6 @@
-import { JSONPath } from 'jsonpath-plus';
 import { logger } from '../../console/logger.js';
+import type { JSONValue } from '../../types/data/json.js';
+import { getJSONPathMatches } from './jsonPath.js';
 
 /**
  * Flattens a JSON object according to a list of JSON paths.
@@ -8,23 +9,17 @@ import { logger } from '../../console/logger.js';
  * @returns A mapping of json pointers to their values
  */
 export function flattenJson(
-  json: any,
+  json: unknown,
   jsonPaths: string[]
-): Record<string, any> {
-  const extractedJson: Record<string, any> = {};
+): Record<string, JSONValue> {
+  const extractedJson: Record<string, JSONValue> = {};
   for (const jsonPath of jsonPaths) {
     try {
-      const results = JSONPath({
-        json,
-        path: jsonPath,
-        resultType: 'all',
-        flatten: true,
-        wrap: true,
-      });
+      const results = getJSONPathMatches(json as JSONValue, jsonPath);
       if (!results || results.length === 0) {
         continue;
       }
-      results.forEach((result: { pointer: string; value: any }) => {
+      results.forEach((result) => {
         extractedJson[result.pointer] = result.value;
       });
     } catch {
@@ -41,23 +36,17 @@ export function flattenJson(
  * @returns A mapping of json pointers to their values
  */
 export function flattenJsonWithStringFilter(
-  json: any,
+  json: unknown,
   jsonPaths: string[]
-): Record<string, any> {
-  const extractedJson: Record<string, any> = {};
+): Record<string, string> {
+  const extractedJson: Record<string, string> = {};
   for (const jsonPath of jsonPaths) {
     try {
-      const results = JSONPath({
-        json,
-        path: jsonPath,
-        resultType: 'all',
-        flatten: true,
-        wrap: true,
-      });
+      const results = getJSONPathMatches(json as JSONValue, jsonPath);
       if (!results || results.length === 0) {
         continue;
       }
-      results.forEach((result: { pointer: string; value: any }) => {
+      results.forEach((result) => {
         if (typeof result.value === 'string') {
           extractedJson[result.pointer] = result.value;
         }

--- a/packages/cli/src/formats/json/jsonPath.ts
+++ b/packages/cli/src/formats/json/jsonPath.ts
@@ -1,0 +1,35 @@
+import { JSONPath } from 'jsonpath-plus';
+import type { JSONValue } from '../../types/data/json.js';
+
+export type JSONPathMatch = {
+  pointer: string;
+  value: JSONValue;
+  parentProperty: string | number | null;
+};
+
+const jsonPathOptions = (json: JSONValue, path: string) => ({
+  json,
+  path,
+  flatten: true,
+  wrap: true,
+});
+
+export function getJSONPathMatches(
+  json: JSONValue,
+  path: string
+): JSONPathMatch[] | undefined {
+  return JSONPath({
+    ...jsonPathOptions(json, path),
+    resultType: 'all',
+  }) as JSONPathMatch[] | undefined;
+}
+
+export function getJSONPathValues(
+  json: JSONValue,
+  path: string
+): JSONValue[] | undefined {
+  return JSONPath({
+    ...jsonPathOptions(json, path),
+    resultType: 'value',
+  }) as JSONValue[] | undefined;
+}

--- a/packages/cli/src/formats/json/jsonPointer.ts
+++ b/packages/cli/src/formats/json/jsonPointer.ts
@@ -1,0 +1,32 @@
+import JSONPointer from 'jsonpointer';
+import type { JSONValue } from '../../types/data/json.js';
+
+export function getJSONPointerValue(
+  json: JSONValue,
+  pointer: string
+): JSONValue {
+  return JSONPointer.get(json as object, pointer) as JSONValue;
+}
+
+export function setJSONPointerValue(
+  json: JSONValue,
+  pointer: string,
+  value: JSONValue
+): void {
+  JSONPointer.set(json as object, pointer, value);
+}
+
+export function deleteJSONPointerValue(json: JSONValue, pointer: string): void {
+  const lastSlash = pointer.lastIndexOf('/');
+  if (lastSlash < 0) return;
+
+  const parentPointer = pointer.substring(0, lastSlash) || '';
+  const leafKey = pointer.substring(lastSlash + 1);
+  const parent = parentPointer
+    ? getJSONPointerValue(json, parentPointer)
+    : json;
+
+  if (parent && typeof parent === 'object' && leafKey in parent) {
+    delete (parent as Record<string, JSONValue>)[leafKey];
+  }
+}

--- a/packages/cli/src/formats/json/mergeJson.ts
+++ b/packages/cli/src/formats/json/mergeJson.ts
@@ -1,4 +1,3 @@
-import JSONPointer from 'jsonpointer';
 import { AdditionalOptions, SourceObjectOptions } from '../../types/index.js';
 import { exitSync } from '../../console/logging.js';
 import { logger } from '../../console/logger.js';
@@ -10,7 +9,6 @@ import {
   getSourceObjectOptionsArray,
   validateJsonSchema,
 } from './utils.js';
-import { JSONPath } from 'jsonpath-plus';
 import { getLocaleProperties } from 'generaltranslation';
 import { replaceLocalePlaceholders } from '../utils.js';
 import { gt } from '../../utils/gt.js';
@@ -18,6 +16,15 @@ import {
   applyStructuralTransforms,
   unapplyStructuralTransforms,
 } from './transformJson.js';
+import type { JSONObject, JSONValue } from '../../types/data/json.js';
+import { getJSONPathMatches, getJSONPathValues } from './jsonPath.js';
+import { getJSONPointerValue, setJSONPointerValue } from './jsonPointer.js';
+
+type ParsedTarget = {
+  translatedContent: string;
+  targetLocale: string;
+  parsedContent: JSONObject;
+};
 
 export function mergeJson(
   originalContent: string,
@@ -35,7 +42,7 @@ export function mergeJson(
     return targets.map((target) => target.translatedContent);
   }
 
-  let originalJson: any;
+  let originalJson: JSONValue;
   try {
     originalJson = JSON.parse(originalContent);
   } catch {
@@ -66,14 +73,14 @@ export function mergeJson(
     for (const target of targets) {
       // Must clone the original JSON to avoid mutations
       const mergedJson = structuredClone(originalJson);
-      const translatedJson = JSON.parse(target.translatedContent);
+      const translatedJson = JSON.parse(target.translatedContent) as JSONObject;
       for (const [jsonPointer, translatedValue] of Object.entries(
         translatedJson
       )) {
         try {
-          const value = JSONPointer.get(mergedJson, jsonPointer);
+          const value = getJSONPointerValue(mergedJson, jsonPointer);
           if (!value) continue;
-          JSONPointer.set(mergedJson, jsonPointer, translatedValue);
+          setJSONPointerValue(mergedJson, jsonPointer, translatedValue);
         } catch {
           /* empty */
         }
@@ -95,14 +102,14 @@ export function mergeJson(
   // Pre-parse all target contents ONCE (avoid re-parsing per pointer)
   const parsedTargets = targets.map((target) => ({
     ...target,
-    parsedContent: JSON.parse(target.translatedContent),
-  }));
+    parsedContent: JSON.parse(target.translatedContent) as JSONObject,
+  })) satisfies ParsedTarget[];
 
   // Create mapping of sourceObjectPointer to SourceObjectOptions
-  const sourceObjectPointers: Record<
-    string,
-    { sourceObjectValue: any; sourceObjectOptions: SourceObjectOptions }
-  > = generateSourceObjectPointers(jsonSchema.composite, originalJson);
+  const sourceObjectPointers = generateSourceObjectPointers(
+    jsonSchema.composite,
+    originalJson
+  );
 
   // Find the source object
   for (const [
@@ -150,7 +157,7 @@ export function mergeJson(
       // 9. Check that items to add is >= items to remove
       // 10. Remove all items for the target locale (they can be identified by the key)
       const indiciesToRemove = new Set<number>();
-      const itemsToAdd: any[] = [];
+      const itemsToAdd: JSONValue[] = [];
       for (const target of parsedTargets) {
         let targetItems = target.parsedContent[sourceObjectPointer];
         // 1. Get the target items
@@ -174,8 +181,8 @@ export function mergeJson(
 
         // Remap mismatched positional keys to current source positions
         const sourceKeys = [...matchingDefaultLocaleItemKeys];
-        const remappedTargetItems: Record<string, any> = {};
-        for (const [key, value] of Object.entries(targetItems)) {
+        const remappedTargetItems: Record<string, JSONValue> = {};
+        for (const [key, value] of Object.entries(targetItems as JSONObject)) {
           if (matchingDefaultLocaleItemKeys.has(key)) {
             remappedTargetItems[key] = value;
           } else if (
@@ -228,7 +235,7 @@ export function mergeJson(
               sourceObjectPointer,
               sourceObjectOptions
             );
-          JSONPointer.set(
+          setJSONPointerValue(
             mutatedSourceItem,
             defaultLocaleKeyPointer,
             targetLocaleKeyProperty
@@ -236,7 +243,7 @@ export function mergeJson(
           for (const [
             translatedKeyJsonPointer,
             translatedValue,
-          ] of Object.entries(targetItem || {})) {
+          ] of Object.entries((targetItem || {}) as JSONObject)) {
             const valueToSet =
               useCanonicalLocaleKeys &&
               defaultLocaleKeyPointer &&
@@ -244,12 +251,12 @@ export function mergeJson(
                 ? targetLocaleKeyProperty
                 : translatedValue;
             try {
-              const value = JSONPointer.get(
+              const value = getJSONPointerValue(
                 mutatedSourceItem,
                 translatedKeyJsonPointer
               );
               if (!value) continue;
-              JSONPointer.set(
+              setJSONPointerValue(
                 mutatedSourceItem,
                 translatedKeyJsonPointer,
                 valueToSet
@@ -286,7 +293,7 @@ export function mergeJson(
       // 10. Add all items to the original JSON
       filteredSourceObjectValue.push(...itemsToAdd);
 
-      JSONPointer.set(
+      setJSONPointerValue(
         mergedJson,
         sourceObjectPointer,
         sortByLocaleOrder(
@@ -305,12 +312,13 @@ export function mergeJson(
         );
         return exitSync(1);
       }
+      const sourceObjectRecord = sourceObjectValue as JSONObject;
       // Validate localeProperty
       const matchingDefaultLocaleItem = findMatchingItemObject(
         canonicalDefaultLocale,
         sourceObjectPointer,
         sourceObjectOptions,
-        sourceObjectValue
+        sourceObjectRecord
       );
       // Validate source item exists
       if (!matchingDefaultLocaleItem.sourceItem) {
@@ -343,14 +351,14 @@ export function mergeJson(
             : target.targetLocale,
           sourceObjectPointer,
           sourceObjectOptions,
-          sourceObjectValue
+          sourceObjectRecord
         );
         const mutateSourceItemKey = matchingTargetItem.keyParentProperty;
 
         // If the source item is a string, use the translated string directly
         if (typeof defaultLocaleSourceItem === 'string') {
           if (typeof targetItems === 'string') {
-            sourceObjectValue[mutateSourceItemKey] = targetItems;
+            sourceObjectRecord[mutateSourceItemKey] = targetItems;
           }
           // If no translation found, leave the locale slot unchanged
           continue;
@@ -361,9 +369,11 @@ export function mergeJson(
         const mutateSourceItem = structuredClone(defaultLocaleSourceItem);
 
         // 3. Merge the target items with the source item (if there are transformations to perform)
-        const mergedItems = {
-          ...(sourceObjectOptions.transform ? defaultLocaleSourceItem : {}),
-          ...targetItems,
+        const mergedItems: Record<string, JSONValue> = {
+          ...(sourceObjectOptions.transform
+            ? (defaultLocaleSourceItem as JSONObject)
+            : {}),
+          ...(targetItems as JSONObject),
         };
 
         // 4. Validate that the mergedItems is not empty
@@ -380,12 +390,12 @@ export function mergeJson(
           translatedValue,
         ] of Object.entries(mergedItems || {})) {
           try {
-            const value = JSONPointer.get(
+            const value = getJSONPointerValue(
               mutateSourceItem,
               translatedKeyJsonPointer
             );
             if (!value) continue;
-            JSONPointer.set(
+            setJSONPointerValue(
               mutateSourceItem,
               translatedKeyJsonPointer,
               translatedValue
@@ -403,9 +413,9 @@ export function mergeJson(
         );
 
         // 7. Merge the source item with the original JSON
-        sourceObjectValue[mutateSourceItemKey] = mutateSourceItem;
+        sourceObjectRecord[mutateSourceItemKey] = mutateSourceItem;
       }
-      JSONPointer.set(mergedJson, sourceObjectPointer, sourceObjectValue);
+      setJSONPointerValue(mergedJson, sourceObjectPointer, sourceObjectValue);
     }
   }
   if (jsonSchema.structuralTransform && jsonSchema.composite) {
@@ -420,12 +430,12 @@ export function mergeJson(
 }
 
 function sortByLocaleOrder(
-  items: any[],
+  items: JSONValue[],
   sourceObjectOptions: SourceObjectOptions,
   localeOrder: string[],
   sourceObjectPointer: string,
   defaultLocale: string
-): any[] {
+): JSONValue[] {
   const sortMode = sourceObjectOptions.experimentalSort;
   if (!sortMode || !sourceObjectOptions.key) {
     return items;
@@ -434,13 +444,7 @@ function sortByLocaleOrder(
   const itemsWithLocale = items.map((item) => {
     let localeValue: string | undefined;
     try {
-      const values = JSONPath({
-        json: item,
-        path: sourceObjectOptions.key as string,
-        resultType: 'value',
-        flatten: true,
-        wrap: true,
-      });
+      const values = getJSONPathValues(item, sourceObjectOptions.key as string);
       const value = values?.[0];
       if (typeof value === 'string') {
         localeValue = value;
@@ -468,7 +472,7 @@ function sortByLocaleOrder(
       )
     );
 
-    const orderedItems: any[] = [];
+    const orderedItems: JSONValue[] = [];
     const remainingItems = [...itemsWithLocale];
 
     for (const localeValue of localeOrderValues) {
@@ -534,7 +538,7 @@ function sortByLocaleOrder(
  * @param defaultLocale - The default locale
  */
 export function applyTransformations(
-  sourceItem: any,
+  sourceItem: JSONValue,
   transform: SourceObjectOptions['transform'],
   targetLocale: string,
   defaultLocale: string
@@ -551,17 +555,11 @@ export function applyTransformations(
     ) {
       continue;
     }
-    const results = JSONPath({
-      json: sourceItem,
-      path: transformPath,
-      resultType: 'all',
-      flatten: true,
-      wrap: true,
-    });
+    const results = getJSONPathMatches(sourceItem, transformPath);
     if (!results || results.length === 0) {
       continue;
     }
-    results.forEach((result: { pointer: string; value: any }) => {
+    results.forEach((result) => {
       if (typeof result.value !== 'string') {
         return;
       }
@@ -594,7 +592,7 @@ export function applyTransformations(
       }
 
       // Update the actual sourceItem using JSONPointer
-      JSONPointer.set(sourceItem, result.pointer, result.value);
+      setJSONPointerValue(sourceItem, result.pointer, result.value);
     });
   }
 }

--- a/packages/cli/src/formats/json/parseJson.ts
+++ b/packages/cli/src/formats/json/parseJson.ts
@@ -1,6 +1,5 @@
-import { AdditionalOptions, SourceObjectOptions } from '../../types/index.js';
+import { AdditionalOptions } from '../../types/index.js';
 import { flattenJson, flattenJsonWithStringFilter } from './flattenJson.js';
-import { JSONPath } from 'jsonpath-plus';
 import { exitSync } from '../../console/logging.js';
 import { logger } from '../../console/logger.js';
 import {
@@ -10,6 +9,8 @@ import {
   validateJsonSchema,
 } from './utils.js';
 import { applyStructuralTransforms } from './transformJson.js';
+import type { JSONObject, JSONValue } from '../../types/data/json.js';
+import { getJSONPathMatches, type JSONPathMatch } from './jsonPath.js';
 
 // Parse a JSON file according to a JSON schema
 export function parseJson(
@@ -24,7 +25,7 @@ export function parseJson(
     return content;
   }
 
-  let json: any;
+  let json: JSONValue;
   try {
     json = JSON.parse(content);
   } catch {
@@ -54,15 +55,15 @@ export function parseJson(
 
   // Construct lvl 1
   // Create mapping of sourceObjectPointer to SourceObjectOptions
-  const sourceObjectPointers: Record<
-    string,
-    { sourceObjectValue: any; sourceObjectOptions: SourceObjectOptions }
-  > = generateSourceObjectPointers(jsonSchema.composite, json);
+  const sourceObjectPointers = generateSourceObjectPointers(
+    jsonSchema.composite,
+    json
+  );
 
   // Construct lvl 2
   const sourceObjectsToTranslate: Record<
     string,
-    Record<string, Record<string, string>> | string
+    Record<string, Record<string, JSONValue>> | JSONValue
   > = {};
   for (const [
     sourceObjectPointer,
@@ -98,22 +99,19 @@ export function parseJson(
         return exitSync(1);
       }
       // Construct lvl 3
-      const sourceItemsToTranslate: Record<string, Record<string, string>> = {};
+      const sourceItemsToTranslate: Record<
+        string,
+        Record<string, JSONValue>
+      > = {};
       for (const [arrayPointer, matchingItem] of Object.entries(
         matchingItems
       )) {
         const { sourceItem, keyPointer } = matchingItem;
         // Get the fields to translate from the includes
-        const matchingItemsToTranslate: any[] = [];
+        const matchingItemsToTranslate: JSONPathMatch[] = [];
         for (const include of sourceObjectOptions.include) {
           try {
-            const matchingItems = JSONPath({
-              json: sourceItem,
-              path: include,
-              resultType: 'all',
-              flatten: true,
-              wrap: true,
-            });
+            const matchingItems = getJSONPathMatches(sourceItem, include);
             if (matchingItems) {
               matchingItemsToTranslate.push(...matchingItems);
             }
@@ -124,14 +122,8 @@ export function parseJson(
         // Filter out the key pointer
         sourceItemsToTranslate[arrayPointer] = Object.fromEntries(
           matchingItemsToTranslate
-            .filter(
-              (item: { pointer: string; value: any }) =>
-                item.pointer !== keyPointer
-            )
-            .map((item: { pointer: string; value: string }) => [
-              item.pointer,
-              item.value,
-            ])
+            .filter((item) => item.pointer !== keyPointer)
+            .map((item) => [item.pointer, item.value])
         );
       }
 
@@ -146,13 +138,14 @@ export function parseJson(
         );
         return exitSync(1);
       }
+      const sourceObjectRecord = sourceObjectValue as JSONObject;
 
       // Validate localeProperty
       const matchingItem = findMatchingItemObject(
         defaultLocale,
         sourceObjectPointer,
         sourceObjectOptions,
-        sourceObjectValue
+        sourceObjectRecord
       );
       // Validate source item exists
       if (!matchingItem.sourceItem) {
@@ -171,7 +164,10 @@ export function parseJson(
 
       // Get the fields to translate from the includes
       const flatten = filterStrings ? flattenJsonWithStringFilter : flattenJson;
-      const itemsToTranslate = flatten(sourceItem, sourceObjectOptions.include);
+      const itemsToTranslate = flatten(
+        sourceItem as JSONObject,
+        sourceObjectOptions.include
+      );
 
       // Add the items to translate to the result
       sourceObjectsToTranslate[sourceObjectPointer] = itemsToTranslate;

--- a/packages/cli/src/formats/json/transformJson.ts
+++ b/packages/cli/src/formats/json/transformJson.ts
@@ -1,6 +1,11 @@
-import JSONPointer from 'jsonpointer';
 import { StructuralTransform, SourceObjectOptions } from '../../types/index.js';
-import { JSONPath } from 'jsonpath-plus';
+import type { JSONValue } from '../../types/data/json.js';
+import { getJSONPathMatches } from './jsonPath.js';
+import {
+  deleteJSONPointerValue,
+  getJSONPointerValue,
+  setJSONPointerValue,
+} from './jsonPointer.js';
 
 /**
  * Derive entry parent paths from composite sourceObjectPaths by trimming the last segment.
@@ -25,20 +30,14 @@ function deriveEntryPaths(
  * Mutates json in-place.
  */
 export function applyStructuralTransforms(
-  json: any,
+  json: JSONValue,
   transforms: StructuralTransform[],
   compositeConfig: Record<string, SourceObjectOptions>
-): any {
+): JSONValue {
   const entryPaths = deriveEntryPaths(compositeConfig);
 
   for (const entryPath of entryPaths) {
-    const entries = JSONPath({
-      json,
-      path: entryPath,
-      resultType: 'all',
-      flatten: true,
-      wrap: true,
-    });
+    const entries = getJSONPathMatches(json, entryPath);
     if (!entries) continue;
 
     for (const entry of entries) {
@@ -46,9 +45,16 @@ export function applyStructuralTransforms(
       if (typeof entryObj !== 'object' || entryObj === null) continue;
 
       for (const transform of transforms) {
-        const sourceValue = JSONPointer.get(entryObj, transform.sourcePointer);
+        const sourceValue = getJSONPointerValue(
+          entryObj,
+          transform.sourcePointer
+        );
         if (sourceValue !== undefined) {
-          JSONPointer.set(entryObj, transform.destinationPointer, sourceValue);
+          setJSONPointerValue(
+            entryObj,
+            transform.destinationPointer,
+            sourceValue
+          );
         }
       }
     }
@@ -63,20 +69,14 @@ export function applyStructuralTransforms(
  * Leaves sourcePointer untouched. Mutates json in-place.
  */
 export function unapplyStructuralTransforms(
-  json: any,
+  json: JSONValue,
   transforms: StructuralTransform[],
   compositeConfig: Record<string, SourceObjectOptions>
-): any {
+): JSONValue {
   const entryPaths = deriveEntryPaths(compositeConfig);
 
   for (const entryPath of entryPaths) {
-    const entries = JSONPath({
-      json,
-      path: entryPath,
-      resultType: 'all',
-      flatten: true,
-      wrap: true,
-    });
+    const entries = getJSONPathMatches(json, entryPath);
     if (!entries) continue;
 
     for (const entry of entries) {
@@ -84,21 +84,8 @@ export function unapplyStructuralTransforms(
       if (typeof entryObj !== 'object' || entryObj === null) continue;
 
       for (const transform of transforms) {
-        // Navigate to parent of destinationPointer and delete the leaf key
-        const pointer = transform.destinationPointer;
-        const lastSlash = pointer.lastIndexOf('/');
-        if (lastSlash < 0) continue;
-
-        const parentPointer = pointer.substring(0, lastSlash) || '';
-        const leafKey = pointer.substring(lastSlash + 1);
-
         try {
-          const parent = parentPointer
-            ? JSONPointer.get(entryObj, parentPointer)
-            : entryObj;
-          if (parent && typeof parent === 'object' && leafKey in parent) {
-            delete parent[leafKey];
-          }
+          deleteJSONPointerValue(entryObj, transform.destinationPointer);
         } catch {
           /* entry may not have the destination path */
         }

--- a/packages/cli/src/formats/json/utils.ts
+++ b/packages/cli/src/formats/json/utils.ts
@@ -1,7 +1,6 @@
 import { getLocaleProperties } from 'generaltranslation';
 import { exitSync } from '../../console/logging.js';
 import { logger } from '../../console/logger.js';
-import { JSONPath } from 'jsonpath-plus';
 import { LocaleProperties } from 'generaltranslation/types';
 import {
   AdditionalOptions,
@@ -12,7 +11,21 @@ import { flattenJson } from './flattenJson.js';
 import chalk from 'chalk';
 import path from 'node:path';
 import micromatch from 'micromatch';
+import type { JSONObject, JSONValue } from '../../types/data/json.js';
+import { getJSONPathMatches } from './jsonPath.js';
 const { isMatch } = micromatch;
+
+type MatchingArrayItem = {
+  sourceItem: JSONValue;
+  keyParentProperty: string | number;
+  keyPointer: string;
+  index: number;
+};
+
+type SourceObjectPointerMap = Record<
+  string,
+  { sourceObjectValue: JSONValue; sourceObjectOptions: SourceObjectOptions }
+>;
 
 // Find the matching source item in an array
 // where the key matches the identifying locale property
@@ -21,16 +34,8 @@ export function findMatchingItemArray(
   locale: string,
   sourceObjectOptions: SourceObjectOptions,
   sourceObjectPointer: string,
-  sourceObjectValue: any
-): Record<
-  string,
-  {
-    sourceItem: any;
-    keyParentProperty: string;
-    keyPointer: string;
-    index: number;
-  }
-> {
+  sourceObjectValue: JSONValue[]
+): Record<string, MatchingArrayItem> {
   const { identifyingLocaleProperty, localeKeyJsonPath } =
     getSourceObjectOptionsArray(
       locale,
@@ -38,24 +43,10 @@ export function findMatchingItemArray(
       sourceObjectOptions
     );
   // Use the json pointer key to locate the source item
-  const matchingItems: Record<
-    string,
-    {
-      sourceItem: any;
-      keyParentProperty: string;
-      keyPointer: string;
-      index: number;
-    }
-  > = {};
+  const matchingItems: Record<string, MatchingArrayItem> = {};
   for (const [index, item] of sourceObjectValue.entries()) {
     // Get the key candidates
-    const keyCandidates = JSONPath({
-      json: item,
-      path: localeKeyJsonPath,
-      resultType: 'all',
-      flatten: true,
-      wrap: true,
-    });
+    const keyCandidates = getJSONPathMatches(item, localeKeyJsonPath);
     if (!keyCandidates) {
       logger.error(
         `Source item at path: ${sourceObjectPointer} does not have a key value at path: ${localeKeyJsonPath}`
@@ -74,10 +65,17 @@ export function findMatchingItemArray(
       // Validate the key is the identifying locale property
       continue;
     }
+    const keyParentProperty = keyCandidates[0].parentProperty;
+    if (keyParentProperty === null) {
+      logger.error(
+        `Source item at path: ${sourceObjectPointer} has a root-level key match with path: ${localeKeyJsonPath}`
+      );
+      return exitSync(1);
+    }
     // Map the index to the source item
     matchingItems[`/${index}`] = {
       sourceItem: item,
-      keyParentProperty: keyCandidates[0].parentProperty,
+      keyParentProperty,
       keyPointer: keyCandidates[0].pointer,
       index,
     };
@@ -89,8 +87,8 @@ export function findMatchingItemObject(
   locale: string,
   sourceObjectPointer: string,
   sourceObjectOptions: SourceObjectOptions,
-  sourceObjectValue: any
-): { sourceItem: any | undefined; keyParentProperty: string } {
+  sourceObjectValue: JSONObject
+): { sourceItem: JSONValue | undefined; keyParentProperty: string } {
   const { identifyingLocaleProperty } = getSourceObjectOptionsObject(
     locale,
     sourceObjectPointer,
@@ -193,16 +191,10 @@ export function generateSourceObjectPointers(
   jsonSchema: {
     [sourceObjectPath: string]: SourceObjectOptions;
   },
-  originalJson: any
-): Record<
-  string,
-  { sourceObjectValue: any; sourceObjectOptions: SourceObjectOptions }
-> {
-  const sourceObjectPointers: Record<
-    string,
-    { sourceObjectValue: any; sourceObjectOptions: SourceObjectOptions }
-  > = Object.entries(jsonSchema).reduce(
-    (acc: Record<string, any>, [sourceObjectPath, sourceObjectOptions]) => {
+  originalJson: JSONValue
+): SourceObjectPointerMap {
+  const sourceObjectPointers = Object.entries(jsonSchema).reduce(
+    (acc: SourceObjectPointerMap, [sourceObjectPath, sourceObjectOptions]) => {
       const sourceObjects = flattenJson(originalJson, [sourceObjectPath]);
       Object.entries(sourceObjects).forEach(([pointer, value]) => {
         acc[pointer as string] = {
@@ -269,7 +261,7 @@ const UNSUPPORTED_MINTLIFY_FIELDS = ['$ref'];
  * matches one of the unsupported field names.
  */
 function findMintlifyUnsupportedFields(
-  value: any,
+  value: JSONValue,
   fieldNames: string[],
   pointer: string = ''
 ): { pointer: string; field: string; fieldValue: string }[] {
@@ -289,17 +281,18 @@ function findMintlifyUnsupportedFields(
     return results;
   }
   // Check if this object contains an unsupported field
+  const objectValue = value as JSONObject;
   for (const field of fieldNames) {
-    if (typeof value[field] === 'string') {
-      return [{ pointer, field, fieldValue: value[field] }];
+    if (typeof objectValue[field] === 'string') {
+      return [{ pointer, field, fieldValue: objectValue[field] }];
     }
   }
   // Recurse into child properties
   const results: { pointer: string; field: string; fieldValue: string }[] = [];
-  for (const key of Object.keys(value)) {
+  for (const key of Object.keys(objectValue)) {
     results.push(
       ...findMintlifyUnsupportedFields(
-        value[key],
+        objectValue[key],
         fieldNames,
         `${pointer}/${key}`
       )
@@ -313,7 +306,7 @@ function findMintlifyUnsupportedFields(
  * Logs a warning listing the fields found.
  */
 export function detectMintlifyUnsupportedFields(
-  json: any,
+  json: JSONValue,
   filePath: string
 ): void {
   const unsupported = findMintlifyUnsupportedFields(

--- a/packages/cli/src/fs/__tests__/copyFile.test.ts
+++ b/packages/cli/src/fs/__tests__/copyFile.test.ts
@@ -46,22 +46,7 @@ describe('copyFile', () => {
         options: {},
       };
 
-      await copyFile(settings as any);
-
-      expect(fs.promises.mkdir).not.toHaveBeenCalled();
-      expect(fs.promises.copyFile).not.toHaveBeenCalled();
-    });
-
-    it('should return early if copyFiles is null', async () => {
-      const settings = {
-        defaultLocale: 'en',
-        locales: ['en', 'fr'],
-        options: {
-          copyFiles: null,
-        },
-      };
-
-      await copyFile(settings as any);
+      await copyFile(settings);
 
       expect(fs.promises.mkdir).not.toHaveBeenCalled();
       expect(fs.promises.copyFile).not.toHaveBeenCalled();
@@ -76,7 +61,7 @@ describe('copyFile', () => {
         },
       };
 
-      await copyFile(settings as any);
+      await copyFile(settings);
 
       expect(fs.promises.mkdir).not.toHaveBeenCalled();
       expect(fs.promises.copyFile).not.toHaveBeenCalled();
@@ -111,7 +96,7 @@ describe('copyFile', () => {
         },
       };
 
-      await copyFile(settings as any);
+      await copyFile(settings);
 
       // Should create directories for target locales
       expect(fs.promises.mkdir).toHaveBeenCalledTimes(2);
@@ -146,7 +131,7 @@ describe('copyFile', () => {
         },
       };
 
-      await copyFile(settings as any);
+      await copyFile(settings);
 
       // Should create directories for both files and target locale
       expect(fs.promises.mkdir).toHaveBeenCalledTimes(2);
@@ -178,7 +163,7 @@ describe('copyFile', () => {
         },
       };
 
-      await copyFile(settings as any);
+      await copyFile(settings);
 
       // Should create directories for all target locales (excluding default)
       expect(fs.promises.mkdir).toHaveBeenCalledTimes(4);
@@ -224,7 +209,7 @@ describe('copyFile', () => {
         },
       };
 
-      await copyFile(settings as any);
+      await copyFile(settings);
 
       // Should only create directories for non-default locales
       expect(fs.promises.mkdir).toHaveBeenCalledTimes(2);
@@ -256,7 +241,7 @@ describe('copyFile', () => {
         },
       };
 
-      await copyFile(settings as any);
+      await copyFile(settings);
 
       // Should create the nested directory structure
       expect(fs.promises.mkdir).toHaveBeenCalledTimes(1);
@@ -287,7 +272,7 @@ describe('copyFile', () => {
         },
       };
 
-      await copyFile(settings as any);
+      await copyFile(settings);
 
       // Should create directory once for all files in same directory
       expect(fs.promises.mkdir).toHaveBeenCalledTimes(4);
@@ -340,9 +325,7 @@ describe('copyFile', () => {
         },
       };
 
-      await expect(copyFile(settings as any)).rejects.toThrow(
-        'Permission denied'
-      );
+      await expect(copyFile(settings)).rejects.toThrow('Permission denied');
     });
 
     it('should propagate copyFile errors', async () => {
@@ -360,9 +343,7 @@ describe('copyFile', () => {
         },
       };
 
-      await expect(copyFile(settings as any)).rejects.toThrow(
-        'Source file not found'
-      );
+      await expect(copyFile(settings)).rejects.toThrow('Source file not found');
     });
 
     it('should log error when source file does not exist', async () => {
@@ -378,7 +359,7 @@ describe('copyFile', () => {
         },
       };
 
-      await copyFile(settings as any);
+      await copyFile(settings);
 
       // Should log error for missing source file
       expect(vi.mocked(logger.error)).toHaveBeenCalledWith(
@@ -406,7 +387,7 @@ describe('copyFile', () => {
         },
       };
 
-      await copyFile(settings as any);
+      await copyFile(settings);
 
       // Should log error for each missing source file
       expect(vi.mocked(logger.error)).toHaveBeenCalledTimes(2);
@@ -442,7 +423,7 @@ describe('copyFile', () => {
         },
       };
 
-      await copyFile(settings as any);
+      await copyFile(settings);
 
       // Should only log error for the missing file
       expect(vi.mocked(logger.error)).toHaveBeenCalledTimes(1);
@@ -487,7 +468,7 @@ describe('copyFile', () => {
         },
       };
 
-      await copyFile(settings as any);
+      await copyFile(settings);
 
       // Should not create any directories or copy any files
       expect(fs.promises.mkdir).not.toHaveBeenCalled();
@@ -503,7 +484,7 @@ describe('copyFile', () => {
         },
       };
 
-      await copyFile(settings as any);
+      await copyFile(settings);
 
       // Should create directory
       expect(fs.promises.mkdir).toHaveBeenCalledTimes(1);
@@ -528,7 +509,7 @@ describe('copyFile', () => {
         },
       };
 
-      await copyFile(settings as any);
+      await copyFile(settings);
 
       expect(fs.promises.mkdir).toHaveBeenCalledWith(
         '/project/src/components/ui/zh-CN/translations',

--- a/packages/cli/src/fs/copyFile.ts
+++ b/packages/cli/src/fs/copyFile.ts
@@ -1,14 +1,16 @@
 import path from 'node:path';
 import fs from 'node:fs';
-import { Settings } from '../types/index.js';
+import type { Settings } from '../types/index.js';
 import { logger } from '../console/logger.js';
+
+type CopyFileSettings = Pick<Settings, 'defaultLocale' | 'locales' | 'options'>;
 
 /**
  * Copy a file to target locale without translation
  *
  * This is a naive approach, does not allow for wild cards
  */
-export default async function copyFile(settings: Settings) {
+export default async function copyFile(settings: CopyFileSettings) {
   if (!settings.options?.copyFiles || settings.options.copyFiles.length === 0) {
     return;
   }

--- a/packages/cli/src/types/data/json.ts
+++ b/packages/cli/src/types/data/json.ts
@@ -1,4 +1,10 @@
-type JSONValue = string | number | boolean | null | JSONObject | JSONArray;
+export type JSONValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JSONObject
+  | JSONArray;
 
 export type JSONObject = { [key: string]: JSONValue };
 export type JSONArray = JSONValue[];

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -258,6 +258,19 @@ export type Settings = {
   sharedStaticAssets?: SharedStaticAssetsConfig;
 };
 
+export type StaticLocalizationFiles = Pick<
+  Settings['files'],
+  'placeholderPaths' | 'resolvedPaths'
+> &
+  Partial<Pick<Settings['files'], 'transformPaths' | 'transformFormats'>>;
+
+export type StaticLocalizationSettings = Pick<
+  Settings,
+  'defaultLocale' | 'locales' | 'options'
+> & {
+  files?: StaticLocalizationFiles | null;
+};
+
 export type BranchOptions = {
   currentBranch?: string;
   autoDetectBranches?: boolean;

--- a/packages/cli/src/utils/__tests__/addExplicitAnchorIds.test.ts
+++ b/packages/cli/src/utils/__tests__/addExplicitAnchorIds.test.ts
@@ -749,15 +749,11 @@ This is just an example
       const settings = {
         options: { experimentalAddHeaderAnchorIds: 'mintlify' as const },
       };
-      const first = addExplicitAnchorIds(
-        input,
-        sourceHeadingMap,
-        settings as any
-      );
+      const first = addExplicitAnchorIds(input, sourceHeadingMap, settings);
       const second = addExplicitAnchorIds(
         first.content,
         sourceHeadingMap,
-        settings as any
+        settings
       );
 
       expect(first.hasChanges).toBe(true);
@@ -776,7 +772,7 @@ This is just an example
       const result = addExplicitAnchorIds(
         translatedContent,
         sourceHeadingMap,
-        settings as any
+        settings
       );
 
       expect(result.hasChanges).toBe(true);

--- a/packages/cli/src/utils/__tests__/localizeRelativeAssets.test.ts
+++ b/packages/cli/src/utils/__tests__/localizeRelativeAssets.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import localizeRelativeAssets, {
   localizeRelativeAssetsForContent,
+  type RelativeAssetSettings,
 } from '../localizeRelativeAssets';
+
+const createSettings = (
+  settings: RelativeAssetSettings
+): RelativeAssetSettings => settings;
 
 vi.mock('fs', () => ({
   promises: {
@@ -39,7 +44,7 @@ describe('localizeRelativeAssets', () => {
       "<img src='whatsapp-clawd.jpg' />"
     );
     vi.mocked(fs.promises.writeFile).mockResolvedValue(undefined);
-    vi.mocked(fs.existsSync).mockImplementation((p: any) => {
+    vi.mocked(fs.existsSync).mockImplementation((p) => {
       if (p === '/proj/es/demoIndex.mdx') return true;
       if (p === '/proj/demoIndex.mdx') return true;
       if (p === '/proj/es/whatsapp-clawd.jpg') return false;
@@ -49,17 +54,16 @@ describe('localizeRelativeAssets', () => {
 
     const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/proj');
 
-    const settings = {
+    const settings = createSettings({
       files: {
         placeholderPaths: { docs: '/docs' },
         resolvedPaths: {},
         transformPaths: {},
       },
       locales: ['en', 'es'],
-      defaultLocale: 'en',
-    };
+    });
 
-    await localizeRelativeAssets(settings as any, ['es']);
+    await localizeRelativeAssets(settings, ['es']);
 
     expect(fs.promises.writeFile).toHaveBeenCalledTimes(1);
     const written = vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string;
@@ -69,7 +73,7 @@ describe('localizeRelativeAssets', () => {
   });
 
   it('does not rewrite if target-relative asset exists', () => {
-    vi.mocked(fs.existsSync).mockImplementation((p: any) => {
+    vi.mocked(fs.existsSync).mockImplementation((p) => {
       if (p === '/proj/es/whatsapp-clawd.jpg') return true;
       return false;
     });
@@ -100,7 +104,7 @@ describe('localizeRelativeAssets', () => {
   });
 
   it('does not rewrite markdown links', () => {
-    vi.mocked(fs.existsSync).mockImplementation((p: any) => {
+    vi.mocked(fs.existsSync).mockImplementation((p) => {
       if (p === '/proj/whatsapp-clawd.jpg') return true;
       return false;
     });

--- a/packages/cli/src/utils/__tests__/localizeStaticImports.test.ts
+++ b/packages/cli/src/utils/__tests__/localizeStaticImports.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
-import localizeStaticImports from '../localizeStaticImports';
+import localizeStaticImports, {
+  type StaticImportSettings,
+} from '../localizeStaticImports';
+
+type ExactStaticImportSettings<T extends StaticImportSettings> = T &
+  Record<Exclude<keyof T, keyof StaticImportSettings>, never>;
+
+const createSettings = <T extends StaticImportSettings>(
+  settings: ExactStaticImportSettings<T>
+): StaticImportSettings => settings;
 
 // Mock fs module
 vi.mock('fs', () => ({
@@ -42,7 +51,7 @@ describe('localizeStaticImports', () => {
         locales: ['en', 'ja'],
       };
 
-      await localizeStaticImports(settings as any);
+      await localizeStaticImports(createSettings(settings));
 
       expect(createFileMapping).not.toHaveBeenCalled();
     });
@@ -51,19 +60,20 @@ describe('localizeStaticImports', () => {
       const settings = {
         files: {
           placeholderPaths: { gt: 'some-path' },
-          resolvedPaths: [],
+          resolvedPaths: {},
         },
         defaultLocale: 'en',
         locales: ['en', 'ja'],
       };
 
-      await localizeStaticImports(settings as any);
+      await localizeStaticImports(createSettings(settings));
 
       expect(createFileMapping).not.toHaveBeenCalled();
     });
 
     it('should process md/mdx files for localization', async () => {
       const mockFileMapping = {
+        en: {},
         ja: {
           'file1.md': '/path/to/ja/file1.md',
           'file2.mdx': '/path/to/ja/file2.mdx',
@@ -80,7 +90,7 @@ describe('localizeStaticImports', () => {
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['file1', 'file2'],
+          resolvedPaths: { mdx: ['file1', 'file2'] },
           transformPaths: {},
           transformFormats: {},
         },
@@ -92,10 +102,10 @@ describe('localizeStaticImports', () => {
         },
       };
 
-      await localizeStaticImports(settings as any);
+      await localizeStaticImports(createSettings(settings));
 
       expect(createFileMapping).toHaveBeenCalledWith(
-        ['file1', 'file2'],
+        { mdx: ['file1', 'file2'] },
         { docs: '/docs' },
         {},
         {},
@@ -127,7 +137,7 @@ describe('localizeStaticImports', () => {
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -138,7 +148,7 @@ describe('localizeStaticImports', () => {
           },
         };
 
-        await localizeStaticImports(settings as any);
+        await localizeStaticImports(createSettings(settings));
       });
 
       it('should handle double quotes in import statements', async () => {
@@ -159,7 +169,7 @@ describe('localizeStaticImports', () => {
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -170,7 +180,7 @@ describe('localizeStaticImports', () => {
           },
         };
 
-        await localizeStaticImports(settings as any);
+        await localizeStaticImports(createSettings(settings));
       });
 
       it('should handle multiple import statements', async () => {
@@ -205,7 +215,7 @@ import Component3 from '/components/ja/component3.mdx'
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -216,7 +226,7 @@ import Component3 from '/components/ja/component3.mdx'
           },
         };
 
-        await localizeStaticImports(settings as any);
+        await localizeStaticImports(createSettings(settings));
       });
 
       it('should handle pattern without leading slash', async () => {
@@ -237,7 +247,7 @@ import Component3 from '/components/ja/component3.mdx'
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -248,7 +258,7 @@ import Component3 from '/components/ja/component3.mdx'
           },
         };
 
-        await localizeStaticImports(settings as any);
+        await localizeStaticImports(createSettings(settings));
       });
 
       it('should handle nested paths correctly', async () => {
@@ -269,7 +279,7 @@ import Component3 from '/components/ja/component3.mdx'
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -280,7 +290,7 @@ import Component3 from '/components/ja/component3.mdx'
           },
         };
 
-        await localizeStaticImports(settings as any);
+        await localizeStaticImports(createSettings(settings));
       });
     });
 
@@ -303,7 +313,7 @@ import Component3 from '/components/ja/component3.mdx'
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -314,7 +324,7 @@ import Component3 from '/components/ja/component3.mdx'
           },
         };
 
-        await localizeStaticImports(settings as any);
+        await localizeStaticImports(createSettings(settings));
       });
 
       it('should handle empty path after pattern', async () => {
@@ -335,7 +345,7 @@ import Component3 from '/components/ja/component3.mdx'
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -346,7 +356,7 @@ import Component3 from '/components/ja/component3.mdx'
           },
         };
 
-        await localizeStaticImports(settings as any);
+        await localizeStaticImports(createSettings(settings));
       });
 
       it('should replace default locale with target locale when hideDefaultLocale is true and import contains default locale', async () => {
@@ -367,7 +377,7 @@ import Component3 from '/components/ja/component3.mdx'
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -378,7 +388,7 @@ import Component3 from '/components/ja/component3.mdx'
           },
         };
 
-        await localizeStaticImports(settings as any);
+        await localizeStaticImports(createSettings(settings));
       });
     });
 
@@ -405,7 +415,7 @@ export default function Component() {}
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -416,7 +426,7 @@ export default function Component() {}
           },
         };
 
-        await localizeStaticImports(settings as any);
+        await localizeStaticImports(createSettings(settings));
       });
 
       it('should handle mixed quote types', async () => {
@@ -443,7 +453,7 @@ import Component2 from "/components/ja/component2.mdx"
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -454,7 +464,7 @@ import Component2 from "/components/ja/component2.mdx"
           },
         };
 
-        await localizeStaticImports(settings as any);
+        await localizeStaticImports(createSettings(settings));
       });
 
       it('should handle complex import patterns', async () => {
@@ -481,7 +491,7 @@ import { Table as DataTable } from '/ui/ja/table.mdx'
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -492,7 +502,7 @@ import { Table as DataTable } from '/ui/ja/table.mdx'
           },
         };
 
-        await localizeStaticImports(settings as any);
+        await localizeStaticImports(createSettings(settings));
       });
 
       it('should handle imports with no path after locale', async () => {
@@ -513,7 +523,7 @@ import { Table as DataTable } from '/ui/ja/table.mdx'
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -524,7 +534,7 @@ import { Table as DataTable } from '/ui/ja/table.mdx'
           },
         };
 
-        await localizeStaticImports(settings as any);
+        await localizeStaticImports(createSettings(settings));
       });
     });
 
@@ -564,7 +574,7 @@ import { Table as DataTable } from '/ui/ja/table.mdx'
           const settings = {
             files: {
               placeholderPaths: { docs: '/docs' },
-              resolvedPaths: ['test'],
+              resolvedPaths: {},
               transformPaths: {},
             },
             defaultLocale: 'en',
@@ -575,7 +585,7 @@ import { Table as DataTable } from '/ui/ja/table.mdx'
             },
           };
 
-          await localizeStaticImports(settings as any);
+          await localizeStaticImports(createSettings(settings));
         }
       });
     });
@@ -599,7 +609,7 @@ import { Table as DataTable } from '/ui/ja/table.mdx'
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'fr', // Different default locale
@@ -610,7 +620,7 @@ import { Table as DataTable } from '/ui/ja/table.mdx'
           },
         };
 
-        await localizeStaticImports(settings as any);
+        await localizeStaticImports(createSettings(settings));
       });
     });
 
@@ -633,7 +643,7 @@ import { Table as DataTable } from '/ui/ja/table.mdx'
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -644,7 +654,7 @@ import { Table as DataTable } from '/ui/ja/table.mdx'
           },
         };
 
-        await localizeStaticImports(settings as any);
+        await localizeStaticImports(createSettings(settings));
       });
 
       it('should use default pattern /[locale] when docsImportPattern is not provided with hideDefaultLocale true', async () => {
@@ -665,7 +675,7 @@ import { Table as DataTable } from '/ui/ja/table.mdx'
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -676,7 +686,7 @@ import { Table as DataTable } from '/ui/ja/table.mdx'
           },
         };
 
-        await localizeStaticImports(settings as any);
+        await localizeStaticImports(createSettings(settings));
       });
 
       it('should handle nested paths with default pattern /[locale]', async () => {
@@ -697,7 +707,7 @@ import { Table as DataTable } from '/ui/ja/table.mdx'
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -708,7 +718,7 @@ import { Table as DataTable } from '/ui/ja/table.mdx'
           },
         };
 
-        await localizeStaticImports(settings as any);
+        await localizeStaticImports(createSettings(settings));
       });
 
       it('should handle empty options object (no docsImportPattern or docsHideDefaultLocaleImport)', async () => {
@@ -729,7 +739,7 @@ import { Table as DataTable } from '/ui/ja/table.mdx'
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -737,7 +747,7 @@ import { Table as DataTable } from '/ui/ja/table.mdx'
           // No options object at all
         };
 
-        await localizeStaticImports(settings as any);
+        await localizeStaticImports(createSettings(settings));
       });
 
       it('should handle undefined docsImportPattern specifically', async () => {
@@ -758,7 +768,7 @@ import { Table as DataTable } from '/ui/ja/table.mdx'
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -769,7 +779,7 @@ import { Table as DataTable } from '/ui/ja/table.mdx'
           },
         };
 
-        await localizeStaticImports(settings as any);
+        await localizeStaticImports(createSettings(settings));
       });
     });
 
@@ -803,7 +813,7 @@ import API from '/components/ja/api.mdx'
           const settings = {
             files: {
               placeholderPaths: { docs: '/docs' },
-              resolvedPaths: ['test'],
+              resolvedPaths: {},
               transformPaths: {},
             },
             defaultLocale: 'en',
@@ -815,7 +825,7 @@ import API from '/components/ja/api.mdx'
             },
           };
 
-          await localizeStaticImports(settings as any);
+          await localizeStaticImports(createSettings(settings));
         });
 
         it('should exclude paths matching glob patterns', async () => {
@@ -846,7 +856,7 @@ import Snippet from '/components/en/snippets/code.mdx'
           const settings = {
             files: {
               placeholderPaths: { docs: '/docs' },
-              resolvedPaths: ['test'],
+              resolvedPaths: {},
               transformPaths: {},
             },
             defaultLocale: 'en',
@@ -861,7 +871,7 @@ import Snippet from '/components/en/snippets/code.mdx'
             },
           };
 
-          await localizeStaticImports(settings as any);
+          await localizeStaticImports(createSettings(settings));
         });
 
         it('should handle [locale] placeholder in exclude patterns', async () => {
@@ -890,7 +900,7 @@ import Images from '/components/en/images/logo.mdx'
           const settings = {
             files: {
               placeholderPaths: { docs: '/docs' },
-              resolvedPaths: ['test'],
+              resolvedPaths: {},
               transformPaths: {},
             },
             defaultLocale: 'en',
@@ -902,7 +912,7 @@ import Images from '/components/en/images/logo.mdx'
             },
           };
 
-          await localizeStaticImports(settings as any);
+          await localizeStaticImports(createSettings(settings));
         });
       });
 
@@ -935,7 +945,7 @@ import API from '/components/ja/api.mdx'
           const settings = {
             files: {
               placeholderPaths: { docs: '/docs' },
-              resolvedPaths: ['test'],
+              resolvedPaths: {},
               transformPaths: {},
             },
             defaultLocale: 'en',
@@ -947,7 +957,7 @@ import API from '/components/ja/api.mdx'
             },
           };
 
-          await localizeStaticImports(settings as any);
+          await localizeStaticImports(createSettings(settings));
         });
 
         it('should exclude paths matching glob patterns', async () => {
@@ -978,7 +988,7 @@ import Snippet from '/components/snippets/code.mdx'
           const settings = {
             files: {
               placeholderPaths: { docs: '/docs' },
-              resolvedPaths: ['test'],
+              resolvedPaths: {},
               transformPaths: {},
             },
             defaultLocale: 'en',
@@ -993,7 +1003,7 @@ import Snippet from '/components/snippets/code.mdx'
             },
           };
 
-          await localizeStaticImports(settings as any);
+          await localizeStaticImports(createSettings(settings));
         });
 
         it('should handle [locale] placeholder in exclude patterns with hideDefaultLocale', async () => {
@@ -1022,7 +1032,7 @@ import Images from '/components/images/logo.mdx'
           const settings = {
             files: {
               placeholderPaths: { docs: '/docs' },
-              resolvedPaths: ['test'],
+              resolvedPaths: {},
               transformPaths: {},
             },
             defaultLocale: 'en',
@@ -1034,7 +1044,7 @@ import Images from '/components/images/logo.mdx'
             },
           };
 
-          await localizeStaticImports(settings as any);
+          await localizeStaticImports(createSettings(settings));
         });
 
         it('should handle [locale] placeholder without pathContent', async () => {
@@ -1063,7 +1073,7 @@ import Images from '/components/images/logo.mdx'
           const settings = {
             files: {
               placeholderPaths: { docs: '/docs' },
-              resolvedPaths: ['test'],
+              resolvedPaths: {},
               transformPaths: {},
             },
             defaultLocale: 'en',
@@ -1075,7 +1085,7 @@ import Images from '/components/images/logo.mdx'
             },
           };
 
-          await localizeStaticImports(settings as any);
+          await localizeStaticImports(createSettings(settings));
         });
 
         it('should handle [locale] placeholder without pathContent with a default locale import', async () => {
@@ -1104,7 +1114,7 @@ import Images from '/components/en/images/logo.mdx'
           const settings = {
             files: {
               placeholderPaths: { docs: '/docs' },
-              resolvedPaths: ['test'],
+              resolvedPaths: {},
               transformPaths: {},
             },
             defaultLocale: 'en',
@@ -1116,7 +1126,7 @@ import Images from '/components/en/images/logo.mdx'
             },
           };
 
-          await localizeStaticImports(settings as any);
+          await localizeStaticImports(createSettings(settings));
         });
       });
 
@@ -1141,7 +1151,7 @@ import Images from '/components/en/images/logo.mdx'
           const settings = {
             files: {
               placeholderPaths: { docs: '/docs' },
-              resolvedPaths: ['test'],
+              resolvedPaths: {},
               transformPaths: {},
             },
             defaultLocale: 'en',
@@ -1153,7 +1163,7 @@ import Images from '/components/en/images/logo.mdx'
             },
           };
 
-          await localizeStaticImports(settings as any);
+          await localizeStaticImports(createSettings(settings));
         });
 
         it('should work when exclude parameter is undefined', async () => {
@@ -1176,7 +1186,7 @@ import Images from '/components/en/images/logo.mdx'
           const settings = {
             files: {
               placeholderPaths: { docs: '/docs' },
-              resolvedPaths: ['test'],
+              resolvedPaths: {},
               transformPaths: {},
             },
             defaultLocale: 'en',
@@ -1188,7 +1198,7 @@ import Images from '/components/en/images/logo.mdx'
             },
           };
 
-          await localizeStaticImports(settings as any);
+          await localizeStaticImports(createSettings(settings));
         });
 
         it('should handle complex glob patterns', async () => {
@@ -1221,7 +1231,7 @@ import Guide from '/components/ja/guide.mdx'
           const settings = {
             files: {
               placeholderPaths: { docs: '/docs' },
-              resolvedPaths: ['test'],
+              resolvedPaths: {},
               transformPaths: {},
             },
             defaultLocale: 'en',
@@ -1233,7 +1243,7 @@ import Guide from '/components/ja/guide.mdx'
             },
           };
 
-          await localizeStaticImports(settings as any);
+          await localizeStaticImports(createSettings(settings));
         });
       });
 
@@ -1270,7 +1280,7 @@ import Fence from '/components/en/fence.mdx'
           const settings = {
             files: {
               placeholderPaths: { docs: '/docs' },
-              resolvedPaths: ['test'],
+              resolvedPaths: {},
               transformPaths: {},
             },
             defaultLocale: 'en',
@@ -1281,7 +1291,7 @@ import Fence from '/components/en/fence.mdx'
             },
           };
 
-          await localizeStaticImports(settings as any);
+          await localizeStaticImports(createSettings(settings));
         });
       });
     });
@@ -1300,13 +1310,13 @@ import Fence from '/components/en/fence.mdx'
 
       const mockFileMapping = {
         en: { 'test.mdx': '/path/test.mdx' },
-      } as any;
+      };
       vi.mocked(createFileMapping).mockReturnValue(mockFileMapping);
 
-      const settings = {
+      const settings = createSettings({
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
@@ -1315,7 +1325,7 @@ import Fence from '/components/en/fence.mdx'
           docsHideDefaultLocaleImport: true,
           docsImportPattern: '/components/[locale]',
         },
-      } as any;
+      });
 
       await localizeStaticImports(settings);
 
@@ -1335,13 +1345,13 @@ import Fence from '/components/en/fence.mdx'
 
       const mockFileMapping = {
         ja: { 'test.mdx': '/path/test.mdx' },
-      } as any;
+      };
       vi.mocked(createFileMapping).mockReturnValue(mockFileMapping);
 
-      const settings = {
+      const settings = createSettings({
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
@@ -1350,7 +1360,7 @@ import Fence from '/components/en/fence.mdx'
           docsHideDefaultLocaleImport: false,
           docsImportPattern: '/components/[locale]',
         },
-      } as any;
+      });
 
       await localizeStaticImports(settings);
       // Ensure re-run is also stable
@@ -1366,19 +1376,19 @@ import Fence from '/components/en/fence.mdx'
 
     const mockFileMapping = {
       ja: { 'test.mdx': '/path/test.mdx' },
-    } as any;
+    };
     vi.mocked(createFileMapping).mockReturnValue(mockFileMapping);
 
-    const settings = {
+    const settings = createSettings({
       files: {
         placeholderPaths: { docs: '/docs' },
-        resolvedPaths: ['test'],
+        resolvedPaths: {},
         transformPaths: {},
       },
       defaultLocale: 'en',
       locales: ['en', 'ja'],
       options: { docsImportPattern: '/components/[locale]' },
-    } as any;
+    });
 
     await localizeStaticImports(settings);
 
@@ -1408,7 +1418,7 @@ import Fence from '/components/en/fence.mdx'
           const settings = {
             files: {
               placeholderPaths: { docs: '/docs' },
-              resolvedPaths: ['test'],
+              resolvedPaths: {},
               transformPaths: {},
             },
             defaultLocale: 'en',
@@ -1419,7 +1429,7 @@ import Fence from '/components/en/fence.mdx'
             },
           };
 
-          await localizeStaticImports(settings as any);
+          await localizeStaticImports(createSettings(settings));
         });
 
         it('should handle real-world scenario - file in en directory with missing locale in imports', async () => {
@@ -1461,7 +1471,7 @@ import SnippetIntro from '/snippets/en/snippet-intro.mdx';
           const settings = {
             files: {
               placeholderPaths: { docs: '/docs' },
-              resolvedPaths: ['reusable-snippets'],
+              resolvedPaths: {},
               transformPaths: {},
             },
             defaultLocale: 'en',
@@ -1472,7 +1482,7 @@ import SnippetIntro from '/snippets/en/snippet-intro.mdx';
             },
           };
 
-          await localizeStaticImports(settings as any);
+          await localizeStaticImports(createSettings(settings));
         });
 
         it('should handle exact user scenario - snippets pattern', async () => {
@@ -1514,7 +1524,7 @@ import SnippetIntro from '/snippets/en/snippet-intro.mdx';
           const settings = {
             files: {
               placeholderPaths: { docs: '/docs' },
-              resolvedPaths: ['reusable-snippets'],
+              resolvedPaths: {},
               transformPaths: {},
             },
             defaultLocale: 'en',
@@ -1525,7 +1535,7 @@ import SnippetIntro from '/snippets/en/snippet-intro.mdx';
             },
           };
 
-          await localizeStaticImports(settings as any);
+          await localizeStaticImports(createSettings(settings));
         });
 
         it('should not modify imports that already have the default locale', async () => {
@@ -1548,7 +1558,7 @@ import SnippetIntro from '/snippets/en/snippet-intro.mdx';
           const settings = {
             files: {
               placeholderPaths: { docs: '/docs' },
-              resolvedPaths: ['test'],
+              resolvedPaths: {},
               transformPaths: {},
             },
             defaultLocale: 'en',
@@ -1559,7 +1569,7 @@ import SnippetIntro from '/snippets/en/snippet-intro.mdx';
             },
           };
 
-          await localizeStaticImports(settings as any);
+          await localizeStaticImports(createSettings(settings));
         });
 
         it('should handle multiple imports with mixed patterns', async () => {
@@ -1590,7 +1600,7 @@ import Component3 from '/snippets/en/outro.mdx';
           const settings = {
             files: {
               placeholderPaths: { docs: '/docs' },
-              resolvedPaths: ['test'],
+              resolvedPaths: {},
               transformPaths: {},
             },
             defaultLocale: 'en',
@@ -1601,7 +1611,7 @@ import Component3 from '/snippets/en/outro.mdx';
             },
           };
 
-          await localizeStaticImports(settings as any);
+          await localizeStaticImports(createSettings(settings));
         });
 
         it('should work with different quote types', async () => {
@@ -1630,7 +1640,7 @@ import Component2 from "/snippets/en/double.mdx";
           const settings = {
             files: {
               placeholderPaths: { docs: '/docs' },
-              resolvedPaths: ['test'],
+              resolvedPaths: {},
               transformPaths: {},
             },
             defaultLocale: 'en',
@@ -1641,7 +1651,7 @@ import Component2 from "/snippets/en/double.mdx";
             },
           };
 
-          await localizeStaticImports(settings as any);
+          await localizeStaticImports(createSettings(settings));
         });
 
         it('should handle nested path patterns', async () => {
@@ -1664,7 +1674,7 @@ import Component2 from "/snippets/en/double.mdx";
           const settings = {
             files: {
               placeholderPaths: { docs: '/docs' },
-              resolvedPaths: ['test'],
+              resolvedPaths: {},
               transformPaths: {},
             },
             defaultLocale: 'en',
@@ -1675,7 +1685,7 @@ import Component2 from "/snippets/en/double.mdx";
             },
           };
 
-          await localizeStaticImports(settings as any);
+          await localizeStaticImports(createSettings(settings));
         });
       });
 
@@ -1700,7 +1710,7 @@ import Component2 from "/snippets/en/double.mdx";
           const settings = {
             files: {
               placeholderPaths: { docs: '/docs' },
-              resolvedPaths: ['test'],
+              resolvedPaths: {},
               transformPaths: {},
             },
             defaultLocale: 'en',
@@ -1711,7 +1721,7 @@ import Component2 from "/snippets/en/double.mdx";
             },
           };
 
-          await localizeStaticImports(settings as any);
+          await localizeStaticImports(createSettings(settings));
         });
       });
     });
@@ -1738,7 +1748,7 @@ import Component2 from "/snippets/en/double.mdx";
           const settings = {
             files: {
               placeholderPaths: { docs: '/docs' },
-              resolvedPaths: ['test'],
+              resolvedPaths: {},
               transformPaths: {},
             },
             defaultLocale: 'en',
@@ -1749,7 +1759,7 @@ import Component2 from "/snippets/en/double.mdx";
             },
           };
 
-          await localizeStaticImports(settings as any);
+          await localizeStaticImports(createSettings(settings));
         });
 
         it('should not modify imports that already have the correct format', async () => {
@@ -1772,7 +1782,7 @@ import Component2 from "/snippets/en/double.mdx";
           const settings = {
             files: {
               placeholderPaths: { docs: '/docs' },
-              resolvedPaths: ['test'],
+              resolvedPaths: {},
               transformPaths: {},
             },
             defaultLocale: 'en',
@@ -1783,7 +1793,7 @@ import Component2 from "/snippets/en/double.mdx";
             },
           };
 
-          await localizeStaticImports(settings as any);
+          await localizeStaticImports(createSettings(settings));
         });
 
         it('should handle multiple imports with mixed patterns', async () => {
@@ -1814,7 +1824,7 @@ import Component3 from '/snippets/outro.mdx';
           const settings = {
             files: {
               placeholderPaths: { docs: '/docs' },
-              resolvedPaths: ['test'],
+              resolvedPaths: {},
               transformPaths: {},
             },
             defaultLocale: 'en',
@@ -1825,7 +1835,7 @@ import Component3 from '/snippets/outro.mdx';
             },
           };
 
-          await localizeStaticImports(settings as any);
+          await localizeStaticImports(createSettings(settings));
         });
 
         it('should work with different quote types', async () => {
@@ -1854,7 +1864,7 @@ import Component2 from "/snippets/double.mdx";
           const settings = {
             files: {
               placeholderPaths: { docs: '/docs' },
-              resolvedPaths: ['test'],
+              resolvedPaths: {},
               transformPaths: {},
             },
             defaultLocale: 'en',
@@ -1865,7 +1875,7 @@ import Component2 from "/snippets/double.mdx";
             },
           };
 
-          await localizeStaticImports(settings as any);
+          await localizeStaticImports(createSettings(settings));
         });
 
         it('should handle nested path patterns', async () => {
@@ -1888,7 +1898,7 @@ import Component2 from "/snippets/double.mdx";
           const settings = {
             files: {
               placeholderPaths: { docs: '/docs' },
-              resolvedPaths: ['test'],
+              resolvedPaths: {},
               transformPaths: {},
             },
             defaultLocale: 'en',
@@ -1899,7 +1909,7 @@ import Component2 from "/snippets/double.mdx";
             },
           };
 
-          await localizeStaticImports(settings as any);
+          await localizeStaticImports(createSettings(settings));
         });
       });
 
@@ -1924,7 +1934,7 @@ import Component2 from "/snippets/double.mdx";
           const settings = {
             files: {
               placeholderPaths: { docs: '/docs' },
-              resolvedPaths: ['test'],
+              resolvedPaths: {},
               transformPaths: {},
             },
             defaultLocale: 'en',
@@ -1935,7 +1945,7 @@ import Component2 from "/snippets/double.mdx";
             },
           };
 
-          await localizeStaticImports(settings as any);
+          await localizeStaticImports(createSettings(settings));
         });
       });
     });
@@ -1980,7 +1990,7 @@ import Component2 from "/snippets/double.mdx";
           },
         };
 
-        await localizeStaticImports(settings as any);
+        await localizeStaticImports(createSettings(settings));
       });
 
       it('should handle non-default locale files that have imports without locale (real-world case)', async () => {
@@ -2035,7 +2045,7 @@ import SnippetIntro from '/snippets/fr/snippet-intro.mdx';
           },
         };
 
-        await localizeStaticImports(settings as any);
+        await localizeStaticImports(createSettings(settings));
       });
 
       it('should still handle standard case where imports already have default locale', async () => {
@@ -2067,7 +2077,7 @@ import SnippetIntro from '/snippets/fr/snippet-intro.mdx';
           },
         };
 
-        await localizeStaticImports(settings as any);
+        await localizeStaticImports(createSettings(settings));
       });
     });
 
@@ -2096,7 +2106,7 @@ import Component2 from '/snippets/excluded.mdx';
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -2108,7 +2118,7 @@ import Component2 from '/snippets/excluded.mdx';
           },
         };
 
-        await localizeStaticImports(settings as any);
+        await localizeStaticImports(createSettings(settings));
       });
 
       it('should work with different default locales', async () => {
@@ -2129,7 +2139,7 @@ import Component2 from '/snippets/excluded.mdx';
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'fr',
@@ -2140,7 +2150,7 @@ import Component2 from '/snippets/excluded.mdx';
           },
         };
 
-        await localizeStaticImports(settings as any);
+        await localizeStaticImports(createSettings(settings));
       });
     });
 
@@ -2163,7 +2173,7 @@ import Component2 from '/snippets/excluded.mdx';
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['system'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -2180,7 +2190,7 @@ import Component2 from '/snippets/excluded.mdx';
           },
         };
 
-        await localizeStaticImports(settings as any);
+        await localizeStaticImports(createSettings(settings));
       });
     });
   });
@@ -2206,7 +2216,7 @@ import ValidComponent from '/components/ja/valid.mdx'`;
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
@@ -2217,7 +2227,7 @@ import ValidComponent from '/components/ja/valid.mdx'`;
         },
       };
 
-      await localizeStaticImports(settings as any);
+      await localizeStaticImports(createSettings(settings));
     });
 
     it('should use fallback processing when MDX has unclosed JSX tags', async () => {
@@ -2242,7 +2252,7 @@ import Component from '/components/ja/test.mdx'
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
@@ -2253,7 +2263,7 @@ import Component from '/components/ja/test.mdx'
         },
       };
 
-      await localizeStaticImports(settings as any);
+      await localizeStaticImports(createSettings(settings));
     });
 
     it('should use fallback processing when MDX has nested unclosed tags', async () => {
@@ -2286,7 +2296,7 @@ import Component from '/components/ja/test.mdx'`;
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
@@ -2297,7 +2307,7 @@ import Component from '/components/ja/test.mdx'`;
         },
       };
 
-      await localizeStaticImports(settings as any);
+      await localizeStaticImports(createSettings(settings));
     });
 
     it('should use fallback processing when MDX has mismatched JSX tags', async () => {
@@ -2326,7 +2336,7 @@ Some content here`;
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
@@ -2337,7 +2347,7 @@ Some content here`;
         },
       };
 
-      await localizeStaticImports(settings as any);
+      await localizeStaticImports(createSettings(settings));
     });
 
     it('should use fallback processing when MDX has invalid JSX attributes', async () => {
@@ -2362,7 +2372,7 @@ Some content here`;
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
@@ -2373,7 +2383,7 @@ Some content here`;
         },
       };
 
-      await localizeStaticImports(settings as any);
+      await localizeStaticImports(createSettings(settings));
     });
 
     it('should use fallback processing when MDX has complex invalid syntax', async () => {
@@ -2406,7 +2416,7 @@ Some content here`;
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
@@ -2417,7 +2427,7 @@ Some content here`;
         },
       };
 
-      await localizeStaticImports(settings as any);
+      await localizeStaticImports(createSettings(settings));
     });
   });
 
@@ -2448,7 +2458,7 @@ Some content here`;
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
@@ -2459,7 +2469,7 @@ Some content here`;
         },
       };
 
-      await localizeStaticImports(settings as any);
+      await localizeStaticImports(createSettings(settings));
     });
 
     it('should transform imports when target file exists', async () => {
@@ -2483,7 +2493,7 @@ Some content here`;
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
@@ -2494,7 +2504,7 @@ Some content here`;
         },
       };
 
-      await localizeStaticImports(settings as any);
+      await localizeStaticImports(createSettings(settings));
     });
 
     it('should check for files with common extensions', async () => {
@@ -2522,7 +2532,7 @@ Some content here`;
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
@@ -2533,7 +2543,7 @@ Some content here`;
         },
       };
 
-      await localizeStaticImports(settings as any);
+      await localizeStaticImports(createSettings(settings));
     });
 
     it('should handle mixed scenarios - some files exist, others do not', async () => {
@@ -2570,7 +2580,7 @@ import AnotherExisting from '/components/ja/another.mdx'
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
@@ -2581,7 +2591,7 @@ import AnotherExisting from '/components/ja/another.mdx'
         },
       };
 
-      await localizeStaticImports(settings as any);
+      await localizeStaticImports(createSettings(settings));
     });
 
     it('should handle relative import paths with proper separator', async () => {
@@ -2605,7 +2615,7 @@ import AnotherExisting from '/components/ja/another.mdx'
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
@@ -2616,7 +2626,7 @@ import AnotherExisting from '/components/ja/another.mdx'
         },
       };
 
-      await localizeStaticImports(settings as any);
+      await localizeStaticImports(createSettings(settings));
     });
 
     it('should handle absolute/root import paths', async () => {
@@ -2640,7 +2650,7 @@ import AnotherExisting from '/components/ja/another.mdx'
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
@@ -2651,7 +2661,7 @@ import AnotherExisting from '/components/ja/another.mdx'
         },
       };
 
-      await localizeStaticImports(settings as any);
+      await localizeStaticImports(createSettings(settings));
     });
 
     it('should not transform relative paths when target file does not exist', async () => {
@@ -2681,7 +2691,7 @@ import AnotherExisting from '/components/ja/another.mdx'
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
@@ -2692,7 +2702,7 @@ import AnotherExisting from '/components/ja/another.mdx'
         },
       };
 
-      await localizeStaticImports(settings as any);
+      await localizeStaticImports(createSettings(settings));
     });
   });
 
@@ -2717,7 +2727,7 @@ import AnotherExisting from '/components/ja/another.mdx'
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
@@ -2728,7 +2738,7 @@ import AnotherExisting from '/components/ja/another.mdx'
         },
       };
 
-      await localizeStaticImports(settings as any);
+      await localizeStaticImports(createSettings(settings));
     });
 
     it('should handle locale at root level', async () => {
@@ -2751,7 +2761,7 @@ import AnotherExisting from '/components/ja/another.mdx'
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
@@ -2762,7 +2772,7 @@ import AnotherExisting from '/components/ja/another.mdx'
         },
       };
 
-      await localizeStaticImports(settings as any);
+      await localizeStaticImports(createSettings(settings));
     });
 
     it('should handle complex relative patterns with multiple levels', async () => {
@@ -2785,7 +2795,7 @@ import AnotherExisting from '/components/ja/another.mdx'
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
@@ -2796,7 +2806,7 @@ import AnotherExisting from '/components/ja/another.mdx'
         },
       };
 
-      await localizeStaticImports(settings as any);
+      await localizeStaticImports(createSettings(settings));
     });
 
     it('should not transform paths that contain pattern but are not at the expected position', async () => {
@@ -2819,7 +2829,7 @@ import AnotherExisting from '/components/ja/another.mdx'
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
@@ -2830,7 +2840,7 @@ import AnotherExisting from '/components/ja/another.mdx'
         },
       };
 
-      await localizeStaticImports(settings as any);
+      await localizeStaticImports(createSettings(settings));
     });
 
     it('should handle patterns with multiple path segments after locale', async () => {
@@ -2853,7 +2863,7 @@ import AnotherExisting from '/components/ja/another.mdx'
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
@@ -2864,7 +2874,7 @@ import AnotherExisting from '/components/ja/another.mdx'
         },
       };
 
-      await localizeStaticImports(settings as any);
+      await localizeStaticImports(createSettings(settings));
     });
 
     it('should add locale to relative imports in non-default locale files', async () => {
@@ -2887,7 +2897,7 @@ import AnotherExisting from '/components/ja/another.mdx'
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
@@ -2898,7 +2908,7 @@ import AnotherExisting from '/components/ja/another.mdx'
         },
       };
 
-      await localizeStaticImports(settings as any);
+      await localizeStaticImports(createSettings(settings));
     });
 
     it('should add locale to current directory relative imports', async () => {
@@ -2921,7 +2931,7 @@ import AnotherExisting from '/components/ja/another.mdx'
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
@@ -2932,7 +2942,7 @@ import AnotherExisting from '/components/ja/another.mdx'
         },
       };
 
-      await localizeStaticImports(settings as any);
+      await localizeStaticImports(createSettings(settings));
     });
 
     it('should handle deeply nested relative imports without locale', async () => {
@@ -2955,7 +2965,7 @@ import AnotherExisting from '/components/ja/another.mdx'
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
@@ -2966,7 +2976,7 @@ import AnotherExisting from '/components/ja/another.mdx'
         },
       };
 
-      await localizeStaticImports(settings as any);
+      await localizeStaticImports(createSettings(settings));
     });
 
     it('should not add locale to relative imports when target file does not exist', async () => {
@@ -2994,7 +3004,7 @@ import AnotherExisting from '/components/ja/another.mdx'
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
@@ -3005,7 +3015,7 @@ import AnotherExisting from '/components/ja/another.mdx'
         },
       };
 
-      await localizeStaticImports(settings as any);
+      await localizeStaticImports(createSettings(settings));
     });
   });
 });

--- a/packages/cli/src/utils/__tests__/localizeStaticImports.test.ts
+++ b/packages/cli/src/utils/__tests__/localizeStaticImports.test.ts
@@ -4,12 +4,8 @@ import localizeStaticImports, {
   type StaticImportSettings,
 } from '../localizeStaticImports';
 
-type ExactStaticImportSettings<T extends StaticImportSettings> = T &
-  Record<Exclude<keyof T, keyof StaticImportSettings>, never>;
-
-const createSettings = <T extends StaticImportSettings>(
-  settings: ExactStaticImportSettings<T>
-): StaticImportSettings => settings;
+const createSettings = (settings: StaticImportSettings): StaticImportSettings =>
+  settings;
 
 // Mock fs module
 vi.mock('fs', () => ({

--- a/packages/cli/src/utils/__tests__/localizeStaticUrls.test.ts
+++ b/packages/cli/src/utils/__tests__/localizeStaticUrls.test.ts
@@ -1,6 +1,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
-import localizeStaticUrls, { transformUrlPath } from '../localizeStaticUrls';
+import localizeStaticUrls, {
+  transformUrlPath,
+  type StaticUrlSettings,
+} from '../localizeStaticUrls';
+
+type ExactStaticUrlSettings<T extends StaticUrlSettings> = T &
+  Record<Exclude<keyof T, keyof StaticUrlSettings>, never>;
+
+const createSettings = <T extends StaticUrlSettings>(
+  settings: ExactStaticUrlSettings<T>
+): StaticUrlSettings => settings;
 
 // Mock fs module
 vi.mock('fs', () => ({
@@ -37,7 +47,7 @@ describe('localizeStaticUrls', () => {
         locales: ['en', 'ja'],
       };
 
-      await localizeStaticUrls(settings as any);
+      await localizeStaticUrls(createSettings(settings));
 
       expect(createFileMapping).not.toHaveBeenCalled();
     });
@@ -46,19 +56,20 @@ describe('localizeStaticUrls', () => {
       const settings = {
         files: {
           placeholderPaths: { gt: 'some-path' },
-          resolvedPaths: [],
+          resolvedPaths: {},
         },
         defaultLocale: 'en',
         locales: ['en', 'ja'],
       };
 
-      await localizeStaticUrls(settings as any);
+      await localizeStaticUrls(createSettings(settings));
 
       expect(createFileMapping).not.toHaveBeenCalled();
     });
 
     it('should process md/mdx files for localization', async () => {
       const mockFileMapping = {
+        en: {},
         ja: {
           'file1.md': '/path/to/ja/file1.md',
           'file2.mdx': '/path/to/ja/file2.mdx',
@@ -75,22 +86,21 @@ describe('localizeStaticUrls', () => {
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['file1', 'file2'],
+          resolvedPaths: { mdx: ['file1', 'file2'] },
           transformPaths: {},
           transformFormats: {},
         },
         defaultLocale: 'en',
         locales: ['en', 'ja'],
-        experimentalHideDefaultLocale: false,
         options: {
           docsUrlPattern: '/docs/[locale]',
         },
       };
 
-      await localizeStaticUrls(settings as any);
+      await localizeStaticUrls(createSettings(settings));
 
       expect(createFileMapping).toHaveBeenCalledWith(
-        ['file1', 'file2'],
+        { mdx: ['file1', 'file2'] },
         { docs: '/docs' },
         {},
         {},
@@ -122,18 +132,17 @@ describe('localizeStaticUrls', () => {
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
           locales: ['en', 'ja'],
-          experimentalHideDefaultLocale: false,
           options: {
             docsUrlPattern: '/docs/[locale]',
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
 
       it('should handle markdown links without trailing paths', async () => {
@@ -154,18 +163,17 @@ describe('localizeStaticUrls', () => {
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
           locales: ['en', 'ja'],
-          experimentalHideDefaultLocale: false,
           options: {
             docsUrlPattern: '/docs/[locale]',
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
     });
 
@@ -188,7 +196,7 @@ describe('localizeStaticUrls', () => {
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -199,7 +207,7 @@ describe('localizeStaticUrls', () => {
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
 
       it('should not modify already localized markdown links', async () => {
@@ -220,7 +228,7 @@ describe('localizeStaticUrls', () => {
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -231,7 +239,7 @@ describe('localizeStaticUrls', () => {
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
     });
 
@@ -254,7 +262,7 @@ describe('localizeStaticUrls', () => {
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['file1'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
@@ -262,7 +270,7 @@ describe('localizeStaticUrls', () => {
         options: { docsUrlPattern: '/docs/[locale]' },
       };
 
-      await localizeStaticUrls(settings as any, ['ja']);
+      await localizeStaticUrls(createSettings(settings), ['ja']);
 
       // If no changes detected, writeFile may not be called
       // Ensure the content remains unchanged
@@ -287,7 +295,7 @@ describe('localizeStaticUrls', () => {
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['file1'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
@@ -298,7 +306,7 @@ describe('localizeStaticUrls', () => {
         },
       };
 
-      await localizeStaticUrls(settings as any, ['ja']);
+      await localizeStaticUrls(createSettings(settings), ['ja']);
       expect(vi.mocked(fs.promises.readFile)).toHaveBeenCalled();
     });
 
@@ -320,7 +328,7 @@ describe('localizeStaticUrls', () => {
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['file1'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
@@ -331,7 +339,7 @@ describe('localizeStaticUrls', () => {
         },
       };
 
-      await localizeStaticUrls(settings as any, ['ja']);
+      await localizeStaticUrls(createSettings(settings), ['ja']);
       expect(vi.mocked(fs.promises.readFile)).toHaveBeenCalled();
     });
   });
@@ -356,18 +364,17 @@ describe('localizeStaticUrls', () => {
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
           locales: ['en', 'ja'],
-          experimentalHideDefaultLocale: false,
           options: {
             docsUrlPattern: '/docs/[locale]',
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
 
       it('should handle href attributes without trailing paths', async () => {
@@ -388,7 +395,7 @@ describe('localizeStaticUrls', () => {
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -399,7 +406,7 @@ describe('localizeStaticUrls', () => {
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
 
       it('should handle complex href attributes with query parameters and fragments', async () => {
@@ -420,18 +427,17 @@ describe('localizeStaticUrls', () => {
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
           locales: ['en', 'ja'],
-          experimentalHideDefaultLocale: false,
           options: {
             docsUrlPattern: '/docs/[locale]',
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
     });
 
@@ -454,7 +460,7 @@ describe('localizeStaticUrls', () => {
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -465,7 +471,7 @@ describe('localizeStaticUrls', () => {
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
 
       it('should handle href attributes without trailing paths', async () => {
@@ -486,7 +492,7 @@ describe('localizeStaticUrls', () => {
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -497,7 +503,7 @@ describe('localizeStaticUrls', () => {
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
 
       it('should not modify already localized href attributes', async () => {
@@ -518,7 +524,7 @@ describe('localizeStaticUrls', () => {
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -529,7 +535,7 @@ describe('localizeStaticUrls', () => {
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
     });
   });
@@ -565,18 +571,17 @@ More content with [another link](/docs/ja/tutorial) and <a href="/docs/ja/refere
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
         locales: ['en', 'ja'],
-        experimentalHideDefaultLocale: false,
         options: {
           docsUrlPattern: '/docs/[locale]',
         },
       };
 
-      await localizeStaticUrls(settings as any);
+      await localizeStaticUrls(createSettings(settings));
     });
   });
 
@@ -600,7 +605,7 @@ More content with [another link](/docs/ja/tutorial) and <a href="/docs/ja/refere
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -612,7 +617,7 @@ More content with [another link](/docs/ja/tutorial) and <a href="/docs/ja/refere
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
 
       it('should exclude href attributes matching exact paths', async () => {
@@ -633,7 +638,7 @@ More content with [another link](/docs/ja/tutorial) and <a href="/docs/ja/refere
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -645,7 +650,7 @@ More content with [another link](/docs/ja/tutorial) and <a href="/docs/ja/refere
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
 
       it('should exclude paths matching glob patterns', async () => {
@@ -666,7 +671,7 @@ More content with [another link](/docs/ja/tutorial) and <a href="/docs/ja/refere
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -678,7 +683,7 @@ More content with [another link](/docs/ja/tutorial) and <a href="/docs/ja/refere
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
 
       it('should handle [locale] placeholder in exclude patterns', async () => {
@@ -699,19 +704,18 @@ More content with [another link](/docs/ja/tutorial) and <a href="/docs/ja/refere
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
           locales: ['en', 'ja'],
-          experimentalHideDefaultLocale: false,
           options: {
             docsUrlPattern: '/docs/[locale]',
             excludeStaticUrls: ['/docs/[locale]/images/**'],
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
     });
 
@@ -734,7 +738,7 @@ More content with [another link](/docs/ja/tutorial) and <a href="/docs/ja/refere
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -746,7 +750,7 @@ More content with [another link](/docs/ja/tutorial) and <a href="/docs/ja/refere
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
 
       it('should exclude href attributes matching exact paths', async () => {
@@ -767,7 +771,7 @@ More content with [another link](/docs/ja/tutorial) and <a href="/docs/ja/refere
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -779,7 +783,7 @@ More content with [another link](/docs/ja/tutorial) and <a href="/docs/ja/refere
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
 
       it('should exclude paths matching glob patterns', async () => {
@@ -800,7 +804,7 @@ More content with [another link](/docs/ja/tutorial) and <a href="/docs/ja/refere
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -812,7 +816,7 @@ More content with [another link](/docs/ja/tutorial) and <a href="/docs/ja/refere
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
 
       it('should handle [locale] placeholder in exclude patterns with hideDefaultLocale', async () => {
@@ -833,7 +837,7 @@ More content with [another link](/docs/ja/tutorial) and <a href="/docs/ja/refere
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -845,7 +849,7 @@ More content with [another link](/docs/ja/tutorial) and <a href="/docs/ja/refere
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
     });
 
@@ -878,19 +882,18 @@ More content with [another link](/docs/ja/tutorial) and <a href="/docs/ja/refere
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
           locales: ['en', 'ja'],
-          experimentalHideDefaultLocale: false,
           options: {
             docsUrlPattern: '/docs/[locale]',
             excludeStaticUrls: ['/docs/en/images/**', '/docs/en/snippets/**'],
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
     });
 
@@ -913,19 +916,18 @@ More content with [another link](/docs/ja/tutorial) and <a href="/docs/ja/refere
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
           locales: ['en', 'ja'],
-          experimentalHideDefaultLocale: false,
           options: {
             docsUrlPattern: '/docs/[locale]',
             excludeStaticUrls: [],
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
 
       it('should work when exclude parameter is undefined', async () => {
@@ -946,19 +948,18 @@ More content with [another link](/docs/ja/tutorial) and <a href="/docs/ja/refere
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
           locales: ['en', 'ja'],
-          experimentalHideDefaultLocale: false,
           options: {
             docsUrlPattern: '/docs/[locale]',
             // excludeStaticUrls not provided
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
 
       it('should handle complex glob patterns', async () => {
@@ -989,19 +990,18 @@ More content with [another link](/docs/ja/tutorial) and <a href="/docs/ja/refere
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
           locales: ['en', 'ja'],
-          experimentalHideDefaultLocale: false,
           options: {
             docsUrlPattern: '/docs/[locale]',
             excludeStaticUrls: ['/docs/[locale]/{images,assets}/**'],
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
     });
   });
@@ -1026,18 +1026,17 @@ More content with [another link](/docs/ja/tutorial) and <a href="/docs/ja/refere
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
           locales: ['en', 'ja'],
-          experimentalHideDefaultLocale: false,
           options: {
             docsUrlPattern: '/[locale]',
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
 
       it('should handle href attributes with /[locale] pattern', async () => {
@@ -1058,18 +1057,17 @@ More content with [another link](/docs/ja/tutorial) and <a href="/docs/ja/refere
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
           locales: ['en', 'ja'],
-          experimentalHideDefaultLocale: false,
           options: {
             docsUrlPattern: '/[locale]',
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
     });
 
@@ -1092,7 +1090,7 @@ More content with [another link](/docs/ja/tutorial) and <a href="/docs/ja/refere
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -1103,7 +1101,7 @@ More content with [another link](/docs/ja/tutorial) and <a href="/docs/ja/refere
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
 
       it('should handle href attributes with /[locale] pattern when hideDefaultLocale is true', async () => {
@@ -1124,7 +1122,7 @@ More content with [another link](/docs/ja/tutorial) and <a href="/docs/ja/refere
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -1135,7 +1133,7 @@ More content with [another link](/docs/ja/tutorial) and <a href="/docs/ja/refere
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
     });
 
@@ -1158,19 +1156,18 @@ More content with [another link](/docs/ja/tutorial) and <a href="/docs/ja/refere
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
           locales: ['en', 'ja'],
-          experimentalHideDefaultLocale: false,
           options: {
             docsUrlPattern: '/[locale]',
             excludeStaticUrls: ['/[locale]/images/**'],
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
 
       it('should include paths with /[locale] pattern when hideDefaultLocale is true when locale path is specified', async () => {
@@ -1191,7 +1188,7 @@ More content with [another link](/docs/ja/tutorial) and <a href="/docs/ja/refere
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -1203,7 +1200,7 @@ More content with [another link](/docs/ja/tutorial) and <a href="/docs/ja/refere
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
     });
   });
@@ -1231,18 +1228,17 @@ Some content without any matching links.
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
         locales: ['en', 'ja'],
-        experimentalHideDefaultLocale: false,
         options: {
           docsUrlPattern: '/docs/[locale]',
         },
       };
 
-      await localizeStaticUrls(settings as any);
+      await localizeStaticUrls(createSettings(settings));
     });
 
     it('should handle special characters in pattern', async () => {
@@ -1263,18 +1259,17 @@ Some content without any matching links.
       const settings = {
         files: {
           placeholderPaths: { docs: '/api-docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
         locales: ['en', 'ja'],
-        experimentalHideDefaultLocale: false,
         options: {
           docsUrlPattern: '/api-docs/[locale]',
         },
       };
 
-      await localizeStaticUrls(settings as any);
+      await localizeStaticUrls(createSettings(settings));
     });
 
     it('should handle pattern without leading slash', async () => {
@@ -1295,18 +1290,17 @@ Some content without any matching links.
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
         locales: ['en', 'ja'],
-        experimentalHideDefaultLocale: false,
         options: {
           docsUrlPattern: 'docs/[locale]', // No leading slash
         },
       };
 
-      await localizeStaticUrls(settings as any);
+      await localizeStaticUrls(createSettings(settings));
     });
 
     it('should use default pattern when docsUrlPattern is not provided', async () => {
@@ -1327,18 +1321,17 @@ Some content without any matching links.
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
         locales: ['en', 'ja'],
-        experimentalHideDefaultLocale: false,
         options: {
           // docsUrlPattern not provided - should default to '/[locale]'
         },
       };
 
-      await localizeStaticUrls(settings as any);
+      await localizeStaticUrls(createSettings(settings));
     });
 
     it('should work with different target locales', async () => {
@@ -1365,18 +1358,17 @@ Some content without any matching links.
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
           locales: ['en', locale],
-          experimentalHideDefaultLocale: false,
           options: {
             docsUrlPattern: '/docs/[locale]',
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       }
     });
   });
@@ -1405,18 +1397,17 @@ Some content without any matching links.
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
           locales: ['en', 'ja'],
-          experimentalHideDefaultLocale: false,
           options: {
             docsUrlPattern: '/docs/[locale]',
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
 
       it('should handle multiple Card components with different href patterns', async () => {
@@ -1461,18 +1452,17 @@ Some content without any matching links.
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
           locales: ['en', 'ja'],
-          experimentalHideDefaultLocale: false,
           options: {
             docsUrlPattern: '/docs/[locale]',
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
 
       it('should handle JSX components with single quotes in href', async () => {
@@ -1497,18 +1487,17 @@ Some content without any matching links.
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
           locales: ['en', 'ja'],
-          experimentalHideDefaultLocale: false,
           options: {
             docsUrlPattern: '/docs/[locale]',
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
 
       it('should handle JSX components mixed with markdown links and regular href attributes', async () => {
@@ -1565,18 +1554,17 @@ import TestSnippet from "/snippets/en/test-snippet.mdx";
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
           locales: ['en', 'ja'],
-          experimentalHideDefaultLocale: false,
           options: {
             docsUrlPattern: '/docs/[locale]',
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
     });
 
@@ -1603,7 +1591,7 @@ import TestSnippet from "/snippets/en/test-snippet.mdx";
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -1614,7 +1602,7 @@ import TestSnippet from "/snippets/en/test-snippet.mdx";
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
 
       it('should replace default locale with target locale when href contains default locale', async () => {
@@ -1639,7 +1627,7 @@ import TestSnippet from "/snippets/en/test-snippet.mdx";
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -1650,7 +1638,7 @@ import TestSnippet from "/snippets/en/test-snippet.mdx";
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
 
       it('should not modify already localized JSX component href attributes with hideDefaultLocale = true', async () => {
@@ -1675,7 +1663,7 @@ import TestSnippet from "/snippets/en/test-snippet.mdx";
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -1686,7 +1674,7 @@ import TestSnippet from "/snippets/en/test-snippet.mdx";
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
 
       it('should handle multiple identical href attributes in raw JSX strings correctly', async () => {
@@ -1724,7 +1712,7 @@ import TestSnippet from "/snippets/en/test-snippet.mdx";
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -1735,7 +1723,7 @@ import TestSnippet from "/snippets/en/test-snippet.mdx";
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
 
       it('should handle multiple identical href attributes in JSX correctly', async () => {
@@ -1760,7 +1748,7 @@ import TestSnippet from "/snippets/en/test-snippet.mdx";
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -1771,7 +1759,7 @@ import TestSnippet from "/snippets/en/test-snippet.mdx";
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
     });
   });
@@ -1808,13 +1796,12 @@ import TestSnippet from "/snippets/en/test-snippet.mdx";
           },
           defaultLocale: 'en',
           locales: ['en', 'ja'],
-          experimentalHideDefaultLocale: false,
           options: {
             docsUrlPattern: '/docs/[locale]',
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
 
       it('should not modify URLs that already have default locale', async () => {
@@ -1845,13 +1832,12 @@ import TestSnippet from "/snippets/en/test-snippet.mdx";
           },
           defaultLocale: 'en',
           locales: ['en', 'ja'],
-          experimentalHideDefaultLocale: false,
           options: {
             docsUrlPattern: '/docs/[locale]',
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
     });
 
@@ -1890,7 +1876,7 @@ import TestSnippet from "/snippets/en/test-snippet.mdx";
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
 
       it('should not modify URLs that already lack default locale', async () => {
@@ -1927,7 +1913,7 @@ import TestSnippet from "/snippets/en/test-snippet.mdx";
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
     });
   });
@@ -1952,7 +1938,7 @@ import TestSnippet from "/snippets/en/test-snippet.mdx";
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -1963,7 +1949,7 @@ import TestSnippet from "/snippets/en/test-snippet.mdx";
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
 
       it('should replace default locale with target locale when URL contains default locale', async () => {
@@ -1984,7 +1970,7 @@ import TestSnippet from "/snippets/en/test-snippet.mdx";
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -1995,7 +1981,7 @@ import TestSnippet from "/snippets/en/test-snippet.mdx";
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
 
       it('should handle exact matches by adding target locale', async () => {
@@ -2016,7 +2002,7 @@ import TestSnippet from "/snippets/en/test-snippet.mdx";
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
@@ -2027,7 +2013,7 @@ import TestSnippet from "/snippets/en/test-snippet.mdx";
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
     });
 
@@ -2050,18 +2036,17 @@ import TestSnippet from "/snippets/en/test-snippet.mdx";
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
           locales: ['ja'],
-          experimentalHideDefaultLocale: false,
           options: {
             docsUrlPattern: '/docs/[locale]',
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
 
       it('should replace existing default locale with target locale', async () => {
@@ -2082,18 +2067,17 @@ import TestSnippet from "/snippets/en/test-snippet.mdx";
         const settings = {
           files: {
             placeholderPaths: { docs: '/docs' },
-            resolvedPaths: ['test'],
+            resolvedPaths: {},
             transformPaths: {},
           },
           defaultLocale: 'en',
           locales: ['en', 'ja'],
-          experimentalHideDefaultLocale: false,
           options: {
             docsUrlPattern: '/docs/[locale]',
           },
         };
 
-        await localizeStaticUrls(settings as any);
+        await localizeStaticUrls(createSettings(settings));
       });
     });
   });
@@ -2140,7 +2124,7 @@ description: "Bienvenido al nuevo hogar de tu documentación"
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
@@ -2150,7 +2134,7 @@ description: "Bienvenido al nuevo hogar de tu documentación"
         },
       };
 
-      await localizeStaticUrls(settings as any);
+      await localizeStaticUrls(createSettings(settings));
     });
   });
 
@@ -2174,18 +2158,17 @@ description: "Bienvenido al nuevo hogar de tu documentación"
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
         locales: ['en', 'ja'],
-        experimentalHideDefaultLocale: false,
         options: {
           docsUrlPattern: '/docs/[locale]',
         },
       };
 
-      await localizeStaticUrls(settings as any);
+      await localizeStaticUrls(createSettings(settings));
     });
 
     it('should return original content unchanged when MDX has unclosed JSX tags', async () => {
@@ -2207,18 +2190,17 @@ description: "Bienvenido al nuevo hogar de tu documentación"
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
         locales: ['en', 'ja'],
-        experimentalHideDefaultLocale: false,
         options: {
           docsUrlPattern: '/docs/[locale]',
         },
       };
 
-      await localizeStaticUrls(settings as any);
+      await localizeStaticUrls(createSettings(settings));
     });
 
     it('should return original content unchanged when MDX has nested unclosed tags', async () => {
@@ -2244,18 +2226,17 @@ description: "Bienvenido al nuevo hogar de tu documentación"
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
         locales: ['en', 'ja'],
-        experimentalHideDefaultLocale: false,
         options: {
           docsUrlPattern: '/docs/[locale]',
         },
       };
 
-      await localizeStaticUrls(settings as any);
+      await localizeStaticUrls(createSettings(settings));
     });
 
     it('should return original content unchanged when MDX has mismatched JSX tags', async () => {
@@ -2279,18 +2260,17 @@ description: "Bienvenido al nuevo hogar de tu documentación"
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
         locales: ['en', 'ja'],
-        experimentalHideDefaultLocale: false,
         options: {
           docsUrlPattern: '/docs/[locale]',
         },
       };
 
-      await localizeStaticUrls(settings as any);
+      await localizeStaticUrls(createSettings(settings));
     });
 
     it('should return original content unchanged when MDX has invalid JSX attributes', async () => {
@@ -2314,18 +2294,17 @@ description: "Bienvenido al nuevo hogar de tu documentación"
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: ['test'],
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
         locales: ['en', 'ja'],
-        experimentalHideDefaultLocale: false,
         options: {
           docsUrlPattern: '/docs/[locale]',
         },
       };
 
-      await localizeStaticUrls(settings as any);
+      await localizeStaticUrls(createSettings(settings));
     });
   });
 
@@ -2361,7 +2340,7 @@ description: "Bienvenido al nuevo hogar de tu documentación"
       },
     };
 
-    await localizeStaticUrls(settings as any);
+    await localizeStaticUrls(createSettings(settings));
 
     const expectedContent = `# Default Locale Content
 
@@ -2402,7 +2381,6 @@ describe('baseDomain', () => {
       },
       defaultLocale: 'en',
       locales: ['fr'],
-      experimentalHideDefaultLocale: false,
       options: {
         docsUrlPattern: '/[locale]',
         excludeStaticUrls: [],
@@ -2410,7 +2388,7 @@ describe('baseDomain', () => {
       },
     };
 
-    await localizeStaticUrls(settings as any);
+    await localizeStaticUrls(createSettings(settings));
 
     vi.mocked(fs.promises.readFile).mockResolvedValue(fileContent);
     vi.mocked(fs.promises.writeFile).mockImplementation((_, content) => {
@@ -2438,19 +2416,18 @@ describe('baseDomain', () => {
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: { mdx: ['test.mdx'] },
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
         locales: ['fr'],
-        experimentalHideDefaultLocale: false,
         options: {
           docsUrlPattern: '/docs/[locale]',
           baseDomain: 'https://example.com',
         },
       };
 
-      await localizeStaticUrls(settings as any);
+      await localizeStaticUrls(createSettings(settings));
     });
 
     it('should handle baseDomain with hideDefaultLocale=true', async () => {
@@ -2471,7 +2448,7 @@ describe('baseDomain', () => {
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: { mdx: ['test.mdx'] },
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
@@ -2483,7 +2460,7 @@ describe('baseDomain', () => {
         },
       };
 
-      await localizeStaticUrls(settings as any);
+      await localizeStaticUrls(createSettings(settings));
     });
 
     it('should not add literal null to baseDomain URLs when transformation fails', async () => {
@@ -2505,19 +2482,18 @@ describe('baseDomain', () => {
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: { mdx: ['test.mdx'] },
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
         locales: ['fr'],
-        experimentalHideDefaultLocale: false,
         options: {
           docsUrlPattern: '/docs/[locale]',
           baseDomain: 'https://example.com',
         },
       };
 
-      await localizeStaticUrls(settings as any);
+      await localizeStaticUrls(createSettings(settings));
     });
 
     it('should handle multiple baseDomain URLs with mixed transformable/non-transformable paths', async () => {
@@ -2549,19 +2525,18 @@ describe('baseDomain', () => {
       const settings = {
         files: {
           placeholderPaths: { docs: '/docs' },
-          resolvedPaths: { mdx: ['test.mdx'] },
+          resolvedPaths: {},
           transformPaths: {},
         },
         defaultLocale: 'en',
         locales: ['fr'],
-        experimentalHideDefaultLocale: false,
         options: {
           docsUrlPattern: '/docs/[locale]',
           baseDomain: 'https://example.com',
         },
       };
 
-      await localizeStaticUrls(settings as any);
+      await localizeStaticUrls(createSettings(settings));
     });
   });
 });

--- a/packages/cli/src/utils/__tests__/localizeStaticUrls.test.ts
+++ b/packages/cli/src/utils/__tests__/localizeStaticUrls.test.ts
@@ -5,12 +5,8 @@ import localizeStaticUrls, {
   type StaticUrlSettings,
 } from '../localizeStaticUrls';
 
-type ExactStaticUrlSettings<T extends StaticUrlSettings> = T &
-  Record<Exclude<keyof T, keyof StaticUrlSettings>, never>;
-
-const createSettings = <T extends StaticUrlSettings>(
-  settings: ExactStaticUrlSettings<T>
-): StaticUrlSettings => settings;
+const createSettings = (settings: StaticUrlSettings): StaticUrlSettings =>
+  settings;
 
 // Mock fs module
 vi.mock('fs', () => ({

--- a/packages/cli/src/utils/__tests__/sharedStaticAssets.test.ts
+++ b/packages/cli/src/utils/__tests__/sharedStaticAssets.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import path from 'node:path';
 import fs from 'node:fs';
+import type { Stats } from 'node:fs';
 import fg from 'fast-glob';
 import processSharedStaticAssets, {
   mirrorAssetsToLocales,
@@ -45,6 +46,12 @@ vi.mock('fast-glob', () => ({
 vi.mock('../../formats/files/fileMapping.js', () => ({
   createFileMapping: vi.fn(),
 }));
+
+const createFileStat = (size = 0): Stats =>
+  ({
+    isFile: () => true,
+    size,
+  }) as Stats;
 
 describe('processSharedStaticAssets', () => {
   beforeEach(() => {
@@ -326,7 +333,7 @@ describe('processSharedStaticAssets', () => {
 
       vi.mocked(fg.sync).mockReturnValue([assetPath]);
       vi.mocked(fs.promises.stat)
-        .mockResolvedValueOnce({ isFile: () => true } as any) // Destination exists
+        .mockResolvedValueOnce(createFileStat()) // Destination exists
         .mockRejectedValue(new Error('Not found')); // Source doesn't exist anymore after unlink
 
       const settings = {
@@ -367,7 +374,7 @@ describe('processSharedStaticAssets', () => {
       vi.mocked(fg.sync).mockReturnValue([assetPath]);
       vi.mocked(fs.promises.stat).mockImplementation((filePath) => {
         if (filePath === mdxFile) {
-          return Promise.resolve({} as any); // MDX file exists
+          return Promise.resolve(createFileStat()); // MDX file exists
         }
         return Promise.reject(new Error('Not found')); // Everything else doesn't exist
       });
@@ -434,7 +441,7 @@ describe('processSharedStaticAssets', () => {
       vi.mocked(fg.sync).mockReturnValue([assetPath]);
       vi.mocked(fs.promises.stat).mockImplementation((path) => {
         if (path === mdxFile || path === mdFile) {
-          return Promise.resolve({} as any); // Files exist
+          return Promise.resolve(createFileStat()); // Files exist
         }
         return Promise.reject(new Error('Not found')); // Everything else doesn't exist
       });
@@ -903,7 +910,7 @@ describe('processSharedStaticAssets', () => {
       // Both source and target exist with same size
       vi.mocked(fs.promises.stat).mockImplementation((p) => {
         if (p === assetPath || p === '/project/i18n/fr/docs/images/pic.png') {
-          return Promise.resolve({ isFile: () => true, size: 1024 } as any);
+          return Promise.resolve(createFileStat(1024));
         }
         return Promise.reject(new Error('Not found'));
       });

--- a/packages/cli/src/utils/addExplicitAnchorIds.ts
+++ b/packages/cli/src/utils/addExplicitAnchorIds.ts
@@ -4,10 +4,15 @@ import remarkMdx from 'remark-mdx';
 import remarkFrontmatter from 'remark-frontmatter';
 import remarkStringify from 'remark-stringify';
 import { visit } from 'unist-util-visit';
-import type { Root, Heading, Node } from 'mdast';
+import type { Root, Heading, Literal, Node } from 'mdast';
 import { logger } from '../console/logger.js';
 import { escapeHtmlInTextNodes, normalizeCJKCharacters } from 'gt-remark';
 import { decode } from 'html-entities';
+import type { AdditionalOptions } from '../types/index.js';
+
+type AnchorIdSettings = {
+  options?: Pick<AdditionalOptions, 'experimentalAddHeaderAnchorIds'>;
+};
 
 /**
  * Generates a slug from heading text
@@ -176,7 +181,7 @@ export function extractHeadingInfo(mdxContent: string): HeadingInfo[] {
 export function addExplicitAnchorIds(
   translatedContent: string,
   sourceHeadingMap: HeadingInfo[],
-  settings?: any,
+  settings?: AnchorIdSettings,
   sourcePath?: string,
   translatedPath?: string,
   fileTypeHint?: 'md' | 'mdx'
@@ -361,7 +366,7 @@ function applyInlineIds(
       .use(remarkStringify, {
         handlers: {
           // Custom handler to prevent escaping of {#id} syntax
-          text(node: any) {
+          text(node: Literal) {
             return node.value;
           },
         },

--- a/packages/cli/src/utils/localizeRelativeAssets.ts
+++ b/packages/cli/src/utils/localizeRelativeAssets.ts
@@ -6,12 +6,26 @@ import remarkMdx from 'remark-mdx';
 import remarkFrontmatter from 'remark-frontmatter';
 import remarkStringify from 'remark-stringify';
 import { visit } from 'unist-util-visit';
-import type { Root } from 'mdast';
+import type { Literal, Root } from 'mdast';
 import { escapeHtmlInTextNodes, normalizeCJKCharacters } from 'gt-remark';
-import { Settings } from '../types/index.js';
+import type { StaticLocalizationSettings } from '../types/index.js';
 import { createFileMapping } from '../formats/files/fileMapping.js';
 
 type RewriteResult = { content: string; hasChanges: boolean };
+export type RelativeAssetSettings = StaticLocalizationSettings;
+
+type MdxAssetNode = {
+  type?: string;
+  name?: unknown;
+  attributes?: unknown;
+  url?: unknown;
+};
+
+type MdxAttribute = {
+  type?: string;
+  name?: string;
+  value?: unknown;
+};
 
 function stripQueryAndHash(url: string): { base: string; suffix: string } {
   const match = url.match(/^[^?#]+/);
@@ -90,27 +104,28 @@ export function localizeRelativeAssetsForContent(
     return newPath + suffix;
   };
 
-  visit(ast, (node: any) => {
-    if (node.type === 'image' && typeof node.url === 'string') {
-      const newUrl = maybeRewrite(node.url);
-      if (newUrl) node.url = newUrl;
+  visit(ast, (node) => {
+    const assetNode = node as MdxAssetNode;
+    if (assetNode.type === 'image' && typeof assetNode.url === 'string') {
+      const newUrl = maybeRewrite(assetNode.url);
+      if (newUrl) assetNode.url = newUrl;
       return;
     }
     if (
-      (node.type === 'mdxJsxFlowElement' ||
-        node.type === 'mdxJsxTextElement') &&
-      node.name === 'img' &&
-      Array.isArray(node.attributes)
+      (assetNode.type === 'mdxJsxFlowElement' ||
+        assetNode.type === 'mdxJsxTextElement') &&
+      assetNode.name === 'img' &&
+      Array.isArray(assetNode.attributes)
     ) {
-      for (const attr of node.attributes) {
+      for (const attr of assetNode.attributes) {
+        const attribute = attr as MdxAttribute;
         if (
-          attr &&
-          attr.type === 'mdxJsxAttribute' &&
-          attr.name === 'src' &&
-          typeof attr.value === 'string'
+          attribute.type === 'mdxJsxAttribute' &&
+          attribute.name === 'src' &&
+          typeof attribute.value === 'string'
         ) {
-          const newUrl = maybeRewrite(attr.value);
-          if (newUrl) attr.value = newUrl;
+          const newUrl = maybeRewrite(attribute.value);
+          if (newUrl) attribute.value = newUrl;
         }
       }
     }
@@ -124,13 +139,13 @@ export function localizeRelativeAssetsForContent(
       .use(escapeHtmlInTextNodes)
       .use(remarkStringify, {
         handlers: {
-          text(node: any) {
+          text(node: Literal) {
             return node.value;
           },
         },
       });
-    const outTree = s.runSync(ast);
-    let out = s.stringify(outTree as any);
+    const outTree = s.runSync(ast) as Root;
+    let out = s.stringify(outTree);
     if (out.endsWith('\n') && !content.endsWith('\n')) out = out.slice(0, -1);
     if (content.startsWith('\n') && !out.startsWith('\n')) out = '\n' + out;
     return { content: out, hasChanges: changed };
@@ -140,7 +155,7 @@ export function localizeRelativeAssetsForContent(
 }
 
 export default async function localizeRelativeAssets(
-  settings: Settings,
+  settings: RelativeAssetSettings,
   targetLocales?: string[],
   includeFiles?: Set<string>
 ) {
@@ -158,8 +173,8 @@ export default async function localizeRelativeAssets(
   const fileMapping = createFileMapping(
     sourceFiles,
     settings.files.placeholderPaths,
-    settings.files.transformPaths,
-    settings.files.transformFormats,
+    settings.files.transformPaths ?? {},
+    settings.files.transformFormats ?? {},
     settings.locales,
     settings.defaultLocale
   );

--- a/packages/cli/src/utils/localizeStaticImports.ts
+++ b/packages/cli/src/utils/localizeStaticImports.ts
@@ -1,6 +1,9 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { Options, Settings, AdditionalOptions } from '../types/index.js';
+import type {
+  AdditionalOptions,
+  StaticLocalizationSettings,
+} from '../types/index.js';
 import { createFileMapping } from '../formats/files/fileMapping.js';
 import micromatch from 'micromatch';
 import { unified } from 'unified';
@@ -12,6 +15,8 @@ import type { Root } from 'mdast';
 import type { MdxjsEsm } from 'mdast-util-mdxjs-esm';
 
 const { isMatch } = micromatch;
+
+export type StaticImportSettings = StaticLocalizationSettings;
 
 /**
  * Localizes static imports in content files.
@@ -27,7 +32,7 @@ const { isMatch } = micromatch;
  * - Support more complex paths
  */
 export default async function localizeStaticImports(
-  settings: Settings,
+  settings: StaticImportSettings,
   includeFiles?: Set<string>
 ) {
   if (
@@ -42,8 +47,8 @@ export default async function localizeStaticImports(
   const fileMapping = createFileMapping(
     sourceFiles,
     settings.files.placeholderPaths,
-    settings.files.transformPaths,
-    settings.files.transformFormats,
+    settings.files.transformPaths ?? {},
+    settings.files.transformFormats ?? {},
     settings.locales,
     settings.defaultLocale
   );
@@ -453,7 +458,7 @@ function transformMdxImports(
       pattern,
       exclude,
       currentFilePath,
-      options as any
+      options
     );
   }
 
@@ -559,7 +564,7 @@ function transformImportsStringFallback(
   pattern: string = '/[locale]',
   exclude: string[] = [],
   currentFilePath?: string,
-  options?: Options
+  options?: AdditionalOptions
 ): ImportTransformResult {
   const transformedImports: Array<{ originalPath: string; newPath: string }> =
     [];

--- a/packages/cli/src/utils/localizeStaticUrls.ts
+++ b/packages/cli/src/utils/localizeStaticUrls.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { Settings } from '../types/index.js';
+import type { StaticLocalizationSettings } from '../types/index.js';
 import { createFileMapping } from '../formats/files/fileMapping.js';
 import micromatch from 'micromatch';
 import { unified } from 'unified';
@@ -13,6 +13,8 @@ import type { MdxJsxFlowElement, MdxJsxTextElement } from 'mdast-util-mdx-jsx';
 import { escapeHtmlInTextNodes, normalizeCJKCharacters } from 'gt-remark';
 
 const { isMatch } = micromatch;
+
+export type StaticUrlSettings = StaticLocalizationSettings;
 
 /**
  * Localizes static urls in content files.
@@ -28,7 +30,7 @@ const { isMatch } = micromatch;
  * - Support more complex paths
  */
 export default async function localizeStaticUrls(
-  settings: Settings,
+  settings: StaticUrlSettings,
   targetLocales?: string[],
   includeFiles?: Set<string>
 ) {
@@ -47,8 +49,8 @@ export default async function localizeStaticUrls(
   const fileMapping = createFileMapping(
     sourceFiles,
     settings.files.placeholderPaths,
-    settings.files.transformPaths,
-    settings.files.transformFormats,
+    settings.files.transformPaths ?? {},
+    settings.files.transformFormats ?? {},
     settings.locales, // Always use all locales for mapping, filter later
     settings.defaultLocale
   );
@@ -555,7 +557,7 @@ function transformMdxUrls(
       .use(remarkStringify, {
         handlers: {
           // Handler to prevent escaping (avoids '&lt;' -> '\&lt;')
-          text(node: any) {
+          text(node: Literal) {
             return node.value;
           },
         },

--- a/packages/cli/src/utils/sharedStaticAssets.ts
+++ b/packages/cli/src/utils/sharedStaticAssets.ts
@@ -7,11 +7,24 @@ import remarkMdx from 'remark-mdx';
 import remarkFrontmatter from 'remark-frontmatter';
 import remarkStringify from 'remark-stringify';
 import { visit } from 'unist-util-visit';
-import type { Root } from 'mdast';
+import type { Literal, Root } from 'mdast';
 import { escapeHtmlInTextNodes, normalizeCJKCharacters } from 'gt-remark';
-import type { Settings, SharedStaticAssetsConfig } from '../types/index.js';
+import type { Settings } from '../types/index.js';
 import { createFileMapping } from '../formats/files/fileMapping.js';
 import { TEMPLATE_FILE_NAME } from './constants.js';
+
+type MdxAssetNode = {
+  type?: string;
+  name?: unknown;
+  attributes?: unknown;
+  url?: unknown;
+};
+
+type MdxAttribute = {
+  type?: string;
+  name?: string;
+  value?: unknown;
+};
 
 function derivePublicPath(outDir: string, provided?: string): string {
   if (provided) return provided;
@@ -36,14 +49,10 @@ async function moveFile(src: string, dest: string) {
   try {
     await ensureDir(path.dirname(dest));
     await fs.promises.rename(src, dest);
-  } catch (err: any) {
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
     // Fallback to copy+unlink for cross-device or existing files
-    if (
-      err &&
-      (err.code === 'EXDEV' ||
-        err.code === 'EEXIST' ||
-        err.code === 'ENOTEMPTY')
-    ) {
+    if (code === 'EXDEV' || code === 'EEXIST' || code === 'ENOTEMPTY') {
       const data = await fs.promises.readFile(src);
       await ensureDir(path.dirname(dest));
       await fs.promises.writeFile(dest, data);
@@ -52,7 +61,7 @@ async function moveFile(src: string, dest: string) {
       } catch {
         // Ignore cleanup errors for source files that were already moved.
       }
-    } else if (err && err.code === 'ENOENT') {
+    } else if (code === 'ENOENT') {
       // already moved or missing; ignore
       return;
     } else {
@@ -151,34 +160,35 @@ function rewriteMdxContent(
     return null;
   };
 
-  visit(ast, (node: any) => {
+  visit(ast, (node) => {
+    const assetNode = node as MdxAssetNode;
     // Markdown image: ![alt](url)
-    if (node.type === 'image' && typeof node.url === 'string') {
-      const newUrl = maybeRewrite(node.url);
-      if (newUrl) node.url = newUrl;
+    if (assetNode.type === 'image' && typeof assetNode.url === 'string') {
+      const newUrl = maybeRewrite(assetNode.url);
+      if (newUrl) assetNode.url = newUrl;
       return;
     }
     // Markdown link: [text](url) — useful for PDFs and other downloadable assets
-    if (node.type === 'link' && typeof node.url === 'string') {
-      const newUrl = maybeRewrite(node.url);
-      if (newUrl) node.url = newUrl;
+    if (assetNode.type === 'link' && typeof assetNode.url === 'string') {
+      const newUrl = maybeRewrite(assetNode.url);
+      if (newUrl) assetNode.url = newUrl;
       return;
     }
     // MDX <img src="..." />
     if (
-      (node.type === 'mdxJsxFlowElement' ||
-        node.type === 'mdxJsxTextElement') &&
-      Array.isArray(node.attributes)
+      (assetNode.type === 'mdxJsxFlowElement' ||
+        assetNode.type === 'mdxJsxTextElement') &&
+      Array.isArray(assetNode.attributes)
     ) {
-      for (const attr of node.attributes) {
+      for (const attr of assetNode.attributes) {
+        const attribute = attr as MdxAttribute;
         if (
-          attr &&
-          attr.type === 'mdxJsxAttribute' &&
-          (attr.name === 'src' || attr.name === 'href') &&
-          typeof attr.value === 'string'
+          attribute.type === 'mdxJsxAttribute' &&
+          (attribute.name === 'src' || attribute.name === 'href') &&
+          typeof attribute.value === 'string'
         ) {
-          const newUrl = maybeRewrite(attr.value);
-          if (newUrl) attr.value = newUrl;
+          const newUrl = maybeRewrite(attribute.value);
+          if (newUrl) attribute.value = newUrl;
         }
       }
     }
@@ -192,13 +202,13 @@ function rewriteMdxContent(
       .use(escapeHtmlInTextNodes)
       .use(remarkStringify, {
         handlers: {
-          text(node: any) {
+          text(node: Literal) {
             return node.value;
           },
         },
       });
-    const outTree = s.runSync(ast);
-    let out = s.stringify(outTree as any);
+    const outTree = s.runSync(ast) as Root;
+    let out = s.stringify(outTree);
     // Preserve trailing/leading newlines similar to localizeStaticUrls
     if (out.endsWith('\n') && !content.endsWith('\n')) out = out.slice(0, -1);
     if (content.startsWith('\n') && !out.startsWith('\n')) out = '\n' + out;
@@ -219,8 +229,7 @@ function resolveAssetPaths(include: string[], cwd: string): Set<string> {
 }
 
 export async function mirrorAssetsToLocales(settings: Settings) {
-  const cfg: SharedStaticAssetsConfig | undefined =
-    settings.sharedStaticAssets as any;
+  const cfg = settings.sharedStaticAssets;
   if (!cfg?.mirrorToLocales) return;
   if (!settings.files) return;
 
@@ -334,8 +343,7 @@ export async function mirrorAssetsToLocales(settings: Settings) {
  * @returns
  */
 export default async function processSharedStaticAssets(settings: Settings) {
-  const cfg: SharedStaticAssetsConfig | undefined =
-    settings.sharedStaticAssets as any;
+  const cfg = settings.sharedStaticAssets;
   if (!cfg) return;
 
   // mirrorToLocales is handled separately after translations are downloaded

--- a/packages/cli/src/workflows/steps/BranchStep.ts
+++ b/packages/cli/src/workflows/steps/BranchStep.ts
@@ -1,8 +1,8 @@
 import { WorkflowStep } from './WorkflowStep.js';
 import { logErrorAndExit } from '../../console/logging.js';
 import { logger } from '../../console/logger.js';
-import { GT } from 'generaltranslation';
-import { Settings } from '../../types/index.js';
+import type { GT } from 'generaltranslation';
+import type { Settings } from '../../types/index.js';
 import chalk from 'chalk';
 import {
   getCurrentBranch,
@@ -12,14 +12,17 @@ import {
 import { BranchData } from '../../types/branch.js';
 import { ApiError } from 'generaltranslation/errors';
 
+type BranchStepClient = Pick<GT, 'queryBranchData' | 'createBranch'>;
+type BranchStepSettings = Pick<Settings, 'branchOptions'>;
+
 // Step 1: Resolve the current branch id & update API with branch information
 export class BranchStep extends WorkflowStep<null, BranchData | null> {
   private spinner = logger.createSpinner('dots');
   private branchData: BranchData;
-  private settings: Settings;
-  private gt: GT;
+  private settings: BranchStepSettings;
+  private gt: BranchStepClient;
 
-  constructor(gt: GT, settings: Settings) {
+  constructor(gt: BranchStepClient, settings: BranchStepSettings) {
     super();
     this.gt = gt;
     this.settings = settings;

--- a/packages/cli/src/workflows/steps/UploadSourcesStep.ts
+++ b/packages/cli/src/workflows/steps/UploadSourcesStep.ts
@@ -2,8 +2,8 @@ import type { FileToUpload } from 'generaltranslation/types';
 import { WorkflowStep } from './WorkflowStep.js';
 import { logger } from '../../console/logger.js';
 import { recordWarning } from '../../state/translateWarnings.js';
-import { GT } from 'generaltranslation';
-import { Settings } from '../../types/index.js';
+import type { GT } from 'generaltranslation';
+import type { Settings } from '../../types/index.js';
 import chalk from 'chalk';
 import { BranchData } from '../../types/branch.js';
 import type {
@@ -18,6 +18,15 @@ type MoveMapping = {
   newFileName: string;
 };
 
+type UploadSourcesClient = Pick<
+  GT,
+  | 'queryFileData'
+  | 'getOrphanedFiles'
+  | 'processFileMoves'
+  | 'uploadSourceFiles'
+>;
+type UploadSourcesSettings = Pick<Settings, 'defaultLocale' | 'modelProvider'>;
+
 export class UploadSourcesStep extends WorkflowStep<
   { files: FileToUpload[]; branchData: BranchData },
   FileReference[]
@@ -26,8 +35,8 @@ export class UploadSourcesStep extends WorkflowStep<
   private result: FileReference[] | null = null;
 
   constructor(
-    private gt: GT,
-    private settings: Settings
+    private gt: UploadSourcesClient,
+    private settings: UploadSourcesSettings
   ) {
     super();
   }

--- a/packages/cli/src/workflows/steps/__tests__/BranchStep.test.ts
+++ b/packages/cli/src/workflows/steps/__tests__/BranchStep.test.ts
@@ -62,7 +62,7 @@ function makeSettings(
       remoteName: 'origin',
       currentBranch: overrides.currentBranch,
     },
-  } as any;
+  };
 }
 
 describe('BranchStep', () => {
@@ -93,7 +93,7 @@ describe('BranchStep', () => {
         defaultBranch,
       });
 
-      const step = new BranchStep(mockGt as any, makeSettings());
+      const step = new BranchStep(mockGt, makeSettings());
       const result = await step.run();
 
       expect(result?.currentBranch).toEqual(featureBranch);
@@ -109,7 +109,7 @@ describe('BranchStep', () => {
         defaultBranch,
       });
 
-      const step = new BranchStep(mockGt as any, makeSettings());
+      const step = new BranchStep(mockGt, makeSettings());
       const result = await step.run();
 
       expect(result?.currentBranch).toEqual(defaultBranch);
@@ -128,7 +128,7 @@ describe('BranchStep', () => {
         defaultBranch,
       });
 
-      const step = new BranchStep(mockGt as any, makeSettings());
+      const step = new BranchStep(mockGt, makeSettings());
       const result = await step.run();
 
       expect(result?.currentBranch).toEqual(featureBranch);
@@ -142,7 +142,7 @@ describe('BranchStep', () => {
         defaultBranch,
       });
 
-      const step = new BranchStep(mockGt as any, makeSettings());
+      const step = new BranchStep(mockGt, makeSettings());
       const result = await step.run();
 
       expect(result?.checkedOutBranch).toEqual(defaultBranch);
@@ -158,7 +158,7 @@ describe('BranchStep', () => {
       });
 
       const step = new BranchStep(
-        mockGt as any,
+        mockGt,
         makeSettings({ currentBranch: 'feature-x' })
       );
       const result = await step.run();
@@ -174,7 +174,7 @@ describe('BranchStep', () => {
       });
 
       const step = new BranchStep(
-        mockGt as any,
+        mockGt,
         makeSettings({ currentBranch: 'feature-x' })
       );
       const result = await step.run();
@@ -191,7 +191,7 @@ describe('BranchStep', () => {
       });
 
       const step = new BranchStep(
-        mockGt as any,
+        mockGt,
         makeSettings({ autoDetectBranches: false, currentBranch: 'feature-x' })
       );
       const result = await step.run();
@@ -209,10 +209,7 @@ describe('BranchStep', () => {
         defaultBranch,
       });
 
-      const step = new BranchStep(
-        mockGt as any,
-        makeSettings({ enabled: false })
-      );
+      const step = new BranchStep(mockGt, makeSettings({ enabled: false }));
       const result = await step.run();
 
       expect(result?.currentBranch).toEqual(defaultBranch);
@@ -235,7 +232,7 @@ describe('BranchStep', () => {
         branch: { id: 'new-id', name: 'new-branch' },
       });
 
-      const step = new BranchStep(mockGt as any, makeSettings());
+      const step = new BranchStep(mockGt, makeSettings());
       const result = await step.run();
 
       expect(mockGt.createBranch).toHaveBeenCalledWith({

--- a/packages/cli/src/workflows/steps/__tests__/UploadSourcesStep.test.ts
+++ b/packages/cli/src/workflows/steps/__tests__/UploadSourcesStep.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { UploadSourcesStep } from '../UploadSourcesStep.js';
 import type { FileToUpload } from 'generaltranslation/types';
+import type { BranchData } from '../../../types/branch.js';
 
 // Mock the GT class
 const mockGt = {
@@ -30,10 +31,10 @@ describe('UploadSourcesStep', () => {
     modelProvider: undefined,
   };
 
-  const mockBranchData = {
+  const mockBranchData: BranchData = {
     currentBranch: { id: 'branch-123', name: 'main' },
-    incomingBranch: undefined,
-    checkedOutBranch: undefined,
+    incomingBranch: null,
+    checkedOutBranch: null,
   };
 
   beforeEach(() => {
@@ -85,8 +86,8 @@ describe('UploadSourcesStep', () => {
         count: 0,
       });
 
-      const step = new UploadSourcesStep(mockGt as any, mockSettings as any);
-      await step.run({ files: localFiles, branchData: mockBranchData as any });
+      const step = new UploadSourcesStep(mockGt, mockSettings);
+      await step.run({ files: localFiles, branchData: mockBranchData });
 
       // Verify move was detected and processed
       expect(mockGt.processFileMoves).toHaveBeenCalledWith(
@@ -131,8 +132,8 @@ describe('UploadSourcesStep', () => {
         count: 1,
       });
 
-      const step = new UploadSourcesStep(mockGt as any, mockSettings as any);
-      await step.run({ files: localFiles, branchData: mockBranchData as any });
+      const step = new UploadSourcesStep(mockGt, mockSettings);
+      await step.run({ files: localFiles, branchData: mockBranchData });
 
       // No move should be processed - it's a new file
       expect(mockGt.processFileMoves).not.toHaveBeenCalled();
@@ -168,8 +169,8 @@ describe('UploadSourcesStep', () => {
         count: 0,
       });
 
-      const step = new UploadSourcesStep(mockGt as any, mockSettings as any);
-      await step.run({ files: localFiles, branchData: mockBranchData as any });
+      const step = new UploadSourcesStep(mockGt, mockSettings);
+      await step.run({ files: localFiles, branchData: mockBranchData });
 
       // No move, file already exists at same path
       expect(mockGt.processFileMoves).not.toHaveBeenCalled();
@@ -226,8 +227,8 @@ describe('UploadSourcesStep', () => {
         count: 0,
       });
 
-      const step = new UploadSourcesStep(mockGt as any, mockSettings as any);
-      await step.run({ files: localFiles, branchData: mockBranchData as any });
+      const step = new UploadSourcesStep(mockGt, mockSettings);
+      await step.run({ files: localFiles, branchData: mockBranchData });
 
       expect(mockGt.processFileMoves).toHaveBeenCalledWith(
         expect.arrayContaining([
@@ -281,10 +282,10 @@ describe('UploadSourcesStep', () => {
         count: 0,
       });
 
-      const step = new UploadSourcesStep(mockGt as any, mockSettings as any);
+      const step = new UploadSourcesStep(mockGt, mockSettings);
       const result = await step.run({
         files: localFiles,
-        branchData: mockBranchData as any,
+        branchData: mockBranchData,
       });
 
       // Upload should be called with empty array (file was moved, not uploaded)
@@ -300,10 +301,10 @@ describe('UploadSourcesStep', () => {
     });
 
     it('should handle empty files array', async () => {
-      const step = new UploadSourcesStep(mockGt as any, mockSettings as any);
+      const step = new UploadSourcesStep(mockGt, mockSettings);
       const result = await step.run({
         files: [],
-        branchData: mockBranchData as any,
+        branchData: mockBranchData,
       });
 
       expect(result).toEqual([]);
@@ -335,8 +336,8 @@ describe('UploadSourcesStep', () => {
         count: 1,
       });
 
-      const step = new UploadSourcesStep(mockGt as any, mockSettings as any);
-      await step.run({ files: localFiles, branchData: mockBranchData as any });
+      const step = new UploadSourcesStep(mockGt, mockSettings);
+      await step.run({ files: localFiles, branchData: mockBranchData });
 
       expect(mockGt.processFileMoves).not.toHaveBeenCalled();
       expect(mockGt.uploadSourceFiles).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- type JSON runtime helpers without changing behavior
- centralize jsonpath-plus and jsonpointer dynamic boundaries
- reduce CLI lint warnings in JSON format runtime files

## Verification
- pnpm format:fix
- pnpm exec oxlint packages/cli/src/formats/json/utils.ts packages/cli/src/formats/json/mergeJson.ts packages/cli/src/formats/json/flattenJson.ts packages/cli/src/formats/json/parseJson.ts packages/cli/src/formats/json/transformJson.ts packages/cli/src/formats/json/extractJson.ts packages/cli/src/formats/json/jsonPath.ts packages/cli/src/formats/json/jsonPointer.ts packages/cli/src/types/data/json.ts
- pnpm --filter gt typecheck
- git diff --check
- pnpm --filter gt test -- src/formats/json --runInBand

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces inline `jsonpath-plus` and `jsonpointer` calls across the JSON format helpers with typed wrapper modules (`jsonPath.ts`, `jsonPointer.ts`) and substitutes `any` throughout with proper `JSONValue`/`JSONObject` types, without changing observable runtime behaviour.

- **New boundary modules**: `jsonPath.ts` exports `getJSONPathMatches` / `getJSONPathValues` with a typed `JSONPathMatch` (including `parentProperty: string | number | null`); `jsonPointer.ts` exports `get`, `set`, and a self-contained `deleteJSONPointerValue` helper.
- **Type narrowing**: `any` replaced with `JSONValue` / `JSONObject` throughout `utils.ts`, `mergeJson.ts`, `parseJson.ts`, `flattenJson.ts`, `transformJson.ts`, and `extractJson.ts`.
- **Runtime guard added**: `findMatchingItemArray` now explicitly errors-and-exits when `parentProperty` is `null` (root-level JSONPath match), closing the gap identified by the previous type annotation.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — purely a type-safety refactoring with no observable runtime behaviour changes.

All changes replace inline any-typed calls with properly typed wrapper functions. The new jsonPath.ts and jsonPointer.ts modules are thin, direct pass-throughs to the underlying libraries with no new logic. The one new runtime guard (null check for root-level parentProperty in findMatchingItemArray) is a defensive improvement over the previous unguarded code. All callers that previously used try/catch still do; callers that did not use try/catch preserve the same throw-on-invalid-pointer behaviour as before.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/formats/json/jsonPath.ts | New file — typed wrapper around jsonpath-plus; correctly models parentProperty as string | number | null and returns undefined-safe arrays. |
| packages/cli/src/formats/json/jsonPointer.ts | New file — typed wrappers for jsonpointer get/set and a standalone deleteJSONPointerValue; delete logic correctly resolves parent-pointer edge cases. |
| packages/cli/src/formats/json/utils.ts | Replaced any with JSONValue/JSONObject; added runtime null-check for root-level parentProperty in findMatchingItemArray; extracted MatchingArrayItem and SourceObjectPointerMap types. |
| packages/cli/src/formats/json/mergeJson.ts | All direct JSONPointer/JSONPath calls replaced with the new helpers; any replaced with JSONValue/JSONObject; ParsedTarget type introduced for clarity. |
| packages/cli/src/formats/json/parseJson.ts | JSONPath inline calls replaced with getJSONPathMatches; matchingItemsToTranslate typed as JSONPathMatch[]; minor type narrowing throughout. |
| packages/cli/src/formats/json/transformJson.ts | Inline deletion logic extracted into deleteJSONPointerValue; all JSONPointer/JSONPath calls routed through the new wrappers; no behaviour change. |
| packages/cli/src/formats/json/flattenJson.ts | flattenJsonWithStringFilter return type narrowed from Record<string, any> to Record<string, string>; JSONPath calls replaced with getJSONPathMatches. |
| packages/cli/src/formats/json/extractJson.ts | any replaced with JSONValue/JSONObject; necessary type assertions added at composite-result indexing sites. |
| packages/cli/src/types/data/json.ts | JSONValue exported; no structural change to the existing types. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Consumers
        EJ[extractJson.ts]
        FJ[flattenJson.ts]
        MJ[mergeJson.ts]
        PJ[parseJson.ts]
        TJ[transformJson.ts]
        UT[utils.ts]
    end

    subgraph New Boundary Modules
        JP[jsonPath.ts\ngetJSONPathMatches\ngetJSONPathValues]
        JPR[jsonPointer.ts\ngetJSONPointerValue\nsetJSONPointerValue\ndeleteJSONPointerValue]
    end

    subgraph Third-Party Libraries
        JPPLUS[jsonpath-plus]
        JPTR[jsonpointer]
    end

    subgraph Types
        JTYPE[types/data/json.ts\nJSONValue · JSONObject · JSONArray]
    end

    EJ --> JP
    EJ --> JPR
    FJ --> JP
    MJ --> JP
    MJ --> JPR
    PJ --> JP
    TJ --> JP
    TJ --> JPR
    UT --> JP

    JP --> JPPLUS
    JPR --> JPTR

    EJ --> JTYPE
    FJ --> JTYPE
    MJ --> JTYPE
    PJ --> JTYPE
    TJ --> JTYPE
    UT --> JTYPE
    JP --> JTYPE
    JPR --> JTYPE
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(cli): type JSON runtime helpers"](https://github.com/generaltranslation/gt/commit/161fa844aef118ff99535f20079ae52fadb1fcb3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31377135)</sub>

<!-- /greptile_comment -->