### PR TITLE
refactor: type chatbot artifact metadata

### DIFF
--- a/examples/next-chatbot/app/(auth)/auth.config.ts
+++ b/examples/next-chatbot/app/(auth)/auth.config.ts
@@ -17,7 +17,7 @@ export const authConfig = {
       const isOnLogin = nextUrl.pathname.startsWith('/login');
 
       if (isLoggedIn && (isOnLogin || isOnRegister)) {
-        return Response.redirect(new URL('/', nextUrl as unknown as URL));
+        return Response.redirect(new URL('/', nextUrl.href));
       }
 
       if (isOnRegister || isOnLogin) {
@@ -30,7 +30,7 @@ export const authConfig = {
       }
 
       if (isLoggedIn) {
-        return Response.redirect(new URL('/', nextUrl as unknown as URL));
+        return Response.redirect(new URL('/', nextUrl.href));
       }
 
       return true;

--- a/examples/next-chatbot/app/(auth)/auth.ts
+++ b/examples/next-chatbot/app/(auth)/auth.ts
@@ -11,7 +11,9 @@ interface ExtendedSession extends Session {
   user: User;
 }
 
-type LoginCredentials = Partial<Record<'email' | 'password', unknown>>;
+type LoginCredentials = Partial<
+  Record<'email' | 'password', FormDataEntryValue>
+>;
 
 export const {
   handlers: { GET, POST },

--- a/examples/next-chatbot/app/(chat)/layout.tsx
+++ b/examples/next-chatbot/app/(chat)/layout.tsx
@@ -13,7 +13,7 @@ type ScriptWithSrcProps = ScriptProps & {
   src: string;
 };
 
-const ScriptWithSrc = Script as unknown as ComponentType<ScriptWithSrcProps>;
+const ScriptWithSrc = Script as ComponentType<ScriptWithSrcProps>;
 
 export default async function Layout({
   children,

--- a/examples/next-chatbot/artifacts/code/client.tsx
+++ b/examples/next-chatbot/artifacts/code/client.tsx
@@ -62,18 +62,20 @@ function detectRequiredHandlers(code: string): string[] {
   return handlers;
 }
 
-interface Metadata {
+export interface CodeArtifactMetadata {
   outputs: Array<ConsoleOutput>;
 }
 
-export const codeArtifact = new Artifact<'code', Metadata>({
+const initialCodeArtifactMetadata: CodeArtifactMetadata = {
+  outputs: [],
+};
+
+export const codeArtifact = new Artifact<'code', CodeArtifactMetadata | null>({
   kind: 'code',
   description:
     'Useful for code generation; Code execution is only available for python code.',
   initialize: async ({ setMetadata }) => {
-    setMetadata({
-      outputs: [],
-    });
+    setMetadata(initialCodeArtifactMetadata);
   },
   onStreamPart: ({ streamPart, setArtifact }) => {
     if (streamPart.type === 'code-delta') {
@@ -121,9 +123,9 @@ export const codeArtifact = new Artifact<'code', Metadata>({
         const outputContent: Array<ConsoleOutputContent> = [];
 
         setMetadata((metadata) => ({
-          ...metadata,
+          ...(metadata ?? initialCodeArtifactMetadata),
           outputs: [
-            ...metadata.outputs,
+            ...(metadata?.outputs ?? []),
             {
               id: runId,
               contents: [],
@@ -152,9 +154,11 @@ export const codeArtifact = new Artifact<'code', Metadata>({
           await currentPyodideInstance.loadPackagesFromImports(content, {
             messageCallback: (message: string) => {
               setMetadata((metadata) => ({
-                ...metadata,
+                ...(metadata ?? initialCodeArtifactMetadata),
                 outputs: [
-                  ...metadata.outputs.filter((output) => output.id !== runId),
+                  ...(metadata?.outputs ?? []).filter(
+                    (output) => output.id !== runId
+                  ),
                   {
                     id: runId,
                     contents: [{ type: 'text', value: message }],
@@ -183,9 +187,11 @@ export const codeArtifact = new Artifact<'code', Metadata>({
           await currentPyodideInstance.runPythonAsync(content);
 
           setMetadata((metadata) => ({
-            ...metadata,
+            ...(metadata ?? initialCodeArtifactMetadata),
             outputs: [
-              ...metadata.outputs.filter((output) => output.id !== runId),
+              ...(metadata?.outputs ?? []).filter(
+                (output) => output.id !== runId
+              ),
               {
                 id: runId,
                 contents: outputContent,
@@ -198,9 +204,11 @@ export const codeArtifact = new Artifact<'code', Metadata>({
             error instanceof Error ? error.message : String(error);
 
           setMetadata((metadata) => ({
-            ...metadata,
+            ...(metadata ?? initialCodeArtifactMetadata),
             outputs: [
-              ...metadata.outputs.filter((output) => output.id !== runId),
+              ...(metadata?.outputs ?? []).filter(
+                (output) => output.id !== runId
+              ),
               {
                 id: runId,
                 contents: [{ type: 'text', value: errorMessage }],

--- a/examples/next-chatbot/artifacts/image/client.tsx
+++ b/examples/next-chatbot/artifacts/image/client.tsx
@@ -3,7 +3,7 @@ import { CopyIcon, RedoIcon, UndoIcon } from '@/components/icons';
 import { ImageEditor } from '@/components/image-editor';
 import { toast } from 'sonner';
 
-export const imageArtifact = new Artifact({
+export const imageArtifact = new Artifact<'image'>({
   kind: 'image',
   description: 'Useful for image generation',
   onStreamPart: ({ streamPart, setArtifact }) => {

--- a/examples/next-chatbot/artifacts/sheet/client.tsx
+++ b/examples/next-chatbot/artifacts/sheet/client.tsx
@@ -10,9 +10,7 @@ import { SpreadsheetEditor } from '@/components/sheet-editor';
 import { parse, unparse } from 'papaparse';
 import { toast } from 'sonner';
 
-type Metadata = Record<string, never>;
-
-export const sheetArtifact = new Artifact<'sheet', Metadata>({
+export const sheetArtifact = new Artifact<'sheet'>({
   kind: 'sheet',
   description: 'Useful for working with spreadsheets',
   initialize: async () => {},

--- a/examples/next-chatbot/artifacts/text/client.tsx
+++ b/examples/next-chatbot/artifacts/text/client.tsx
@@ -14,11 +14,11 @@ import { Suggestion } from '@/lib/db/schema';
 import { toast } from 'sonner';
 import { getSuggestions } from '../actions';
 
-interface TextArtifactMetadata {
+export interface TextArtifactMetadata {
   suggestions: Array<Suggestion>;
 }
 
-export const textArtifact = new Artifact<'text', TextArtifactMetadata>({
+export const textArtifact = new Artifact<'text', TextArtifactMetadata | null>({
   kind: 'text',
   description: 'Useful for text content, like drafting essays and emails.',
   initialize: async ({ documentId, setMetadata }) => {
@@ -33,7 +33,7 @@ export const textArtifact = new Artifact<'text', TextArtifactMetadata>({
       setMetadata((metadata) => {
         return {
           suggestions: [
-            ...metadata.suggestions,
+            ...(metadata?.suggestions ?? []),
             streamPart.content as Suggestion,
           ],
         };

--- a/examples/next-chatbot/components/artifact-actions.tsx
+++ b/examples/next-chatbot/components/artifact-actions.tsx
@@ -1,11 +1,12 @@
 import { Button } from './ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
-import { artifactDefinitions, UIArtifact } from './artifact';
+import {
+  type ArtifactMetadata,
+  getArtifactDefinition,
+  type UIArtifact,
+} from './artifact';
 import { Dispatch, memo, SetStateAction, useState } from 'react';
-import type {
-  Artifact as ArtifactDefinition,
-  ArtifactActionContext,
-} from './create-artifact';
+import type { ArtifactActionContext } from './create-artifact';
 import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
 import { useGT } from 'gt-next/client';
@@ -15,8 +16,8 @@ interface ArtifactActionsProps {
   currentVersionIndex: number;
   isCurrentVersion: boolean;
   mode: 'edit' | 'diff';
-  metadata: unknown;
-  setMetadata: Dispatch<SetStateAction<unknown>>;
+  metadata: ArtifactMetadata;
+  setMetadata: Dispatch<SetStateAction<ArtifactMetadata>>;
 }
 
 function PureArtifactActions({
@@ -30,15 +31,13 @@ function PureArtifactActions({
 }: ArtifactActionsProps) {
   const [isLoading, setIsLoading] = useState(false);
   const t = useGT();
-  const artifactDefinition = artifactDefinitions.find(
-    (definition) => definition.kind === artifact.kind
-  ) as ArtifactDefinition<string, unknown> | undefined;
+  const artifactDefinition = getArtifactDefinition(artifact.kind);
 
   if (!artifactDefinition) {
     throw new Error('Artifact definition not found!');
   }
 
-  const actionContext: ArtifactActionContext<unknown> = {
+  const actionContext: ArtifactActionContext<ArtifactMetadata> = {
     content: artifact.content,
     handleVersionChange,
     currentVersionIndex,

--- a/examples/next-chatbot/components/artifact.tsx
+++ b/examples/next-chatbot/components/artifact.tsx
@@ -26,22 +26,44 @@ import { ArtifactCloseButton } from './artifact-close-button';
 import { ArtifactMessages } from './artifact-messages';
 import { useSidebar } from './ui/sidebar';
 import { useArtifact } from '@/hooks/use-artifact';
+import {
+  codeArtifact,
+  type CodeArtifactMetadata,
+} from '@/artifacts/code/client';
 import { imageArtifact } from '@/artifacts/image/client';
-import { codeArtifact } from '@/artifacts/code/client';
 import { sheetArtifact } from '@/artifacts/sheet/client';
-import { textArtifact } from '@/artifacts/text/client';
+import {
+  textArtifact,
+  type TextArtifactMetadata,
+} from '@/artifacts/text/client';
 import equal from 'fast-deep-equal';
 import { T } from 'gt-next';
-import type { Artifact as ArtifactDefinition } from './create-artifact';
+import type { Artifact as ArtifactConfiguration } from './create-artifact';
 
 export const artifactDefinitions = [
   textArtifact,
   codeArtifact,
   imageArtifact,
   sheetArtifact,
-];
+] as const;
 
 export type ArtifactKind = (typeof artifactDefinitions)[number]['kind'];
+export type ArtifactMetadata =
+  | CodeArtifactMetadata
+  | TextArtifactMetadata
+  | null;
+export type ArtifactDefinition = ArtifactConfiguration<
+  ArtifactKind,
+  ArtifactMetadata
+>;
+
+export function getArtifactDefinition(
+  kind: ArtifactKind
+): ArtifactDefinition | undefined {
+  return artifactDefinitions.find((definition) => definition.kind === kind) as
+    | ArtifactDefinition
+    | undefined;
+}
 
 export interface UIArtifact {
   title: string;
@@ -247,9 +269,7 @@ function PureArtifact({
   const { width: windowWidth, height: windowHeight } = useWindowSize();
   const isMobile = windowWidth ? windowWidth < 768 : false;
 
-  const artifactDefinition = artifactDefinitions.find(
-    (definition) => definition.kind === artifact.kind
-  ) as ArtifactDefinition<string, unknown> | undefined;
+  const artifactDefinition = getArtifactDefinition(artifact.kind);
 
   if (!artifactDefinition) {
     throw new Error('Artifact definition not found!');

--- a/examples/next-chatbot/components/code-block.tsx
+++ b/examples/next-chatbot/components/code-block.tsx
@@ -1,9 +1,9 @@
 'use client';
 
+import type { ExtraProps } from 'react-markdown';
 import type { HTMLAttributes, ReactNode } from 'react';
 
-interface CodeBlockProps extends HTMLAttributes<HTMLElement> {
-  node?: unknown;
+interface CodeBlockProps extends HTMLAttributes<HTMLElement>, ExtraProps {
   inline?: boolean;
   className?: string;
   children?: ReactNode;

--- a/examples/next-chatbot/components/create-artifact.tsx
+++ b/examples/next-chatbot/components/create-artifact.tsx
@@ -4,7 +4,7 @@ import { ComponentType, Dispatch, ReactNode, SetStateAction } from 'react';
 import { DataStreamDelta } from './data-stream-handler';
 import { UIArtifact } from './artifact';
 
-export type ArtifactActionContext<M = unknown> = {
+export type ArtifactActionContext<M = null> = {
   content: string;
   handleVersionChange: (type: 'next' | 'prev' | 'toggle' | 'latest') => void;
   currentVersionIndex: number;
@@ -14,7 +14,7 @@ export type ArtifactActionContext<M = unknown> = {
   setMetadata: Dispatch<SetStateAction<M>>;
 };
 
-type ArtifactAction<M = unknown> = {
+type ArtifactAction<M = null> = {
   icon: ReactNode;
   label?: string;
   description: string;
@@ -32,7 +32,7 @@ export type ArtifactToolbarItem = {
   onClick: (context: ArtifactToolbarContext) => void;
 };
 
-interface ArtifactContent<M = unknown> {
+interface ArtifactContent<M = null> {
   title: string;
   content: string;
   mode: 'edit' | 'diff';
@@ -48,12 +48,12 @@ interface ArtifactContent<M = unknown> {
   setMetadata: Dispatch<SetStateAction<M>>;
 }
 
-interface InitializeParameters<M = unknown> {
+interface InitializeParameters<M = null> {
   documentId: string;
   setMetadata: Dispatch<SetStateAction<M>>;
 }
 
-type ArtifactConfig<T extends string, M = unknown> = {
+type ArtifactConfig<T extends string, M = null> = {
   kind: T;
   description: string;
   content: ComponentType<ArtifactContent<M>>;
@@ -67,7 +67,7 @@ type ArtifactConfig<T extends string, M = unknown> = {
   }) => void;
 };
 
-export class Artifact<T extends string, M = unknown> {
+export class Artifact<T extends string, M = null> {
   readonly kind: T;
   readonly description: string;
   readonly content: ComponentType<ArtifactContent<M>>;

--- a/examples/next-chatbot/components/data-stream-handler.tsx
+++ b/examples/next-chatbot/components/data-stream-handler.tsx
@@ -2,7 +2,7 @@
 
 import { useChat } from 'ai/react';
 import { useEffect, useRef } from 'react';
-import { artifactDefinitions, ArtifactKind } from './artifact';
+import { ArtifactKind, getArtifactDefinition } from './artifact';
 import { Suggestion } from '@/lib/db/schema';
 import { initialArtifactData, useArtifact } from '@/hooks/use-artifact';
 
@@ -33,9 +33,7 @@ export function DataStreamHandler({ id }: { id: string }) {
     lastProcessedIndex.current = dataStream.length - 1;
 
     (newDeltas as DataStreamDelta[]).forEach((delta: DataStreamDelta) => {
-      const artifactDefinition = artifactDefinitions.find(
-        (artifactDefinition) => artifactDefinition.kind === artifact.kind
-      );
+      const artifactDefinition = getArtifactDefinition(artifact.kind);
 
       if (artifactDefinition?.onStreamPart) {
         artifactDefinition.onStreamPart({

--- a/examples/next-chatbot/hooks/use-artifact.ts
+++ b/examples/next-chatbot/hooks/use-artifact.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import useSWR from 'swr';
-import { UIArtifact } from '@/components/artifact';
+import type { ArtifactMetadata, UIArtifact } from '@/components/artifact';
 import { useCallback, useMemo } from 'react';
 
 export const initialArtifactData: UIArtifact = {
@@ -43,10 +43,7 @@ export function useArtifact() {
     }
   );
 
-  const artifact = useMemo(() => {
-    if (!localArtifact) return initialArtifactData;
-    return localArtifact;
-  }, [localArtifact]);
+  const artifact = localArtifact ?? initialArtifactData;
 
   const setArtifact = useCallback(
     (updaterFn: UIArtifact | ((currentArtifact: UIArtifact) => UIArtifact)) => {
@@ -64,7 +61,7 @@ export function useArtifact() {
   );
 
   const { data: localArtifactMetadata, mutate: setLocalArtifactMetadata } =
-    useSWR<unknown>(
+    useSWR<ArtifactMetadata>(
       () =>
         artifact.documentId ? `artifact-metadata-${artifact.documentId}` : null,
       null,
@@ -73,13 +70,34 @@ export function useArtifact() {
       }
     );
 
+  const metadata = localArtifactMetadata ?? null;
+
+  const setMetadata = useCallback(
+    (
+      updaterFn:
+        | ArtifactMetadata
+        | ((currentMetadata: ArtifactMetadata) => ArtifactMetadata)
+    ) => {
+      setLocalArtifactMetadata((currentMetadata) => {
+        const metadataToUpdate = currentMetadata ?? null;
+
+        if (typeof updaterFn === 'function') {
+          return updaterFn(metadataToUpdate);
+        }
+
+        return updaterFn;
+      });
+    },
+    [setLocalArtifactMetadata]
+  );
+
   return useMemo(
     () => ({
       artifact,
       setArtifact,
-      metadata: localArtifactMetadata,
-      setMetadata: setLocalArtifactMetadata,
+      metadata,
+      setMetadata,
     }),
-    [artifact, setArtifact, localArtifactMetadata, setLocalArtifactMetadata]
+    [artifact, setArtifact, metadata, setMetadata]
   );
 }


### PR DESCRIPTION
## Summary
- replace broad next-chatbot artifact metadata `unknown` plumbing with explicit metadata types
- add a typed artifact definition lookup and React-style metadata setter wrapper
- remove remaining next-chatbot `unknown` casts where a concrete type is available

## Verification
- pnpm --filter ai-chatbot typecheck
- pnpm --filter ai-chatbot lint
- pnpm exec oxfmt --check examples/next-chatbot
- pnpm lint

Stacked on #1399.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces broad `unknown` typing across the next-chatbot artifact metadata system with concrete typed unions (`CodeArtifactMetadata | TextArtifactMetadata | null`), and adds a typed `getArtifactDefinition` lookup helper and a typed `setMetadata` wrapper in `useArtifact`.

- **`artifact.tsx`**: Introduces `ArtifactMetadata`, `ArtifactDefinition`, and `getArtifactDefinition()`, which centralises the definition lookup used in three components and removes repeated inline `as ArtifactDefinition<string, unknown>` casts.
- **`use-artifact.ts`**: Wraps `useSWR`'s `mutate` in a typed `setMetadata` callback that correctly handles both direct-value and updater-function forms, and simplifies the `artifact` derivation from a `useMemo` to a single `??` expression.
- **`code/client.tsx`, `text/client.tsx`**: Change to `M | null` union generics and add `?? initialMetadata` fallbacks in every `setMetadata` updater callback to guard against the pre-initialization `null` state.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes are a pure type-system tightening with no behavioural changes to runtime logic.

Every changed code path was already working correctly; this PR only narrows types from unknown/Record<string,never> to concrete unions and adds null-safe guards in metadata updater callbacks that were already required by the pre-existing | null fallback pattern. The as ArtifactDefinition cast in getArtifactDefinition is an intentional widening to let a single helper serve all call sites. Auth and layout changes are equivalent refactors removing double-casts.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| examples/next-chatbot/components/artifact.tsx | Introduces ArtifactMetadata union type, ArtifactDefinition alias, and getArtifactDefinition helper; removes repeated inline casts for definition lookup. |
| examples/next-chatbot/hooks/use-artifact.ts | Adds typed setMetadata wrapper handling both value and updater-function forms; simplifies artifact derivation from useMemo to ?? expression. |
| examples/next-chatbot/components/create-artifact.tsx | Changes default generic M from `unknown` to `null` across all artifact config types and the Artifact class. |
| examples/next-chatbot/artifacts/code/client.tsx | Changes to Artifact<'code', CodeArtifactMetadata | null>; adds null-safe spread and optional-chaining on every setMetadata updater callback. |
| examples/next-chatbot/artifacts/text/client.tsx | Exports TextArtifactMetadata; changes to Artifact<'text', TextArtifactMetadata | null>; guards metadata.suggestions spread with ??. |
| examples/next-chatbot/components/artifact-actions.tsx | Uses getArtifactDefinition helper and typed ArtifactMetadata for metadata/setMetadata props, removing unknown casts. |
| examples/next-chatbot/components/data-stream-handler.tsx | Replaces inline artifactDefinitions.find with getArtifactDefinition helper; no behavioural change. |
| examples/next-chatbot/app/(auth)/auth.config.ts | Replaces nextUrl as unknown as URL double-cast with nextUrl.href; semantically equivalent and removes unsafe cast. |
| examples/next-chatbot/app/(auth)/auth.ts | Refines LoginCredentials type from unknown to FormDataEntryValue, matching actual credential values from FormData. |
| examples/next-chatbot/components/code-block.tsx | Replaces node?: unknown with ExtraProps from react-markdown for proper typing of the AST node prop. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    UA["useArtifact()\nhooks/use-artifact.ts"]
    SWR["useSWR<ArtifactMetadata>\nartifact-metadata-{documentId}"]
    SM["setMetadata wrapper\n(value | updaterFn) → void"]
    GAD["getArtifactDefinition(kind)\ncomponents/artifact.tsx"]
    AD["ArtifactDefinition\nArtifact<ArtifactKind, ArtifactMetadata>"]
    CA["codeArtifact\nArtifact<'code', CodeArtifactMetadata | null>"]
    TA["textArtifact\nArtifact<'text', TextArtifactMetadata | null>"]
    IA["imageArtifact\nArtifact<'image', null>"]
    SA["sheetArtifact\nArtifact<'sheet', null>"]
    ART["Artifact component\ncomponents/artifact.tsx"]
    AA["ArtifactActions\ncomponents/artifact-actions.tsx"]
    DSH["DataStreamHandler\ncomponents/data-stream-handler.tsx"]

    UA --> SWR
    SWR --> SM
    UA -->|"metadata: ArtifactMetadata"| ART
    UA -->|"setMetadata"| ART
    ART -->|"initialize / onStreamPart"| GAD
    ART -->|"metadata + setMetadata"| AA
    DSH -->|"onStreamPart"| GAD
    GAD -->|"as ArtifactDefinition"| AD
    AD --> CA
    AD --> TA
    AD --> IA
    AD --> SA
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: type chatbot artifact metadata"](https://github.com/generaltranslation/gt/commit/e2d40089e036d035ffff3a33c704223a44bf7f5c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31425417)</sub>

<!-- /greptile_comment -->