### PR TITLE
chore: add react-core tsdown changeset

### DIFF
--- a/.changeset/react-core-tsdown-build.md
+++ b/.changeset/react-core-tsdown-build.md
@@ -1,0 +1,5 @@
+---
+"@generaltranslation/react-core": patch
+---
+
+Switch the React Core package build pipeline to tsdown while preserving the existing public entrypoints.


### PR DESCRIPTION
## Summary
- add the missing changeset for the merged React Core tsdown migration (#1413)
- mark @generaltranslation/react-core for a patch release

## Verification
- pnpm changeset status --since=origin/main

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->