### PR TITLE
chore: double minimumReleaseAge from 24h to 48h

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,7 @@ packages:
 enableGlobalVirtualStore: true
 hoist: false
 
-minimumReleaseAge: 1440
+minimumReleaseAge: 2880
 
 minimumReleaseAgeExclude:
   - '@generaltranslation/*'


### PR DESCRIPTION
Doubles `minimumReleaseAge` in `pnpm-workspace.yaml` from 1440 minutes (24h) to 2880 minutes (48h).

This gives third-party dependencies more time to be vetted before pnpm will resolve them, reducing supply-chain risk.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR doubles `minimumReleaseAge` in `pnpm-workspace.yaml` from 1440 minutes (24 h) to 2880 minutes (48 h), giving third-party packages more time to be vetted before pnpm resolves them.

- The `minimumReleaseAgeExclude` list (first-party packages, `react`, `next`, etc.) is untouched, so the longer wait window only applies to external dependencies.
- No code changes are involved; the impact is limited to the pnpm dependency-resolution step during installs.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — single integer value change in workspace config with no code impact.

The change is a one-line value bump in `pnpm-workspace.yaml`. It extends the minimum package age window for third-party deps from 24 h to 48 h, tightening supply-chain hygiene. The exclude list for first-party and core packages is unchanged, so development workflows for those packages are unaffected. There is no logic, no code paths, and no data at risk.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pnpm-workspace.yaml | Doubles `minimumReleaseAge` from 1440 to 2880 minutes (24h → 48h) to extend the vetting window for third-party dependencies; no other changes. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pnpm install triggered] --> B{Package in minimumReleaseAgeExclude?}
    B -- Yes --> C[Resolve immediately e.g. generaltranslation, react, next]
    B -- No --> D{Package age >= 48h?}
    D -- Yes --> E[Resolve third-party package]
    D -- No --> F[Block resolution - package too new]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: double minimumReleaseAge from 24h..."](https://github.com/generaltranslation/gt/commit/9e53c2fd544e9d8b156a6f658a9b066d029506eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31716826)</sub>

<!-- /greptile_comment -->