### PR TITLE
feat: expose external store components and entrypoints

### DIFF
--- a/.changeset/internal-external-store-entrypoints.md
+++ b/.changeset/internal-external-store-entrypoints.md
@@ -1,0 +1,6 @@
+---
+'@generaltranslation/react-core': patch
+'gt-react': patch
+---
+
+Add internal-external-store entrypoints for the experimental external store exports.

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -11,7 +11,7 @@
   ],
   "sideEffects": false,
   "peerDependencies": {
-    "react": ">=16.8.0"
+    "react": ">=18.0.0"
   },
   "dependencies": {
     "@generaltranslation/supported-locales": "workspace:*",
@@ -59,6 +59,11 @@
       "require": "./dist/internal.cjs.min.cjs",
       "import": "./dist/internal.esm.min.mjs"
     },
+    "./internal-external-store": {
+      "types": "./dist/internal-external-store.d.ts",
+      "require": "./dist/internal-external-store.cjs.min.cjs",
+      "import": "./dist/internal-external-store.esm.min.mjs"
+    },
     "./errors": {
       "types": "./dist/errors.d.ts",
       "require": "./dist/errors.cjs.min.cjs",
@@ -76,6 +81,9 @@
       "internal": [
         "./dist/internal.d.ts"
       ],
+      "internal-external-store": [
+        "./dist/internal-external-store.d.ts"
+      ],
       "errors": [
         "./dist/errors.d.ts"
       ]
@@ -86,6 +94,9 @@
     "paths": {
       "@generaltranslation/react-core/internal": [
         "./dist/internal"
+      ],
+      "@generaltranslation/react-core/internal-external-store": [
+        "./dist/internal-external-store"
       ],
       "@generaltranslation/react-core/types": [
         "./dist/types.d.ts"

--- a/packages/react-core/rollup.config.mjs
+++ b/packages/react-core/rollup.config.mjs
@@ -16,6 +16,10 @@ export default createReactBundleConfigs(
   [
     { input: './src/index.ts', outputName: 'index' },
     { input: './src/internal.ts', outputName: 'internal' },
+    {
+      input: './src/internal-external-store.ts',
+      outputName: 'internal-external-store',
+    },
     { input: './src/errors.ts', outputName: 'errors' },
     { input: './src/types.ts', outputName: 'types', bundle: false },
   ],

--- a/packages/react-core/src/external-store/components/branches/Branch.tsx
+++ b/packages/react-core/src/external-store/components/branches/Branch.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from 'react';
+
+// ===== Component ===== //
+
+/**
+ * External-store version of the `<Branch>` component.
+ */
+function Branch({
+  children,
+  branch,
+  ...branches
+}: {
+  children?: ReactNode;
+  branch?: string | number | boolean;
+  [key: string]: ReactNode;
+}): ReactNode {
+  let branchKey = branch?.toString();
+  if (typeof branchKey === 'string' && branchKey.startsWith('data-')) {
+    branchKey = undefined;
+  }
+  return branchKey && typeof branches[branchKey] !== 'undefined'
+    ? branches[branchKey]
+    : children;
+}
+
+function GtInternalBranch(props: {
+  children?: ReactNode;
+  branch?: string | number | boolean;
+  [key: string]: ReactNode;
+}): ReactNode {
+  return Branch(props);
+}
+
+/** @internal _gtt - The GT transformation for the component. */
+Branch._gtt = 'branch';
+GtInternalBranch._gtt = 'branch-automatic';
+
+// ===== Exports ===== //
+
+export { GtInternalBranch, Branch };

--- a/packages/react-core/src/external-store/components/branches/Plural.tsx
+++ b/packages/react-core/src/external-store/components/branches/Plural.tsx
@@ -1,0 +1,47 @@
+import getPluralBranch from '../../../branches/plurals/getPluralBranch';
+import { useLocale } from '../../hooks/condition-hooks';
+import { useDefaultLocale } from '../../hooks/i18n-manager-hooks';
+import type { ReactNode } from 'react';
+
+// ===== Component ===== //
+
+function Plural({
+  children,
+  n,
+  locales: localesProp,
+  ...branches
+}: {
+  children?: ReactNode;
+  n: number;
+  locales?: string;
+  [key: string]: ReactNode;
+}): ReactNode {
+  const locale = useLocale();
+  const defaultLocale = useDefaultLocale();
+  const locales = [
+    ...(localesProp ? [localesProp] : []),
+    locale,
+    defaultLocale,
+  ];
+  if (typeof n !== 'number') {
+    return children;
+  }
+  return getPluralBranch(n, locales, branches) || children;
+}
+
+function GtInternalPlural(props: {
+  children?: ReactNode;
+  n: number;
+  locales?: string;
+  [key: string]: ReactNode;
+}): ReactNode {
+  return Plural(props);
+}
+
+/** @internal _gtt - The GT transformation for the component. */
+Plural._gtt = 'plural';
+GtInternalPlural._gtt = 'plural-automatic';
+
+// ===== Exports ===== //
+
+export { GtInternalPlural, Plural };

--- a/packages/react-core/src/external-store/components/derivation/Derive.tsx
+++ b/packages/react-core/src/external-store/components/derivation/Derive.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from 'react';
+
+// ===== Component ===== //
+
+function Derive<T extends ReactNode>({ children }: { children: T }): T {
+  return children;
+}
+
+function GtInternalDerive<T extends ReactNode>({
+  children,
+}: {
+  children: T;
+}): T {
+  return children;
+}
+
+function Static<T extends ReactNode>(props: { children: T }): T {
+  return Derive(props);
+}
+
+/** @internal _gtt - The GT transformation for the component. */
+Derive._gtt = 'derive';
+GtInternalDerive._gtt = 'derive-automatic';
+Static._gtt = 'derive';
+
+// ===== Exports ===== //
+
+export { GtInternalDerive, Derive, Static };

--- a/packages/react-core/src/external-store/components/translation/T.tsx
+++ b/packages/react-core/src/external-store/components/translation/T.tsx
@@ -1,0 +1,178 @@
+import { useCallback, useMemo } from 'react';
+import { requiresTranslation } from 'generaltranslation';
+import addGTIdentifier from '../../../internal/addGTIdentifier';
+import { removeInjectedT } from '../../../internal/removeInjectedT';
+import writeChildrenAsObjects from '../../../internal/writeChildrenAsObjects';
+import renderDefaultChildren from '../../../rendering/renderDefaultChildren';
+import renderTranslatedChildren from '../../../rendering/renderTranslatedChildren';
+import { renderVariable } from '../variables/renderVariable';
+import { useLocale } from '../../hooks/condition-hooks';
+import {
+  useCustomMapping,
+  useEnableI18n,
+  useDefaultLocale,
+  useLocales,
+  useTranslate,
+} from '../../hooks/i18n-manager-hooks';
+import type { JsxTranslationOptions as JsxTranslationOptionsWithSugar } from 'gt-i18n/types';
+import type { JsxChildren } from 'generaltranslation/types';
+import type { TaggedChildren } from '../../../types-dir/types';
+import type { ReactNode } from 'react';
+
+// ===== Component ===== //
+
+/**
+ * External-store version of the `<T>` component.
+ */
+function T(
+  props: {
+    children: ReactNode;
+  } & JsxTranslationOptions
+): ReactNode {
+  return useComputeT(props);
+}
+
+/** @internal _gtt - The GT transformation for the component. */
+T._gtt = 'translate-client';
+
+function GtInternalTranslateJsx(
+  props: {
+    children: ReactNode;
+  } & JsxTranslationOptions
+): ReactNode {
+  return T(props);
+}
+
+/** @internal _gtt - The GT transformation for the component. */
+GtInternalTranslateJsx._gtt = 'translate-client-automatic';
+
+export { GtInternalTranslateJsx, T };
+
+// ===== Render Logic ===== //
+
+function useComputeT({
+  children: sourceChildren,
+  ...params
+}: {
+  children: ReactNode;
+} & JsxTranslationOptions): ReactNode {
+  // Prepare our source children for rendering
+  const {
+    defaultLocale,
+    locale,
+    targetOptions,
+    taggedSourceChildren,
+    sourceJsxChildren,
+    translationRequired,
+  } = usePrepSourceRender({
+    sourceChildren,
+    params,
+  });
+
+  // Create a function to render source children
+  const renderSourceChildren = useCallback(() => {
+    return renderDefaultChildren({
+      children: taggedSourceChildren,
+      defaultLocale,
+      renderVariable,
+    });
+  }, [defaultLocale, taggedSourceChildren]);
+
+  // Lookup translation in cache
+  const targetJsxChildren = useTranslate({
+    locale,
+    message: sourceJsxChildren,
+    options: targetOptions,
+  });
+
+  // Render source children
+  if (!translationRequired || !targetJsxChildren) {
+    return renderSourceChildren();
+  }
+
+  // Render translated children if found in cache
+  return renderTranslatedChildren({
+    source: taggedSourceChildren,
+    target: targetJsxChildren,
+    locales: [locale, defaultLocale],
+    renderVariable,
+  });
+}
+
+// ===== Source Preparation ===== //
+
+function usePrepSourceRender({
+  sourceChildren,
+  params,
+}: {
+  sourceChildren: ReactNode;
+  params: JsxTranslationOptions;
+}): {
+  defaultLocale: string;
+  locale: string;
+  taggedSourceChildren: TaggedChildren;
+  sourceJsxChildren: JsxChildren;
+  targetOptions: JsxTranslationOptionsWithSugar & {
+    $format: 'JSX';
+    $locale: string;
+  };
+  translationRequired: boolean;
+} {
+  const locale = useLocale();
+  const defaultLocale = useDefaultLocale();
+  const locales = useLocales();
+  const customMapping = useCustomMapping();
+  const enableI18n = useEnableI18n();
+  const taggedSourceChildren = useMemo(
+    () => addGTIdentifier(removeInjectedT(sourceChildren)),
+    [sourceChildren]
+  );
+  const sourceJsxChildren = useMemo(
+    () => writeChildrenAsObjects(taggedSourceChildren),
+    [taggedSourceChildren]
+  );
+  const options = useMemo(() => normalizeParameters(params), [params]);
+  const targetOptions = useMemo(
+    () => ({ ...options, $locale: locale }),
+    [locale, options]
+  );
+  const translationRequired =
+    enableI18n &&
+    requiresTranslation(defaultLocale, locale, [...locales], customMapping);
+
+  return {
+    defaultLocale,
+    locale,
+    taggedSourceChildren,
+    sourceJsxChildren,
+    targetOptions,
+    translationRequired,
+  };
+}
+
+// ===== Options ===== //
+
+function normalizeParameters(
+  parameters: {
+    context?: string;
+    id?: string;
+    _hash?: string;
+  } & JsxTranslationOptions
+): JsxTranslationOptionsWithSugar & { $format: 'JSX' } {
+  return {
+    ...parameters,
+    $format: 'JSX',
+    $context: parameters.$context ?? parameters.context,
+    $id: parameters.$id ?? parameters.id,
+    $_hash: parameters.$_hash ?? parameters._hash,
+  };
+}
+
+// ===== Types ===== //
+
+type StripDollarPrefix<T> = {
+  [K in keyof T as K extends `$${infer Rest}` ? Rest : K]: T[K];
+};
+
+type JsxTranslationOptions = StripDollarPrefix<JsxTranslationOptionsWithSugar> &
+  JsxTranslationOptionsWithSugar;

--- a/packages/react-core/src/external-store/components/variables/Currency.tsx
+++ b/packages/react-core/src/external-store/components/variables/Currency.tsx
@@ -1,0 +1,45 @@
+import { useI18nManager } from '../../provider/GTContext';
+import { useFormatLocales } from '../../hooks/utils';
+
+// ===== Component ===== //
+
+function GtInternalCurrency({
+  children,
+  currency = 'USD',
+  options = {},
+  locales: localesProp = [],
+}: {
+  children: number | string | null | undefined;
+  currency?: string;
+  options?: Intl.NumberFormatOptions;
+  locales?: string[];
+  name?: string;
+}): string | null {
+  const locales = useFormatLocales(localesProp);
+  const gt = useI18nManager().getGTClass();
+  if (children == null) return null;
+  const parsedNumber =
+    typeof children === 'string' ? parseFloat(children) : children;
+  return gt.formatCurrency(parsedNumber, currency, {
+    locales,
+    ...options,
+  });
+}
+
+function Currency(props: {
+  children: number | string | null | undefined;
+  currency?: string;
+  options?: Intl.NumberFormatOptions;
+  locales?: string[];
+  name?: string;
+}): string | null {
+  return GtInternalCurrency(props);
+}
+
+/** @internal _gtt - The GT transformation for the component. */
+GtInternalCurrency._gtt = 'variable-currency-automatic';
+Currency._gtt = 'variable-currency';
+
+// ===== Exports ===== //
+
+export { GtInternalCurrency, Currency };

--- a/packages/react-core/src/external-store/components/variables/DateTime.tsx
+++ b/packages/react-core/src/external-store/components/variables/DateTime.tsx
@@ -1,0 +1,39 @@
+import { useI18nManager } from '../../provider/GTContext';
+import { useFormatLocales } from '../../hooks/utils';
+
+// ===== Component ===== //
+
+function GtInternalDateTime({
+  children,
+  options = {},
+  locales: localesProp = [],
+}: {
+  children: Date | null | undefined;
+  locales?: string[];
+  options?: Intl.DateTimeFormatOptions;
+  name?: string;
+}): string | null {
+  const locales = useFormatLocales(localesProp);
+  const gt = useI18nManager().getGTClass();
+  if (children == null) return null;
+  return gt
+    .formatDateTime(children, { locales, ...options })
+    .replace(/[\u200F\u202B\u202E]/g, '');
+}
+
+function DateTime(props: {
+  children: Date | null | undefined;
+  locales?: string[];
+  options?: Intl.DateTimeFormatOptions;
+  name?: string;
+}): string | null {
+  return GtInternalDateTime(props);
+}
+
+/** @internal _gtt - The GT transformation for the component. */
+GtInternalDateTime._gtt = 'variable-datetime-automatic';
+DateTime._gtt = 'variable-datetime';
+
+// ===== Exports ===== //
+
+export { GtInternalDateTime, DateTime };

--- a/packages/react-core/src/external-store/components/variables/Num.tsx
+++ b/packages/react-core/src/external-store/components/variables/Num.tsx
@@ -1,0 +1,39 @@
+import { useI18nManager } from '../../provider/GTContext';
+import { useFormatLocales } from '../../hooks/utils';
+
+// ===== Component ===== //
+
+function GtInternalNum({
+  children,
+  options = {},
+  locales: localesProp = [],
+}: {
+  children: number | string | null | undefined;
+  options?: Intl.NumberFormatOptions;
+  locales?: string[];
+  name?: string;
+}): string | null {
+  const locales = useFormatLocales(localesProp);
+  const gt = useI18nManager().getGTClass();
+  if (children == null) return null;
+  const parsedNumber =
+    typeof children === 'string' ? parseFloat(children) : children;
+  return gt.formatNum(parsedNumber, { locales, ...options });
+}
+
+function Num(props: {
+  children: number | string | null | undefined;
+  options?: Intl.NumberFormatOptions;
+  locales?: string[];
+  name?: string;
+}): string | null {
+  return GtInternalNum(props);
+}
+
+/** @internal _gtt - The GT transformation for the component. */
+GtInternalNum._gtt = 'variable-number-automatic';
+Num._gtt = 'variable-number';
+
+// ===== Exports ===== //
+
+export { GtInternalNum, Num };

--- a/packages/react-core/src/external-store/components/variables/RelativeTime.tsx
+++ b/packages/react-core/src/external-store/components/variables/RelativeTime.tsx
@@ -1,0 +1,75 @@
+import { useI18nManager } from '../../provider/GTContext';
+import { useFormatLocales } from '../../hooks/utils';
+
+// ===== Component ===== //
+
+function GtInternalRelativeTime({
+  date,
+  children,
+  value,
+  unit,
+  baseDate,
+  locales: localesProp = [],
+  options = {},
+}: {
+  date?: Date | null | undefined;
+  children?: Date | null | undefined;
+  name?: string;
+  value?: number;
+  unit?: Intl.RelativeTimeFormatUnit;
+  baseDate?: Date;
+  locales?: string[];
+  options?: Intl.RelativeTimeFormatOptions;
+}): string | null {
+  const locales = useFormatLocales(localesProp);
+  const gt = useI18nManager().getGTClass();
+  const resolvedDate = date ?? children;
+
+  if (process.env.NODE_ENV === 'development' && value !== undefined && !unit) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      '<RelativeTime>: `value` was provided without `unit`. The `value` prop will be ignored.'
+    );
+  }
+
+  if (value !== undefined && unit) {
+    return gt.formatRelativeTime(value, unit, {
+      locales,
+      numeric: options.numeric,
+      style: options.style,
+      localeMatcher: options.localeMatcher,
+    });
+  }
+
+  if (resolvedDate != null) {
+    return gt.formatRelativeTimeFromDate(resolvedDate, {
+      locales,
+      baseDate: baseDate ?? new Date(),
+      numeric: options.numeric,
+      style: options.style,
+      localeMatcher: options.localeMatcher,
+    });
+  }
+
+  return null;
+}
+
+function RelativeTime(props: {
+  date?: Date | null | undefined;
+  children?: Date | null | undefined;
+  value?: number;
+  unit?: Intl.RelativeTimeFormatUnit;
+  baseDate?: Date;
+  locales?: string[];
+  options?: Intl.RelativeTimeFormatOptions;
+}): string | null {
+  return GtInternalRelativeTime(props);
+}
+
+/** @internal _gtt - The GT transformation for the component. */
+GtInternalRelativeTime._gtt = 'variable-relative-time-automatic';
+RelativeTime._gtt = 'variable-relative-time';
+
+// ===== Exports ===== //
+
+export { GtInternalRelativeTime, RelativeTime };

--- a/packages/react-core/src/external-store/components/variables/Var.tsx
+++ b/packages/react-core/src/external-store/components/variables/Var.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from 'react';
+
+// ===== Shared Logic ===== //
+
+function computeVar<T extends ReactNode>({ children }: { children: T }): T {
+  return children;
+}
+
+// ===== Component ===== //
+
+/**
+ * External-store version of the `<Var>` component.
+ */
+function Var<T extends ReactNode>({
+  children,
+}: {
+  children: T;
+  name?: string;
+}): T {
+  return computeVar({ children });
+}
+
+function GtInternalVar<T extends ReactNode>({
+  children,
+}: {
+  children: T;
+  name?: string;
+}): T {
+  return computeVar({ children });
+}
+
+/** @internal _gtt - The GT transformation for the component. */
+Var._gtt = 'variable-variable';
+GtInternalVar._gtt = 'variable-variable-automatic';
+
+// ===== Exports ===== //
+
+export { GtInternalVar, Var, computeVar };

--- a/packages/react-core/src/external-store/components/variables/renderVariable.tsx
+++ b/packages/react-core/src/external-store/components/variables/renderVariable.tsx
@@ -1,0 +1,84 @@
+import { GtInternalCurrency, Currency as GtExternalCurrency } from './Currency';
+import { GtInternalDateTime, DateTime as GtExternalDateTime } from './DateTime';
+import { GtInternalNum, Num as GtExternalNum } from './Num';
+import {
+  GtInternalRelativeTime,
+  RelativeTime as GtExternalRelativeTime,
+} from './RelativeTime';
+import { computeVar, Var as GtExternalVar } from './Var';
+import type {
+  RelativeTimeFormatOptions,
+  RenderVariable,
+} from '../../../types-dir/types';
+
+// ===== Renderer ===== //
+
+const renderVariable: RenderVariable = ({
+  variableType,
+  variableValue,
+  variableOptions,
+  injectionType,
+}) => {
+  if (variableType === 'n') {
+    const Num = injectionType === 'automatic' ? GtExternalNum : GtInternalNum;
+    const numOptions = variableOptions as Intl.NumberFormatOptions | undefined;
+    return <Num options={numOptions}>{variableValue}</Num>;
+  }
+  if (variableType === 'd') {
+    const DateTime =
+      injectionType === 'automatic' ? GtExternalDateTime : GtInternalDateTime;
+    const dateTimeOptions = variableOptions as
+      | Intl.DateTimeFormatOptions
+      | undefined;
+    return <DateTime options={dateTimeOptions}>{variableValue}</DateTime>;
+  }
+  if (variableType === 'c') {
+    const Currency =
+      injectionType === 'automatic' ? GtExternalCurrency : GtInternalCurrency;
+    const currencyOptions = variableOptions as
+      | Intl.NumberFormatOptions
+      | undefined;
+    return <Currency options={currencyOptions}>{variableValue}</Currency>;
+  }
+  if (variableType === 'rt') {
+    const RelativeTime =
+      injectionType === 'automatic'
+        ? GtExternalRelativeTime
+        : GtInternalRelativeTime;
+    const relativeTimeOptions = variableOptions as
+      | RelativeTimeFormatOptions
+      | undefined;
+    if (typeof variableValue === 'number' && relativeTimeOptions?.unit) {
+      return (
+        <RelativeTime
+          value={variableValue}
+          unit={relativeTimeOptions.unit}
+          baseDate={relativeTimeOptions?.baseDate}
+          options={relativeTimeOptions}
+        />
+      );
+    }
+    const dateValue =
+      variableValue instanceof Date
+        ? variableValue
+        : typeof variableValue === 'string' || typeof variableValue === 'number'
+          ? new Date(variableValue)
+          : undefined;
+    return (
+      <RelativeTime
+        date={dateValue && !isNaN(dateValue.getTime()) ? dateValue : undefined}
+        baseDate={relativeTimeOptions?.baseDate}
+        options={relativeTimeOptions}
+      />
+    );
+  }
+  return injectionType === 'automatic' ? (
+    computeVar({ children: variableValue })
+  ) : (
+    <GtExternalVar>{variableValue}</GtExternalVar>
+  );
+};
+
+// ===== Exports ===== //
+
+export { renderVariable };

--- a/packages/react-core/src/external-store/hooks/utils.ts
+++ b/packages/react-core/src/external-store/hooks/utils.ts
@@ -1,0 +1,10 @@
+import { useDefaultLocale } from './i18n-manager-hooks';
+import { useLocale } from './condition-hooks';
+
+function useFormatLocales(localesProp: string[] = []): string[] {
+  const locale = useLocale();
+  const defaultLocale = useDefaultLocale();
+  return [...localesProp, locale, defaultLocale];
+}
+
+export { useFormatLocales };

--- a/packages/react-core/src/internal-external-store.ts
+++ b/packages/react-core/src/internal-external-store.ts
@@ -1,4 +1,17 @@
 export {
+  Branch,
+  GtInternalBranch,
+} from './external-store/components/branches/Branch';
+export {
+  Plural,
+  GtInternalPlural,
+} from './external-store/components/branches/Plural';
+export {
+  Derive,
+  GtInternalDerive,
+  Static,
+} from './external-store/components/derivation/Derive';
+export {
   useLocale,
   useRegion,
   useSetLocale,
@@ -6,12 +19,10 @@ export {
 } from './external-store/hooks/condition-hooks';
 export {
   useCustomMapping,
+  useEnableI18n,
   useDefaultLocale,
   useDictionaryEntry,
   useDictionaryObject,
-  useEnableI18n,
-  useI18nExternalStore,
-  useI18nManager,
   useLocales,
   useTranslate,
   useTranslateMany,
@@ -19,6 +30,8 @@ export {
 export {
   GTContext,
   useConditionStore,
+  useI18nExternalStore,
+  useI18nManager,
 } from './external-store/provider/GTContext';
 export {
   GTProvider,
@@ -48,3 +61,27 @@ export type {
   TranslateSnapshot,
   Unsubscribe,
 } from './external-store/store/storeTypes';
+export {
+  GtInternalTranslateJsx,
+  T,
+} from './external-store/components/translation/T';
+export {
+  Currency,
+  GtInternalCurrency,
+} from './external-store/components/variables/Currency';
+export {
+  DateTime,
+  GtInternalDateTime,
+} from './external-store/components/variables/DateTime';
+export { GtInternalNum, Num } from './external-store/components/variables/Num';
+export {
+  GtInternalRelativeTime,
+  RelativeTime,
+} from './external-store/components/variables/RelativeTime';
+export {
+  GtInternalVar,
+  Var,
+  computeVar,
+} from './external-store/components/variables/Var';
+export { renderVariable } from './external-store/components/variables/renderVariable';
+export { useFormatLocales } from './external-store/hooks/utils';

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -14,8 +14,8 @@
     "./dist/macros.*"
   ],
   "peerDependencies": {
-    "react": ">=16.8.0",
-    "react-dom": ">=16.8.0"
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
   },
   "dependencies": {
     "@generaltranslation/supported-locales": "workspace:*",
@@ -65,6 +65,11 @@
       "require": "./dist/internal.cjs.min.cjs",
       "import": "./dist/internal.esm.min.mjs"
     },
+    "./internal-external-store": {
+      "types": "./dist/internal-external-store.d.ts",
+      "require": "./dist/internal-external-store.cjs.min.cjs",
+      "import": "./dist/internal-external-store.esm.min.mjs"
+    },
     "./client": {
       "types": "./dist/client.d.ts",
       "require": "./dist/client.cjs.min.cjs",
@@ -92,6 +97,9 @@
       "internal": [
         "./dist/internal.d.ts"
       ],
+      "internal-external-store": [
+        "./dist/internal-external-store.d.ts"
+      ],
       "setup": [
         "./dist/setup.d.ts"
       ],
@@ -114,6 +122,9 @@
       ],
       "gt-react/internal": [
         "./dist/internal"
+      ],
+      "gt-react/internal-external-store": [
+        "./dist/internal-external-store"
       ],
       "gt-react/setup": [
         "./dist/setup.d.ts"

--- a/packages/react/rollup.config.mjs
+++ b/packages/react/rollup.config.mjs
@@ -18,6 +18,10 @@ export default createReactBundleConfigs(
   [
     { input: './src/index.ts', outputName: 'index' },
     { input: './src/internal.ts', outputName: 'internal' },
+    {
+      input: './src/internal-external-store.ts',
+      outputName: 'internal-external-store',
+    },
     { input: 'src/client.ts', outputName: 'client' },
     { input: './src/browser.ts', outputName: 'browser' },
     {

--- a/packages/react/src/internal-external-store.ts
+++ b/packages/react/src/internal-external-store.ts
@@ -1,0 +1,1 @@
+export * from '@generaltranslation/react-core/internal-external-store';


### PR DESCRIPTION
## Summary
- add external-store implementations for translation, variable, branch, plural, and derivation components
- wire those components to the new external-store hooks
- add @generaltranslation/react-core/internal-external-store and gt-react/internal-external-store package entrypoints
- add a changeset for the package export changes

## Scope
- T uses useTranslate and renders source children when translation is undefined
- no Suspense inside T
- variables use the provider-owned manager via useI18nManager

## Test Plan
- pnpm --filter @generaltranslation/react-core typecheck
- pnpm --filter @generaltranslation/react-core test -- packages/react-core/src/external-store/store/__tests__/store-subscriptions.test.ts
- pnpm --filter @generaltranslation/react-core build
- pnpm --filter gt-react typecheck
- pnpm exec oxlint packages/react-core/src/external-store packages/react-core/src/internal-external-store.ts packages/react/src/internal-external-store.ts packages/react-core/rollup.config.mjs packages/react/rollup.config.mjs

Stacked on #1404.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR exposes external-store implementations of the `T`, `Branch`, `Plural`, `Derive`, and variable (`Num`, `Currency`, `DateTime`, `RelativeTime`, `Var`) components, wires them to the new external-store hooks, and adds `internal-external-store` package entrypoints to both `@generaltranslation/react-core` and `gt-react`. It also lifts the React peer-dependency floor to `>=18.0.0` to reflect the use of `useSyncExternalStore`.

- **New components** (`T`, `Branch`, `Plural`, `Derive`, variable types) are added under `packages/react-core/src/external-store/components/` and re-exported via the new `internal-external-store` entrypoints in both packages.
- **`T.tsx`** has a subscription-churn issue: spreading props into `...params` creates a new object every render, so the `useMemo` calls that compute `options` and `targetOptions` are effectively no-ops, and `useTranslate`'s `useSyncExternalStore` subscription is torn down and re-created on every render.
- **`renderVariable.tsx`** selects the wrong component variant for each `injectionType` direction (both currently produce identical output, so no user-visible regression today), and `GtInternalVar` is defined but never used in this file.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge for initial experimental exposure, but the T component's subscription behaviour degrades under frequent re-renders and should be fixed before relying on it in production

The T component creates a new `params` object on every render, neutralising two layers of `useMemo` and forcing `useSyncExternalStore` to tear down and re-create its subscription on every render. In a list of translated strings this compounds into measurable subscription churn. The renderVariable `injectionType` mapping is inverted but functionally equivalent today. The peer-dependency floor change is tracked as a patch when it narrows the supported React range.

T.tsx (subscription-churn issue), renderVariable.tsx (inverted injectionType mapping and unused GtInternalVar), both package.json files (peer-dep bump vs changeset classification)
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/external-store/components/translation/T.tsx | New external-store T component; has a subscription-churn issue because the spread `params` object is a new reference every render, making `options`/`targetOptions` memoization ineffective and causing `useTranslate` to re-subscribe on every render |
| packages/react-core/src/external-store/components/variables/renderVariable.tsx | New renderVariable for the external-store path; `injectionType` component selection is inverted for all variable types, and `GtInternalVar` is exported but never referenced here |
| packages/react-core/src/external-store/components/branches/Branch.tsx | External-store Branch component; pure logic, no hooks, safe |
| packages/react-core/src/external-store/components/branches/Plural.tsx | External-store Plural component; uses useLocale and useDefaultLocale from condition hooks, logic mirrors existing implementation |
| packages/react-core/src/external-store/components/variables/Currency.tsx | External-store Currency variable component; uses useFormatLocales and useI18nManager, parses string children to float |
| packages/react-core/src/external-store/components/variables/RelativeTime.tsx | External-store RelativeTime variable component; supports both value+unit and date-based relative formatting |
| packages/react-core/src/internal-external-store.ts | Barrel file wiring the new external-store components and existing hooks into the internal-external-store entrypoint |
| packages/react-core/package.json | Adds internal-external-store export entry and bumps react peer-dependency floor to >=18.0.0 tracked only as a patch |
| packages/react/package.json | Adds internal-external-store export entry; bumps react and react-dom peer-dep floors to >=18.0.0 |
| packages/react-core/src/external-store/hooks/utils.ts | Simple utility hook useFormatLocales combining localesProp, current locale, and default locale |
| packages/react/src/internal-external-store.ts | Thin re-export of @generaltranslation/react-core/internal-external-store for gt-react consumers |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
packages/react-core/src/external-store/components/translation/T.tsx:134-138
**Unstable `params` object defeats memoization and causes subscription churn**

`params` is created by rest-destructuring component props (`...params`) inside `useComputeT`, so it gets a new object reference on every render. `useMemo(() => normalizeParameters(params), [params])` therefore recomputes on every render, and `options`'s instability propagates to `targetOptions`. Because `targetOptions` feeds the `lookup` object passed to `useTranslate` → `useSyncExternalStore`, React will unsubscribe and re-subscribe to the translation store on every render, causing subscription churn. For components rendered in lists this is especially costly.

The fix is to destructure the individual props of `JsxTranslationOptions` directly and list them as `useMemo` dependencies (e.g. `$context`, `$id`, `$_hash`) rather than depending on the whole `params` object.

### Issue 2 of 4
packages/react-core/src/external-store/components/variables/renderVariable.tsx:22-23
**`injectionType` mapping appears inverted across all variable branches**

When `injectionType === 'automatic'` the code selects `GtExternalNum` (which is the plain `Num` export with `_gtt = 'variable-number'`) and when it is NOT `'automatic'` it selects `GtInternalNum` (with `_gtt = 'variable-number-automatic'`). The same pattern is repeated for `DateTime`, `Currency`, and `RelativeTime`. Given that `InjectionType = 'automatic' | 'manual'` and the `-automatic` suffix on `_gtt` matches the automatic injection path, the roles appear reversed — the automatic injection type should select the `GtInternal*` component (the one carrying the `-automatic` tag). Both components produce identical output at runtime (they call the same hooks), so this has no user-visible effect today, but it introduces a discrepancy between the component in the React tree and the declared `_gtt` tag that could affect tooling or future build-time analysis.

### Issue 3 of 4
packages/react-core/src/external-store/components/variables/renderVariable.tsx:75-79
**`GtInternalVar` is never used — Var's automatic path is inconsistent with other variable types**

For every other variable type (`n`, `d`, `c`, `rt`) there is a `GtInternal*` component selected when `injectionType` calls for it, but the `Var` fallback branch uses `computeVar` (a plain function) for one path and `GtExternalVar` for the other, while the imported (but unused) `GtInternalVar` export goes unreferenced. The inconsistency means `GtInternalVar` is dead code in this file, and the Var branch behaves differently from the other variable-type branches regardless of `injectionType` semantics.

### Issue 4 of 4
.changeset/internal-external-store-entrypoints.md:2-3
**Breaking peer-dependency bump classified as `patch`**

Both `@generaltranslation/react-core` and `gt-react` have their `react` peer-dependency floor raised from `>=16.8.0` to `>=18.0.0` in this PR (and `react-dom` likewise for `gt-react`). Dropping support for React 16 and 17 is a semver-breaking change; it should be a `major` bump, or at minimum a `minor` with an explicit note in the changelog, rather than a `patch`. Any consumer running React 16 or 17 will silently receive a build that fails at runtime when `useSyncExternalStore` (or other React 18 APIs) is called.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: expose external store components a..."](https://github.com/generaltranslation/gt/commit/1172d90cd43f23347bcf91e576e510585305c49e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31465548)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->