### PR TITLE
feat(react-core): add unopinionated external store provider

### DIFF
--- a/packages/react-core/src/external-store/provider/GTContext.ts
+++ b/packages/react-core/src/external-store/provider/GTContext.ts
@@ -1,0 +1,30 @@
+import { createContext, useContext } from 'react';
+import type { I18nManager } from 'gt-i18n/internal';
+import type { Translation } from 'gt-i18n/types';
+import type { I18nExternalStore } from '../store/I18nExternalStore';
+import type { ProviderConditionStore } from '../store/ProviderConditionStore';
+import { getI18nExternalStore } from '../store/singleton-operations';
+
+export const GTContext = createContext<ProviderConditionStore | null>(null);
+
+// ===== Condition Store Access ===== //
+
+export function useConditionStore(): ProviderConditionStore {
+  const conditionStore = useContext(GTContext);
+  if (!conditionStore) {
+    throw new Error(
+      'GTProvider is required before external-store hooks can be used.'
+    );
+  }
+  return conditionStore;
+}
+
+// ===== Manager Store Access ===== //
+
+export function useI18nExternalStore(): I18nExternalStore {
+  return getI18nExternalStore();
+}
+
+export function useI18nManager(): I18nManager<Translation> {
+  return useI18nExternalStore().getI18nManager();
+}

--- a/packages/react-core/src/external-store/provider/GTProvider.tsx
+++ b/packages/react-core/src/external-store/provider/GTProvider.tsx
@@ -1,0 +1,63 @@
+import { useRef } from 'react';
+import { I18nManager } from 'gt-i18n/internal';
+import { GTContext } from './GTContext';
+import { ProviderConditionStore } from '../store/ProviderConditionStore';
+import { I18nExternalStore } from '../store/I18nExternalStore';
+import { setI18nExternalStore } from '../store/singleton-operations';
+import type { I18nManagerConstructorParams } from 'gt-i18n/internal/types';
+import type { ReactNode } from 'react';
+import type { Translation } from 'gt-i18n/types';
+
+export type GTProviderProps = I18nManagerConstructorParams<Translation> & {
+  children?: ReactNode;
+  locale?: string;
+  region?: string;
+  getLocale?: () => string | undefined;
+};
+
+// ===== Component ===== //
+
+/**
+ * Minimal external-store provider.
+ *
+ * The condition store is created once per provider instance and exposed
+ * through context. The manager-backed external store is initialized as a
+ * singleton for hooks that read I18nManager snapshots.
+ */
+export function GTProvider({
+  children,
+  locale,
+  region,
+  getLocale,
+  ...managerParams
+}: GTProviderProps) {
+  const conditionStoreRef = useRef<ProviderConditionStore | undefined>(
+    undefined
+  );
+
+  if (!conditionStoreRef.current) {
+    const i18nManager = new I18nManager<Translation>(
+      managerParams as I18nManagerConstructorParams<Translation>
+    );
+    const conditionStore = new ProviderConditionStore({
+      defaultLocale: i18nManager.getDefaultLocale(),
+      locales: i18nManager.getLocales(),
+      customMapping: i18nManager.getCustomMapping(),
+      locale: locale || undefined,
+      region,
+      getLocale,
+    });
+
+    setI18nExternalStore(new I18nExternalStore({ i18nManager }));
+    conditionStoreRef.current = conditionStore;
+  }
+
+  const conditionStore = conditionStoreRef.current;
+  if (!conditionStore) {
+    throw new Error('GTProvider failed to initialize a condition store.');
+  }
+
+  return (
+    <GTContext.Provider value={conditionStore}>{children}</GTContext.Provider>
+  );
+}

--- a/packages/react-core/src/internal-external-store.ts
+++ b/packages/react-core/src/internal-external-store.ts
@@ -11,6 +11,14 @@ export {
   useTranslateMany,
 } from './external-store/hooks/i18n-manager-hooks';
 export {
+  GTContext,
+  useConditionStore,
+} from './external-store/provider/GTContext';
+export {
+  GTProvider,
+  type GTProviderProps,
+} from './external-store/provider/GTProvider';
+export {
   I18nExternalStore,
   type I18nExternalStoreParams,
 } from './external-store/store/I18nExternalStore';


### PR DESCRIPTION
## Summary
- add external-store GTContext and useConditionStore helper
- add a minimal GTProvider that initializes I18nManager, ProviderConditionStore, and the I18nExternalStore singleton
- keep provider behavior unopinionated: no Suspense boundary, no load gate, and no translation or locale loading side effects

## Scope
- no locale/region condition hooks
- no component migration
- no package entrypoint changes

## Test Plan
- pnpm --filter @generaltranslation/react-core typecheck
- pnpm exec oxlint packages/react-core/src/external-store/provider packages/react-core/src/internal-external-store.ts

Stacked on #1402.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a minimal `GTProvider` component and `GTContext` that initialize an `I18nManager`, a `ProviderConditionStore`, and an `I18nExternalStore` singleton, exposing them via React context and module-level access hooks.

- **`GTProvider`** creates a `ProviderConditionStore` once per instance (via `useRef`) and calls `setI18nExternalStore` to register a module-level singleton; props (`locale`, `region`, `managerParams`) are consumed only during the first render and never synced on updates.
- **`GTContext`** exposes `useConditionStore` (context-scoped) alongside `useI18nExternalStore`/`useI18nManager` (singleton-backed), creating a split access pattern where the two stores can diverge when multiple `GTProvider` instances are mounted simultaneously.
- **`internal-external-store.ts`** is a simple barrel re-export with no logic changes.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The provider correctly wires context for ProviderConditionStore, but the I18nExternalStore singleton is not context-scoped, meaning any nested or sibling GTProvider silently takes over the global store for all useI18nManager consumers.

Two defects are present in GTProvider.tsx: the module-level I18nExternalStore singleton is overwritten each time a new provider mounts (so useI18nManager() and useConditionStore() will reflect different providers in a multi-provider tree), and prop changes after the initial render including locale are permanently dropped. Both can cause subtle, hard-to-diagnose incorrect behavior in production apps.

GTProvider.tsx needs the most attention: the singleton-overwrite path and the missing prop-sync logic both live there.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/external-store/provider/GTProvider.tsx | New minimal GTProvider component; has a singleton-overwrite bug when multiple providers coexist and silently drops prop updates after initial render. |
| packages/react-core/src/external-store/provider/GTContext.ts | Introduces GTContext and access hooks; useI18nExternalStore/useI18nManager bypass context and contain no React hook calls despite the use prefix. |
| packages/react-core/src/internal-external-store.ts | Adds exports for the new GTContext/GTProvider symbols; straightforward barrel change with no issues. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant App
    participant GTProvider
    participant ProviderConditionStore
    participant I18nExternalStore
    participant Singleton as Module Singleton
    participant useConditionStore
    participant useI18nManager

    App->>GTProvider: mount(locale, region, managerParams)
    GTProvider->>GTProvider: useRef guard (first render only)
    GTProvider->>ProviderConditionStore: new ProviderConditionStore(locale, region, ...)
    GTProvider->>I18nExternalStore: new I18nExternalStore(i18nManager)
    GTProvider->>Singleton: setI18nExternalStore(store) overwrites
    GTProvider->>GTContext.Provider: "value=conditionStore"

    useConditionStore->>GTContext.Provider: useContext(GTContext) context-scoped
    useI18nManager->>Singleton: getI18nExternalStore() last-set singleton
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
packages/react-core/src/external-store/provider/GTProvider.tsx:50-53
**Singleton overwrite with multiple providers**

`setI18nExternalStore` is called once per `GTProvider` instance (inside the `useRef` guard), meaning the last-mounted provider wins the module-level singleton. `useI18nManager()` bypasses React context entirely and reads from that singleton, so in a multi-provider tree the manager each component sees is determined by mount order, not by nearest ancestor. A component inside the *first* `GTProvider` will use the *second* provider's `I18nManager` once the second mounts — while `useConditionStore()` correctly returns the nearest ancestor's store. The two stores become mismatched.

### Issue 2 of 4
packages/react-core/src/external-store/provider/GTProvider.tsx:27-55
**Prop changes silently ignored after initial render**

`locale`, `region`, `getLocale`, and `managerParams` are captured only during the first render (inside the `useRef` guard). Subsequent prop changes are never forwarded to the `ProviderConditionStore` — there's no call to `conditionStore.setLocale` / `conditionStore.setRegion` when props update. If the caller passes a new `locale` prop, the store will retain the stale value indefinitely.

### Issue 3 of 4
packages/react-core/src/external-store/provider/GTContext.ts:23-29
**`use`-prefixed functions that contain no hook calls**

`useI18nExternalStore` and `useI18nManager` follow the React hooks naming convention but don't call any React hook internally — they are plain getters. React's linter will enforce the Rules of Hooks on these (e.g., no conditional calls), which is unnecessarily restrictive, and consumers may expect them to trigger re-renders or subscriptions when the underlying store changes, which they won't.

### Issue 4 of 4
packages/react-core/src/external-store/provider/GTProvider.tsx:46
`locale || undefined` coerces any falsy string (including `""`) to `undefined`. Prefer nullish coalescing to only treat `null`/`undefined` as absent.

```suggestion
      locale: locale ?? undefined,
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(react-core): add unopinionated exte..."](https://github.com/generaltranslation/gt/commit/068c61c16b154ab8acf8daa20bdca8a761a82ffd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31465537)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->