### PR TITLE
feat(react-core): add external store condition hooks

### DIFF
--- a/packages/react-core/src/external-store/hooks/condition-hooks.ts
+++ b/packages/react-core/src/external-store/hooks/condition-hooks.ts
@@ -1,0 +1,28 @@
+import { useSyncExternalStore } from 'react';
+import { useConditionStore } from '../provider/GTContext';
+
+export function useLocale(): string {
+  const store = useConditionStore();
+  return useSyncExternalStore(
+    store.subscribeToLocale,
+    store.getLocale,
+    store.getLocale
+  );
+}
+
+export function useRegion(): string | undefined {
+  const store = useConditionStore();
+  return useSyncExternalStore(
+    store.subscribeToRegion,
+    store.getRegion,
+    store.getRegion
+  );
+}
+
+export function useSetLocale(): (locale: string) => void {
+  return useConditionStore().setLocale;
+}
+
+export function useSetRegion(): (region: string | undefined) => void {
+  return useConditionStore().setRegion;
+}

--- a/packages/react-core/src/internal-external-store.ts
+++ b/packages/react-core/src/internal-external-store.ts
@@ -1,4 +1,10 @@
 export {
+  useLocale,
+  useRegion,
+  useSetLocale,
+  useSetRegion,
+} from './external-store/hooks/condition-hooks';
+export {
   useCustomMapping,
   useDefaultLocale,
   useDictionaryEntry,


### PR DESCRIPTION
## Summary
- add useLocale and useRegion via useSyncExternalStore against ProviderConditionStore
- add useSetLocale and useSetRegion setter hooks
- update the source-level internal-external-store exports for condition hooks

## Scope
- condition hooks subscribe directly to ProviderConditionStore, not I18nExternalStore
- no component migration
- no package entrypoint changes

## Test Plan
- pnpm --filter @generaltranslation/react-core typecheck
- pnpm exec oxlint packages/react-core/src/external-store/hooks/condition-hooks.ts packages/react-core/src/internal-external-store.ts

Stacked on #1403.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `useLocale`, `useRegion`, `useSetLocale`, and `useSetRegion` hooks that subscribe directly to `ProviderConditionStore` via `useSyncExternalStore`, and re-exports them through `internal-external-store.ts` for use by framework adapter packages.

- **`useLocale` / `useRegion`** follow the exact same `useSyncExternalStore` pattern as existing hooks in `i18n-manager-hooks.ts`, passing the class arrow-function properties (`store.subscribeToLocale`, `store.getLocale`) as stable references.
- **`useSetLocale` / `useSetRegion`** return the setter methods directly from the store instance; since `GTProvider` creates `ProviderConditionStore` once via `useRef` and `setLocale`/`setRegion` are class field arrow functions, the returned references are stable throughout the provider's lifetime.
- The barrel export in `internal-external-store.ts` adds the four hooks without conflicting with any existing named exports.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — two small files, consistent with established patterns, no behavioural changes to existing code.

The hooks follow the same useSyncExternalStore shape as the existing i18n-manager-hooks, the store instance is kept stable via useRef in GTProvider so setter references are always the same object, and the barrel export introduces no naming conflicts.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/external-store/hooks/condition-hooks.ts | New file adding useLocale, useRegion, useSetLocale, useSetRegion hooks backed by ProviderConditionStore via useSyncExternalStore; follows the same patterns as i18n-manager-hooks.ts with stable class-arrow-function references. |
| packages/react-core/src/internal-external-store.ts | Re-exports the four new condition hooks at the top of the source-level barrel; no conflicts with existing exports. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Component
    participant useLocale/useRegion
    participant useSyncExternalStore
    participant ProviderConditionStore

    Component->>useLocale/useRegion: call hook
    useLocale/useRegion->>useConditionStore: get store from GTContext
    useConditionStore-->>useLocale/useRegion: ProviderConditionStore instance
    useLocale/useRegion->>useSyncExternalStore: subscribe(store.subscribeToLocale, store.getLocale, store.getLocale)
    useSyncExternalStore-->>Component: current locale/region snapshot

    Note over Component,ProviderConditionStore: On locale change via useSetLocale
    Component->>useSetLocale/useSetRegion: call hook
    useSetLocale/useSetRegion->>useConditionStore: get store from GTContext
    useConditionStore-->>useSetLocale/useSetRegion: ProviderConditionStore instance
    useSetLocale/useSetRegion-->>Component: store.setLocale / store.setRegion (stable ref)
    Component->>ProviderConditionStore: call setLocale("fr")
    ProviderConditionStore->>useSyncExternalStore: emit localeListeners
    useSyncExternalStore->>Component: re-render with new locale snapshot
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(react-core): add external store con..."](https://github.com/generaltranslation/gt/commit/22236823f4d9d6c88917e344986471187210062e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31465543)</sub>

<!-- /greptile_comment -->