### PR TITLE
fix: clean up gt-react hook usage

### DIFF
--- a/packages/react/src/i18n-context/functions/translation/GtInternalTranslateJsx.tsx
+++ b/packages/react/src/i18n-context/functions/translation/GtInternalTranslateJsx.tsx
@@ -25,7 +25,7 @@ function GtInternalTranslateJsx(
     children: ReactNode;
   } & JsxTranslationOptions
 ): ReactNode {
-  return computeT(props);
+  return useComputeT(props);
 }
 
 /**
@@ -36,7 +36,7 @@ function T(
     children: ReactNode;
   } & JsxTranslationOptions
 ): ReactNode {
-  return computeT(props);
+  return useComputeT(props);
 }
 
 /** @internal _gtt - The GT transformation and injection identifier for the component. */
@@ -50,7 +50,7 @@ export { GtInternalTranslateJsx, T };
 /**
  * Implementation for the T component logic
  */
-function computeT({
+function useComputeT({
   children: sourceChildren,
   ...params
 }: {

--- a/packages/react/src/react-context/provider/hooks/useEnableI18n.ts
+++ b/packages/react/src/react-context/provider/hooks/useEnableI18n.ts
@@ -24,7 +24,7 @@ export function useEnableI18n({
   const isFirstRender = useRef(true);
 
   // Extract state from cookie or default _enableI18n flag
-  const [enableI18n, setEnableI18n] = useState(
+  const [enableI18n, setEnableI18n] = useState(() =>
     getInitialEnableI18n({
       _enableI18n,
       asyncEnabled,


### PR DESCRIPTION
## Summary
- rename the internal JSX translation helper to follow custom hook naming
- lazy-initialize the enableI18n state initializer

## Verification
- pnpm --filter gt-react typecheck
- npx react-doctor@latest packages/react

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two focused housekeeping changes to the `gt-react` package: it renames the internal `computeT` helper to `useComputeT` so React's rules-of-hooks linter can correctly track its hook calls (`useMemo`, `useCallback` via `usePrepSourceRender`), and it wraps the `useState` initializer in `useEnableI18n` with a lazy function to avoid re-evaluating `getInitialEnableI18n` (which reads `document.cookie`) on every re-render.

- **`GtInternalTranslateJsx.tsx`**: `computeT` → `useComputeT` rename fixes a naming-convention violation; both `T` and `GtInternalTranslateJsx` are PascalCase components, so calling the renamed hook from them remains valid.
- **`useEnableI18n.ts`**: `useState(getInitialEnableI18n(...))` → `useState(() => getInitialEnableI18n(...))` — correct lazy-initializer pattern preventing unnecessary work on subsequent renders.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — both changes are small, correct, and low-risk refactors with no behavioral changes to the translation or i18n-enable logic.

The rename and lazy-initializer changes are straightforward. One JSDoc comment in `GtInternalTranslateJsx.tsx` was not updated to reflect the new `useComputeT` name, leaving a stale reference.

The stale `computeT()` reference in the `DevTranslationResolver` JSDoc within `GtInternalTranslateJsx.tsx` is the only item worth a second look.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/react/src/i18n-context/functions/translation/GtInternalTranslateJsx.tsx | Renames `computeT` → `useComputeT` to follow React custom hook naming convention; the function calls hooks (`useMemo`, `useCallback`) via `usePrepSourceRender` so the `use` prefix is required. One JSDoc comment still references the old name `computeT()`. |
| packages/react/src/react-context/provider/hooks/useEnableI18n.ts | Wraps `getInitialEnableI18n` in a lazy initializer for `useState`, avoiding a redundant cookie read (`document.cookie`) on every re-render. The change is correct and follows the React pattern. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["T / GtInternalTranslateJsx\n(React components)"] -->|calls| B["useComputeT(props)\n(renamed from computeT)"]
    B --> C["usePrepSourceRender()\n(useMemo x3, useCallback x1)"]
    C --> D{requiresTranslation?}
    D -- No --> E[renderSourceChildren]
    D -- Yes --> F{resolveJsx cache hit?}
    F -- Yes --> G[renderTranslatedChildren]
    F -- No --> H{isDevHotReloadJsx?}
    H -- Yes --> I["Suspense + DevTranslationResolver\n(use() suspends)"]
    H -- No --> E
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/react/src/i18n-context/functions/translation/GtInternalTranslateJsx.tsx`, line 183 ([link](https://github.com/generaltranslation/gt/blob/1ddd68c06fdf9e35f3dfd9d11ce8671cc7d88410/packages/react/src/i18n-context/functions/translation/GtInternalTranslateJsx.tsx#L183)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> The JSDoc comment for `DevTranslationResolver` still references the old `computeT()` name after the rename to `useComputeT()`.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/react/src/i18n-context/functions/translation/GtInternalTranslateJsx.tsx
   Line: 183

   Comment:
   The JSDoc comment for `DevTranslationResolver` still references the old `computeT()` name after the rename to `useComputeT()`.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/react/src/i18n-context/functions/translation/GtInternalTranslateJsx.tsx:183
The JSDoc comment for `DevTranslationResolver` still references the old `computeT()` name after the rename to `useComputeT()`.

```suggestion
 * Sync cache check already happened in useComputeT() — this only handles cache misses.
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: clean up gt-react hook usage"](https://github.com/generaltranslation/gt/commit/1ddd68c06fdf9e35f3dfd9d11ce8671cc7d88410) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31385700)</sub>

<!-- /greptile_comment -->