### PR TITLE
feat(react-core): add external store manager hooks

### DIFF
--- a/packages/react-core/src/external-store/hooks/i18n-manager-hooks.ts
+++ b/packages/react-core/src/external-store/hooks/i18n-manager-hooks.ts
@@ -1,0 +1,102 @@
+import { useSyncExternalStore } from 'react';
+import type { I18nManager } from 'gt-i18n/internal';
+import type { Translation } from 'gt-i18n/types';
+import type { CustomMapping } from 'generaltranslation/types';
+import { getI18nExternalStore } from '../store/singleton-operations';
+import type { I18nExternalStore } from '../store/I18nExternalStore';
+import type {
+  DictionaryEntrySnapshot,
+  DictionaryLookup,
+  DictionaryObjectSnapshot,
+  TranslateLookup,
+  TranslateManySnapshot,
+  TranslateSnapshot,
+} from '../store/storeTypes';
+
+export function useI18nExternalStore(): I18nExternalStore {
+  return getI18nExternalStore();
+}
+
+export function useI18nManager(): I18nManager<Translation> {
+  return useI18nExternalStore().getI18nManager();
+}
+
+export function useDefaultLocale(): string {
+  const store = useI18nExternalStore();
+  return useSyncExternalStore(
+    store.subscribeToDefaultLocale,
+    store.getDefaultLocaleSnapshot,
+    store.getDefaultLocaleSnapshot
+  );
+}
+
+export function useLocales(): readonly string[] {
+  const store = useI18nExternalStore();
+  return useSyncExternalStore(
+    store.subscribeToLocales,
+    store.getLocalesSnapshot,
+    store.getLocalesSnapshot
+  );
+}
+
+export function useCustomMapping(): CustomMapping {
+  const store = useI18nExternalStore();
+  return useSyncExternalStore(
+    store.subscribeToCustomMapping,
+    store.getCustomMappingSnapshot,
+    store.getCustomMappingSnapshot
+  );
+}
+
+export function useEnableI18n(): boolean {
+  const store = useI18nExternalStore();
+  return useSyncExternalStore(
+    store.subscribeToEnableI18n,
+    store.getEnableI18nSnapshot,
+    store.getEnableI18nSnapshot
+  );
+}
+
+export function useTranslate<T extends Translation>(
+  lookup: TranslateLookup<T>
+): TranslateSnapshot<T> {
+  const store = useI18nExternalStore();
+  return useSyncExternalStore(
+    (listener) => store.subscribeToTranslate(lookup, listener),
+    () => store.getTranslateSnapshot(lookup),
+    () => store.getTranslateSnapshot(lookup)
+  );
+}
+
+export function useTranslateMany<T extends Translation>(
+  lookups: readonly TranslateLookup<T>[]
+): TranslateManySnapshot<T> {
+  const store = useI18nExternalStore();
+  return useSyncExternalStore(
+    (listener) => store.subscribeToTranslateMany(lookups, listener),
+    () => store.getTranslateManySnapshot(lookups),
+    () => store.getTranslateManySnapshot(lookups)
+  );
+}
+
+export function useDictionaryEntry(
+  lookup: DictionaryLookup
+): DictionaryEntrySnapshot {
+  const store = useI18nExternalStore();
+  return useSyncExternalStore(
+    (listener) => store.subscribeToDictionaryEntry(lookup, listener),
+    () => store.getDictionaryEntrySnapshot(lookup),
+    () => store.getDictionaryEntrySnapshot(lookup)
+  );
+}
+
+export function useDictionaryObject(
+  lookup: DictionaryLookup
+): DictionaryObjectSnapshot {
+  const store = useI18nExternalStore();
+  return useSyncExternalStore(
+    (listener) => store.subscribeToDictionaryObject(lookup, listener),
+    () => store.getDictionaryObjectSnapshot(lookup),
+    () => store.getDictionaryObjectSnapshot(lookup)
+  );
+}

--- a/packages/react-core/src/internal-external-store.ts
+++ b/packages/react-core/src/internal-external-store.ts
@@ -1,0 +1,36 @@
+export {
+  useCustomMapping,
+  useDefaultLocale,
+  useDictionaryEntry,
+  useDictionaryObject,
+  useEnableI18n,
+  useI18nExternalStore,
+  useI18nManager,
+  useLocales,
+  useTranslate,
+  useTranslateMany,
+} from './external-store/hooks/i18n-manager-hooks';
+export {
+  I18nExternalStore,
+  type I18nExternalStoreParams,
+} from './external-store/store/I18nExternalStore';
+export {
+  ProviderConditionStore,
+  type ProviderConditionStoreParams,
+} from './external-store/store/ProviderConditionStore';
+export {
+  getI18nExternalStore,
+  setI18nExternalStore,
+} from './external-store/store/singleton-operations';
+export type {
+  DictionaryEntrySnapshot,
+  DictionaryLookup,
+  DictionaryObjectSnapshot,
+  I18nExternalConditionStore,
+  ListenerSet,
+  StoreListener,
+  TranslateLookup,
+  TranslateManySnapshot,
+  TranslateSnapshot,
+  Unsubscribe,
+} from './external-store/store/storeTypes';


### PR DESCRIPTION
## Summary
- add useSyncExternalStore-backed hooks for I18nManager snapshots and lookups
- expose useDefaultLocale, useLocales, useCustomMapping, useEnableI18n, useTranslate, useTranslateMany, useDictionaryEntry, useDictionaryObject, useI18nExternalStore, and useI18nManager
- add the source-level internal-external-store export file for the hook/store surface

## Scope
- no locale/region condition hooks
- no GTProvider wiring
- no component migration
- no package entrypoint changes

## Test Plan
- pnpm --filter @generaltranslation/react-core typecheck
- pnpm exec oxlint packages/react-core/src/external-store/hooks packages/react-core/src/internal-external-store.ts

Stacked on #1401.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a set of `useSyncExternalStore`-backed React hooks that expose `I18nManager` state (default locale, locales, custom mapping, i18n toggle, translations, and dictionary entries) from a module-level singleton, plus a barrel export file (`internal-external-store.ts`) that surfaces both the hooks and the underlying store/singleton API.

- **`useDefaultLocale`, `useLocales`, `useCustomMapping`, `useEnableI18n`** are correctly wired to `useSyncExternalStore` with stable bound-method references from the store class, giving safe concurrent-mode snapshots.
- **`useI18nManager` and `useI18nExternalStore`** bypass `useSyncExternalStore` entirely, reading the singleton directly; they are susceptible to tearing if the singleton is replaced during a concurrent render.
- **`useTranslate`, `useTranslateMany`, `useDictionaryEntry`, `useDictionaryObject`** wrap per-lookup subscribe/snapshot callbacks in inline lambdas, which causes React to tear down and rebuild subscriptions on every render even when the lookup values are unchanged.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge in this stacked/internal context, but useI18nManager and useI18nExternalStore have a correctness gap that should be addressed before components consume them in concurrent React.

The static-subscription hooks are correctly implemented with stable bound methods. useI18nManager and useI18nExternalStore read the module singleton directly without concurrent-mode protection, and the four parameterized hooks create new subscribe lambdas on every render causing subscription churn — most impactfully for useTranslateMany which fans out to N subscriptions per call.

packages/react-core/src/external-store/hooks/i18n-manager-hooks.ts — specifically the useI18nManager/useI18nExternalStore implementations and the subscribe callback patterns in the four parameterized hooks.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/external-store/hooks/i18n-manager-hooks.ts | New hooks file backing I18nManager state with useSyncExternalStore; useI18nManager/useI18nExternalStore lack reactive backing and are susceptible to concurrent-mode tearing; parameterized hooks create unstable subscribe lambdas causing per-render re-subscription churn. |
| packages/react-core/src/internal-external-store.ts | Source-level barrel export for the external-store surface; straightforward re-exports of hooks, store classes, singleton operations, and type definitions with no logic of its own. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/react-core/src/external-store/hooks/i18n-manager-hooks.ts:22-24
**`useI18nManager` is non-reactive and tears in concurrent mode**

Neither `useI18nExternalStore` nor `useI18nManager` are backed by `useSyncExternalStore`. In React's concurrent renderer, a single component tree render can be interrupted and restarted; if `setI18nExternalStore` is called between two attempts, `getI18nExternalStore()` returns a different value in the second attempt, violating the "consistent snapshot" contract. The hook is exported as part of the public internal surface, so consumers building reactive components on top of it will get subtly stale managers without any React re-render being triggered.

### Issue 2 of 2
packages/react-core/src/external-store/hooks/i18n-manager-hooks.ts:66-77
**Inline subscribe lambdas force re-subscription on every render**

The `subscribe` argument to `useSyncExternalStore` is a new inline lambda on every render for `useTranslate`, `useTranslateMany`, `useDictionaryEntry`, and `useDictionaryObject`. Per React's contract, changing the subscribe reference causes it to unsubscribe from the old subscription and call the new one synchronously. For `useTranslateMany` this means `subscribeToTranslateMany` teardown + setup of _N_ subscriptions on every render cycle, even when `lookup`/`lookups` values haven't changed. Wrapping the subscribe and snapshot callbacks with `useCallback`/`useMemo` (or a `useRef`-based stable wrapper) keyed on the lookup parameters would eliminate this churn.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(react-core): add external store man..."](https://github.com/generaltranslation/gt/commit/5c588a4d07fe5e307b85c13ff0b18672771b0105) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31465533)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->