### PR TITLE
fix: honor custom locale region display names

### DIFF
--- a/.changeset/format-locale-cleanup.md
+++ b/.changeset/format-locale-cleanup.md
@@ -1,0 +1,6 @@
+---
+"@generaltranslation/format": patch
+"generaltranslation": patch
+---
+
+Honor custom locale region display-name overrides and simplify shared locale formatting helpers.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -10,6 +10,7 @@ export type {
   CustomRegionMapping,
   CutoffFormatOptions,
   DataFormat,
+  FormatVariables,
   GTProp,
   HtmlContentPropKeysRecord,
   HtmlContentPropValuesRecord,
@@ -128,11 +129,6 @@ export type Metadata = {
   filePaths?: string[];
   [key: string]: unknown;
 };
-
-export type FormatVariables = Record<
-  string,
-  string | number | boolean | null | undefined | Date
->;
 
 /**
  * @deprecated This type is deprecated and will be removed in a future version.

--- a/packages/format/src/LocaleConfig.ts
+++ b/packages/format/src/LocaleConfig.ts
@@ -1,15 +1,14 @@
 import {
   _formatCurrency,
-  _formatCutoff,
   _formatDateTime,
   _formatList,
   _formatListToParts,
   _formatMessageICU,
-  _formatMessageString,
   _formatNum,
   _formatRelativeTime,
-  _formatRelativeTimeFromDate,
+  _selectRelativeTimeUnit,
 } from './formatting/format';
+import { intlCache } from './cache/IntlCache';
 import { _requiresTranslation } from './locales/requiresTranslation';
 import { _determineLocale } from './locales/determineLocale';
 import { _isSameLanguage } from './locales/isSameLanguage';
@@ -62,36 +61,17 @@ export class LocaleConfig {
     this.customMapping = customMapping;
   }
 
-  private get translationLocales() {
-    return this.locales.length ? this.locales : undefined;
-  }
-
-  private resolveCanonicalLocaleList(locales: string[]) {
-    return locales.map((locale) => this.resolveCanonicalLocale(locale));
-  }
-
-  private resolveCanonicalLocaleArgs(locales: (string | string[])[]) {
-    return locales.map((locale) =>
-      Array.isArray(locale)
-        ? this.resolveCanonicalLocaleList(locale)
-        : this.resolveCanonicalLocale(locale)
-    );
-  }
-
-  private toLocaleList(locales: string | string[]) {
-    return Array.isArray(locales) ? locales : [locales];
-  }
-
   private getFormattingLocales(
     targetLocale?: string,
     locales?: string | string[]
   ) {
-    const localeList =
-      locales !== undefined
-        ? this.toLocaleList(locales)
-        : [targetLocale, this.defaultLocale, libraryDefaultLocale];
-
-    return localeList
+    return (
+      locales === undefined
+        ? [targetLocale, this.defaultLocale, libraryDefaultLocale]
+        : Array.isArray(locales)
+          ? locales
+          : [locales]
+    )
       .filter((locale): locale is string => !!locale)
       .map((locale) => this.resolveCanonicalLocale(locale));
   }
@@ -160,9 +140,13 @@ export class LocaleConfig {
     > = {}
   ) {
     const { locales, baseDate, ...intlOptions } = options;
-    return _formatRelativeTimeFromDate({
+    const { value, unit } = _selectRelativeTimeUnit(
       date,
-      baseDate: baseDate ?? new Date(),
+      baseDate ?? new Date()
+    );
+    return _formatRelativeTime({
+      value,
+      unit,
       locales: this.getFormattingLocales(targetLocale, locales),
       options: intlOptions,
     });
@@ -174,11 +158,13 @@ export class LocaleConfig {
     options: WithLocales<CutoffFormatOptions> = {}
   ) {
     const { locales, ...formatOptions } = options;
-    return _formatCutoff({
-      value,
-      locales: this.getFormattingLocales(targetLocale, locales),
-      options: formatOptions,
-    });
+    return intlCache
+      .get(
+        'CutoffFormat',
+        this.getFormattingLocales(targetLocale, locales),
+        formatOptions
+      )
+      .format(value);
   }
 
   formatMessage(
@@ -190,7 +176,7 @@ export class LocaleConfig {
     }> = {}
   ) {
     const { locales, variables, dataFormat } = options;
-    if (dataFormat === 'STRING') return _formatMessageString(message);
+    if (dataFormat === 'STRING') return message;
     return _formatMessageICU(
       message,
       this.getFormattingLocales(targetLocale, locales),
@@ -239,13 +225,15 @@ export class LocaleConfig {
   requiresTranslation(
     targetLocale: string,
     sourceLocale: string = this.defaultLocale,
-    approvedLocales: string[] | undefined = this.translationLocales
+    approvedLocales: string[] | undefined = this.locales.length
+      ? this.locales
+      : undefined
   ) {
     return _requiresTranslation(
       this.resolveCanonicalLocale(sourceLocale),
       this.resolveCanonicalLocale(targetLocale),
       approvedLocales
-        ? this.resolveCanonicalLocaleList(approvedLocales)
+        ? approvedLocales.map((locale) => this.resolveCanonicalLocale(locale))
         : undefined,
       this.customMapping
     );
@@ -261,17 +249,16 @@ export class LocaleConfig {
     }));
     const resolvedLocale = _determineLocale(
       Array.isArray(locales)
-        ? this.resolveCanonicalLocaleList(locales)
+        ? locales.map((locale) => this.resolveCanonicalLocale(locale))
         : this.resolveCanonicalLocale(locales),
       approvedLocalePairs.map(({ canonicalLocale }) => canonicalLocale),
       this.customMapping
     );
     if (!resolvedLocale) return undefined;
-    return (
-      approvedLocalePairs.find(
-        ({ canonicalLocale }) => canonicalLocale === resolvedLocale
-      )?.locale || this.resolveAliasLocale(resolvedLocale)
+    const approvedLocale = approvedLocalePairs.find(
+      ({ canonicalLocale }) => canonicalLocale === resolvedLocale
     );
+    return approvedLocale?.locale ?? this.resolveAliasLocale(resolvedLocale);
   }
 
   getLocaleDirection(locale: string) {
@@ -295,11 +282,23 @@ export class LocaleConfig {
   }
 
   isSameDialect(...locales: (string | string[])[]) {
-    return _isSameDialect(...this.resolveCanonicalLocaleArgs(locales));
+    return _isSameDialect(
+      ...locales.map((locale) =>
+        Array.isArray(locale)
+          ? locale.map((code) => this.resolveCanonicalLocale(code))
+          : this.resolveCanonicalLocale(locale)
+      )
+    );
   }
 
   isSameLanguage(...locales: (string | string[])[]) {
-    return _isSameLanguage(...this.resolveCanonicalLocaleArgs(locales));
+    return _isSameLanguage(
+      ...locales.map((locale) =>
+        Array.isArray(locale)
+          ? locale.map((code) => this.resolveCanonicalLocale(code))
+          : this.resolveCanonicalLocale(locale)
+      )
+    );
   }
 
   isSupersetLocale(superLocale: string, subLocale: string) {

--- a/packages/format/src/__tests__/format-package.test.ts
+++ b/packages/format/src/__tests__/format-package.test.ts
@@ -47,9 +47,14 @@ describe('@generaltranslation/format package export', () => {
         `
           const assert = require('node:assert/strict');
           const {
+            formatCurrency,
             LocaleConfig,
             formatCutoff,
+            formatList,
             formatMessage,
+            formatNum,
+            formatRelativeTime,
+            formatRelativeTimeFromDate,
             getRegionProperties,
             standardizeLocale,
           } = require('@generaltranslation/format');
@@ -59,6 +64,15 @@ describe('@generaltranslation/format package export', () => {
             'Hi Ada'
           );
           assert.equal(formatCutoff('Hello, world!', { maxChars: 8 }), 'Hello, …');
+          assert.equal(formatNum(1234.5), '1,234.5');
+          assert.equal(formatCurrency(1234.5, 'USD'), '$1,234.50');
+          assert.equal(formatList(['apples', 'bananas']), 'apples and bananas');
+          assert.equal(formatRelativeTime(-1, 'day'), 'yesterday');
+          const relativeFromDate = formatRelativeTimeFromDate(
+            new Date(Date.now() - 24 * 60 * 60 * 1000),
+            undefined,
+          );
+          assert.equal(typeof relativeFromDate, 'string');
           assert.equal(new LocaleConfig().formatNum(1234.5, 'en-US'), '1,234.5');
           assert.equal(getRegionProperties('US').name, 'United States');
           assert.equal(standardizeLocale('en-us'), 'en-US');
@@ -78,8 +92,13 @@ describe('@generaltranslation/format package export', () => {
           import assert from 'node:assert/strict';
           import {
             LocaleConfig,
+            formatCurrency,
             formatCutoff,
+            formatList,
             formatMessage,
+            formatNum,
+            formatRelativeTime,
+            formatRelativeTimeFromDate,
             getRegionProperties,
             isValidLocale,
             resolveCanonicalLocale,
@@ -90,6 +109,15 @@ describe('@generaltranslation/format package export', () => {
             'Hi Ada'
           );
           assert.equal(formatCutoff('Hello, world!', { maxChars: 8 }), 'Hello, …');
+          assert.equal(formatNum(1234.5), '1,234.5');
+          assert.equal(formatCurrency(1234.5, 'USD'), '$1,234.50');
+          assert.equal(formatList(['apples', 'bananas']), 'apples and bananas');
+          assert.equal(formatRelativeTime(-1, 'day'), 'yesterday');
+          const relativeFromDate = formatRelativeTimeFromDate(
+            new Date(Date.now() - 24 * 60 * 60 * 1000),
+            undefined,
+          );
+          assert.equal(typeof relativeFromDate, 'string');
           assert.equal(
             new LocaleConfig({ customMapping: { en: 'English' } }).getLocaleName('en'),
             'English'

--- a/packages/format/src/cache/IntlCache.ts
+++ b/packages/format/src/cache/IntlCache.ts
@@ -29,17 +29,13 @@ const CustomIntl: CustomIntlType = {
  * Uses a two-level structure: constructor name -> cache key -> instance.
  */
 class IntlCache {
-  private cache: IntlCacheObject;
-
-  constructor() {
-    this.cache = {};
-  }
+  private cache: IntlCacheObject = {};
 
   /**
    * Generates a consistent cache key from locales and options.
    * Handles all LocalesArgument types (string, Locale, array, undefined).
    */
-  private _generateKey(locales: Intl.LocalesArgument, options = {}) {
+  private generateKey(locales: Intl.LocalesArgument, options = {}) {
     // Normalize locales to string representation
     const localeKey = !locales
       ? 'undefined'
@@ -65,14 +61,18 @@ class IntlCache {
     ...args: ConstructorParameters<CustomIntlConstructors[K]>
   ): InstanceType<ConstructorType<K>> {
     const [locales = libraryDefaultLocale, options = {}] = args;
-    const key = this._generateKey(locales, options);
-    let intlObject = this.cache[constructor]?.[key];
+    const key = this.generateKey(locales, options);
+    let cache = this.cache[constructor];
+    if (cache === undefined) {
+      cache = {};
+      this.cache[constructor] = cache;
+    }
+    let intlObject = cache[key];
 
     if (intlObject === undefined) {
       // Create new instance and cache it
       intlObject = new CustomIntl[constructor](...args);
-      if (!this.cache[constructor]) this.cache[constructor] = {};
-      this.cache[constructor][key] = intlObject;
+      cache[key] = intlObject;
     }
 
     return intlObject;

--- a/packages/format/src/core.ts
+++ b/packages/format/src/core.ts
@@ -1,15 +1,14 @@
 import {
   _formatCurrency,
-  _formatCutoff,
   _formatDateTime,
   _formatList,
   _formatListToParts,
   _formatMessageICU,
-  _formatMessageString,
   _formatNum,
   _formatRelativeTime,
-  _formatRelativeTimeFromDate,
+  _selectRelativeTimeUnit,
 } from './formatting/format';
+import { intlCache } from './cache/IntlCache';
 import type { CutoffFormatOptions } from './formatting/custom-formats/CutoffFormat/types';
 import { _determineLocale } from './locales/determineLocale';
 import { _getLocaleDirection } from './locales/getLocaleDirection';
@@ -19,10 +18,6 @@ import {
   type LocaleProperties,
 } from './locales/getLocaleProperties';
 import { _getLocaleName } from './locales/getLocaleName';
-import {
-  _getRegionProperties,
-  type CustomRegionMapping,
-} from './locales/getRegionProperties';
 import { _isSameDialect } from './locales/isSameDialect';
 import { _isSameLanguage } from './locales/isSameLanguage';
 import { _isSupersetLocale } from './locales/isSupersetLocale';
@@ -37,6 +32,19 @@ export {
   LocaleConfig,
   type LocaleConfigConstructorParams,
 } from './LocaleConfig';
+export {
+  getRegionProperties,
+  type CustomRegionMapping,
+} from './locales/getRegionProperties';
+
+type LocalesOption = {
+  locales?: string | string[];
+};
+
+type MessageFormatOptions = LocalesOption & {
+  variables?: FormatVariables;
+  dataFormat?: StringFormat;
+};
 
 /**
  * Core formatting and locale helpers.
@@ -90,11 +98,10 @@ export {
  */
 export function formatCutoff(
   value: string,
-  options?: {
-    locales?: string | string[];
-  } & CutoffFormatOptions
+  options?: LocalesOption & CutoffFormatOptions
 ) {
-  return _formatCutoff({ value, locales: options?.locales, options });
+  const { locales, ...formatOptions } = options ?? {};
+  return intlCache.get('CutoffFormat', locales, formatOptions).format(value);
 }
 
 /**
@@ -117,20 +124,9 @@ export function formatCutoff(
  *   variables: { name: 'John' }
  * });
  */
-export function formatMessage(
-  message: string,
-  options?: {
-    locales?: string | string[];
-    variables?: FormatVariables;
-    dataFormat?: StringFormat;
-  }
-) {
-  switch (options?.dataFormat) {
-    case 'STRING':
-      return _formatMessageString(message);
-    default:
-      return _formatMessageICU(message, options?.locales, options?.variables);
-  }
+export function formatMessage(message: string, options?: MessageFormatOptions) {
+  if (options?.dataFormat === 'STRING') return message;
+  return _formatMessageICU(message, options?.locales, options?.variables);
 }
 
 /**
@@ -143,14 +139,13 @@ export function formatMessage(
  */
 export function formatNum(
   number: number,
-  options: {
-    locales: string | string[];
-  } & Intl.NumberFormatOptions
+  options?: LocalesOption & Intl.NumberFormatOptions
 ): string {
+  const { locales, ...intlOptions } = options ?? {};
   return _formatNum({
     value: number,
-    locales: options?.locales,
-    options,
+    locales,
+    options: intlOptions,
   });
 }
 
@@ -164,14 +159,13 @@ export function formatNum(
  */
 export function formatDateTime(
   date: Date,
-  options?: {
-    locales?: string | string[];
-  } & Intl.DateTimeFormatOptions
+  options?: LocalesOption & Intl.DateTimeFormatOptions
 ): string {
+  const { locales, ...intlOptions } = options ?? {};
   return _formatDateTime({
     value: date,
-    locales: options?.locales,
-    options,
+    locales,
+    options: intlOptions,
   });
 }
 
@@ -187,15 +181,14 @@ export function formatDateTime(
 export function formatCurrency(
   value: number,
   currency: string,
-  options: {
-    locales: string | string[];
-  } & Intl.NumberFormatOptions
+  options?: LocalesOption & Intl.NumberFormatOptions
 ): string {
+  const { locales, ...intlOptions } = options ?? {};
   return _formatCurrency({
     value,
     currency,
-    locales: options?.locales,
-    options,
+    locales,
+    options: intlOptions,
   });
 }
 
@@ -209,14 +202,13 @@ export function formatCurrency(
  */
 export function formatList(
   array: Array<string | number>,
-  options: {
-    locales: string | string[];
-  } & Intl.ListFormatOptions
+  options?: LocalesOption & Intl.ListFormatOptions
 ): string {
+  const { locales, ...intlOptions } = options ?? {};
   return _formatList({
     value: array,
-    locales: options?.locales,
-    options,
+    locales,
+    options: intlOptions,
   });
 }
 
@@ -230,14 +222,13 @@ export function formatList(
  */
 export function formatListToParts<T>(
   array: Array<T>,
-  options?: {
-    locales?: string | string[];
-  } & Intl.ListFormatOptions
+  options?: LocalesOption & Intl.ListFormatOptions
 ): Array<T | string> {
+  const { locales, ...intlOptions } = options ?? {};
   return _formatListToParts<T>({
     value: array,
-    locales: options?.locales,
-    options,
+    locales,
+    options: intlOptions,
   });
 }
 
@@ -253,15 +244,14 @@ export function formatListToParts<T>(
 export function formatRelativeTime(
   value: number,
   unit: Intl.RelativeTimeFormatUnit,
-  options: {
-    locales: string | string[];
-  } & Omit<Intl.RelativeTimeFormatOptions, 'locales'>
+  options?: LocalesOption & Omit<Intl.RelativeTimeFormatOptions, 'locales'>
 ): string {
+  const { locales, ...intlOptions } = options ?? {};
   return _formatRelativeTime({
     value,
     unit,
-    locales: options?.locales,
-    options,
+    locales,
+    options: intlOptions,
   });
 }
 
@@ -275,15 +265,16 @@ export function formatRelativeTime(
  */
 export function formatRelativeTimeFromDate(
   date: Date,
-  options: {
-    locales: string | string[];
-    baseDate?: Date;
-  } & Omit<Intl.RelativeTimeFormatOptions, 'locales'>
+  options?: LocalesOption &
+    Omit<Intl.RelativeTimeFormatOptions, 'locales'> & {
+      baseDate?: Date;
+    }
 ): string {
   const { locales, baseDate, ...intlOptions } = options ?? {};
-  return _formatRelativeTimeFromDate({
-    date,
-    baseDate: baseDate ?? new Date(),
+  const { value, unit } = _selectRelativeTimeUnit(date, baseDate ?? new Date());
+  return _formatRelativeTime({
+    value,
+    unit,
     locales,
     options: intlOptions,
   });
@@ -422,49 +413,6 @@ export function getLocaleProperties(
   customMapping?: CustomMapping
 ): LocaleProperties {
   return _getLocaleProperties(locale, defaultLocale, customMapping);
-}
-
-/**
- * Retrieves multiple properties for a given region code, including:
- * - `code`: the original region code
- * - `name`: the localized display name
- * - `emoji`: the associated flag or symbol
- *
- * Behavior:
- * - Accepts ISO 3166-1 alpha-2 or UN M.49 region codes (e.g., `"US"`, `"FR"`, `"419"`).
- * - If `customMapping` contains a `name` or `emoji` for the region, those override the default values.
- * - Otherwise, uses `Intl.DisplayNames` to get the localized region name in the given `defaultLocale`,
- *   falling back to `libraryDefaultLocale`.
- * - Falls back to the region code as `name` if display name resolution fails.
- * - Falls back to `defaultEmoji` if no emoji mapping is found in `emojis` or `customMapping`.
- *
- * @param {string} region - The region code to look up (e.g., `"US"`, `"GB"`, `"DE"`).
- * @param {string} [defaultLocale=libraryDefaultLocale] - The locale to use when localizing the region name.
- * @param {CustomRegionMapping} [customMapping] - Optional mapping of region codes to custom names and/or emojis.
- * @returns {{ code: string, name: string, emoji: string, locale?: string }} An object containing:
- *  - `code`: the input region code
- *  - `name`: the localized or custom region name
- *  - `emoji`: the matching emoji flag or symbol
- *  - `locale`: the optional associated locale from custom mapping
- *
- * @example
- * getRegionProperties('US', 'en');
- * // => { code: 'US', name: 'United States', emoji: '🇺🇸' }
- *
- * @example
- * getRegionProperties('US', 'fr');
- * // => { code: 'US', name: 'États-Unis', emoji: '🇺🇸' }
- *
- * @example
- * getRegionProperties('US', 'en', { US: { name: 'USA', emoji: '🗽' } });
- * // => { code: 'US', name: 'USA', emoji: '🗽' }
- */
-export function getRegionProperties(
-  region: string,
-  defaultLocale?: string,
-  customMapping?: CustomRegionMapping
-): { code: string; name: string; emoji: string; locale?: string } {
-  return _getRegionProperties(region, defaultLocale, customMapping);
 }
 
 /**

--- a/packages/format/src/formatting/__tests__/relativeTime.test.ts
+++ b/packages/format/src/formatting/__tests__/relativeTime.test.ts
@@ -1,9 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import {
-  _selectRelativeTimeUnit,
-  _formatRelativeTimeFromDate,
-  _formatRelativeTime,
-} from '../format';
+import { _selectRelativeTimeUnit, _formatRelativeTime } from '../format';
+import { formatRelativeTimeFromDate } from '../../core';
 
 describe('_selectRelativeTimeUnit', () => {
   beforeEach(() => {
@@ -111,7 +108,7 @@ describe('_selectRelativeTimeUnit', () => {
   });
 });
 
-describe('_formatRelativeTimeFromDate', () => {
+describe('formatRelativeTimeFromDate', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-06-15T12:00:00Z'));
@@ -123,8 +120,7 @@ describe('_formatRelativeTimeFromDate', () => {
 
   it('should format a date 2 hours ago', () => {
     const date = new Date(Date.now() - 2 * 60 * 60 * 1000);
-    const result = _formatRelativeTimeFromDate({
-      date,
+    const result = formatRelativeTimeFromDate(date, {
       baseDate: new Date(),
       locales: ['en'],
     });
@@ -133,8 +129,7 @@ describe('_formatRelativeTimeFromDate', () => {
 
   it('should format a future date', () => {
     const date = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000);
-    const result = _formatRelativeTimeFromDate({
-      date,
+    const result = formatRelativeTimeFromDate(date, {
       baseDate: new Date(),
       locales: ['en'],
     });
@@ -143,8 +138,7 @@ describe('_formatRelativeTimeFromDate', () => {
 
   it('should format 2 weeks ago', () => {
     const date = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000);
-    const result = _formatRelativeTimeFromDate({
-      date,
+    const result = formatRelativeTimeFromDate(date, {
       baseDate: new Date(),
       locales: ['en'],
     });

--- a/packages/format/src/formatting/custom-formats/CutoffFormat/CutoffFormat.ts
+++ b/packages/format/src/formatting/custom-formats/CutoffFormat/CutoffFormat.ts
@@ -8,17 +8,31 @@ import {
 import {
   CutoffFormat,
   CutoffFormatOptions,
-  CutoffFormatStyle,
   PostpendedCutoffParts,
   PrependedCutoffParts,
   ResolvedCutoffFormatOptions,
-  ResolvedTerminatorOptions,
 } from './types';
 
 export class CutoffFormatConstructor implements CutoffFormat {
   private locale: string;
   private options: ResolvedCutoffFormatOptions;
   private additionLength: number;
+
+  private static resolveLocale(locales: Intl.LocalesArgument) {
+    try {
+      // Normalize locales to string
+      const localesList = !locales
+        ? [libraryDefaultLocale]
+        : Array.isArray(locales)
+          ? locales.map(String)
+          : [String(locales)];
+      const [canonicalLocale] = Intl.getCanonicalLocales(localesList);
+      return canonicalLocale ?? libraryDefaultLocale;
+    } catch {
+      return libraryDefaultLocale;
+    }
+  }
+
   /**
    * Constructor
    * @param {Intl.LocalesArgument} locales - The locales to use for formatting.
@@ -45,48 +59,27 @@ export class CutoffFormatConstructor implements CutoffFormat {
     options: CutoffFormatOptions = {}
   ) {
     // Determine locale (this replicates Intl.NumberFormat behavior including silent failure)
-    try {
-      // Normalize locales to string
-      const localesList = !locales
-        ? [libraryDefaultLocale]
-        : Array.isArray(locales)
-          ? locales.map((l) => String(l))
-          : [String(locales)];
-      const canonicalLocales = Intl.getCanonicalLocales(localesList);
-      this.locale = canonicalLocales.length
-        ? canonicalLocales[0]
-        : libraryDefaultLocale;
-    } catch {
-      this.locale = libraryDefaultLocale;
-    }
+    this.locale = CutoffFormatConstructor.resolveLocale(locales);
 
     // Follows Intl.NumberFormat behavior of throwing an error when currency is invalid
-    if (!TERMINATOR_MAP[options.style ?? DEFAULT_CUTOFF_FORMAT_STYLE]) {
-      throw new Error(
-        createInvalidCutoffStyleError(
-          options.style ?? DEFAULT_CUTOFF_FORMAT_STYLE
-        )
-      );
+    const style = options.style ?? DEFAULT_CUTOFF_FORMAT_STYLE;
+    if (!TERMINATOR_MAP[style]) {
+      throw new Error(createInvalidCutoffStyleError(style));
     }
 
     // Resolve terminator options.
-    let style: CutoffFormatStyle | undefined;
-    let presetTerminatorOptions: ResolvedTerminatorOptions | undefined;
-    if (options.maxChars !== undefined) {
-      style = options.style ?? DEFAULT_CUTOFF_FORMAT_STYLE;
-      // TODO: need more sophisticated locale negotiation if we want to add support for region/script/etc.-specific terminators in the future
-      const languageCode = new Intl.Locale(this.locale).language;
-      presetTerminatorOptions =
-        TERMINATOR_MAP[style][languageCode] ||
-        TERMINATOR_MAP[style][DEFAULT_TERMINATOR_KEY];
-    }
-    let terminator: ResolvedTerminatorOptions['terminator'] =
-      options.terminator ?? presetTerminatorOptions?.terminator;
-    let separator: ResolvedTerminatorOptions['separator'] =
+    // TODO: need more sophisticated locale negotiation if we want to add support for region/script/etc.-specific terminators in the future
+    const presetTerminatorOptions =
+      options.maxChars === undefined
+        ? undefined
+        : TERMINATOR_MAP[style][new Intl.Locale(this.locale).language] ||
+          TERMINATOR_MAP[style][DEFAULT_TERMINATOR_KEY];
+    let terminator = options.terminator ?? presetTerminatorOptions?.terminator;
+    let separator =
       terminator != null
         ? (options.separator ?? presetTerminatorOptions?.separator)
         : undefined;
-    // // Remove terminator and separator if maxChars does have enough space
+    // Remove terminator and separator if maxChars cannot fit them.
     this.additionLength = (terminator?.length ?? 0) + (separator?.length ?? 0);
     if (
       options.maxChars !== undefined &&
@@ -98,7 +91,7 @@ export class CutoffFormatConstructor implements CutoffFormat {
 
     this.options = {
       maxChars: options.maxChars,
-      style,
+      style: options.maxChars === undefined ? undefined : style,
       terminator,
       separator,
     };
@@ -135,8 +128,7 @@ export class CutoffFormatConstructor implements CutoffFormat {
   formatToParts(value: string): PrependedCutoffParts | PostpendedCutoffParts {
     const { maxChars, terminator, separator } = this.options;
 
-    // Slice our value
-    // const additionLength = (terminator?.length ?? 0) + (separator?.length ?? 0);
+    // Slice our value.
     const adjustedChars =
       maxChars === undefined || Math.abs(maxChars) >= value.length
         ? maxChars
@@ -166,11 +158,9 @@ export class CutoffFormatConstructor implements CutoffFormat {
         : [slicedValue, terminator];
     }
     // Prepended cutoff.
-    else {
-      return separator != null
-        ? [terminator, separator, slicedValue]
-        : [terminator, slicedValue];
-    }
+    return separator != null
+      ? [terminator, separator, slicedValue]
+      : [terminator, slicedValue];
   }
 
   /**

--- a/packages/format/src/formatting/format.ts
+++ b/packages/format/src/formatting/format.ts
@@ -1,41 +1,13 @@
-import { FormatVariables, I18nextMessage } from '../types';
+import { FormatVariables } from '../types';
 import { intlCache } from '../cache/IntlCache';
 import { libraryDefaultLocale } from '../settings/settings';
 import { IntlMessageFormat } from 'intl-messageformat';
-import { formatI18nextWarning, formatJsxWarning } from '../logging/warnings';
-import { warnFormatting } from '../logging/warnFormatting';
-import { JsxChildren } from '../types';
-import { CutoffFormatOptions } from './custom-formats/CutoffFormat/types';
 
-/**
- * Formats a string value with cutoff behavior according to the specified locales and options.
- *
- * @param {Object} params - The parameters for the cutoff formatting.
- * @param {string} params.value - The string value to format with cutoff behavior.
- * @param {string | string[]} [params.locales='en'] - The locales to use for formatting.
- * @param {CutoffFormatOptions} [params.options={}] - Additional options for cutoff formatting.
- * @param {number} [params.options.maxChars] - The maximum number of characters to display.
- * @param {CutoffFormatStyle} [params.options.style='ellipsis'] - The style of the terminator.
- * @param {string} [params.options.terminator] - Optional override for the terminator to use.
- * @param {string} [params.options.separator] - Optional override for the separator between terminator and value.
- *
- * @returns {string} The formatted string with terminator applied if cutoff occurs.
- * @internal
- *
- * @example
- * _formatCutoff({ value: 'Hello, world!', options: { maxChars: 8 } }); // Returns 'Hello, w...'
- */
-export function _formatCutoff({
-  value,
-  locales = libraryDefaultLocale,
-  options = {},
-}: {
-  value: string;
+type FormatParams<Value, Options> = {
+  value: Value;
   locales?: string | string[];
-  options?: CutoffFormatOptions;
-}): string {
-  return intlCache.get('CutoffFormat', locales, options).format(value);
-}
+  options?: Options;
+};
 
 /**
  * Formats a message according to the specified locales and options.
@@ -59,19 +31,6 @@ export function _formatMessageICU(
 }
 
 /**
- * Returns the message as-is without any formatting.
- *
- * @param {string} message - The message to return.
- * @returns {string} The original message, unchanged.
- * @internal
- *
- * TODO: Add this to custom formats.
- */
-export function _formatMessageString(message: string): string {
-  return message;
-}
-
-/**
  * Formats a number according to the specified locales and options.
  *
  * @param {Object} params - The parameters for the number formatting.
@@ -86,18 +45,13 @@ export function _formatNum({
   value,
   locales = [libraryDefaultLocale],
   options = {},
-}: {
-  value: number;
-  locales?: string | string[];
-  options?: Intl.NumberFormatOptions;
-}): string {
-  const res = intlCache
+}: FormatParams<number, Intl.NumberFormatOptions>): string {
+  return intlCache
     .get('NumberFormat', locales, {
       numberingSystem: 'latn',
       ...options,
     })
     .format(value);
-  return res;
 }
 
 /**
@@ -115,11 +69,7 @@ export function _formatDateTime({
   value,
   locales = [libraryDefaultLocale],
   options = {},
-}: {
-  value: Date;
-  locales?: string | string[];
-  options?: Intl.DateTimeFormatOptions;
-}): string {
+}: FormatParams<Date, Intl.DateTimeFormatOptions>): string {
   return intlCache
     .get('DateTimeFormat', locales, {
       calendar: 'gregory',
@@ -147,11 +97,9 @@ export function _formatCurrency({
   locales = [libraryDefaultLocale],
   currency = 'USD',
   options = {},
-}: {
+}: FormatParams<number, Intl.NumberFormatOptions> & {
   value: number;
   currency?: string;
-  locales?: string | string[];
-  options?: Intl.NumberFormatOptions;
 }): string {
   return intlCache
     .get('NumberFormat', locales, {
@@ -178,11 +126,7 @@ export function _formatList({
   value,
   locales = [libraryDefaultLocale],
   options = {},
-}: {
-  value: Array<string | number>;
-  locales?: string | string[];
-  options?: Intl.ListFormatOptions;
-}): string {
+}: FormatParams<Array<string | number>, Intl.ListFormatOptions>): string {
   return intlCache
     .get('ListFormat', locales, {
       type: 'conjunction', // Default type, can be overridden via options
@@ -205,11 +149,7 @@ export function _formatListToParts<T>({
   value,
   locales = [libraryDefaultLocale],
   options = {},
-}: {
-  value: Array<T>;
-  locales?: string | string[];
-  options?: Intl.ListFormatOptions;
-}) {
+}: FormatParams<Array<T>, Intl.ListFormatOptions>) {
   const formatListParts = intlCache
     .get('ListFormat', locales, {
       type: 'conjunction', // Default type, can be overridden via options
@@ -266,25 +206,6 @@ export function _selectRelativeTimeUnit(
 }
 
 /**
- * Formats a relative time from a Date, automatically selecting the best unit.
- * @internal
- */
-export function _formatRelativeTimeFromDate({
-  date,
-  baseDate,
-  locales = [libraryDefaultLocale],
-  options = {},
-}: {
-  date: Date;
-  baseDate: Date;
-  locales?: string | string[];
-  options?: Intl.RelativeTimeFormatOptions;
-}): string {
-  const { value, unit } = _selectRelativeTimeUnit(date, baseDate);
-  return _formatRelativeTime({ value, unit, locales, options });
-}
-
-/**
  * Formats a relative time value according to the specified locales and options.
  *
  * @param {Object} params - The parameters for the relative time formatting.
@@ -301,11 +222,8 @@ export function _formatRelativeTime({
   unit,
   locales = [libraryDefaultLocale],
   options = {},
-}: {
-  value: number;
+}: FormatParams<number, Intl.RelativeTimeFormatOptions> & {
   unit: Intl.RelativeTimeFormatUnit;
-  locales?: string | string[];
-  options?: Intl.RelativeTimeFormatOptions;
 }): string {
   return intlCache
     .get('RelativeTimeFormat', locales, {
@@ -314,40 +232,4 @@ export function _formatRelativeTime({
       ...options,
     })
     .format(value, unit);
-}
-
-/**
- * @experimental This function is not currently supported but will be implemented in a future version.
- * Use {@link _formatMessageICU} for current ICU message format support.
- * Formats an I18next message according to the specified locales and options.
- *
- * @param message - The I18next message to format.
- * @param variables - The variables to use for formatting.
- * @returns The formatted I18next message.
- * @internal
- */
-export function _formatI18next(
-  message: I18nextMessage,
-  _variables: FormatVariables = {}
-): string {
-  warnFormatting(formatI18nextWarning);
-  return message;
-}
-
-/**
- * @experimental This function is not currently supported but will be implemented in a future version.
- * Use {@link _formatMessageICU} for current ICU message format support.
- * Formats a JSX message according to the specified locales and options.
- *
- * @param message - The JSX message to format.
- * @param variables - The variables to use for formatting.
- * @returns The formatted JSX message.
- * @internal
- */
-export function _formatJsx(
-  message: JsxChildren,
-  _variables: FormatVariables = {}
-): JsxChildren {
-  warnFormatting(formatJsxWarning);
-  return message;
 }

--- a/packages/format/src/locales/__tests__/getLocaleProperties.test.ts
+++ b/packages/format/src/locales/__tests__/getLocaleProperties.test.ts
@@ -128,6 +128,22 @@ describe('_getLocaleProperties', () => {
     expect(result.emoji).toBe('🎯');
   });
 
+  it('should apply custom region-code display names', () => {
+    const customMapping: CustomMapping = {
+      'en-US': {
+        nameWithRegionCode: 'Custom English Region',
+        nativeNameWithRegionCode: 'Custom Native English Region',
+      },
+    };
+
+    const result = _getLocaleProperties('en-US', 'en', customMapping);
+
+    expect(result.nameWithRegionCode).toBe('Custom English Region');
+    expect(result.nativeNameWithRegionCode).toBe(
+      'Custom Native English Region'
+    );
+  });
+
   it('should handle custom mapping with region and script overrides', () => {
     const customMapping: CustomMapping = {
       'test-locale': {

--- a/packages/format/src/locales/customLocaleMapping.ts
+++ b/packages/format/src/locales/customLocaleMapping.ts
@@ -1,38 +1,32 @@
 import type { LocaleProperties } from './getLocaleProperties';
-import { _isValidLocale } from './isValidLocale';
 
-export type FullCustomMapping = Record<string, LocaleProperties>;
 export type CustomMapping = Record<string, string | Partial<LocaleProperties>>;
+
+function isCustomLocaleObject(
+  value: CustomMapping[string] | null | undefined
+): value is Partial<LocaleProperties> {
+  return typeof value === 'object' && value !== null;
+}
 
 export const getCustomProperty = (
   customMapping: CustomMapping,
   locale: string,
   property: keyof LocaleProperties
-): string | undefined => {
-  if (customMapping?.[locale]) {
-    if (typeof customMapping[locale] === 'string') {
-      return property === 'name' ? customMapping[locale] : undefined;
-    }
-    return customMapping[locale][property];
+) => {
+  const value = customMapping?.[locale];
+  if (!value) return undefined;
+  if (typeof value === 'string') {
+    return property === 'name' ? value : undefined;
   }
-  return undefined;
+  return value[property];
 };
 
-/**
- * Checks if a given locale should use the canonical locale.
- * @param locale - The locale to check if it should use the canonical locale
- * @param customMapping - The custom mapping to use for checking if the locale should use the canonical locale
- * @returns True if the locale should use the canonical locale, false otherwise
- */
-export const shouldUseCanonicalLocale = (
-  locale: string,
-  customMapping: CustomMapping
-): boolean => {
-  return !!(
-    customMapping?.[locale] &&
-    typeof customMapping[locale] === 'object' &&
-    'code' in (customMapping[locale] as object) &&
-    (customMapping[locale] as { code: string }).code &&
-    _isValidLocale((customMapping[locale] as { code: string }).code)
-  );
+export const getCustomLocaleCode = (
+  customMapping: CustomMapping | undefined,
+  locale: string
+) => {
+  const value = customMapping?.[locale];
+  return isCustomLocaleObject(value) && typeof value.code === 'string'
+    ? value.code
+    : undefined;
 };

--- a/packages/format/src/locales/determineLocale.ts
+++ b/packages/format/src/locales/determineLocale.ts
@@ -1,8 +1,33 @@
 import { _isValidLocale, _standardizeLocale } from './isValidLocale';
 import { _isSameLanguage } from './isSameLanguage';
-import { _isSameDialect } from './isSameDialect';
-import { _getLocaleProperties } from './getLocaleProperties';
+import {
+  _getLocaleProperties,
+  type LocaleProperties,
+} from './getLocaleProperties';
 import { CustomMapping } from './customLocaleMapping';
+
+function standardizeValidLocales(
+  locales: string[],
+  customMapping?: CustomMapping
+) {
+  return locales
+    .filter((locale) => _isValidLocale(locale, customMapping))
+    .map(_standardizeLocale);
+}
+
+function getMatchingCode(
+  locale: string,
+  { languageCode, minimizedCode, regionCode, scriptCode }: LocaleProperties,
+  candidates: Set<string>
+) {
+  const localeCodes = [
+    locale, // If the full locale is supported under this language category
+    `${languageCode}-${regionCode}`, // Attempt to match parts
+    `${languageCode}-${scriptCode}`,
+    minimizedCode, // If a minimized variant of this locale is supported
+  ];
+  return localeCodes.find((localeCode) => candidates.has(localeCode));
+}
 
 /**
  * Given a list of locales and a list of approved locales, sorted in preference order
@@ -14,48 +39,25 @@ export function _determineLocale(
   approvedLocales: string[],
   customMapping?: CustomMapping
 ): string | undefined {
-  if (typeof locales === 'string') locales = [locales];
-  locales = locales
-    .filter((locale) => _isValidLocale(locale, customMapping))
-    .map(_standardizeLocale);
-  approvedLocales = approvedLocales
-    .filter((locale) => _isValidLocale(locale, customMapping))
-    .map(_standardizeLocale);
+  locales = standardizeValidLocales(
+    Array.isArray(locales) ? locales : [locales],
+    customMapping
+  );
+  approvedLocales = standardizeValidLocales(approvedLocales, customMapping);
   for (const locale of locales) {
-    const candidates = approvedLocales.filter((approvedLocale) =>
-      _isSameLanguage(locale, approvedLocale)
+    const candidates = new Set(
+      approvedLocales.filter((approvedLocale) =>
+        _isSameLanguage(locale, approvedLocale)
+      )
     );
-    const getMatchingCode = ({
-      locale,
-      languageCode,
-      minimizedCode,
-      regionCode,
-      scriptCode,
-    }: {
-      locale: string;
-      languageCode: string;
-      minimizedCode: string;
-      regionCode: string;
-      scriptCode: string;
-    }) => {
-      const locales = [
-        locale, // If the full locale is supported under this language category
-        `${languageCode}-${regionCode}`, // Attempt to match parts
-        `${languageCode}-${scriptCode}`,
-        minimizedCode, // If a minimized variant of this locale is supported
-      ];
-      for (const l of locales) {
-        if (candidates.includes(l)) return l;
-      }
-      return null;
-    };
-    const { languageCode, ...codes } = _getLocaleProperties(locale);
+    const properties = _getLocaleProperties(locale);
     const matchingCode =
-      getMatchingCode({ locale, languageCode, ...codes }) ||
-      getMatchingCode({
-        locale: languageCode,
-        ..._getLocaleProperties(languageCode),
-      });
+      getMatchingCode(locale, properties, candidates) ||
+      getMatchingCode(
+        properties.languageCode,
+        _getLocaleProperties(properties.languageCode),
+        candidates
+      );
     if (matchingCode) return matchingCode;
   }
   return undefined;

--- a/packages/format/src/locales/getLocaleDirection.ts
+++ b/packages/format/src/locales/getLocaleDirection.ts
@@ -17,15 +17,19 @@ export function _getLocaleDirection(code: string): 'ltr' | 'rtl' {
       return textInfoDirection;
     }
   } catch {
-    // silent
+    // Fall back to language/script heuristics below.
   }
 
   // Fallback to simple heuristics
   const { scriptCode, languageCode } = _getLocaleProperties(code);
 
   // Handle RTL script or language
-  if (scriptCode) return isRtlScript(scriptCode) ? 'rtl' : 'ltr';
-  if (languageCode) return isRtlLanguage(languageCode) ? 'rtl' : 'ltr';
+  if (scriptCode) {
+    return RTL_SCRIPTS.has(scriptCode.toLowerCase()) ? 'rtl' : 'ltr';
+  }
+  if (languageCode) {
+    return RTL_LANGUAGES.has(languageCode.toLowerCase()) ? 'rtl' : 'ltr';
+  }
 
   return 'ltr';
 }
@@ -75,27 +79,13 @@ const RTL_LANGUAGES = new Set([
  * This is not supported by all browsers yet.
  * See: {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getTextInfo#browser_compatibility}
  */
-function extractDirectionWithTextInfo(
-  locale: Intl.Locale
-): 'ltr' | 'rtl' | undefined {
-  if (
+function extractDirectionWithTextInfo(locale: Intl.Locale) {
+  const direction =
     'textInfo' in locale &&
     typeof locale.textInfo === 'object' &&
     locale.textInfo !== null &&
-    'direction' in locale.textInfo &&
-    (locale.textInfo?.direction === 'rtl' ||
-      locale.textInfo?.direction === 'ltr')
-  ) {
-    return locale.textInfo?.direction;
-  }
-
-  return undefined;
-}
-
-function isRtlScript(script: string | undefined): boolean {
-  return script ? RTL_SCRIPTS.has(script.toLowerCase()) : false;
-}
-
-function isRtlLanguage(language: string | undefined): boolean {
-  return language ? RTL_LANGUAGES.has(language.toLowerCase()) : false;
+    'direction' in locale.textInfo
+      ? locale.textInfo.direction
+      : undefined;
+  return direction === 'rtl' || direction === 'ltr' ? direction : undefined;
 }

--- a/packages/format/src/locales/getLocaleEmoji.ts
+++ b/packages/format/src/locales/getLocaleEmoji.ts
@@ -1,10 +1,7 @@
 import { intlCache } from '../cache/IntlCache';
-import {
-  getCustomProperty,
-  shouldUseCanonicalLocale,
-  type CustomMapping,
-} from './customLocaleMapping';
+import { getCustomProperty, type CustomMapping } from './customLocaleMapping';
 import { _standardizeLocale } from './isValidLocale';
+import { _resolveCanonicalLocale } from './resolveCanonicalLocale';
 
 /**
  * @internal
@@ -14,9 +11,7 @@ export function _getLocaleEmoji(
   customMapping?: CustomMapping
 ): string {
   const aliasedLocale = locale;
-  if (customMapping && shouldUseCanonicalLocale(locale, customMapping)) {
-    locale = (customMapping[locale] as { code: string }).code;
-  }
+  locale = _resolveCanonicalLocale(locale, customMapping);
 
   try {
     const standardizedLocale = _standardizeLocale(locale);
@@ -322,11 +317,11 @@ const flagRegions = new Set([
 
 const regionalIndicatorOffset = 0x1f1e6 - 'A'.charCodeAt(0);
 
-export function getRegionEmoji(region: string): string {
+export function getRegionEmoji(region: string) {
   return getSupportedRegionEmoji(region) || defaultEmoji;
 }
 
-function getSupportedRegionEmoji(region: string): string | undefined {
+function getSupportedRegionEmoji(region: string) {
   const normalizedRegion = region.toUpperCase();
   const specialEmoji = specialRegionEmojis[normalizedRegion];
   if (specialEmoji) return specialEmoji;

--- a/packages/format/src/locales/getLocaleName.ts
+++ b/packages/format/src/locales/getLocaleName.ts
@@ -1,11 +1,8 @@
 import { intlCache } from '../cache/IntlCache';
 import { libraryDefaultLocale } from '../settings/settings';
-import {
-  CustomMapping,
-  getCustomProperty,
-  shouldUseCanonicalLocale,
-} from './customLocaleMapping';
+import { CustomMapping, getCustomProperty } from './customLocaleMapping';
 import { _standardizeLocale } from './isValidLocale';
+import { _resolveCanonicalLocale } from './resolveCanonicalLocale';
 
 /**
  * Retrieves the display name(s) of locale code(s) using Intl.DisplayNames.
@@ -22,10 +19,7 @@ export function _getLocaleName(
 ): string {
   // Check for canonical locale
   const aliasedLocale = locale;
-  if (customMapping && shouldUseCanonicalLocale(locale, customMapping)) {
-    // Override locale with canonical locale
-    locale = (customMapping[locale] as { code: string }).code;
-  }
+  locale = _resolveCanonicalLocale(locale, customMapping);
 
   defaultLocale ||= libraryDefaultLocale;
   try {

--- a/packages/format/src/locales/getLocaleProperties.ts
+++ b/packages/format/src/locales/getLocaleProperties.ts
@@ -3,7 +3,8 @@ import { defaultEmoji } from './getLocaleEmoji';
 import { _isValidLocale, _standardizeLocale } from './isValidLocale';
 import { _getLocaleEmoji } from './getLocaleEmoji';
 import { intlCache } from '../cache/IntlCache';
-import { CustomMapping, shouldUseCanonicalLocale } from './customLocaleMapping';
+import { CustomMapping } from './customLocaleMapping';
+import { _resolveCanonicalLocale } from './resolveCanonicalLocale';
 
 export type LocaleProperties = {
   // assume code = "de-AT", defaultLocale = "en-US"
@@ -55,21 +56,20 @@ export function createCustomLocaleProperties(
   lArray: string[],
   customMapping?: CustomMapping
 ): Partial<LocaleProperties> | undefined {
-  if (customMapping) {
-    let merged: Partial<LocaleProperties> = {};
-    for (const l of lArray) {
-      const value = customMapping[l];
-      if (value) {
-        if (typeof value === 'string') {
-          merged.name ||= value;
-        } else if (value) {
-          merged = { ...value, ...merged };
-        }
+  if (!customMapping) return undefined;
+
+  let merged: Partial<LocaleProperties> = {};
+  for (const l of lArray) {
+    const value = customMapping[l];
+    if (value) {
+      if (typeof value === 'string') {
+        merged.name ||= value;
+      } else {
+        merged = { ...value, ...merged };
       }
     }
-    return merged;
   }
-  return undefined;
+  return merged;
 }
 
 /**
@@ -82,10 +82,8 @@ export function _getLocaleProperties(
 ): LocaleProperties {
   // Check for canonical locale
   const aliasedLocale = locale;
-  if (customMapping && shouldUseCanonicalLocale(locale, customMapping)) {
-    // Override locale with canonical locale
-    locale = (customMapping[locale] as { code: string }).code;
-  }
+  // Override locale with canonical locale
+  locale = _resolveCanonicalLocale(locale, customMapping);
 
   defaultLocale ||= libraryDefaultLocale;
 
@@ -174,9 +172,8 @@ export function _getLocaleProperties(
       locale; // "Deutsch"
 
     const nameWithRegionCode =
-      customLocaleProperties?.nameWithRegionCode || baseRegion
-        ? `${languageName} (${baseRegion})`
-        : name; // German (AT)
+      customLocaleProperties?.nameWithRegionCode ||
+      (baseRegion ? `${languageName} (${baseRegion})` : name); // German (AT)
     const nativeNameWithRegionCode =
       customLocaleProperties?.nativeNameWithRegionCode ||
       (baseRegion ? `${nativeLanguageName} (${baseRegion})` : nativeName) ||
@@ -253,11 +250,10 @@ export function _getLocaleProperties(
     };
   } catch {
     let code = _isValidLocale(locale) ? _standardizeLocale(locale) : locale;
-    const codeParts = code?.split('-');
-    let languageCode = codeParts?.[0] || code || '';
-    let regionCode =
-      codeParts.length > 2 ? codeParts?.[2] : codeParts?.[1] || '';
-    let scriptCode = codeParts?.[3] || '';
+    const codeParts = code.split('-');
+    let languageCode = codeParts[0] || code;
+    let regionCode = codeParts.length > 2 ? codeParts[2] : codeParts[1] || '';
+    let scriptCode = codeParts[3] || '';
 
     const customLocaleProperties = createCustomLocaleProperties(
       [code, languageCode],

--- a/packages/format/src/locales/getRegionProperties.ts
+++ b/packages/format/src/locales/getRegionProperties.ts
@@ -23,25 +23,25 @@ export type CustomRegionMapping = {
  * @param {string} region - The region code to look up (e.g., `"US"`, `"GB"`, `"DE"`).
  * @param {string} [defaultLocale=libraryDefaultLocale] - The locale to use when localizing the region name.
  * @param {CustomRegionMapping} [customMapping] - Optional mapping of region codes to custom names and/or emojis.
- * @returns {{ code: string, name: string, emoji: string }} An object containing:
+ * @returns {{ code: string, name: string, emoji: string, locale?: string }} An object containing:
  *  - `code`: the input region code
  *  - `name`: the localized or custom region name
  *  - `emoji`: the matching emoji flag or symbol
- * @internal
+ *  - `locale`: the optional associated locale from custom mapping
  *
  * @example
- * _getRegionProperties('US', 'en');
+ * getRegionProperties('US', 'en');
  * // => { code: 'US', name: 'United States', emoji: '🇺🇸' }
  *
  * @example
- * _getRegionProperties('US', 'fr');
+ * getRegionProperties('US', 'fr');
  * // => { code: 'US', name: 'États-Unis', emoji: '🇺🇸' }
  *
  * @example
- * _getRegionProperties('US', 'en', { US: { name: 'USA', emoji: '🗽' } });
+ * getRegionProperties('US', 'en', { US: { name: 'USA', emoji: '🗽' } });
  * // => { code: 'US', name: 'USA', emoji: '🗽' }
  */
-export function _getRegionProperties(
+export function getRegionProperties(
   region: string,
   defaultLocale: string = libraryDefaultLocale,
   customMapping?: CustomRegionMapping
@@ -52,24 +52,18 @@ export function _getRegionProperties(
   locale?: string; // locale is a hidden return field, because we don't want to guarantee it, but we also need customMapping to work with it
 } {
   defaultLocale ||= libraryDefaultLocale;
+  let name = region;
+  let emoji = defaultEmoji;
   try {
     const displayNames = intlCache.get(
       'DisplayNames',
       [defaultLocale, libraryDefaultLocale], // default language order
       { type: 'region' }
     );
-    return {
-      code: region,
-      name: displayNames.of(region) || region,
-      emoji: getRegionEmoji(region),
-      ...customMapping?.[region],
-    };
+    name = displayNames.of(region) || region;
+    emoji = getRegionEmoji(region);
   } catch {
-    return {
-      code: region,
-      name: region,
-      emoji: defaultEmoji,
-      ...customMapping?.[region],
-    };
+    // Keep fallbacks initialized above.
   }
+  return { code: region, name, emoji, ...customMapping?.[region] };
 }

--- a/packages/format/src/locales/isSameDialect.ts
+++ b/packages/format/src/locales/isSameDialect.ts
@@ -1,23 +1,6 @@
 import { intlCache } from '../cache/IntlCache';
 import { _standardizeLocale } from './isValidLocale';
 
-function checkTwoLocalesAreSameDialect(codeA: string, codeB: string) {
-  const {
-    language: languageA,
-    region: regionA,
-    script: scriptA,
-  } = intlCache.get('Locale', codeA);
-  const {
-    language: languageB,
-    region: regionB,
-    script: scriptB,
-  } = intlCache.get('Locale', codeB);
-  if (languageA !== languageB) return false;
-  if (regionA && regionB && regionA !== regionB) return false;
-  if (scriptA && scriptB && scriptA !== scriptB) return false;
-  return true;
-}
-
 /**
  * Test two or more language codes to determine if they are exactly the same
  * e.g. "en-US" and "en" would be exactly the same.
@@ -28,18 +11,24 @@ function checkTwoLocalesAreSameDialect(codeA: string, codeB: string) {
 export function _isSameDialect(...locales: (string | string[])[]): boolean {
   try {
     // standardize codes
-    const flattenedCodes = locales.flat().map(_standardizeLocale);
+    const localeObjects = locales
+      .flat()
+      .map((locale) => intlCache.get('Locale', _standardizeLocale(locale)));
+    const [firstLocale] = localeObjects;
+    const regions = new Set(
+      localeObjects.map(({ region }) => region).filter(Boolean)
+    );
+    const scripts = new Set(
+      localeObjects.map(({ script }) => script).filter(Boolean)
+    );
 
-    for (let i = 0; i < flattenedCodes.length; i++) {
-      for (let j = i + 1; j < flattenedCodes.length; j++) {
-        if (
-          !checkTwoLocalesAreSameDialect(flattenedCodes[i], flattenedCodes[j])
-        )
-          return false;
-      }
-    }
-
-    return true;
+    return (
+      localeObjects.every(
+        ({ language }) => language === firstLocale?.language
+      ) &&
+      regions.size <= 1 &&
+      scripts.size <= 1
+    );
   } catch (error) {
     console.error(error);
     return false;

--- a/packages/format/src/locales/isValidLocale.ts
+++ b/packages/format/src/locales/isValidLocale.ts
@@ -1,10 +1,17 @@
 import { intlCache } from '../cache/IntlCache';
 import { libraryDefaultLocale } from '../settings/settings';
-import { CustomMapping } from './customLocaleMapping';
+import { getCustomLocaleCode, type CustomMapping } from './customLocaleMapping';
 
-const scriptExceptions = ['Cham', 'Jamo', 'Kawi', 'Lisu', 'Toto', 'Thai'];
+const scriptExceptions = new Set([
+  'Cham',
+  'Jamo',
+  'Kawi',
+  'Lisu',
+  'Toto',
+  'Thai',
+]);
 
-//// According to BCP 47, the range qaa–qtz is reserved for private-use language codes
+// According to BCP 47, the range qaa-qtz is reserved for private-use language codes
 const isCustomLanguage = (language: string) => {
   return language >= 'qaa' && language <= 'qtz';
 };
@@ -20,28 +27,13 @@ export const _isValidLocale = (
   locale: string,
   customMapping?: CustomMapping
 ): boolean => {
-  // If in custom mapping, return true
-  if (
-    customMapping?.[locale] &&
-    typeof customMapping[locale] === 'object' &&
-    'code' in (customMapping[locale] as object) &&
-    (customMapping[locale] as { code: string }).code
-  ) {
-    locale = (customMapping[locale] as { code: string }).code;
-  }
+  // Use the canonical code from custom mappings when one is configured.
+  locale = getCustomLocaleCode(customMapping, locale) || locale;
 
   try {
     const { language, region, script } = intlCache.get('Locale', locale);
-    if (
-      locale.split('-').length !==
-      (() => {
-        let partCount = 1;
-        if (region) partCount += 1;
-        if (script) partCount += 1;
-        return partCount;
-      })()
-    )
-      return false;
+    const partCount = 1 + Number(Boolean(region)) + Number(Boolean(script));
+    if (locale.split('-').length !== partCount) return false;
     const displayLanguageNames = intlCache.get(
       'DisplayNames',
       [libraryDefaultLocale],
@@ -74,7 +66,7 @@ export const _isValidLocale = (
       );
       if (
         displayScriptNames.of(script) === script &&
-        !scriptExceptions.includes(script)
+        !scriptExceptions.has(script)
       )
         return false;
     }

--- a/packages/format/src/locales/requiresTranslation.ts
+++ b/packages/format/src/locales/requiresTranslation.ts
@@ -16,13 +16,13 @@ export function _requiresTranslation(
   customMapping?: CustomMapping
 ): boolean {
   // If codes are invalid
+  const localesToValidate = [
+    sourceLocale,
+    targetLocale,
+    ...(approvedLocales ?? []),
+  ];
   if (
-    !_isValidLocale(sourceLocale, customMapping) ||
-    !_isValidLocale(targetLocale, customMapping) ||
-    (approvedLocales &&
-      approvedLocales.some(
-        (approvedLocale) => !_isValidLocale(approvedLocale, customMapping)
-      ))
+    localesToValidate.some((locale) => !_isValidLocale(locale, customMapping))
   ) {
     return false;
   }
@@ -34,14 +34,8 @@ export function _requiresTranslation(
 
   // Check that the target locale is within the approvedLocales scope, if not, a translation is not required
   // isSameLanguage rather than checkTwoLocalesAreSameDialect so we can show different dialects as a fallback
-  if (
-    approvedLocales &&
-    !approvedLocales.some((approvedLocale) =>
-      _isSameLanguage(targetLocale, approvedLocale)
-    )
-  ) {
-    return false;
-  }
-  // Otherwise, a translation is required!
-  return true;
+  if (!approvedLocales) return true;
+  return approvedLocales.some((approvedLocale) =>
+    _isSameLanguage(targetLocale, approvedLocale)
+  );
 }

--- a/packages/format/src/locales/resolveAliasLocale.ts
+++ b/packages/format/src/locales/resolveAliasLocale.ts
@@ -1,4 +1,4 @@
-import { CustomMapping } from './customLocaleMapping';
+import { getCustomLocaleCode, type CustomMapping } from './customLocaleMapping';
 
 /**
  * Resolves the alias locale for a given locale.
@@ -10,16 +10,11 @@ export function _resolveAliasLocale(
   locale: string,
   customMapping?: CustomMapping
 ): string {
-  let reverseCustomMapping: Record<string, string> | undefined;
-  if (customMapping) {
-    reverseCustomMapping = Object.fromEntries(
-      Object.entries(customMapping)
-        .filter(
-          ([, value]) => value && typeof value === 'object' && 'code' in value
-        )
-        .map(([key, value]) => [(value as { code: string }).code, key])
-    );
-  }
+  if (!customMapping) return locale;
 
-  return reverseCustomMapping?.[locale] || locale;
+  return (
+    Object.keys(customMapping).find(
+      (alias) => getCustomLocaleCode(customMapping, alias) === locale
+    ) ?? locale
+  );
 }

--- a/packages/format/src/locales/resolveCanonicalLocale.ts
+++ b/packages/format/src/locales/resolveCanonicalLocale.ts
@@ -1,5 +1,5 @@
-import { shouldUseCanonicalLocale } from './customLocaleMapping';
-import { CustomMapping } from './customLocaleMapping';
+import { getCustomLocaleCode, type CustomMapping } from './customLocaleMapping';
+import { _isValidLocale } from './isValidLocale';
 
 /**
  * Resolves the canonical locale for a given locale.
@@ -11,9 +11,8 @@ export function _resolveCanonicalLocale(
   locale: string,
   customMapping?: CustomMapping
 ): string {
-  if (customMapping && shouldUseCanonicalLocale(locale, customMapping)) {
-    return (customMapping[locale] as { code: string }).code;
-  }
-
-  return locale;
+  const customLocaleCode = getCustomLocaleCode(customMapping, locale);
+  return customLocaleCode && _isValidLocale(customLocaleCode)
+    ? customLocaleCode
+    : locale;
 }

--- a/packages/format/src/logging/warnFormatting.ts
+++ b/packages/format/src/logging/warnFormatting.ts
@@ -1,6 +1,0 @@
-export function warnFormatting(message: string): void {
-  if (typeof process !== 'undefined' && process.env?._GT_LOG_LEVEL === 'off') {
-    return;
-  }
-  console.warn(message);
-}

--- a/packages/format/src/logging/warnings.ts
+++ b/packages/format/src/logging/warnings.ts
@@ -1,5 +1,0 @@
-export const formatI18nextWarning =
-  'Warning: formatI18next is not currently supported but will be implemented in a future version. Use _formatMessageICU for current ICU message format support.';
-
-export const formatJsxWarning =
-  'Warning: formatJsx is not currently supported but will be implemented in a future version. Use _formatMessageICU for current ICU message format support.';


### PR DESCRIPTION
## TL;DR

Fix custom locale region display-name overrides and simplify shared format/locale helper internals.

## Code Changes

- Honor custom `nameWithRegionCode` and `nativeNameWithRegionCode` values in `getLocaleProperties`.
- Simplify format wrappers, locale alias/canonical helpers, and Intl cache plumbing.
- Preserve runtime compatibility for JS callers that omit standalone formatting options, even where TypeScript marks options as required.
- Remove unused formatting warning helpers.
- Add a patch changeset for `@generaltranslation/format` and `generaltranslation`.
- Apply existing changelog formatting fixes so root formatting passes.

## Notes / Flags

- Public behavior change is patch-level: custom region-code display-name overrides now take effect.
- Verified with targeted format/core tests and typechecks, `@generaltranslation/format` export tests, `generaltranslation` build/test, root `pnpm format`, and root `pnpm lint`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a JavaScript operator-precedence bug that prevented custom `nameWithRegionCode` locale display-name overrides from taking effect, and simultaneously simplifies the internal formatting and locale helper plumbing by removing dead wrappers, inlining logic, and tightening types.

- **Core bug fix** (`getLocaleProperties.ts`): The old expression `customLocaleProperties?.nameWithRegionCode || baseRegion ? ... : name` was parsed as `(customLocaleProperties?.nameWithRegionCode || baseRegion) ? ... : name`, so a custom override was silently discarded whenever `baseRegion` was truthy. The fix adds parens to restore the intended semantics.
- **Dead-code removal**: Several internal wrapper functions (`_formatCutoff`, `_formatMessageString`, `_formatRelativeTimeFromDate`, `_formatI18next`, `_formatJsx`, `warnFormatting`, `warnings`) are removed; their call sites are inlined or re-routed to the public API.
- **Type and API cleanup**: `options` is made optional for all public formatting functions, `FormatVariables` is re-exported from `@generaltranslation/core`, and the `isSameDialect` logic is rewritten as a set-based O(n) check while preserving equivalent semantics.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the operator-precedence fix is targeted and correct, all simplification refactors preserve equivalent semantics, and the public API changes are strictly backwards compatible.

The core bug fix is a one-line parenthesisation that directly maps to the failing test case added in the PR. Every refactored function was verified to produce the same outputs across the relevant edge cases (empty arrays, locales with/without region/script, custom alias mappings). Making options optional on formatting functions is additive and does not break existing callers. Dead-code removal carries no runtime risk since none of those paths were reachable in production.

No files require special attention. The resolveAliasLocale.ts change has a harmless ordering difference when multiple aliases map to the same canonical code, but this scenario is not part of any documented contract.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/format/src/locales/getLocaleProperties.ts | Fixes operator-precedence bug in nameWithRegionCode; custom override now correctly takes effect. Also switches from shouldUseCanonicalLocale to _resolveCanonicalLocale and removes null-coalescing dead code in the catch branch. |
| packages/format/src/locales/isSameDialect.ts | Replaces O(n²) pairwise loop with a set-based O(n) approach; semantics preserved across all language/region/script combinations tested. |
| packages/format/src/locales/resolveCanonicalLocale.ts | Replaces shouldUseCanonicalLocale with getCustomLocaleCode + _isValidLocale guard; equivalent behavior with cleaner extraction. |
| packages/format/src/locales/customLocaleMapping.ts | Removes shouldUseCanonicalLocale and FullCustomMapping; adds getCustomLocaleCode helper and isCustomLocaleObject type guard. Cleaner and less duplicated across callers. |
| packages/format/src/locales/resolveAliasLocale.ts | Replaces pre-built reverse map with Object.keys().find(). When multiple aliases map to the same canonical code, the old code returned the last alias while the new code returns the first — a minor ordering difference in an edge case unlikely to matter in practice. |
| packages/format/src/formatting/format.ts | Removes dead wrappers (_formatCutoff, _formatMessageString, _formatRelativeTimeFromDate, _formatI18next, _formatJsx); introduces shared FormatParams generic to DRY up parameter shapes. |
| packages/format/src/core.ts | All public format functions now accept optional options (previously required with required locales), preserving JS runtime compatibility. getRegionProperties re-exported directly from its module. |
| packages/format/src/LocaleConfig.ts | Removes private helper methods that were simple one-liners by inlining equivalent logic; CutoffFormat and relative-time formatting now use intlCache directly. |
| packages/format/src/cache/IntlCache.ts | Minor cleanup: drops constructor body in favour of field initializer, renames _generateKey to generateKey (private so no API impact), and removes double-write on cache miss. |
| packages/format/src/locales/isValidLocale.ts | scriptExceptions converted from array to Set for O(1) lookup; canonical code resolution now uses getCustomLocaleCode; partCount calculation simplified with Number(Boolean(...)). |
| packages/format/src/locales/requiresTranslation.ts | Validation loop unified into a single array; early-return logic inverted to return the approvedLocales.some(...) result directly. No semantic change. |
| packages/format/src/locales/determineLocale.ts | Inner getMatchingCode extracted as a module-level function; candidates now use a Set; standardizeValidLocales helper avoids code duplication between the two locale arrays. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["getLocaleProperties(locale, defaultLocale, customMapping)"] --> B["_resolveCanonicalLocale(locale, customMapping)"]
    B --> C{"getCustomLocaleCode returns code\n&& _isValidLocale(code)?"}
    C -- yes --> D["use canonical code"]
    C -- no --> E["use original locale"]
    D & E --> F["createCustomLocaleProperties(lArray, customMapping)"]
    F --> G["Build LocaleProperties via Intl APIs"]
    G --> H{"customLocaleProperties?.nameWithRegionCode?"}
    H -- yes --> I["use custom nameWithRegionCode"]
    H -- no --> J{"baseRegion present?"}
    J -- yes --> K["languageName (baseRegion)"]
    J -- no --> L["name"]
    I & K & L --> M["Return LocaleProperties"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: honor custom locale region display ..."](https://github.com/generaltranslation/gt/commit/c9c2137237953b9845a3ee9606dafd9c68928e72) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31843240)</sub>

<!-- /greptile_comment -->