### PR TITLE
feat(react-core): add external store manager hooks

### DIFF
--- a/packages/react-core/src/external-store/hooks/i18n-manager-hooks.ts
+++ b/packages/react-core/src/external-store/hooks/i18n-manager-hooks.ts
@@ -1,0 +1,102 @@
+import { useSyncExternalStore } from 'react';
+import type { I18nManager } from 'gt-i18n/internal';
+import type { Translation } from 'gt-i18n/types';
+import type { CustomMapping } from 'generaltranslation/types';
+import { getI18nExternalStore } from '../store/singleton-operations';
+import type { I18nExternalStore } from '../store/I18nExternalStore';
+import type {
+  DictionaryEntrySnapshot,
+  DictionaryLookup,
+  DictionaryObjectSnapshot,
+  TranslateLookup,
+  TranslateManySnapshot,
+  TranslateSnapshot,
+} from '../store/storeTypes';
+
+export function useI18nExternalStore(): I18nExternalStore {
+  return getI18nExternalStore();
+}
+
+export function useI18nManager(): I18nManager<Translation> {
+  return useI18nExternalStore().getI18nManager();
+}
+
+export function useDefaultLocale(): string {
+  const store = useI18nExternalStore();
+  return useSyncExternalStore(
+    store.subscribeToDefaultLocale,
+    store.getDefaultLocaleSnapshot,
+    store.getDefaultLocaleSnapshot
+  );
+}
+
+export function useLocales(): readonly string[] {
+  const store = useI18nExternalStore();
+  return useSyncExternalStore(
+    store.subscribeToLocales,
+    store.getLocalesSnapshot,
+    store.getLocalesSnapshot
+  );
+}
+
+export function useCustomMapping(): CustomMapping {
+  const store = useI18nExternalStore();
+  return useSyncExternalStore(
+    store.subscribeToCustomMapping,
+    store.getCustomMappingSnapshot,
+    store.getCustomMappingSnapshot
+  );
+}
+
+export function useEnableI18n(): boolean {
+  const store = useI18nExternalStore();
+  return useSyncExternalStore(
+    store.subscribeToEnableI18n,
+    store.getEnableI18nSnapshot,
+    store.getEnableI18nSnapshot
+  );
+}
+
+export function useTranslate<T extends Translation>(
+  lookup: TranslateLookup<T>
+): TranslateSnapshot<T> {
+  const store = useI18nExternalStore();
+  return useSyncExternalStore(
+    (listener) => store.subscribeToTranslate(lookup, listener),
+    () => store.getTranslateSnapshot(lookup),
+    () => store.getTranslateSnapshot(lookup)
+  );
+}
+
+export function useTranslateMany<T extends Translation>(
+  lookups: readonly TranslateLookup<T>[]
+): TranslateManySnapshot<T> {
+  const store = useI18nExternalStore();
+  return useSyncExternalStore(
+    (listener) => store.subscribeToTranslateMany(lookups, listener),
+    () => store.getTranslateManySnapshot(lookups),
+    () => store.getTranslateManySnapshot(lookups)
+  );
+}
+
+export function useDictionaryEntry(
+  lookup: DictionaryLookup
+): DictionaryEntrySnapshot {
+  const store = useI18nExternalStore();
+  return useSyncExternalStore(
+    (listener) => store.subscribeToDictionaryEntry(lookup, listener),
+    () => store.getDictionaryEntrySnapshot(lookup),
+    () => store.getDictionaryEntrySnapshot(lookup)
+  );
+}
+
+export function useDictionaryObject(
+  lookup: DictionaryLookup
+): DictionaryObjectSnapshot {
+  const store = useI18nExternalStore();
+  return useSyncExternalStore(
+    (listener) => store.subscribeToDictionaryObject(lookup, listener),
+    () => store.getDictionaryObjectSnapshot(lookup),
+    () => store.getDictionaryObjectSnapshot(lookup)
+  );
+}

--- a/packages/react-core/src/external-store/store/I18nExternalStore.ts
+++ b/packages/react-core/src/external-store/store/I18nExternalStore.ts
@@ -1,0 +1,448 @@
+import type { I18nManager } from 'gt-i18n/internal';
+import { hashSource } from 'generaltranslation/id';
+import { indexVars } from 'generaltranslation/internal';
+import type { CustomMapping, IcuMessage } from 'generaltranslation/types';
+import type {
+  DictionaryValue,
+  LookupOptions,
+  Translation,
+} from 'gt-i18n/types';
+import {
+  DICTIONARY_ENTRY_EVENT_NAME,
+  LOCALES_DICTIONARY_EVENT_NAME,
+  LOCALES_EVENT_NAME,
+  TRANSLATION_EVENT_NAME,
+} from './managerEvents';
+import type {
+  DictionaryEntrySnapshot,
+  DictionaryLookup,
+  DictionaryObjectSnapshot,
+  ListenerSet,
+  StoreListener,
+  TranslateLookup,
+  TranslateManySnapshot,
+  TranslateSnapshot,
+  Unsubscribe,
+} from './storeTypes';
+
+type LocaleCacheEvent<T> = {
+  locale: string;
+  value: Record<string, T>;
+};
+type EntryCacheEvent<T> = {
+  locale: string;
+  id: string;
+  value: T;
+};
+type TranslateStoreEvent =
+  | LocaleCacheEvent<Translation>
+  | EntryCacheEvent<Translation>;
+type TranslateStoreListener = (event: TranslateStoreEvent) => void;
+type DictionaryStoreEvent =
+  | LocaleCacheEvent<DictionaryValue>
+  | EntryCacheEvent<DictionaryEntrySnapshot>;
+type DictionaryStoreListener = (event: DictionaryStoreEvent) => void;
+
+export type I18nExternalStoreParams = {
+  i18nManager: I18nManager<Translation>;
+};
+
+/**
+ * External store adapter between React and I18nManager.
+ *
+ * Locale and region are runtime conditions owned by the active condition store.
+ * This class is only responsible for manager-backed snapshots and cache
+ * invalidation events.
+ */
+export class I18nExternalStore {
+  private i18nManager: I18nManager<Translation>;
+
+  private defaultLocaleListeners: ListenerSet = new Set();
+  private localesListeners: ListenerSet = new Set();
+  private customMappingListeners: ListenerSet = new Set();
+  private enableI18nListeners: ListenerSet = new Set();
+  private translateListeners = new Set<TranslateStoreListener>();
+  private translateManySnapshotCache = new WeakMap<
+    readonly TranslateLookup[],
+    TranslateManySnapshot
+  >();
+  private dictionaryEntryListeners = new Set<DictionaryStoreListener>();
+  private dictionaryObjectListeners = new Set<DictionaryStoreListener>();
+
+  private unsubscribeLocalesEvents: Unsubscribe | undefined;
+  private unsubscribeTranslateEvents: Unsubscribe | undefined;
+  private unsubscribeLocalesDictionaryEvents: Unsubscribe | undefined;
+  private unsubscribeDictionaryEntryEvents: Unsubscribe | undefined;
+
+  constructor({ i18nManager }: I18nExternalStoreParams) {
+    this.i18nManager = i18nManager;
+  }
+
+  getI18nManager = (): I18nManager<Translation> => {
+    return this.i18nManager;
+  };
+
+  subscribeToDefaultLocale = (listener: StoreListener): Unsubscribe => {
+    return this.subscribeToStaticSet(this.defaultLocaleListeners, listener);
+  };
+
+  subscribeToLocales = (listener: StoreListener): Unsubscribe => {
+    return this.subscribeToStaticSet(this.localesListeners, listener);
+  };
+
+  subscribeToCustomMapping = (listener: StoreListener): Unsubscribe => {
+    return this.subscribeToStaticSet(this.customMappingListeners, listener);
+  };
+
+  subscribeToEnableI18n = (listener: StoreListener): Unsubscribe => {
+    return this.subscribeToStaticSet(this.enableI18nListeners, listener);
+  };
+
+  subscribeToTranslate<T extends Translation>(
+    lookup: TranslateLookup<T>,
+    listener: StoreListener
+  ): Unsubscribe {
+    const lookupKey = getTranslateListenerKey(lookup);
+    const wrappedListener: TranslateStoreListener = (event) => {
+      if (translateEventMatchesLookup(event, lookupKey)) {
+        listener();
+      }
+    };
+    return this.subscribeToTranslateSet(wrappedListener);
+  }
+
+  subscribeToTranslateMany<T extends Translation>(
+    lookups: readonly TranslateLookup<T>[],
+    listener: StoreListener
+  ): Unsubscribe {
+    const unsubscribes = lookups.map((lookup) =>
+      this.subscribeToTranslate(lookup, listener)
+    );
+    return () => {
+      unsubscribes.forEach((unsubscribe) => unsubscribe());
+    };
+  }
+
+  subscribeToDictionaryEntry(
+    lookup: DictionaryLookup,
+    listener: StoreListener
+  ): Unsubscribe {
+    const lookupKey = getDictionaryListenerKey(lookup);
+    const wrappedListener: DictionaryStoreListener = (event) => {
+      if (dictionaryEntryEventMatchesLookup(event, lookupKey)) {
+        listener();
+      }
+    };
+    return this.subscribeToDictionarySet(
+      this.dictionaryEntryListeners,
+      wrappedListener
+    );
+  }
+
+  subscribeToDictionaryObject(
+    lookup: DictionaryLookup,
+    listener: StoreListener
+  ): Unsubscribe {
+    const lookupKey = getDictionaryListenerKey(lookup);
+    const wrappedListener: DictionaryStoreListener = (event) => {
+      if (dictionaryObjectEventMatchesLookup(event, lookupKey)) {
+        listener();
+      }
+    };
+    return this.subscribeToDictionarySet(
+      this.dictionaryObjectListeners,
+      wrappedListener
+    );
+  }
+
+  getDefaultLocaleSnapshot = (): string => {
+    return this.i18nManager.getDefaultLocale();
+  };
+
+  getLocalesSnapshot = (): readonly string[] => {
+    return this.i18nManager.getLocales();
+  };
+
+  getCustomMappingSnapshot = (): CustomMapping => {
+    return this.i18nManager.getCustomMapping();
+  };
+
+  getEnableI18nSnapshot = (): boolean => {
+    return this.i18nManager.isTranslationEnabled();
+  };
+
+  getTranslateSnapshot = <T extends Translation>({
+    locale,
+    message,
+    options,
+  }: TranslateLookup<T>): TranslateSnapshot<T> => {
+    return this.i18nManager.lookupTranslation<T>(locale, message, options);
+  };
+
+  getTranslateManySnapshot = <T extends Translation>(
+    lookups: readonly TranslateLookup<T>[]
+  ): TranslateManySnapshot<T> => {
+    const nextSnapshot = lookups.map((lookup) =>
+      this.getTranslateSnapshot(lookup)
+    );
+    const previousSnapshot = this.translateManySnapshotCache.get(lookups);
+    if (
+      previousSnapshot &&
+      previousSnapshot.length === nextSnapshot.length &&
+      previousSnapshot.every((value, index) =>
+        Object.is(value, nextSnapshot[index])
+      )
+    ) {
+      return previousSnapshot as TranslateManySnapshot<T>;
+    }
+
+    this.translateManySnapshotCache.set(lookups, nextSnapshot);
+    return nextSnapshot;
+  };
+
+  getDictionaryEntrySnapshot = ({
+    locale,
+    id,
+  }: DictionaryLookup): DictionaryEntrySnapshot => {
+    return this.i18nManager.lookupDictionary(locale, id);
+  };
+
+  getDictionaryObjectSnapshot = ({
+    locale,
+    id,
+  }: DictionaryLookup): DictionaryObjectSnapshot => {
+    return this.i18nManager.lookupDictionaryObj(locale, id);
+  };
+
+  private subscribeToStaticSet(
+    listenerSet: ListenerSet,
+    listener: StoreListener
+  ): Unsubscribe {
+    listenerSet.add(listener);
+    return () => {
+      listenerSet.delete(listener);
+    };
+  }
+
+  private subscribeToTranslateSet(
+    listener: TranslateStoreListener
+  ): Unsubscribe {
+    const hadListeners = this.sourceListenerCount() > 0;
+    this.translateListeners.add(listener);
+    if (!hadListeners) {
+      this.connect();
+    }
+
+    return () => {
+      this.translateListeners.delete(listener);
+      if (this.sourceListenerCount() === 0) {
+        this.disconnect();
+      }
+    };
+  }
+
+  private subscribeToDictionarySet(
+    listenerSet: Set<DictionaryStoreListener>,
+    listener: DictionaryStoreListener
+  ): Unsubscribe {
+    const hadListeners = this.sourceListenerCount() > 0;
+    listenerSet.add(listener);
+    if (!hadListeners) {
+      this.connect();
+    }
+
+    return () => {
+      listenerSet.delete(listener);
+      if (this.sourceListenerCount() === 0) {
+        this.disconnect();
+      }
+    };
+  }
+
+  private connect(): void {
+    if (this.unsubscribeLocalesEvents) {
+      return;
+    }
+
+    this.subscribeToManager();
+  }
+
+  private disconnect(): void {
+    this.unsubscribeLocalesEvents?.();
+    this.unsubscribeTranslateEvents?.();
+    this.unsubscribeLocalesDictionaryEvents?.();
+    this.unsubscribeDictionaryEntryEvents?.();
+    this.unsubscribeLocalesEvents = undefined;
+    this.unsubscribeTranslateEvents = undefined;
+    this.unsubscribeLocalesDictionaryEvents = undefined;
+    this.unsubscribeDictionaryEntryEvents = undefined;
+  }
+
+  private subscribeToManager(): void {
+    // Cache events are invalidation signals. Listeners reread snapshots instead
+    // of receiving payload values, matching useSyncExternalStore's contract.
+    this.unsubscribeLocalesEvents = this.i18nManager.subscribe(
+      LOCALES_EVENT_NAME,
+      (event) => {
+        this.emitTranslateEvent({
+          locale: event.locale,
+          value: event.translations,
+        });
+      }
+    );
+    this.unsubscribeTranslateEvents = this.i18nManager.subscribe(
+      TRANSLATION_EVENT_NAME,
+      (event) => {
+        this.emitTranslateEvent({
+          locale: event.locale,
+          id: event.hash,
+          value: event.translation,
+        });
+      }
+    );
+    this.unsubscribeLocalesDictionaryEvents = this.i18nManager.subscribe(
+      LOCALES_DICTIONARY_EVENT_NAME,
+      (event) => {
+        this.emitDictionaryEvent({
+          locale: event.locale,
+          value: event.dictionary,
+        });
+      }
+    );
+    this.unsubscribeDictionaryEntryEvents = this.i18nManager.subscribe(
+      DICTIONARY_ENTRY_EVENT_NAME,
+      (event) => {
+        this.emitDictionaryEvent({
+          locale: event.locale,
+          id: event.id,
+          value: event.dictionaryEntry,
+        });
+      }
+    );
+  }
+
+  private emitTranslateEvent(event: TranslateStoreEvent): void {
+    this.translateListeners.forEach((listener) => listener(event));
+  }
+
+  private emitDictionaryEvent(event: DictionaryStoreEvent): void {
+    this.dictionaryEntryListeners.forEach((listener) => listener(event));
+    this.dictionaryObjectListeners.forEach((listener) => listener(event));
+  }
+
+  private sourceListenerCount(): number {
+    return (
+      this.translateListeners.size +
+      this.dictionaryEntryListeners.size +
+      this.dictionaryObjectListeners.size
+    );
+  }
+}
+
+function getTranslateListenerKey<T extends Translation>(
+  lookup: TranslateLookup<T> | { locale: string; hash: string }
+): string {
+  const hash =
+    'hash' in lookup
+      ? lookup.hash
+      : getTranslateHash(lookup.message, lookup.options);
+  return `${lookup.locale}:${hash}`;
+}
+
+function getDictionaryListenerKey({ locale, id }: DictionaryLookup): string {
+  return `${locale}:${id}`;
+}
+
+function getDictionaryLookupFromKey(lookupKey: string): DictionaryLookup {
+  const separatorIndex = lookupKey.indexOf(':');
+  return {
+    locale: lookupKey.slice(0, separatorIndex),
+    id: lookupKey.slice(separatorIndex + 1),
+  };
+}
+
+function translateEventMatchesLookup(
+  event: TranslateStoreEvent,
+  lookupKey: string
+): boolean {
+  if ('id' in event) {
+    return (
+      getTranslateListenerKey({
+        locale: event.locale,
+        hash: event.id,
+      }) === lookupKey
+    );
+  }
+  return Object.keys(event.value).some(
+    (hash) =>
+      getTranslateListenerKey({ locale: event.locale, hash }) === lookupKey
+  );
+}
+
+function dictionaryEntryEventMatchesLookup(
+  event: DictionaryStoreEvent,
+  lookupKey: string
+): boolean {
+  if ('id' in event) {
+    return getDictionaryListenerKey(event) === lookupKey;
+  }
+  const { locale, id } = getDictionaryLookupFromKey(lookupKey);
+  const value = getDictionaryPathValue(event.value, id);
+  return locale === event.locale && value != null && !isDictionaryObject(value);
+}
+
+function dictionaryObjectEventMatchesLookup(
+  event: DictionaryStoreEvent,
+  lookupKey: string
+): boolean {
+  const { locale, id } = getDictionaryLookupFromKey(lookupKey);
+  if (locale !== event.locale) {
+    return false;
+  }
+  if ('id' in event) {
+    return id === '' || event.id === id || event.id.startsWith(`${id}.`);
+  }
+  return getDictionaryPathValue(event.value, id) != null;
+}
+
+function getTranslateHash<T extends Translation>(
+  message: T,
+  options: LookupOptions
+): string {
+  if (options.$_hash != null) {
+    return options.$_hash;
+  }
+
+  return hashSource({
+    source:
+      options.$format === 'ICU' ? indexVars(message as IcuMessage) : message,
+    ...(options.$context && { context: options.$context }),
+    ...(options.$id && { id: options.$id }),
+    ...('$maxChars' in options &&
+      options.$maxChars != null && {
+        maxChars: Math.abs(options.$maxChars),
+      }),
+    dataFormat: options.$format,
+  });
+}
+
+function getDictionaryPathValue(
+  dictionary: Record<string, DictionaryValue>,
+  id: string
+): DictionaryValue | undefined {
+  return id
+    .split('.')
+    .filter(Boolean)
+    .reduce<DictionaryValue | undefined>((value, key) => {
+      if (!isDictionaryObject(value)) {
+        return undefined;
+      }
+      return value[key];
+    }, dictionary);
+}
+
+function isDictionaryObject(
+  value: DictionaryValue | undefined
+): value is Record<string, DictionaryValue> {
+  return typeof value === 'object' && value != null && !Array.isArray(value);
+}

--- a/packages/react-core/src/external-store/store/ProviderConditionStore.ts
+++ b/packages/react-core/src/external-store/store/ProviderConditionStore.ts
@@ -1,0 +1,101 @@
+import { createLocaleResolver } from 'gt-i18n/internal';
+import type {
+  ConditionStoreConfig,
+  LocaleCandidates,
+  WritableConditionStore,
+} from 'gt-i18n/internal/types';
+import type {
+  I18nExternalConditionStore,
+  ListenerSet,
+  StoreListener,
+  Unsubscribe,
+} from './storeTypes';
+
+export type ProviderConditionStoreParams = ConditionStoreConfig & {
+  locale?: string;
+  region?: string;
+  getLocale?: () => string | undefined;
+};
+
+/**
+ * Condition store implementation owned by GTProvider.
+ *
+ * Locale and region are mutable runtime conditions. Subscribers receive
+ * value-less notifications so React can reread snapshots.
+ */
+export class ProviderConditionStore
+  implements WritableConditionStore, I18nExternalConditionStore
+{
+  private locale: string | undefined;
+  private region: string | undefined;
+  private resolveLocale: (candidates?: LocaleCandidates) => string;
+  private customGetLocale: (() => string | undefined) | undefined;
+
+  private localeListeners: ListenerSet = new Set();
+  private regionListeners: ListenerSet = new Set();
+
+  constructor({
+    defaultLocale,
+    locales,
+    customMapping,
+    locale,
+    region,
+    getLocale,
+  }: ProviderConditionStoreParams = {}) {
+    this.locale = locale;
+    this.region = region;
+    this.customGetLocale = getLocale;
+    this.resolveLocale = createLocaleResolver({
+      defaultLocale,
+      locales,
+      customMapping,
+    });
+  }
+
+  getLocale = (): string => {
+    return this.resolveLocale(this.customGetLocale?.() ?? this.locale);
+  };
+
+  setLocale = (locale: string): void => {
+    const previousLocale = this.getLocale();
+    this.locale = locale;
+    const nextLocale = this.getLocale();
+    if (nextLocale !== previousLocale) {
+      emit(this.localeListeners);
+    }
+  };
+
+  subscribeToLocale = (listener: StoreListener): Unsubscribe => {
+    return subscribeToSet(this.localeListeners, listener);
+  };
+
+  getRegion = (): string | undefined => {
+    return this.region;
+  };
+
+  setRegion = (region: string | undefined): void => {
+    const previousRegion = this.region;
+    this.region = region;
+    if (this.region !== previousRegion) {
+      emit(this.regionListeners);
+    }
+  };
+
+  subscribeToRegion = (listener: StoreListener): Unsubscribe => {
+    return subscribeToSet(this.regionListeners, listener);
+  };
+}
+
+function subscribeToSet(
+  listenerSet: ListenerSet,
+  listener: StoreListener
+): Unsubscribe {
+  listenerSet.add(listener);
+  return () => {
+    listenerSet.delete(listener);
+  };
+}
+
+function emit(listenerSet: ListenerSet): void {
+  listenerSet.forEach((listener) => listener());
+}

--- a/packages/react-core/src/external-store/store/__tests__/store-subscriptions.test.ts
+++ b/packages/react-core/src/external-store/store/__tests__/store-subscriptions.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it, vi } from 'vitest';
+import { I18nManager } from 'gt-i18n/internal';
+import { I18nExternalStore } from '../I18nExternalStore';
+import { ProviderConditionStore } from '../ProviderConditionStore';
+
+function createManager() {
+  return new I18nManager({
+    defaultLocale: 'en',
+    locales: ['en', 'fr', 'es'],
+    dictionary: {
+      greeting: 'Hello',
+      user: {
+        profile: {
+          name: 'Name',
+        },
+      },
+    },
+    loadDictionary: vi.fn().mockResolvedValue({
+      greeting: 'Bonjour',
+      user: {
+        profile: {
+          name: 'Nom',
+        },
+      },
+    }),
+    loadTranslations: vi.fn().mockResolvedValue({
+      hash: 'Bonjour',
+    }),
+  });
+}
+
+function createConditionStore(locale = 'en') {
+  return new ProviderConditionStore({
+    defaultLocale: 'en',
+    locales: ['en', 'fr', 'es'],
+    locale,
+  });
+}
+
+describe('external store subscriptions', () => {
+  it('notifies locale subscribers when locale changes', () => {
+    const conditionStore = createConditionStore('en');
+    const localeListener = vi.fn();
+    const unsubscribe = conditionStore.subscribeToLocale(localeListener);
+
+    conditionStore.setLocale('fr');
+
+    expect(conditionStore.getLocale()).toBe('fr');
+    expect(localeListener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    conditionStore.setLocale('es');
+    expect(localeListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('notifies region subscribers when region changes', () => {
+    const conditionStore = createConditionStore('en');
+    const regionListener = vi.fn();
+    const unsubscribe = conditionStore.subscribeToRegion(regionListener);
+
+    conditionStore.setRegion('US');
+
+    expect(conditionStore.getRegion()).toBe('US');
+    expect(regionListener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    conditionStore.setRegion('CA');
+    expect(regionListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('notifies translation subscribers for matching cache updates', async () => {
+    const manager = createManager();
+    const externalStore = new I18nExternalStore({ i18nManager: manager });
+    const matchingListener = vi.fn();
+    const otherHashListener = vi.fn();
+    const otherLocaleListener = vi.fn();
+
+    const unsubscribeMatching = externalStore.subscribeToTranslate(
+      {
+        locale: 'fr',
+        message: 'Hello',
+        options: { $format: 'ICU', $_hash: 'hash' },
+      },
+      matchingListener
+    );
+    const unsubscribeOtherHash = externalStore.subscribeToTranslate(
+      {
+        locale: 'fr',
+        message: 'Other',
+        options: { $format: 'ICU', $_hash: 'other' },
+      },
+      otherHashListener
+    );
+    const unsubscribeOtherLocale = externalStore.subscribeToTranslate(
+      {
+        locale: 'es',
+        message: 'Hello',
+        options: { $format: 'ICU', $_hash: 'hash' },
+      },
+      otherLocaleListener
+    );
+
+    await manager.lookupTranslationWithFallback('fr', 'Hello', {
+      $format: 'ICU',
+      $_hash: 'hash',
+    });
+
+    expect(matchingListener).toHaveBeenCalledTimes(1);
+    expect(otherHashListener).not.toHaveBeenCalled();
+    expect(otherLocaleListener).not.toHaveBeenCalled();
+
+    unsubscribeMatching();
+    unsubscribeOtherHash();
+    unsubscribeOtherLocale();
+  });
+
+  it('notifies translate many subscribers for matching cache updates', async () => {
+    const manager = createManager();
+    const externalStore = new I18nExternalStore({ i18nManager: manager });
+    const listener = vi.fn();
+    const lookups = [
+      {
+        locale: 'fr',
+        message: 'Hello',
+        options: { $format: 'ICU' as const, $_hash: 'hash' },
+      },
+      {
+        locale: 'fr',
+        message: 'Other',
+        options: { $format: 'ICU' as const, $_hash: 'other' },
+      },
+    ];
+
+    const initialSnapshot = externalStore.getTranslateManySnapshot(lookups);
+    expect(externalStore.getTranslateManySnapshot(lookups)).toBe(
+      initialSnapshot
+    );
+
+    const unsubscribe = externalStore.subscribeToTranslateMany(
+      lookups,
+      listener
+    );
+
+    await manager.lookupTranslationWithFallback('fr', 'Hello', {
+      $format: 'ICU',
+      $_hash: 'hash',
+    });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(externalStore.getTranslateManySnapshot(lookups)).toEqual([
+      'Bonjour',
+      undefined,
+    ]);
+
+    unsubscribe();
+  });
+
+  it('notifies dictionary entry subscribers for matching cache misses', async () => {
+    const manager = createManager();
+    const externalStore = new I18nExternalStore({ i18nManager: manager });
+    const matchingListener = vi.fn();
+    const otherListener = vi.fn();
+
+    const unsubscribeMatching = externalStore.subscribeToDictionaryEntry(
+      { locale: 'fr', id: 'greeting' },
+      matchingListener
+    );
+    const unsubscribeOther = externalStore.subscribeToDictionaryEntry(
+      { locale: 'fr', id: 'other' },
+      otherListener
+    );
+
+    await manager.lookupDictionaryWithFallback('fr', 'greeting');
+
+    expect(matchingListener).toHaveBeenCalledTimes(1);
+    expect(otherListener).not.toHaveBeenCalled();
+
+    unsubscribeMatching();
+    unsubscribeOther();
+  });
+
+  it('notifies dictionary object subscribers for matching cache misses', async () => {
+    const manager = createManager();
+    const externalStore = new I18nExternalStore({ i18nManager: manager });
+    const matchingListener = vi.fn();
+    const otherListener = vi.fn();
+
+    const unsubscribeMatching = externalStore.subscribeToDictionaryObject(
+      { locale: 'fr', id: 'user.profile' },
+      matchingListener
+    );
+    const unsubscribeOther = externalStore.subscribeToDictionaryObject(
+      { locale: 'fr', id: 'other' },
+      otherListener
+    );
+
+    await manager.lookupDictionaryObjWithFallback('fr', 'user.profile');
+
+    expect(matchingListener).toHaveBeenCalledTimes(1);
+    expect(otherListener).not.toHaveBeenCalled();
+
+    unsubscribeMatching();
+    unsubscribeOther();
+  });
+});

--- a/packages/react-core/src/external-store/store/managerEvents.ts
+++ b/packages/react-core/src/external-store/store/managerEvents.ts
@@ -1,0 +1,4 @@
+export const LOCALES_EVENT_NAME = 'locales-cache-miss';
+export const TRANSLATION_EVENT_NAME = 'translations-cache-miss';
+export const LOCALES_DICTIONARY_EVENT_NAME = 'locales-dictionary-cache-miss';
+export const DICTIONARY_ENTRY_EVENT_NAME = 'dictionary-cache-miss';

--- a/packages/react-core/src/external-store/store/singleton-operations.ts
+++ b/packages/react-core/src/external-store/store/singleton-operations.ts
@@ -1,0 +1,16 @@
+import type { I18nExternalStore } from './I18nExternalStore';
+
+let i18nExternalStore: I18nExternalStore | undefined;
+
+export function getI18nExternalStore(): I18nExternalStore {
+  if (!i18nExternalStore) {
+    throw new Error(
+      'I18nExternalStore is not initialized. Render GTProvider before using external-store hooks.'
+    );
+  }
+  return i18nExternalStore;
+}
+
+export function setI18nExternalStore(nextStore: I18nExternalStore): void {
+  i18nExternalStore = nextStore;
+}

--- a/packages/react-core/src/external-store/store/storeTypes.ts
+++ b/packages/react-core/src/external-store/store/storeTypes.ts
@@ -1,0 +1,38 @@
+import type {
+  DictionaryEntry,
+  DictionaryObject,
+  LookupOptions,
+  Translation,
+} from 'gt-i18n/types';
+
+export type Unsubscribe = () => void;
+export type StoreListener = () => void;
+export type ListenerSet = Set<StoreListener>;
+
+export type I18nExternalConditionStore = {
+  getLocale(): string;
+  subscribeToLocale(listener: StoreListener): Unsubscribe;
+  setLocale?(locale: string): void;
+  getRegion?(): string | undefined;
+  subscribeToRegion?(listener: StoreListener): Unsubscribe;
+  setRegion?(region: string | undefined): void;
+};
+
+export type TranslateLookup<T extends Translation = Translation> = {
+  locale: string;
+  message: T;
+  options: LookupOptions;
+};
+
+export type DictionaryLookup = {
+  locale: string;
+  id: string;
+};
+
+export type TranslateSnapshot<T extends Translation = Translation> =
+  | T
+  | undefined;
+export type TranslateManySnapshot<T extends Translation = Translation> =
+  readonly TranslateSnapshot<T>[];
+export type DictionaryEntrySnapshot = DictionaryEntry | undefined;
+export type DictionaryObjectSnapshot = DictionaryObject | undefined;

--- a/packages/react-core/src/internal-external-store.ts
+++ b/packages/react-core/src/internal-external-store.ts
@@ -1,0 +1,36 @@
+export {
+  useCustomMapping,
+  useDefaultLocale,
+  useDictionaryEntry,
+  useDictionaryObject,
+  useEnableI18n,
+  useI18nExternalStore,
+  useI18nManager,
+  useLocales,
+  useTranslate,
+  useTranslateMany,
+} from './external-store/hooks/i18n-manager-hooks';
+export {
+  I18nExternalStore,
+  type I18nExternalStoreParams,
+} from './external-store/store/I18nExternalStore';
+export {
+  ProviderConditionStore,
+  type ProviderConditionStoreParams,
+} from './external-store/store/ProviderConditionStore';
+export {
+  getI18nExternalStore,
+  setI18nExternalStore,
+} from './external-store/store/singleton-operations';
+export type {
+  DictionaryEntrySnapshot,
+  DictionaryLookup,
+  DictionaryObjectSnapshot,
+  I18nExternalConditionStore,
+  ListenerSet,
+  StoreListener,
+  TranslateLookup,
+  TranslateManySnapshot,
+  TranslateSnapshot,
+  Unsubscribe,
+} from './external-store/store/storeTypes';


### PR DESCRIPTION
## Summary
- add the react-core external-store foundation for I18nManager snapshots and subscriptions
- add ProviderConditionStore and shared external-store types/singleton accessors
- add useSyncExternalStore-backed manager hooks and internal source export surface
- add focused subscription tests for translation, dictionary, locale, and region invalidation

## Scope
- no GTProvider wiring
- no condition-store context hooks
- no component migration
- no package export or rollup entrypoint changes

## Test Plan
- pnpm --filter @generaltranslation/react-core typecheck
- pnpm --filter @generaltranslation/react-core test -- packages/react-core/src/external-store/store/__tests__/store-subscriptions.test.ts
- pnpm exec oxlint packages/react-core/src/external-store packages/react-core/src/internal-external-store.ts

## Notes
- PR #1383 is already open for e/react-core/add-use-sync-external-store1, but that branch contains an older prototype layout and is not a clean stack base for this branch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the `react-core` external-store foundation: an `I18nExternalStore` class that bridges `I18nManager` cache-miss events to React's `useSyncExternalStore`, a `ProviderConditionStore` for mutable locale/region runtime conditions, a module-level singleton accessor, and a set of `use*` hooks that expose snapshots to React components.

- **`I18nExternalStore`** wires four `I18nManager` event subscriptions (translations, locales, dictionary entry, locale-dictionary) to per-lookup listener sets, with connect/disconnect lifecycle tied to active subscriber count.
- **`ProviderConditionStore`** owns mutable locale and region state and emits value-less notifications on change, matching the `useSyncExternalStore` contract.
- **Hook layer** (`i18n-manager-hooks.ts`) exposes reactive accessors for locale, locales, custom mapping, i18n-enable flag, translation lookups, and dictionary lookups — two of which have correctness issues described in inline comments.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Not ready to merge without fixing useTranslateMany (infinite render loop on inline arrays) and addressing the non-reactive useI18nManager design.

The useTranslateMany hook will enter an infinite render loop whenever callers pass an inline array literal because the WeakMap snapshot cache always misses on a new array reference, useSyncExternalStore sees the structurally-identical snapshot arrays as unequal, and the cycle never breaks. The useI18nManager/useI18nExternalStore functions carry use* naming but perform a bare singleton read with no subscription, so they will silently return stale data if the singleton is replaced. Both issues sit on the main hook-consumption path. The rest of the store layer is well-structured.

packages/react-core/src/external-store/hooks/i18n-manager-hooks.ts — both the useTranslateMany loop hazard and the non-reactive useI18nManager live here.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/external-store/hooks/i18n-manager-hooks.ts | Defines useSyncExternalStore-backed hooks for translation/dictionary/locale data; useTranslateMany will infinite-loop when callers pass inline array literals, and useI18nManager/useI18nExternalStore are non-reactive despite use* naming. |
| packages/react-core/src/external-store/store/I18nExternalStore.ts | Core store class bridging I18nManager events to React subscriptions; WeakMap snapshot cache is only effective for stable array references, and the connect() guard relies on a single unsubscribe field rather than a dedicated flag. |
| packages/react-core/src/external-store/store/ProviderConditionStore.ts | Locale/region mutable condition store with listener sets; logic is straightforward and correctly emits only on actual value changes. |
| packages/react-core/src/external-store/store/singleton-operations.ts | Module-level singleton accessor for I18nExternalStore; no mechanism to notify consumers when the singleton is replaced via setI18nExternalStore. |
| packages/react-core/src/external-store/store/__tests__/store-subscriptions.test.ts | Good focused subscription tests for locale, region, translation, and dictionary events; does not cover the inline-array useTranslateMany re-render scenario. |
| packages/react-core/src/external-store/store/storeTypes.ts | Clean shared type definitions for store listeners, snapshots, and condition-store interface. |
| packages/react-core/src/external-store/store/managerEvents.ts | Four event-name constants that map I18nManager cache-miss events to this store layer. |
| packages/react-core/src/internal-external-store.ts | Internal re-export surface for the external-store module; straightforward barrel file with no logic. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as React Component
    participant H as i18n-manager-hooks
    participant S as I18nExternalStore (singleton)
    participant M as I18nManager

    C->>H: useTranslate(lookup)
    H->>S: getI18nExternalStore()
    H->>S: subscribeToTranslate(lookup, listener)
    S->>M: subscribe('translations-cache-miss', ...)
    H->>S: getTranslateSnapshot(lookup)
    S->>M: lookupTranslation(locale, message, options)
    M-->>S: "Translation | undefined"
    S-->>H: snapshot
    H-->>C: snapshot

    M->>S: "emit('translations-cache-miss', {locale, hash, translation})"
    S->>S: translateEventMatchesLookup(event, lookupKey)?
    S->>H: listener()
    H->>S: getTranslateSnapshot(lookup)
    S->>M: lookupTranslation(...)
    M-->>S: updated Translation
    S-->>H: new snapshot
    H-->>C: re-render with new snapshot
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/react-core/src/external-store/hooks/i18n-manager-hooks.ts:77-86
**`useTranslateMany` will infinite-loop on inline array arguments**

`getTranslateManySnapshot` uses a `WeakMap` keyed by the `lookups` array reference for its stable-snapshot optimisation. If a caller passes an inline array literal (the common pattern — no `useMemo`), every render allocates a new array, so the WeakMap always misses and returns a new snapshot object. `useSyncExternalStore` compares snapshots with `Object.is`, so the two structurally-identical arrays (`S1` vs `S2`) are never equal, React schedules a re-render, which creates yet another new array, and the loop never terminates. The hook must either document that `lookups` must be referentially stable (identical between renders), or the snapshot comparison must fall back to a structural / per-element `Object.is` check when the WeakMap misses.

### Issue 2 of 3
packages/react-core/src/external-store/hooks/i18n-manager-hooks.ts:22-28
**`useI18nManager` is not reactive**

`useI18nManager` (and `useI18nExternalStore`) calls `getI18nExternalStore()` once per render but subscribes to nothing. If `setI18nExternalStore` is ever called with a new store instance (e.g., when `GTProvider` remounts or reinitialises), components that called `useI18nManager` will continue holding a reference to the old `I18nManager` and will never re-render to pick up the replacement. Since the function is named `use*` and sits alongside `useSyncExternalStore`-backed hooks, callers will reasonably expect it to participate in the same reactivity model.

### Issue 3 of 3
packages/react-core/src/external-store/store/I18nExternalStore.ts:376-382
**`connect()` guard inspects only one of four subscriptions**

`connect()` returns early when `unsubscribeLocalesEvents` is truthy, treating that single field as the canonical "connected" indicator. `disconnect()` sets all four `unsubscribe*` fields to `undefined`, but if any of the three remaining `i18nManager.subscribe` calls in `subscribeToManager()` were to throw or return a falsy value, the other three subscriptions would remain dangling while the guard would still prevent a reconnect. Consider using a dedicated `boolean` `_connected` flag instead of piggybacking on a specific unsubscribe reference.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(react-core): add external store man..."](https://github.com/generaltranslation/gt/commit/1d0d62c895a4ba244715bdf164e3ca8a49cd75aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31421333)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->