### PR TITLE
feat(react-core): add external store foundation

### DIFF
--- a/packages/react-core/src/external-store/store/I18nExternalStore.ts
+++ b/packages/react-core/src/external-store/store/I18nExternalStore.ts
@@ -1,0 +1,448 @@
+import type { I18nManager } from 'gt-i18n/internal';
+import {
+  DICTIONARY_CACHE_MISS_EVENT_NAME as DICTIONARY_ENTRY_EVENT_NAME,
+  LOCALES_CACHE_MISS_EVENT_NAME as LOCALES_EVENT_NAME,
+  LOCALES_DICTIONARY_CACHE_MISS_EVENT_NAME as LOCALES_DICTIONARY_EVENT_NAME,
+  TRANSLATIONS_CACHE_MISS_EVENT_NAME as TRANSLATION_EVENT_NAME,
+} from 'gt-i18n/internal';
+import { hashSource } from 'generaltranslation/id';
+import { indexVars } from 'generaltranslation/internal';
+import type { CustomMapping, IcuMessage } from 'generaltranslation/types';
+import type {
+  DictionaryValue,
+  LookupOptions,
+  Translation,
+} from 'gt-i18n/types';
+import type {
+  DictionaryEntrySnapshot,
+  DictionaryLookup,
+  DictionaryObjectSnapshot,
+  ListenerSet,
+  StoreListener,
+  TranslateLookup,
+  TranslateManySnapshot,
+  TranslateSnapshot,
+  Unsubscribe,
+} from './storeTypes';
+
+type LocaleCacheEvent<T> = {
+  locale: string;
+  value: Record<string, T>;
+};
+type EntryCacheEvent<T> = {
+  locale: string;
+  id: string;
+  value: T;
+};
+type TranslateStoreEvent =
+  | LocaleCacheEvent<Translation>
+  | EntryCacheEvent<Translation>;
+type TranslateStoreListener = (event: TranslateStoreEvent) => void;
+type DictionaryStoreEvent =
+  | LocaleCacheEvent<DictionaryValue>
+  | EntryCacheEvent<DictionaryEntrySnapshot>;
+type DictionaryStoreListener = (event: DictionaryStoreEvent) => void;
+
+export type I18nExternalStoreParams = {
+  i18nManager: I18nManager<Translation>;
+};
+
+/**
+ * External store adapter between React and I18nManager.
+ *
+ * Locale and region are runtime conditions owned by the active condition store.
+ * This class is only responsible for manager-backed snapshots and cache
+ * invalidation events.
+ */
+export class I18nExternalStore {
+  private i18nManager: I18nManager<Translation>;
+
+  private defaultLocaleListeners: ListenerSet = new Set();
+  private localesListeners: ListenerSet = new Set();
+  private customMappingListeners: ListenerSet = new Set();
+  private enableI18nListeners: ListenerSet = new Set();
+  private translateListeners = new Set<TranslateStoreListener>();
+  private translateManySnapshotCache = new WeakMap<
+    readonly TranslateLookup[],
+    TranslateManySnapshot
+  >();
+  private dictionaryEntryListeners = new Set<DictionaryStoreListener>();
+  private dictionaryObjectListeners = new Set<DictionaryStoreListener>();
+
+  private unsubscribeLocalesEvents: Unsubscribe | undefined;
+  private unsubscribeTranslateEvents: Unsubscribe | undefined;
+  private unsubscribeLocalesDictionaryEvents: Unsubscribe | undefined;
+  private unsubscribeDictionaryEntryEvents: Unsubscribe | undefined;
+
+  constructor({ i18nManager }: I18nExternalStoreParams) {
+    this.i18nManager = i18nManager;
+  }
+
+  getI18nManager = (): I18nManager<Translation> => {
+    return this.i18nManager;
+  };
+
+  subscribeToDefaultLocale = (listener: StoreListener): Unsubscribe => {
+    return this.subscribeToStaticSet(this.defaultLocaleListeners, listener);
+  };
+
+  subscribeToLocales = (listener: StoreListener): Unsubscribe => {
+    return this.subscribeToStaticSet(this.localesListeners, listener);
+  };
+
+  subscribeToCustomMapping = (listener: StoreListener): Unsubscribe => {
+    return this.subscribeToStaticSet(this.customMappingListeners, listener);
+  };
+
+  subscribeToEnableI18n = (listener: StoreListener): Unsubscribe => {
+    return this.subscribeToStaticSet(this.enableI18nListeners, listener);
+  };
+
+  subscribeToTranslate<T extends Translation>(
+    lookup: TranslateLookup<T>,
+    listener: StoreListener
+  ): Unsubscribe {
+    const lookupKey = getTranslateListenerKey(lookup);
+    const wrappedListener: TranslateStoreListener = (event) => {
+      if (translateEventMatchesLookup(event, lookupKey)) {
+        listener();
+      }
+    };
+    return this.subscribeToTranslateSet(wrappedListener);
+  }
+
+  subscribeToTranslateMany<T extends Translation>(
+    lookups: readonly TranslateLookup<T>[],
+    listener: StoreListener
+  ): Unsubscribe {
+    const unsubscribes = lookups.map((lookup) =>
+      this.subscribeToTranslate(lookup, listener)
+    );
+    return () => {
+      unsubscribes.forEach((unsubscribe) => unsubscribe());
+    };
+  }
+
+  subscribeToDictionaryEntry(
+    lookup: DictionaryLookup,
+    listener: StoreListener
+  ): Unsubscribe {
+    const lookupKey = getDictionaryListenerKey(lookup);
+    const wrappedListener: DictionaryStoreListener = (event) => {
+      if (dictionaryEntryEventMatchesLookup(event, lookupKey)) {
+        listener();
+      }
+    };
+    return this.subscribeToDictionarySet(
+      this.dictionaryEntryListeners,
+      wrappedListener
+    );
+  }
+
+  subscribeToDictionaryObject(
+    lookup: DictionaryLookup,
+    listener: StoreListener
+  ): Unsubscribe {
+    const lookupKey = getDictionaryListenerKey(lookup);
+    const wrappedListener: DictionaryStoreListener = (event) => {
+      if (dictionaryObjectEventMatchesLookup(event, lookupKey)) {
+        listener();
+      }
+    };
+    return this.subscribeToDictionarySet(
+      this.dictionaryObjectListeners,
+      wrappedListener
+    );
+  }
+
+  getDefaultLocaleSnapshot = (): string => {
+    return this.i18nManager.getDefaultLocale();
+  };
+
+  getLocalesSnapshot = (): readonly string[] => {
+    return this.i18nManager.getLocales();
+  };
+
+  getCustomMappingSnapshot = (): CustomMapping => {
+    return this.i18nManager.getCustomMapping();
+  };
+
+  getEnableI18nSnapshot = (): boolean => {
+    return this.i18nManager.isTranslationEnabled();
+  };
+
+  getTranslateSnapshot = <T extends Translation>({
+    locale,
+    message,
+    options,
+  }: TranslateLookup<T>): TranslateSnapshot<T> => {
+    return this.i18nManager.lookupTranslation<T>(locale, message, options);
+  };
+
+  getTranslateManySnapshot = <T extends Translation>(
+    lookups: readonly TranslateLookup<T>[]
+  ): TranslateManySnapshot<T> => {
+    const nextSnapshot = lookups.map((lookup) =>
+      this.getTranslateSnapshot(lookup)
+    );
+    const previousSnapshot = this.translateManySnapshotCache.get(lookups);
+    if (
+      previousSnapshot &&
+      previousSnapshot.length === nextSnapshot.length &&
+      previousSnapshot.every((value, index) =>
+        Object.is(value, nextSnapshot[index])
+      )
+    ) {
+      return previousSnapshot as TranslateManySnapshot<T>;
+    }
+
+    this.translateManySnapshotCache.set(lookups, nextSnapshot);
+    return nextSnapshot;
+  };
+
+  getDictionaryEntrySnapshot = ({
+    locale,
+    id,
+  }: DictionaryLookup): DictionaryEntrySnapshot => {
+    return this.i18nManager.lookupDictionary(locale, id);
+  };
+
+  getDictionaryObjectSnapshot = ({
+    locale,
+    id,
+  }: DictionaryLookup): DictionaryObjectSnapshot => {
+    return this.i18nManager.lookupDictionaryObj(locale, id);
+  };
+
+  private subscribeToStaticSet(
+    listenerSet: ListenerSet,
+    listener: StoreListener
+  ): Unsubscribe {
+    listenerSet.add(listener);
+    return () => {
+      listenerSet.delete(listener);
+    };
+  }
+
+  private subscribeToTranslateSet(
+    listener: TranslateStoreListener
+  ): Unsubscribe {
+    const hadListeners = this.sourceListenerCount() > 0;
+    this.translateListeners.add(listener);
+    if (!hadListeners) {
+      this.connect();
+    }
+
+    return () => {
+      this.translateListeners.delete(listener);
+      if (this.sourceListenerCount() === 0) {
+        this.disconnect();
+      }
+    };
+  }
+
+  private subscribeToDictionarySet(
+    listenerSet: Set<DictionaryStoreListener>,
+    listener: DictionaryStoreListener
+  ): Unsubscribe {
+    const hadListeners = this.sourceListenerCount() > 0;
+    listenerSet.add(listener);
+    if (!hadListeners) {
+      this.connect();
+    }
+
+    return () => {
+      listenerSet.delete(listener);
+      if (this.sourceListenerCount() === 0) {
+        this.disconnect();
+      }
+    };
+  }
+
+  private connect(): void {
+    if (this.unsubscribeLocalesEvents) {
+      return;
+    }
+
+    this.subscribeToManager();
+  }
+
+  private disconnect(): void {
+    this.unsubscribeLocalesEvents?.();
+    this.unsubscribeTranslateEvents?.();
+    this.unsubscribeLocalesDictionaryEvents?.();
+    this.unsubscribeDictionaryEntryEvents?.();
+    this.unsubscribeLocalesEvents = undefined;
+    this.unsubscribeTranslateEvents = undefined;
+    this.unsubscribeLocalesDictionaryEvents = undefined;
+    this.unsubscribeDictionaryEntryEvents = undefined;
+  }
+
+  private subscribeToManager(): void {
+    // Cache events are invalidation signals. Listeners reread snapshots instead
+    // of receiving payload values, matching useSyncExternalStore's contract.
+    this.unsubscribeLocalesEvents = this.i18nManager.subscribe(
+      LOCALES_EVENT_NAME,
+      (event) => {
+        this.emitTranslateEvent({
+          locale: event.locale,
+          value: event.translations,
+        });
+      }
+    );
+    this.unsubscribeTranslateEvents = this.i18nManager.subscribe(
+      TRANSLATION_EVENT_NAME,
+      (event) => {
+        this.emitTranslateEvent({
+          locale: event.locale,
+          id: event.hash,
+          value: event.translation,
+        });
+      }
+    );
+    this.unsubscribeLocalesDictionaryEvents = this.i18nManager.subscribe(
+      LOCALES_DICTIONARY_EVENT_NAME,
+      (event) => {
+        this.emitDictionaryEvent({
+          locale: event.locale,
+          value: event.dictionary,
+        });
+      }
+    );
+    this.unsubscribeDictionaryEntryEvents = this.i18nManager.subscribe(
+      DICTIONARY_ENTRY_EVENT_NAME,
+      (event) => {
+        this.emitDictionaryEvent({
+          locale: event.locale,
+          id: event.id,
+          value: event.dictionaryEntry,
+        });
+      }
+    );
+  }
+
+  private emitTranslateEvent(event: TranslateStoreEvent): void {
+    this.translateListeners.forEach((listener) => listener(event));
+  }
+
+  private emitDictionaryEvent(event: DictionaryStoreEvent): void {
+    this.dictionaryEntryListeners.forEach((listener) => listener(event));
+    this.dictionaryObjectListeners.forEach((listener) => listener(event));
+  }
+
+  private sourceListenerCount(): number {
+    return (
+      this.translateListeners.size +
+      this.dictionaryEntryListeners.size +
+      this.dictionaryObjectListeners.size
+    );
+  }
+}
+
+function getTranslateListenerKey<T extends Translation>(
+  lookup: TranslateLookup<T> | { locale: string; hash: string }
+): string {
+  const hash =
+    'hash' in lookup
+      ? lookup.hash
+      : getTranslateHash(lookup.message, lookup.options);
+  return `${lookup.locale}:${hash}`;
+}
+
+function getDictionaryListenerKey({ locale, id }: DictionaryLookup): string {
+  return `${locale}:${id}`;
+}
+
+function getDictionaryLookupFromKey(lookupKey: string): DictionaryLookup {
+  const separatorIndex = lookupKey.indexOf(':');
+  return {
+    locale: lookupKey.slice(0, separatorIndex),
+    id: lookupKey.slice(separatorIndex + 1),
+  };
+}
+
+function translateEventMatchesLookup(
+  event: TranslateStoreEvent,
+  lookupKey: string
+): boolean {
+  if ('id' in event) {
+    return (
+      getTranslateListenerKey({
+        locale: event.locale,
+        hash: event.id,
+      }) === lookupKey
+    );
+  }
+  return Object.keys(event.value).some(
+    (hash) =>
+      getTranslateListenerKey({ locale: event.locale, hash }) === lookupKey
+  );
+}
+
+function dictionaryEntryEventMatchesLookup(
+  event: DictionaryStoreEvent,
+  lookupKey: string
+): boolean {
+  if ('id' in event) {
+    return getDictionaryListenerKey(event) === lookupKey;
+  }
+  const { locale, id } = getDictionaryLookupFromKey(lookupKey);
+  const value = getDictionaryPathValue(event.value, id);
+  return locale === event.locale && value != null && !isDictionaryObject(value);
+}
+
+function dictionaryObjectEventMatchesLookup(
+  event: DictionaryStoreEvent,
+  lookupKey: string
+): boolean {
+  const { locale, id } = getDictionaryLookupFromKey(lookupKey);
+  if (locale !== event.locale) {
+    return false;
+  }
+  if ('id' in event) {
+    return id === '' || event.id === id || event.id.startsWith(`${id}.`);
+  }
+  return getDictionaryPathValue(event.value, id) != null;
+}
+
+function getTranslateHash<T extends Translation>(
+  message: T,
+  options: LookupOptions
+): string {
+  if (options.$_hash != null) {
+    return options.$_hash;
+  }
+
+  return hashSource({
+    source:
+      options.$format === 'ICU' ? indexVars(message as IcuMessage) : message,
+    ...(options.$context && { context: options.$context }),
+    ...(options.$id && { id: options.$id }),
+    ...('$maxChars' in options &&
+      options.$maxChars != null && {
+        maxChars: Math.abs(options.$maxChars),
+      }),
+    dataFormat: options.$format,
+  });
+}
+
+function getDictionaryPathValue(
+  dictionary: Record<string, DictionaryValue>,
+  id: string
+): DictionaryValue | undefined {
+  return id
+    .split('.')
+    .filter(Boolean)
+    .reduce<DictionaryValue | undefined>((value, key) => {
+      if (!isDictionaryObject(value)) {
+        return undefined;
+      }
+      return value[key];
+    }, dictionary);
+}
+
+function isDictionaryObject(
+  value: DictionaryValue | undefined
+): value is Record<string, DictionaryValue> {
+  return typeof value === 'object' && value != null && !Array.isArray(value);
+}

--- a/packages/react-core/src/external-store/store/ProviderConditionStore.ts
+++ b/packages/react-core/src/external-store/store/ProviderConditionStore.ts
@@ -1,0 +1,101 @@
+import { createLocaleResolver } from 'gt-i18n/internal';
+import type {
+  ConditionStoreConfig,
+  LocaleCandidates,
+  WritableConditionStore,
+} from 'gt-i18n/internal/types';
+import type {
+  I18nExternalConditionStore,
+  ListenerSet,
+  StoreListener,
+  Unsubscribe,
+} from './storeTypes';
+
+export type ProviderConditionStoreParams = ConditionStoreConfig & {
+  locale?: string;
+  region?: string;
+  getLocale?: () => string | undefined;
+};
+
+/**
+ * Condition store implementation owned by GTProvider.
+ *
+ * Locale and region are mutable runtime conditions. Subscribers receive
+ * value-less notifications so React can reread snapshots.
+ */
+export class ProviderConditionStore
+  implements WritableConditionStore, I18nExternalConditionStore
+{
+  private locale: string | undefined;
+  private region: string | undefined;
+  private resolveLocale: (candidates?: LocaleCandidates) => string;
+  private customGetLocale: (() => string | undefined) | undefined;
+
+  private localeListeners: ListenerSet = new Set();
+  private regionListeners: ListenerSet = new Set();
+
+  constructor({
+    defaultLocale,
+    locales,
+    customMapping,
+    locale,
+    region,
+    getLocale,
+  }: ProviderConditionStoreParams = {}) {
+    this.locale = locale;
+    this.region = region;
+    this.customGetLocale = getLocale;
+    this.resolveLocale = createLocaleResolver({
+      defaultLocale,
+      locales,
+      customMapping,
+    });
+  }
+
+  getLocale = (): string => {
+    return this.resolveLocale(this.customGetLocale?.() ?? this.locale);
+  };
+
+  setLocale = (locale: string): void => {
+    const previousLocale = this.getLocale();
+    this.locale = locale;
+    const nextLocale = this.getLocale();
+    if (nextLocale !== previousLocale) {
+      emit(this.localeListeners);
+    }
+  };
+
+  subscribeToLocale = (listener: StoreListener): Unsubscribe => {
+    return subscribeToSet(this.localeListeners, listener);
+  };
+
+  getRegion = (): string | undefined => {
+    return this.region;
+  };
+
+  setRegion = (region: string | undefined): void => {
+    const previousRegion = this.region;
+    this.region = region;
+    if (this.region !== previousRegion) {
+      emit(this.regionListeners);
+    }
+  };
+
+  subscribeToRegion = (listener: StoreListener): Unsubscribe => {
+    return subscribeToSet(this.regionListeners, listener);
+  };
+}
+
+function subscribeToSet(
+  listenerSet: ListenerSet,
+  listener: StoreListener
+): Unsubscribe {
+  listenerSet.add(listener);
+  return () => {
+    listenerSet.delete(listener);
+  };
+}
+
+function emit(listenerSet: ListenerSet): void {
+  listenerSet.forEach((listener) => listener());
+}

--- a/packages/react-core/src/external-store/store/__tests__/store-subscriptions.test.ts
+++ b/packages/react-core/src/external-store/store/__tests__/store-subscriptions.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it, vi } from 'vitest';
+import { I18nManager } from 'gt-i18n/internal';
+import { I18nExternalStore } from '../I18nExternalStore';
+import { ProviderConditionStore } from '../ProviderConditionStore';
+
+function createManager() {
+  return new I18nManager({
+    defaultLocale: 'en',
+    locales: ['en', 'fr', 'es'],
+    dictionary: {
+      greeting: 'Hello',
+      user: {
+        profile: {
+          name: 'Name',
+        },
+      },
+    },
+    loadDictionary: vi.fn().mockResolvedValue({
+      greeting: 'Bonjour',
+      user: {
+        profile: {
+          name: 'Nom',
+        },
+      },
+    }),
+    loadTranslations: vi.fn().mockResolvedValue({
+      hash: 'Bonjour',
+    }),
+  });
+}
+
+function createConditionStore(locale = 'en') {
+  return new ProviderConditionStore({
+    defaultLocale: 'en',
+    locales: ['en', 'fr', 'es'],
+    locale,
+  });
+}
+
+describe('external store subscriptions', () => {
+  it('notifies locale subscribers when locale changes', () => {
+    const conditionStore = createConditionStore('en');
+    const localeListener = vi.fn();
+    const unsubscribe = conditionStore.subscribeToLocale(localeListener);
+
+    conditionStore.setLocale('fr');
+
+    expect(conditionStore.getLocale()).toBe('fr');
+    expect(localeListener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    conditionStore.setLocale('es');
+    expect(localeListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('notifies region subscribers when region changes', () => {
+    const conditionStore = createConditionStore('en');
+    const regionListener = vi.fn();
+    const unsubscribe = conditionStore.subscribeToRegion(regionListener);
+
+    conditionStore.setRegion('US');
+
+    expect(conditionStore.getRegion()).toBe('US');
+    expect(regionListener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    conditionStore.setRegion('CA');
+    expect(regionListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('notifies translation subscribers for matching cache updates', async () => {
+    const manager = createManager();
+    const externalStore = new I18nExternalStore({ i18nManager: manager });
+    const matchingListener = vi.fn();
+    const otherHashListener = vi.fn();
+    const otherLocaleListener = vi.fn();
+
+    const unsubscribeMatching = externalStore.subscribeToTranslate(
+      {
+        locale: 'fr',
+        message: 'Hello',
+        options: { $format: 'ICU', $_hash: 'hash' },
+      },
+      matchingListener
+    );
+    const unsubscribeOtherHash = externalStore.subscribeToTranslate(
+      {
+        locale: 'fr',
+        message: 'Other',
+        options: { $format: 'ICU', $_hash: 'other' },
+      },
+      otherHashListener
+    );
+    const unsubscribeOtherLocale = externalStore.subscribeToTranslate(
+      {
+        locale: 'es',
+        message: 'Hello',
+        options: { $format: 'ICU', $_hash: 'hash' },
+      },
+      otherLocaleListener
+    );
+
+    await manager.lookupTranslationWithFallback('fr', 'Hello', {
+      $format: 'ICU',
+      $_hash: 'hash',
+    });
+
+    expect(matchingListener).toHaveBeenCalledTimes(1);
+    expect(otherHashListener).not.toHaveBeenCalled();
+    expect(otherLocaleListener).not.toHaveBeenCalled();
+
+    unsubscribeMatching();
+    unsubscribeOtherHash();
+    unsubscribeOtherLocale();
+  });
+
+  it('notifies translate many subscribers for matching cache updates', async () => {
+    const manager = createManager();
+    const externalStore = new I18nExternalStore({ i18nManager: manager });
+    const listener = vi.fn();
+    const lookups = [
+      {
+        locale: 'fr',
+        message: 'Hello',
+        options: { $format: 'ICU' as const, $_hash: 'hash' },
+      },
+      {
+        locale: 'fr',
+        message: 'Other',
+        options: { $format: 'ICU' as const, $_hash: 'other' },
+      },
+    ];
+
+    const initialSnapshot = externalStore.getTranslateManySnapshot(lookups);
+    expect(externalStore.getTranslateManySnapshot(lookups)).toBe(
+      initialSnapshot
+    );
+
+    const unsubscribe = externalStore.subscribeToTranslateMany(
+      lookups,
+      listener
+    );
+
+    await manager.lookupTranslationWithFallback('fr', 'Hello', {
+      $format: 'ICU',
+      $_hash: 'hash',
+    });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(externalStore.getTranslateManySnapshot(lookups)).toEqual([
+      'Bonjour',
+      undefined,
+    ]);
+
+    unsubscribe();
+  });
+
+  it('notifies dictionary entry subscribers for matching cache misses', async () => {
+    const manager = createManager();
+    const externalStore = new I18nExternalStore({ i18nManager: manager });
+    const matchingListener = vi.fn();
+    const otherListener = vi.fn();
+
+    const unsubscribeMatching = externalStore.subscribeToDictionaryEntry(
+      { locale: 'fr', id: 'greeting' },
+      matchingListener
+    );
+    const unsubscribeOther = externalStore.subscribeToDictionaryEntry(
+      { locale: 'fr', id: 'other' },
+      otherListener
+    );
+
+    await manager.lookupDictionaryWithFallback('fr', 'greeting');
+
+    expect(matchingListener).toHaveBeenCalledTimes(1);
+    expect(otherListener).not.toHaveBeenCalled();
+
+    unsubscribeMatching();
+    unsubscribeOther();
+  });
+
+  it('notifies dictionary object subscribers for matching cache misses', async () => {
+    const manager = createManager();
+    const externalStore = new I18nExternalStore({ i18nManager: manager });
+    const matchingListener = vi.fn();
+    const otherListener = vi.fn();
+
+    const unsubscribeMatching = externalStore.subscribeToDictionaryObject(
+      { locale: 'fr', id: 'user.profile' },
+      matchingListener
+    );
+    const unsubscribeOther = externalStore.subscribeToDictionaryObject(
+      { locale: 'fr', id: 'other' },
+      otherListener
+    );
+
+    await manager.lookupDictionaryObjWithFallback('fr', 'user.profile');
+
+    expect(matchingListener).toHaveBeenCalledTimes(1);
+    expect(otherListener).not.toHaveBeenCalled();
+
+    unsubscribeMatching();
+    unsubscribeOther();
+  });
+});

--- a/packages/react-core/src/external-store/store/singleton-operations.ts
+++ b/packages/react-core/src/external-store/store/singleton-operations.ts
@@ -1,0 +1,16 @@
+import type { I18nExternalStore } from './I18nExternalStore';
+
+let i18nExternalStore: I18nExternalStore | undefined;
+
+export function getI18nExternalStore(): I18nExternalStore {
+  if (!i18nExternalStore) {
+    throw new Error(
+      'I18nExternalStore is not initialized. Render GTProvider before using external-store hooks.'
+    );
+  }
+  return i18nExternalStore;
+}
+
+export function setI18nExternalStore(nextStore: I18nExternalStore): void {
+  i18nExternalStore = nextStore;
+}

--- a/packages/react-core/src/external-store/store/storeTypes.ts
+++ b/packages/react-core/src/external-store/store/storeTypes.ts
@@ -1,0 +1,38 @@
+import type {
+  DictionaryEntry,
+  DictionaryObject,
+  LookupOptions,
+  Translation,
+} from 'gt-i18n/types';
+
+export type Unsubscribe = () => void;
+export type StoreListener = () => void;
+export type ListenerSet = Set<StoreListener>;
+
+export type I18nExternalConditionStore = {
+  getLocale(): string;
+  subscribeToLocale(listener: StoreListener): Unsubscribe;
+  setLocale?(locale: string): void;
+  getRegion?(): string | undefined;
+  subscribeToRegion?(listener: StoreListener): Unsubscribe;
+  setRegion?(region: string | undefined): void;
+};
+
+export type TranslateLookup<T extends Translation = Translation> = {
+  locale: string;
+  message: T;
+  options: LookupOptions;
+};
+
+export type DictionaryLookup = {
+  locale: string;
+  id: string;
+};
+
+export type TranslateSnapshot<T extends Translation = Translation> =
+  | T
+  | undefined;
+export type TranslateManySnapshot<T extends Translation = Translation> =
+  readonly TranslateSnapshot<T>[];
+export type DictionaryEntrySnapshot = DictionaryEntry | undefined;
+export type DictionaryObjectSnapshot = DictionaryObject | undefined;


### PR DESCRIPTION
## Summary
- add I18nExternalStore for I18nManager-backed cache subscriptions and snapshots
- add ProviderConditionStore for locale/region get, set, and subscribe behavior
- add singleton operations, manager event constants, and shared external-store types
- add focused store subscription tests

## Scope
- no React provider wiring
- no React hooks
- no component migration
- no package entrypoint changes

## Test Plan
- pnpm --filter generaltranslation --filter gt-i18n --filter @generaltranslation/supported-locales build
- pnpm --filter @generaltranslation/react-core typecheck
- pnpm --filter @generaltranslation/react-core test -- packages/react-core/src/external-store/store/__tests__/store-subscriptions.test.ts
- pnpm exec oxlint packages/react-core/src/external-store/store

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the external store foundation for `@generaltranslation/react-core`, adding `I18nExternalStore` (a `useSyncExternalStore`-compatible adapter over `I18nManager`), `ProviderConditionStore` (mutable locale/region runtime state), singleton accessor helpers, shared types, and focused subscription tests. No React hooks, provider wiring, or public entrypoint changes are included in this PR.

- **`I18nExternalStore`** lazily connects to `I18nManager` events when the first dynamic listener subscribes and disconnects when the last one unsubscribes; translate/dictionary snapshot helpers and a WeakMap-based `translateMany` snapshot cache are provided for referential equality.
- **`ProviderConditionStore`** tracks mutable locale and region state, comparing values before emitting to avoid spurious notifications.
- **`singleton-operations.ts`** exposes module-level get/set for the `I18nExternalStore` instance, which needs care in SSR contexts where the module is shared across concurrent requests.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Mostly safe to merge as a foundation layer; the module-level singleton in `singleton-operations.ts` will cause cross-request state bleed in SSR environments if `GTProvider` is ever server-rendered, and should be resolved before provider wiring is added.

The store logic in `I18nExternalStore` and `ProviderConditionStore` is well-structured and the tests are thorough. The concern is `singleton-operations.ts`: a module-level variable shared across all Node.js requests means that in any SSR context, the last `setI18nExternalStore` call wins globally. Since provider wiring is the immediate next step, resolving this before that integration lands avoids baking the pattern deeper.

`singleton-operations.ts` needs attention before provider wiring is added; `I18nExternalStore.ts` is otherwise solid but callers of `getTranslateManySnapshot` will need to stabilize the `lookups` array reference to get cache hits.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/external-store/store/singleton-operations.ts | Module-level singleton is SSR-unsafe: concurrent requests in the same Node.js process share the same `i18nExternalStore` reference, risking cross-request state bleed. |
| packages/react-core/src/external-store/store/I18nExternalStore.ts | New store adapter bridging I18nManager events to React's useSyncExternalStore pattern; lazy-connect/disconnect from manager is well-designed, but `translateManySnapshotCache` WeakMap key relies on caller reference stability. |
| packages/react-core/src/external-store/store/ProviderConditionStore.ts | Clean locale/region condition store with correct change-detection before emitting; implements both `WritableConditionStore` and `I18nExternalConditionStore` interfaces as intended. |
| packages/react-core/src/external-store/store/__tests__/store-subscriptions.test.ts | Focused tests covering locale, region, translation, translateMany, dictionaryEntry, and dictionaryObject subscription/notification paths; unsubscribe behavior verified for all cases. |
| packages/react-core/src/external-store/store/managerEvents.ts | Simple constants file exporting the four I18nManager event name strings used for subscriptions. |
| packages/react-core/src/external-store/store/storeTypes.ts | Shared type definitions for listeners, unsubscribe functions, lookup shapes, and snapshot types; all optional fields on `I18nExternalConditionStore` appropriately capture the writable subset. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant RC as React Component
    participant ES as I18nExternalStore
    participant CS as ProviderConditionStore
    participant IM as I18nManager

    Note over RC,IM: Subscribe phase
    RC->>ES: subscribeToTranslate(lookup, listener)
    ES->>ES: subscribeToTranslateSet(wrappedListener)
    ES->>IM: manager.subscribe(TRANSLATION_EVENT_NAME)
    ES->>IM: manager.subscribe(LOCALES_EVENT_NAME)

    RC->>CS: subscribeToLocale(listener)
    CS->>CS: add to localeListeners

    Note over RC,IM: Snapshot read (useSyncExternalStore)
    RC->>ES: getTranslateSnapshot(lookup)
    ES->>IM: lookupTranslation(locale, message, options)
    IM-->>ES: "Translation | undefined"
    ES-->>RC: TranslateSnapshot

    RC->>CS: getLocale()
    CS-->>RC: resolved locale string

    Note over RC,IM: Cache miss / invalidation
    IM->>ES: emit TRANSLATION_EVENT_NAME event
    ES->>ES: emitTranslateEvent(event)
    ES->>RC: listener() [if event matches lookup]
    RC->>ES: getTranslateSnapshot(lookup) [re-read]

    Note over RC,IM: Locale change
    CS->>CS: setLocale(newLocale)
    CS->>RC: emit localeListeners (if locale changed)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/react-core/src/external-store/store/singleton-operations.ts:3-16
**Module-level singleton is SSR-unsafe**

`i18nExternalStore` lives at the Node.js module level, so it is shared across all concurrent SSR requests in the same process. If two requests render `GTProvider` concurrently, the second `setI18nExternalStore` call overwrites the first, and the first request will subsequently read the wrong store from `getI18nExternalStore`. This would cause locale/translation state from one user to bleed into another user's response. Consider scoping the singleton to a React context or using an `AsyncLocalStorage`-based approach for SSR, or at minimum document that this module must only be used in client-side rendering contexts.

### Issue 2 of 2
packages/react-core/src/external-store/store/I18nExternalStore.ts:65-68
**`WeakMap` cache hit depends entirely on caller reference stability**

`getTranslateManySnapshot` uses the `lookups` array reference as the `WeakMap` key. Any caller that creates a new array on each render (e.g., `getTranslateManySnapshot([{ locale, message, options }])`) will miss the cache on every call, producing a new snapshot array even when all individual snapshots are unchanged. `useSyncExternalStore` requires `getSnapshot` to return the same reference when data hasn't changed; an always-fresh array would trigger spurious re-renders. The assumption that callers will stabilize the reference with `useMemo` (or similar) should be explicitly documented so future hook authors know not to construct the array inline.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(react-core): add external store fou..."](https://github.com/generaltranslation/gt/commit/575366cf0a9a8ae86ca8d13b43f39865e5d86111) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31465530)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->