### PR TITLE
ci: format changelogs after versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
+          version: pnpm run version-packages
           publish: pnpm run release
           commit: '[ci] release'
           title: '[ci] release'

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "format": "oxfmt --check .",
     "format:fix": "oxfmt .",
     "changeset": "changeset",
-    "version-packages": "changeset version"
+    "version-packages": "changeset version && oxfmt packages/*/CHANGELOG.md"
   },
   "repository": {
     "type": "git",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1083,7 +1083,6 @@
   https://generaltranslation.com/blog/generaltranslation_v8
 
   Please update the following packages to the latest version:
-
   - generaltranslation: `7.9.1` or later
   - gtx-cli: `2.4.15` or later
   - gt-sanity: `1.0.11` or later

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -300,7 +300,6 @@
   https://generaltranslation.com/blog/generaltranslation_v8
 
   Please update the following packages to the latest version:
-
   - generaltranslation: `7.9.1` or later
   - gtx-cli: `2.4.15` or later
   - gt-sanity: `1.0.11` or later

--- a/packages/sanity/CHANGELOG.md
+++ b/packages/sanity/CHANGELOG.md
@@ -354,7 +354,6 @@
   https://generaltranslation.com/blog/generaltranslation_v8
 
   Please update the following packages to the latest version:
-
   - generaltranslation: `7.9.1` or later
   - gtx-cli: `2.4.15` or later
   - gt-sanity: `1.0.11` or later


### PR DESCRIPTION
## TL;DR

Run `oxfmt` on package changelogs after Changesets versions packages so generated release PRs do not fail formatting or lint checks.

## Code Changes

- Updates `version-packages` to run `changeset version && oxfmt packages/*/CHANGELOG.md`.
- Configures `changesets/action` to use `pnpm run version-packages` for release PR generation.
- Applies the current changelog formatting cleanup that the new command produces.

## Notes / Flags

- Verified with `pnpm version-packages`, `pnpm format`, `pnpm lint`, and `git diff --check`.
- `pnpm version-packages` prints a harmless Changesets warning when there are no unreleased changesets, then exits successfully and formats changelogs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ensures that Changesets-generated release PRs pass the repo's `oxfmt` formatting checks by running `oxfmt packages/*/CHANGELOG.md` immediately after `changeset version`. It wires that new `version-packages` script into the `changesets/action` workflow so the generated PR is always formatter-clean.

- **`package.json`**: Extends the `version-packages` script with `&& oxfmt packages/*/CHANGELOG.md` so changelogs are written-formatted after every version bump.
- **`.github/workflows/release.yml`**: Adds `version: pnpm run version-packages` to `changesets/action`, replacing the default bare `changeset version` call.
- **`packages/*/CHANGELOG.md`**: Applies the one-time cleanup (removes a stray blank line before a list) that the new formatting command would now produce on every run.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a small, focused CI change with no runtime impact on published packages.

The change is narrow: one extra command appended to `version-packages` and one new `version:` key in the workflow. The shell glob `packages/*/CHANGELOG.md` correctly covers all 21 existing package changelogs, `oxfmt` runs in write mode (not check mode), and `&&` ensures it only fires after a successful `changeset version`. The three CHANGELOG edits are cosmetic pre-cleanup. Nothing here touches the publish path or any production artifact.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Adds `&& oxfmt packages/*/CHANGELOG.md` to `version-packages`; glob correctly covers all 21 existing package changelogs at the shallow `packages/*/` level. |
| .github/workflows/release.yml | Adds `version: pnpm run version-packages` to `changesets/action`, routing changelog generation through the new formatting-aware script. |
| packages/cli/CHANGELOG.md | One-time formatting cleanup: removes a stray blank line before a list item, consistent with what `oxfmt` now enforces. |
| packages/core/CHANGELOG.md | Same one-time blank-line removal as the other CHANGELOG files. |
| packages/sanity/CHANGELOG.md | Same one-time blank-line removal as the other CHANGELOG files. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: format changelogs after versioning"](https://github.com/generaltranslation/gt/commit/64c8af72dd2678cf580dae2edfb004221e7fa408) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31844733)</sub>

<!-- /greptile_comment -->