### PR TITLE
fix: protect i18n cache internals

### DIFF
--- a/.changeset/fuzzy-caches-wait.md
+++ b/.changeset/fuzzy-caches-wait.md
@@ -1,0 +1,5 @@
+---
+"gt-i18n": patch
+---
+
+Prevent callers from mutating internal translation caches through `getInternalCache()` and start locale cache TTLs after async loads complete.

--- a/packages/i18n/src/i18n-manager/__tests__/I18nManager.test.ts
+++ b/packages/i18n/src/i18n-manager/__tests__/I18nManager.test.ts
@@ -152,7 +152,13 @@ describe('I18nManager', () => {
         name: 'Nom',
       },
     });
-    expect(cachedDictionary).toBe(dictionary);
+    expect(cachedDictionary).toEqual(dictionary);
+    expect(cachedDictionary).not.toBe(dictionary);
+
+    dictionary.greeting = 'Salut';
+    await expect(manager.loadDictionary('fr')).resolves.toMatchObject({
+      greeting: 'Bonjour',
+    });
   });
 
   it.each([

--- a/packages/i18n/src/i18n-manager/translations-manager/Cache.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/Cache.ts
@@ -3,6 +3,18 @@ import type {
   LifecycleParam,
 } from '../lifecycle-hooks/types';
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value == null || typeof value !== 'object') return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function copyCacheValue<CacheValue>(value: CacheValue): CacheValue {
+  if (Array.isArray(value)) return [...value] as CacheValue;
+  if (isPlainObject(value)) return { ...value } as CacheValue;
+  return value;
+}
+
 /**
  * Cache class
  * This is designed in such a way that it is the responsibility of the client
@@ -86,6 +98,18 @@ abstract class Cache<
    * @internal - used by gt-tanstack-start
    */
   public getInternalCache(): Record<CacheKey, CacheValue> {
+    return Object.fromEntries(
+      Object.entries(this.cache).map(([key, value]) => [
+        key,
+        copyCacheValue(value as CacheValue),
+      ])
+    ) as Record<CacheKey, CacheValue>;
+  }
+
+  /**
+   * Get the mutable cache for subclasses that need custom read/write behavior.
+   */
+  protected getMutableCache(): Record<CacheKey, CacheValue> {
     return this.cache;
   }
 

--- a/packages/i18n/src/i18n-manager/translations-manager/DictionaryCache.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/DictionaryCache.ts
@@ -204,7 +204,7 @@ export class DictionaryCache extends Cache<
    * Set the value for a key
    */
   protected setCache(cacheKey: DictionaryPath, value: DictionaryValue): void {
-    const cache = this.getInternalCache() as Dictionary;
+    const cache = this.getMutableCache() as Dictionary;
     const dictionaryPath = getDictionaryPath(cacheKey);
 
     if (dictionaryPath.length === 0) {
@@ -231,7 +231,7 @@ export class DictionaryCache extends Cache<
    */
   protected getCache(key: DictionaryKey): DictionaryValue | undefined {
     const dictionaryPath = getDictionaryPath(this.genKey(key));
-    let current: DictionaryValue = this.getInternalCache() as Dictionary;
+    let current: DictionaryValue = this.getMutableCache() as Dictionary;
 
     if (dictionaryPath.length === 0) {
       return current;

--- a/packages/i18n/src/i18n-manager/translations-manager/LocalesCache.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/LocalesCache.ts
@@ -182,16 +182,14 @@ export class LocalesCache<TranslationValue extends Translation> extends Cache<
     // Fetch translations
     const translationsPromise = this._translationLoader(locale);
 
-    // Get cache expiry time
-    const expiresAt = this.ttl < 0 ? this.ttl : Date.now() + this.ttl;
-
-    // Cache the promise and expiry timestamp
+    // Cache the translations and expiry timestamp
     const translationsCache = new TranslationsCache<TranslationValue>({
       init: await translationsPromise,
       lifecycle: this._createTranslationsCacheLifecycle(locale),
       translateMany: this._createTranslateMany(locale),
       batchConfig: this._batchConfig,
     });
+    const expiresAt = this.ttl < 0 ? this.ttl : Date.now() + this.ttl;
 
     return { translationsCache, expiresAt };
   }

--- a/packages/i18n/src/i18n-manager/translations-manager/LocalesDictionaryCache.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/LocalesDictionaryCache.ts
@@ -188,15 +188,13 @@ export class LocalesDictionaryCache extends Cache<
     // Fetch dictionary
     const dictionaryPromise = this._dictionaryLoader(locale);
 
-    // Get cache expiry time
-    const expiresAt = this.ttl < 0 ? this.ttl : Date.now() + this.ttl;
-
-    // Cache the promise and expiry timestamp
+    // Cache the dictionary and expiry timestamp
     const dictionaryCache = new DictionaryCache({
       init: await dictionaryPromise,
       runtimeTranslate: this._createDictionaryRuntimeTranslate(locale),
       lifecycle: this._createDictionaryCacheLifecycle(locale),
     });
+    const expiresAt = this.ttl < 0 ? this.ttl : Date.now() + this.ttl;
 
     return { dictionaryCache, expiresAt };
   }

--- a/packages/i18n/src/i18n-manager/translations-manager/__tests__/LocalesCache.test.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/__tests__/LocalesCache.test.ts
@@ -119,4 +119,36 @@ describe('LocalesCache', () => {
     vi.advanceTimersByTime(2);
     expect(cache.get('fr')).toBeUndefined();
   });
+
+  it('starts TTL after translations finish loading', async () => {
+    const cache = createCache({ ttl: 5000 });
+    let resolveTranslations!: (translations: Record<Hash, string>) => void;
+    mockLoadTranslations.mockReturnValue(
+      new Promise((resolve) => {
+        resolveTranslations = resolve;
+      })
+    );
+
+    const missPromise = cache.miss('fr');
+    vi.advanceTimersByTime(4000);
+    resolveTranslations(frTranslations);
+    await missPromise;
+
+    vi.advanceTimersByTime(4999);
+    expect(cache.get('fr')).toBeDefined();
+
+    vi.advanceTimersByTime(2);
+    expect(cache.get('fr')).toBeUndefined();
+  });
+
+  it('getInternalCache() returns copied cache entries', async () => {
+    const cache = createCache({ ttl: 5000 });
+    await cache.miss('fr');
+
+    const internal = cache.getInternalCache();
+    internal['fr'].expiresAt = 0;
+
+    expect(cache.get('fr')).toBeDefined();
+    expect(cache.getInternalCache()['fr']).not.toBe(internal['fr']);
+  });
 });

--- a/packages/i18n/src/i18n-manager/translations-manager/__tests__/TranslationsCache.test.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/__tests__/TranslationsCache.test.ts
@@ -98,6 +98,19 @@ describe('TranslationsCache', () => {
     expect(mockTranslateMany).toHaveBeenCalledTimes(1);
   });
 
+  it('getInternalCache() returns a shallow copy', () => {
+    const { message, options, hash } = makeKey('Hello');
+    const cache = new TranslationsCache({
+      init: { [hash]: 'Bonjour' },
+      translateMany: mockTranslateMany,
+    });
+
+    const internal = cache.getInternalCache();
+    internal[hash] = 'Salut';
+
+    expect(cache.get({ message, options })).toBe('Bonjour');
+  });
+
   // ===== NEW BEHAVIOR TESTS ===== //
 
   it('miss() batches multiple requests within BATCH_INTERVAL', async () => {


### PR DESCRIPTION
## Summary
- Return a shallow copy from Cache.getInternalCache() so callers cannot mutate the top-level internal cache record.
- Keep DictionaryCache using a protected mutable cache accessor for internal nested dictionary operations.
- Start locale translation and dictionary cache TTLs after async loads finish.
- Add regression tests for cache snapshots and slow translation loads.

## Tests
- pnpm exec vitest run --config=./vitest.config.ts src/i18n-manager/translations-manager/__tests__/TranslationsCache.test.ts src/i18n-manager/translations-manager/__tests__/LocalesCache.test.ts src/i18n-manager/translations-manager/__tests__/DictionaryCache.test.ts src/i18n-manager/translations-manager/__tests__/LocalesDictionaryCache.test.ts
- pnpm --filter gt-i18n typecheck
- pnpm exec oxfmt --check packages/i18n/src/i18n-manager/translations-manager/Cache.ts packages/i18n/src/i18n-manager/translations-manager/DictionaryCache.ts packages/i18n/src/i18n-manager/translations-manager/LocalesCache.ts packages/i18n/src/i18n-manager/translations-manager/LocalesDictionaryCache.ts packages/i18n/src/i18n-manager/translations-manager/__tests__/LocalesCache.test.ts packages/i18n/src/i18n-manager/translations-manager/__tests__/TranslationsCache.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the cache internals by copying values in `getInternalCache()` (so external callers cannot mutate live entries), routing `DictionaryCache`'s own read/write operations to a new protected `getMutableCache()` accessor, and moving the TTL timestamp calculation to after the async load completes in both `LocalesCache` and `LocalesDictionaryCache`.

- **`Cache.ts`**: `getInternalCache()` now iterates every entry and returns a shallow copy of plain-object and array values via `copyCacheValue`, protecting primitives like `expiresAt` from external zero-out. A new `protected getMutableCache()` accessor returns the live cache for trusted subclass use.
- **`DictionaryCache.ts`**: Internal `setCache`/`getCache` overrides switch from `getInternalCache()` to `getMutableCache()` so nested dictionary path traversal and mutation operate correctly on the live structure.
- **`LocalesCache` / `LocalesDictionaryCache`**: `expiresAt` is now computed after `await translationsPromise` / `await dictionaryPromise`, ensuring slow async loads consume the full configured TTL window rather than a shrunk one.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes are narrowly scoped to cache isolation and TTL timing, with direct regression tests covering the repaired code paths.

All three concerns are addressed correctly: `getInternalCache()` now copies each entry so primitive fields like `expiresAt` are isolated in the snapshot; `DictionaryCache` routes its internal traversal through `getMutableCache()` so nested dictionary mutation still works; and both locale caches now stamp `expiresAt` after the async load resolves. The new tests directly verify the snapshot isolation and TTL timing. The only gap is that the equivalent TTL timing test was not mirrored for `LocalesDictionaryCache`.

`LocalesDictionaryCache.ts` received the same TTL fix as `LocalesCache.ts` but has no new test to guard against future regressions.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/i18n-manager/translations-manager/Cache.ts | Adds `copyCacheValue` helper that shallow-copies plain objects and arrays; `getInternalCache()` now copies each entry value; `getMutableCache()` exposes live cache for trusted subclass access only |
| packages/i18n/src/i18n-manager/translations-manager/DictionaryCache.ts | Switches internal `setCache`/`getCache` from `getInternalCache()` to `getMutableCache()` so nested dictionary path traversal and mutation use the live cache as intended |
| packages/i18n/src/i18n-manager/translations-manager/LocalesCache.ts | Moves `expiresAt` computation to after `await translationsPromise` so the TTL countdown starts when the load finishes, not when it begins |
| packages/i18n/src/i18n-manager/translations-manager/LocalesDictionaryCache.ts | Same TTL-after-load fix as LocalesCache applied to dictionary loading; no corresponding regression test was added for this path |
| packages/i18n/src/i18n-manager/translations-manager/__tests__/LocalesCache.test.ts | Adds two regression tests: one verifying TTL starts after async load, one verifying `getInternalCache()` returns copied entries whose `expiresAt` mutations don't affect the live cache |
| packages/i18n/src/i18n-manager/translations-manager/__tests__/TranslationsCache.test.ts | Adds a snapshot test verifying top-level key mutation in the `getInternalCache()` result does not affect the live cache |
| packages/i18n/src/i18n-manager/__tests__/I18nManager.test.ts | Updates dictionary cache assertion from `toBe` to `toEqual`+`not.toBe` to reflect the copy semantics, and adds a mutation-isolation assertion |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant LocalesCache
    participant missCache as Cache.missCache
    participant fallback as LocalesCache.fallback
    participant Loader as translationLoader

    Caller->>LocalesCache: miss('fr')
    LocalesCache->>missCache: missCache('fr')
    missCache->>fallback: fallback('fr')
    fallback->>Loader: _translationLoader('fr')
    note over Loader: slow async load (e.g. 10s)
    Loader-->>fallback: translations
    note over fallback: expiresAt = Date.now() + ttl (AFTER load)
    fallback-->>missCache: "{ translationsCache, expiresAt }"
    missCache->>missCache: setCache('fr', entry)
    missCache-->>LocalesCache: entry
    LocalesCache-->>Caller: translationsCache

    Caller->>LocalesCache: getInternalCache()
    LocalesCache->>LocalesCache: "copyCacheValue(entry) → { ...entry }"
    note over LocalesCache: expiresAt is a new primitive copy
    LocalesCache-->>Caller: snapshot (isolated plain-object copy)
    Caller->>Caller: "snapshot['fr'].expiresAt = 0"
    note over Caller: live cache unaffected
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/i18n/src/i18n-manager/translations-manager/LocalesDictionaryCache.ts:187-199
**TTL-after-load fix has no regression test**

The same `expiresAt` timing fix applied to `LocalesCache` (and covered by the new `'starts TTL after translations finish loading'` test) was also applied here, but `LocalesDictionaryCache`'s test file was not updated. A slow dictionary load would have the same early-expiry bug pre-fix, so mirroring the `LocalesCache` timing test here would ensure this path stays covered.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: protect i18n cache internals"](https://github.com/generaltranslation/gt/commit/69aaf4e8ff3234dc30f8fd73435ebe3eea514334) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31662908)</sub>

<!-- /greptile_comment -->