### PR TITLE
refactor: simplify diagnostic helpers

### DIFF
--- a/.changeset/quick-trees-sparkle.md
+++ b/.changeset/quick-trees-sparkle.md
@@ -1,0 +1,12 @@
+---
+"generaltranslation": patch
+"gt-i18n": patch
+"@generaltranslation/react-core": patch
+"gt-react": patch
+"gt-react-native": patch
+"gt-next": patch
+"gt": patch
+"gt-sanity": patch
+---
+
+Improve diagnostic messages and package-local diagnostic formatting.

--- a/packages/cli/src/api/saveLocalEdits.ts
+++ b/packages/cli/src/api/saveLocalEdits.ts
@@ -5,6 +5,7 @@ import { gt } from '../utils/gt.js';
 import { BranchStep } from '../workflows/steps/BranchStep.js';
 import { logErrorAndExit } from '../console/logging.js';
 import { logger } from '../console/logger.js';
+import { branchResolutionError } from '../console/index.js';
 import type { FileReference } from 'generaltranslation/types';
 import chalk from 'chalk';
 import { runPublishWorkflow } from '../workflows/publish.js';
@@ -26,9 +27,7 @@ export async function saveLocalEdits(settings: Settings): Promise<void> {
   const branchResult = await branchStep.run();
   await branchStep.wait();
   if (!branchResult) {
-    return logErrorAndExit(
-      'The current git branch could not be resolved. Specify a branch explicitly or run the command from a git worktree with branch metadata available.'
-    );
+    return logErrorAndExit(branchResolutionError);
   }
 
   const uploads = files.map((file) => ({

--- a/packages/cli/src/console/index.ts
+++ b/packages/cli/src/console/index.ts
@@ -408,3 +408,7 @@ export const devApiKeyError = `Development API keys cannot be used with the Gene
 export const noProjectIdError = `No project ID was found. Pass --project-id, add projectId to gt.config.json, or set the GT_PROJECT_ID environment variable.`;
 export const noVersionIdError = `No version ID was found. Pass --version-id or add _versionId to gt.config.json.`;
 export const invalidConfigurationError = `The files configuration cannot be used for this operation. Provide a valid download configuration or set --publish true to upload translations to the CDN.`;
+export const branchResolutionError = `The current git branch could not be resolved. Specify a branch explicitly or run the command from a git worktree with branch metadata available.`;
+
+export const withOriginalError = (message: string, error: unknown): string =>
+  `${message} Original error: ${String(error)}`;

--- a/packages/cli/src/console/index.ts
+++ b/packages/cli/src/console/index.ts
@@ -411,4 +411,4 @@ export const invalidConfigurationError = `The files configuration cannot be used
 export const branchResolutionError = `The current git branch could not be resolved. Specify a branch explicitly or run the command from a git worktree with branch metadata available.`;
 
 export const withOriginalError = (message: string, error: unknown): string =>
-  `${message} Original error: ${String(error)}`;
+  error != null ? `${message} Original error: ${String(error)}` : message;

--- a/packages/cli/src/workflows/download.ts
+++ b/packages/cli/src/workflows/download.ts
@@ -9,6 +9,7 @@ import {
 } from './steps/PollJobsStep.js';
 import { DownloadTranslationsStep } from './steps/DownloadStep.js';
 import { BranchData } from '../types/branch.js';
+import { branchResolutionError } from '../console/index.js';
 import { logErrorAndExit } from '../console/logging.js';
 import { logger } from '../console/logger.js';
 import { recordWarning } from '../state/translateWarnings.js';
@@ -62,9 +63,7 @@ export async function runDownloadWorkflow({
     const branchResult = await branchStep.run();
     await branchStep.wait();
     if (!branchResult) {
-      return logErrorAndExit(
-        'The current git branch could not be resolved. Specify a branch explicitly or run the command from a git worktree with branch metadata available.'
-      );
+      return logErrorAndExit(branchResolutionError);
     }
     branchData = branchResult;
   }

--- a/packages/cli/src/workflows/enqueue.ts
+++ b/packages/cli/src/workflows/enqueue.ts
@@ -1,4 +1,5 @@
 import { logCollectedFiles, logErrorAndExit } from '../console/logging.js';
+import { branchResolutionError, withOriginalError } from '../console/index.js';
 import { Settings, TranslateFlags } from '../types/index.js';
 import { gt } from '../utils/gt.js';
 import { EnqueueFilesResult, FileToUpload } from 'generaltranslation/types';
@@ -40,9 +41,7 @@ export async function runEnqueueWorkflow({
     const branchData = await branchStep.run();
     await branchStep.wait();
     if (!branchData) {
-      return logErrorAndExit(
-        'The current git branch could not be resolved. Specify a branch explicitly or run the command from a git worktree with branch metadata available.'
-      );
+      return logErrorAndExit(branchResolutionError);
     }
     logger.debug('Branch data: ' + JSON.stringify(branchData, null, 2));
 
@@ -61,8 +60,10 @@ export async function runEnqueueWorkflow({
     return enqueueResult;
   } catch (error) {
     return logErrorAndExit(
-      'Translations could not be enqueued. Check the files, branch configuration, and API credentials, then try again. Original error: ' +
+      withOriginalError(
+        'Translations could not be enqueued. Check the files, branch configuration, and API credentials, then try again.',
         error
+      )
     );
   }
 }

--- a/packages/cli/src/workflows/setupProject.ts
+++ b/packages/cli/src/workflows/setupProject.ts
@@ -1,4 +1,5 @@
 import { logErrorAndExit } from '../console/logging.js';
+import { branchResolutionError, withOriginalError } from '../console/index.js';
 import { Settings, TranslateFlags } from '../types/index.js';
 import { gt } from '../utils/gt.js';
 import { FileToUpload } from 'generaltranslation/types';
@@ -40,9 +41,7 @@ export async function runSetupProjectWorkflow(
     await branchStep.wait();
 
     if (!branchData) {
-      return logErrorAndExit(
-        'The current git branch could not be resolved. Specify a branch explicitly or run the command from a git worktree with branch metadata available.'
-      );
+      return logErrorAndExit(branchResolutionError);
     }
 
     // then run the upload step
@@ -56,8 +55,10 @@ export async function runSetupProjectWorkflow(
     return { branchData };
   } catch (error) {
     return logErrorAndExit(
-      'Project setup could not be completed. Check the files, branch configuration, and API credentials, then try again. Original error: ' +
+      withOriginalError(
+        'Project setup could not be completed. Check the files, branch configuration, and API credentials, then try again.',
         error
+      )
     );
   }
 }

--- a/packages/cli/src/workflows/stage.ts
+++ b/packages/cli/src/workflows/stage.ts
@@ -1,4 +1,5 @@
 import { logCollectedFiles, logErrorAndExit } from '../console/logging.js';
+import { branchResolutionError, withOriginalError } from '../console/index.js';
 import { logger } from '../console/logger.js';
 import { Settings, TranslateFlags } from '../types/index.js';
 import { gt } from '../utils/gt.js';
@@ -49,9 +50,7 @@ export async function runStageFilesWorkflow({
     const branchData = await branchStep.run();
     await branchStep.wait();
     if (!branchData) {
-      return logErrorAndExit(
-        'The current git branch could not be resolved. Specify a branch explicitly or run the command from a git worktree with branch metadata available.'
-      );
+      return logErrorAndExit(branchResolutionError);
     }
 
     // then run the upload step
@@ -87,8 +86,10 @@ export async function runStageFilesWorkflow({
     return { branchData, enqueueResult };
   } catch (error) {
     return logErrorAndExit(
-      'Files could not be sent for translation. Check the files, branch configuration, and API credentials, then try again. Original error: ' +
+      withOriginalError(
+        'Files could not be sent for translation. Check the files, branch configuration, and API credentials, then try again.',
         error
+      )
     );
   }
 }

--- a/packages/cli/src/workflows/upload.ts
+++ b/packages/cli/src/workflows/upload.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import { branchResolutionError, withOriginalError } from '../console/index.js';
 import { logger } from '../console/logger.js';
 import { logErrorAndExit } from '../console/logging.js';
 import { Settings } from '../types/index.js';
@@ -47,9 +48,7 @@ export async function runUploadFilesWorkflow({
     await branchStep.wait();
 
     if (!branchData) {
-      return logErrorAndExit(
-        'The current git branch could not be resolved. Specify a branch explicitly or run the command from a git worktree with branch metadata available.'
-      );
+      return logErrorAndExit(branchResolutionError);
     }
 
     await uploadStep.run({ files: files.map((f) => f.source), branchData });
@@ -71,8 +70,10 @@ export async function runUploadFilesWorkflow({
     return { branchData };
   } catch (error) {
     return logErrorAndExit(
-      'Files could not be uploaded. Check the files, branch configuration, and API credentials, then try again. Original error: ' +
+      withOriginalError(
+        'Files could not be uploaded. Check the files, branch configuration, and API credentials, then try again.',
         error
+      )
     );
   }
 }

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -3,7 +3,10 @@ export {
   defaultCacheUrl,
   defaultRuntimeApiUrl,
 } from './settings/settingsUrls';
-export { createDiagnosticMessage } from './logging/diagnostics';
+export {
+  createDiagnosticMessage,
+  formatDiagnosticErrorDetails,
+} from './logging/diagnostics';
 export type {
   DiagnosticMessageInput,
   DiagnosticSeverity,

--- a/packages/core/src/logging/__tests__/diagnostics.test.ts
+++ b/packages/core/src/logging/__tests__/diagnostics.test.ts
@@ -44,6 +44,17 @@ describe('createDiagnosticMessage', () => {
     );
   });
 
+  it('omits empty details', () => {
+    expect(
+      createDiagnosticMessage({
+        source: 'GT',
+        severity: 'Warning',
+        whatHappened: 'Translation hashes do not match',
+        details: [],
+      })
+    ).toBe('GT Warning: Translation hashes do not match.');
+  });
+
   it('formats message bodies without a source prefix', () => {
     expect(
       createDiagnosticMessage({

--- a/packages/core/src/logging/diagnostics.ts
+++ b/packages/core/src/logging/diagnostics.ts
@@ -44,6 +44,13 @@ function formatDetails(details: string | string[] | undefined): string {
   return ensureSentence(`Details: ${detailText}`);
 }
 
+export function formatDiagnosticErrorDetails(
+  error: unknown
+): string | undefined {
+  if (error == null) return undefined;
+  return String(error);
+}
+
 export function createDiagnosticMessage({
   source,
   severity,

--- a/packages/core/src/logging/diagnostics.ts
+++ b/packages/core/src/logging/diagnostics.ts
@@ -40,6 +40,7 @@ function lowercaseFirstWord(text: string): string {
 function formatDetails(details: string | string[] | undefined): string {
   if (!details) return '';
   const detailText = Array.isArray(details) ? details.join(', ') : details;
+  if (!detailText.trim()) return '';
   return ensureSentence(`Details: ${detailText}`);
 }
 

--- a/packages/next/src/errors/cacheComponents.ts
+++ b/packages/next/src/errors/cacheComponents.ts
@@ -1,25 +1,26 @@
-import { createDiagnosticMessage } from 'generaltranslation/internal';
+import {
+  createGtNextDiagnostic,
+  formatDiagnosticErrorDetails,
+} from './diagnostics';
 
 // ---- ERRORS ---- //
-export const cacheComponentsLegacySsgConflictError = createDiagnosticMessage({
-  source: 'gt-next',
+export const cacheComponentsLegacySsgConflictError = createGtNextDiagnostic({
   severity: 'Error',
   whatHappened:
     'experimentalLocaleResolution and deprecated experimentalEnableSSG are both enabled',
   fix: 'Disable one of them before building your app',
 });
 
-export const experimentalLocaleResolutionError =
-  createDiagnosticMessage({
-    source: 'gt-next',
+export const createExperimentalLocaleResolutionError = (error: unknown) =>
+  createGtNextDiagnostic({
     whatHappened: 'Locale resolution with experimentalLocaleResolution failed',
     wayOut: 'gt-next will fall back where possible',
-  }) + ' Original error: ';
+    details: formatDiagnosticErrorDetails(error),
+  });
 
 // ---- WARNINGS ---- //
 export const cacheComponentsMissingExperimentalLocaleResolutionWarning =
-  createDiagnosticMessage({
-    source: 'gt-next',
+  createGtNextDiagnostic({
     whatHappened:
       'cacheComponents is enabled, but experimentalLocaleResolution is not enabled',
     fix: 'Enable experimentalLocaleResolution so i18n can work inside cached components',
@@ -35,8 +36,7 @@ export const cacheComponentsExperimentalLocaleResolutionDisableCustomGetLocaleWa
   'gt-next: experimentalLocaleResolution is enabled. The provided getLocale function will be ignored.';
 
 export const cacheComponentsNonLocalTranslationsWarning =
-  createDiagnosticMessage({
-    source: 'gt-next',
+  createGtNextDiagnostic({
     severity: 'Warning',
     whatHappened:
       'cacheComponents is enabled, but translations are not stored locally',

--- a/packages/next/src/errors/createErrors.ts
+++ b/packages/next/src/errors/createErrors.ts
@@ -1,11 +1,14 @@
 // ---- ERRORS ---- //
 
 import { getLocaleProperties } from '@generaltranslation/format';
-import { createDiagnosticMessage } from 'generaltranslation/internal';
+import {
+  createGtNextDiagnostic,
+  createGtNextPluginDiagnostic,
+  formatDiagnosticErrorDetails,
+} from './diagnostics';
 import { BABEL_PLUGIN_SUPPORT, SWC_PLUGIN_SUPPORT } from '../plugin/constants';
 
-export const remoteTranslationsError = createDiagnosticMessage({
-  source: 'gt-next',
+export const remoteTranslationsError = createGtNextDiagnostic({
   severity: 'Error',
   whatHappened: 'Remote translations could not be loaded',
   fix: 'Check your project ID, API key, and network connection, then try again',
@@ -13,24 +16,21 @@ export const remoteTranslationsError = createDiagnosticMessage({
 });
 
 export const customLoadTranslationsError = (locale: string = '') =>
-  createDiagnosticMessage({
-    source: 'gt-next',
+  createGtNextDiagnostic({
     severity: 'Error',
     whatHappened: `Locally stored translations could not be loaded${locale ? ` for "${locale}"` : ''}`,
     fix: 'If you use loadTranslations(), make sure it returns translations for the requested locale',
   });
 
 export const customLoadDictionaryWarning = (locale: string = '') =>
-  createDiagnosticMessage({
-    source: 'gt-next',
+  createGtNextDiagnostic({
     severity: 'Warning',
     whatHappened: `The local dictionary could not be loaded${locale ? ` for "${locale}"` : ''}`,
     fix: 'If you use loadDictionary(), make sure it returns a dictionary for the requested locale',
   });
 
 export const createUnresolvedNextVersionError = (error: Error) =>
-  createDiagnosticMessage({
-    source: 'gt-next',
+  createGtNextDiagnostic({
     severity: 'Error',
     whatHappened: 'The installed Next.js version could not be resolved',
     fix: 'Check that next is installed in this project',
@@ -38,8 +38,7 @@ export const createUnresolvedNextVersionError = (error: Error) =>
   });
 
 export const createUnresolvedReactVersionError = (error: Error) =>
-  createDiagnosticMessage({
-    source: 'gt-next',
+  createGtNextDiagnostic({
     severity: 'Error',
     whatHappened: 'The installed React version could not be resolved',
     fix: 'Check that react is installed in this project',
@@ -51,8 +50,7 @@ export const createStringTranslationError = (
   id?: string,
   functionName = 'tx'
 ) =>
-  createDiagnosticMessage({
-    source: 'gt-next',
+  createGtNextDiagnostic({
     severity: 'Error',
     whatHappened: `${functionName}("${string}")${id ? ` with id "${id}"` : ''} could not find a translation`,
     wayOut: 'Source content will render as a fallback',
@@ -60,54 +58,47 @@ export const createStringTranslationError = (
   });
 
 export const createDictionaryTranslationError = (id: string) =>
-  createDiagnosticMessage({
-    source: 'gt-next',
+  createGtNextDiagnostic({
     severity: 'Error',
     whatHappened: `Dictionary translation entry "${id}" could not be found`,
     fix: 'Check that the id exists in your dictionary or push translations again',
   });
 
 export const createRequiredPrefixError = (id: string, requiredPrefix: string) =>
-  createDiagnosticMessage({
-    source: 'gt-next',
+  createGtNextDiagnostic({
     severity: 'Error',
     whatHappened: `<GTProvider> is scoped to prefix "${requiredPrefix}", but a child uses id "${id}"`,
     fix: 'Change the <GTProvider> id prop or move the child under the matching dictionary subtree',
   });
 
-export const devApiKeyIncludedInProductionError = createDiagnosticMessage({
-  source: 'gt-next',
+export const devApiKeyIncludedInProductionError = createGtNextDiagnostic({
   severity: 'Error',
   whatHappened: 'Production builds cannot use a development API key',
   fix: 'Replace it with a production API key',
 });
 
 export const createDictionarySubsetError = (id: string, functionName: string) =>
-  createDiagnosticMessage({
-    source: 'gt-next',
+  createGtNextDiagnostic({
     severity: 'Error',
     whatHappened: `${functionName} with id "${id}" could not read a valid dictionary subtree`,
     fix: 'Make sure the id maps to the correct subroute of the dictionary',
   });
 
-export const dictionaryDisabledError = createDiagnosticMessage({
-  source: 'gt-next',
+export const dictionaryDisabledError = createGtNextDiagnostic({
   severity: 'Error',
   whatHappened: 'Dictionaries are not enabled',
   fix: 'Add the withGTConfig() plugin to your Next.js config before using dictionary translations',
   docsUrl: 'https://generaltranslation.com/docs',
 });
 
-export const unresolvedCustomLoadDictionaryError = createDiagnosticMessage({
-  source: 'gt-next',
+export const unresolvedCustomLoadDictionaryError = createGtNextDiagnostic({
   severity: 'Error',
   whatHappened:
     'loadDictionary() was found during the build but could not be resolved at runtime',
   fix: 'Export a loadDictionary() function from the configured file',
 });
 
-export const unresolvedCustomLoadTranslationsError = createDiagnosticMessage({
-  source: 'gt-next',
+export const unresolvedCustomLoadTranslationsError = createGtNextDiagnostic({
   severity: 'Error',
   whatHappened:
     'loadTranslations() was found during the build but could not be resolved at runtime',
@@ -115,24 +106,21 @@ export const unresolvedCustomLoadTranslationsError = createDiagnosticMessage({
 });
 
 export const unresolvedLoadDictionaryBuildError = (path: string) =>
-  createDiagnosticMessage({
-    source: 'gt-next',
+  createGtNextDiagnostic({
     severity: 'Error',
     whatHappened: `The file defining loadDictionary() could not be resolved at ${path}`,
     fix: 'Check the configured path and try again',
   });
 
 export const unresolvedLoadTranslationsBuildError = (path: string) =>
-  createDiagnosticMessage({
-    source: 'gt-next',
+  createGtNextDiagnostic({
     severity: 'Error',
     whatHappened: `The file defining loadTranslations() could not be resolved at ${path}`,
     fix: 'Check the configured path and try again',
   });
 
 export const unresolvedGetLocaleBuildError = (path: string) =>
-  createDiagnosticMessage({
-    source: 'gt-next',
+  createGtNextDiagnostic({
     severity: 'Error',
     whatHappened: `The file defining custom getLocale() could not be resolved at ${path}`,
     fix: 'Check the configured path and try again',
@@ -145,8 +133,7 @@ export const conflictingConfigurationBuildError = (conflicts: string[]) =>
     '\n'
   )}`;
 
-export const typesFileError = createDiagnosticMessage({
-  source: 'gt-next',
+export const typesFileError = createGtNextDiagnostic({
   severity: 'Error',
   whatHappened: 'A types-only entry point was executed at runtime',
   fix: 'Import from the appropriate gt-next runtime entry point instead',
@@ -162,8 +149,7 @@ export const txUseClientError =
   `Use <T> with variables, or render <Tx> from a server component.`;
 
 export const missingVariablesError = (variables: string[], message: string) =>
-  createDiagnosticMessage({
-    source: 'gt-next',
+  createGtNextDiagnostic({
     severity: 'Error',
     whatHappened: `The message "${message}" is missing variables: "${variables.join('", "')}"`,
     fix: 'Provide values for these variables before rendering the translation',
@@ -171,18 +157,18 @@ export const missingVariablesError = (variables: string[], message: string) =>
 
 export const createStringRenderError = (
   message: string,
-  id: string | undefined
+  id: string | undefined,
+  error?: unknown
 ) =>
-  createDiagnosticMessage({
-    source: 'gt-next',
+  createGtNextDiagnostic({
     severity: 'Error',
     whatHappened: `The string ${id ? `for id "${id}" ` : ''}could not be rendered`,
     fix: `Check the message syntax and variables for: "${message}"`,
+    details: formatDiagnosticErrorDetails(error),
   });
 
 export const invalidLocalesError = (locales: string[]) =>
-  createDiagnosticMessage({
-    source: 'gt-next',
+  createGtNextDiagnostic({
     severity: 'Error',
     whatHappened: 'Invalid locale codes in your configuration',
     fix: 'Specify a list of valid locales or use "customMapping" to define aliases for the invalid locales',
@@ -190,8 +176,7 @@ export const invalidLocalesError = (locales: string[]) =>
   });
 
 export const invalidCanonicalLocalesError = (locales: string[]) =>
-  createDiagnosticMessage({
-    source: 'gt-next',
+  createGtNextDiagnostic({
     severity: 'Error',
     whatHappened: 'Invalid canonical locale codes in your configuration',
     fix: 'Use valid BCP 47 locale codes before starting translation',
@@ -199,8 +184,7 @@ export const invalidCanonicalLocalesError = (locales: string[]) =>
   });
 
 export const createInvalidIcuDictionaryEntryError = (id: string) =>
-  createDiagnosticMessage({
-    source: 'gt-next',
+  createGtNextDiagnostic({
     severity: 'Error',
     whatHappened: `Dictionary entry "${id}" contains invalid ICU syntax`,
     fix: 'Fix the ICU message before rendering this translation',
@@ -209,43 +193,37 @@ export const createInvalidIcuDictionaryEntryError = (id: string) =>
 // ---- WARNINGS ---- //
 
 export const createInvalidIcuDictionaryEntryWarning = (id: string) =>
-  createDiagnosticMessage({
-    source: 'gt-next',
+  createGtNextDiagnostic({
     whatHappened: `Dictionary entry "${id}" contains invalid ICU syntax`,
     wayOut: 'Source content will render as a fallback until the entry is fixed',
   });
 
 export const createBadFilepathWarning = (filename: string, dir: string[]) =>
-  createDiagnosticMessage({
-    source: 'gt-next',
+  createGtNextDiagnostic({
     whatHappened: `${filename} was found in ${dir.join(' or ')}, which is not supported`,
     fix: 'Move it to your project root so gt-next can load it',
   });
 
-export const usingDefaultsWarning = createDiagnosticMessage({
-  source: 'gt-next',
+export const usingDefaultsWarning = createGtNextDiagnostic({
   whatHappened: 'The gt-next configuration could not be loaded',
   wayOut: 'Defaults will be used',
   fix: 'Check your config path if this was unexpected',
 });
 
 export const createNoEntryFoundWarning = (id: string) =>
-  createDiagnosticMessage({
-    source: 'gt-next',
+  createGtNextDiagnostic({
     whatHappened: `No valid dictionary entry was found for id "${id}"`,
     wayOut: 'Source content will render as a fallback',
   });
 
 export const createInvalidDictionaryEntryWarning = (id: string) =>
-  createDiagnosticMessage({
-    source: 'gt-next',
+  createGtNextDiagnostic({
     whatHappened: `Dictionary entry "${id}" is invalid`,
     wayOut: 'Source content will render as a fallback until the entry is fixed',
   });
 
 export const createInvalidDictionaryTranslationEntryWarning = (id: string) =>
-  createDiagnosticMessage({
-    source: 'gt-next',
+  createGtNextDiagnostic({
     whatHappened: `Dictionary translation entry "${id}" is invalid`,
     wayOut: 'Source content will render as a fallback until the entry is fixed',
   });
@@ -262,16 +240,14 @@ export const createMismatchingHashWarning = (
   expectedHash: string,
   receivedHash: string
 ) =>
-  createDiagnosticMessage({
-    source: 'gt-next',
+  createGtNextDiagnostic({
     whatHappened: 'Translation hashes do not match',
     reassurance: 'The translation will still render',
     fix: 'Update your translations to the newest version to avoid stale content',
     details: [`expected ${expectedHash}`, `received ${receivedHash}`],
   });
 
-export const projectIdMissingWarn = createDiagnosticMessage({
-  source: 'gt-next',
+export const projectIdMissingWarn = createGtNextDiagnostic({
   whatHappened: 'Runtime translation needs a project ID',
   fix: 'Set GT_PROJECT_ID in your environment or pass projectId to withGTConfig()',
   docsUrl: 'https://generaltranslation.com/dashboard',
@@ -283,8 +259,7 @@ export const noInitGTWarn =
   `and set the projectId and apiKey in your environment. ` +
   `For more information, visit https://generaltranslation.com/docs/next/tutorials/quickstart`;
 
-export const APIKeyMissingWarn = createDiagnosticMessage({
-  source: 'gt-next (plugin)',
+export const APIKeyMissingWarn = createGtNextPluginDiagnostic({
   whatHappened: 'Runtime translation needs a development API key',
   fix: 'Find your development API key at generaltranslation.com/dashboard, or set runtimeUrl to an empty string to disable runtime translation',
 });
@@ -304,13 +279,11 @@ export const createTranslationLoadingWarning = ({
   `In development, hot-reloaded translations may not be be displayed until the page is refreshed. ` +
   `In production, translations will be preloaded and there won't be a warning.`;
 
-export const runtimeTranslationTimeoutWarning = createDiagnosticMessage({
-  source: 'gt-next',
+export const runtimeTranslationTimeoutWarning = createGtNextDiagnostic({
   whatHappened: 'Runtime translation timed out',
 });
 
-export const dictionaryNotFoundWarning = createDiagnosticMessage({
-  source: 'gt-next',
+export const dictionaryNotFoundWarning = createGtNextDiagnostic({
   whatHappened: 'No dictionary was found',
   fix: 'Add dictionary.js or [defaultLocale].json to your project, and make sure withGTConfig() is enabled',
 });
@@ -339,13 +312,14 @@ export const disablingCompileTimeHashWarning = `gt-next (plugin): Compile-time h
 
 export const createStringRenderWarning = (
   message: string,
-  id: string | undefined
+  id: string | undefined,
+  error?: unknown
 ) =>
-  createDiagnosticMessage({
-    source: 'gt-next',
+  createGtNextDiagnostic({
     whatHappened: `The string ${id ? `for id "${id}" ` : ''}could not be rendered`,
     wayOut: 'Source content will render as a fallback',
     fix: `Check the message syntax and variables for: "${message}"`,
+    details: formatDiagnosticErrorDetails(error),
   });
 
 export const swcPluginCompatibilityChangeWarning = `gt-next (plugin): As of gt-next@6.12.4, SWC plugin support is disabled for Next.js versions prior to ${SWC_PLUGIN_SUPPORT}. Update to the latest version of Next.js.`;

--- a/packages/next/src/errors/diagnostics.ts
+++ b/packages/next/src/errors/diagnostics.ts
@@ -1,0 +1,29 @@
+import {
+  createDiagnosticMessage,
+  type DiagnosticMessageInput,
+} from 'generaltranslation/internal';
+
+type GtNextDiagnosticInput = Omit<DiagnosticMessageInput, 'source'>;
+
+export function createGtNextDiagnostic(input: GtNextDiagnosticInput): string {
+  return createDiagnosticMessage({
+    source: 'gt-next',
+    ...input,
+  });
+}
+
+export function createGtNextPluginDiagnostic(
+  input: GtNextDiagnosticInput
+): string {
+  return createDiagnosticMessage({
+    source: 'gt-next (plugin)',
+    ...input,
+  });
+}
+
+export function formatDiagnosticErrorDetails(
+  error: unknown
+): string | undefined {
+  if (error == null) return undefined;
+  return String(error);
+}

--- a/packages/next/src/errors/diagnostics.ts
+++ b/packages/next/src/errors/diagnostics.ts
@@ -1,5 +1,6 @@
 import {
   createDiagnosticMessage,
+  formatDiagnosticErrorDetails,
   type DiagnosticMessageInput,
 } from 'generaltranslation/internal';
 
@@ -21,9 +22,4 @@ export function createGtNextPluginDiagnostic(
   });
 }
 
-export function formatDiagnosticErrorDetails(
-  error: unknown
-): string | undefined {
-  if (error == null) return undefined;
-  return String(error);
-}
+export { formatDiagnosticErrorDetails };

--- a/packages/next/src/errors/ssg.ts
+++ b/packages/next/src/errors/ssg.ts
@@ -1,11 +1,13 @@
-import { createDiagnosticMessage } from 'generaltranslation/internal';
+import {
+  createGtNextDiagnostic,
+  formatDiagnosticErrorDetails,
+} from './diagnostics';
 import { DEPRECATED_REQUEST_FUNCTION_TO_CONFIG_KEY } from '../config-dir/props/withGTConfigProps';
 import { RequestFunctions, StaticRequestFunctions } from '../request/types';
 
 // ========== ERRORS ========== //
 
-export const ssgMissingGetStaticLocaleFunctionError = createDiagnosticMessage({
-  source: 'gt-next',
+export const ssgMissingGetStaticLocaleFunctionError = createGtNextDiagnostic({
   whatHappened: 'SSG is enabled, but getStaticLocale() is not configured',
   fix: 'Define getStaticLocale() so gt-next can resolve locales during static generation',
   docsUrl: 'https://generaltranslation.com/en/docs/next/guides/ssg',
@@ -14,8 +16,7 @@ export const ssgMissingGetStaticLocaleFunctionError = createDiagnosticMessage({
 // ========== WARNINGS ========== //
 
 // This was (1) triggered by SSG without running middleware, or (2) triggered by a request with no locale headers (also no middleware).
-export const noLocalesCouldBeDeterminedWarning = createDiagnosticMessage({
-  source: 'gt-next',
+export const noLocalesCouldBeDeterminedWarning = createGtNextDiagnostic({
   whatHappened: 'No locale could be determined for this request',
   wayOut: 'gt-next will fall back to the default locale',
   fix: 'If you use SSG, configure locale resolution',
@@ -33,31 +34,32 @@ export const createSsgMissingCustomFunctionWarning = (
     ? ''
     : `gt-next: ${functionName.replace('Static', '')}() was invoked during SSG. ${createCustomSSGFunctionSuffix(functionName)}`;
 
-export const invalidSSGConfigurationWarning = createDiagnosticMessage({
-  source: 'gt-next',
+export const invalidSSGConfigurationWarning = createGtNextDiagnostic({
   whatHappened: 'SSG is in use, but withGTConfig() is not configured for SSG',
   fix: 'Add the SSG configuration before building static localized pages',
   docsUrl: 'https://generaltranslation.com/en/docs/next/guides/ssg',
 });
 
 export const createGetRequestFunctionWarning = (
-  functionName: RequestFunctions | StaticRequestFunctions
+  functionName: RequestFunctions | StaticRequestFunctions,
+  error?: unknown
 ) =>
-  createDiagnosticMessage({
-    source: 'gt-next',
+  createGtNextDiagnostic({
     whatHappened: `${functionName}() could not be resolved`,
     wayOut: 'gt-next will fall back where possible',
     fix: 'Check that the function is exported from the configured request file',
+    details: formatDiagnosticErrorDetails(error),
   });
 
 export const createCustomGetRequestFunctionWarning = (
-  functionName: RequestFunctions | StaticRequestFunctions
+  functionName: RequestFunctions | StaticRequestFunctions,
+  error?: unknown
 ) =>
-  createDiagnosticMessage({
-    source: 'gt-next',
+  createGtNextDiagnostic({
     whatHappened: `Custom ${functionName}() could not be resolved`,
     wayOut: 'gt-next will fall back where possible',
     fix: 'Check that the function is exported from the configured request file',
+    details: formatDiagnosticErrorDetails(error),
   });
 
 export const createSsrFunctionDuringSsgWarning = (
@@ -65,21 +67,20 @@ export const createSsrFunctionDuringSsgWarning = (
 ) =>
   process.env._GENERALTRANSLATION_DISABLE_SSG_WARNINGS === 'true'
     ? ''
-    : createDiagnosticMessage({
-        source: 'gt-next',
+    : createGtNextDiagnostic({
         whatHappened: `${functionName}() was invoked during SSG`,
         wayOut: 'Rendering will likely fall back to SSR behavior',
         fix: 'Define a static locale function to avoid this fallback',
       });
 
-export const ssrDetectionFailedWarning = createDiagnosticMessage({
-  source: 'gt-next',
-  whatHappened: 'The runtime mode could not be determined as SSR or SSG',
-  wayOut: 'gt-next will fall back to SSR behavior',
-});
+export const createSsrDetectionFailedWarning = (error: unknown) =>
+  createGtNextDiagnostic({
+    whatHappened: 'The runtime mode could not be determined as SSR or SSG',
+    wayOut: 'gt-next will fall back to SSR behavior',
+    details: formatDiagnosticErrorDetails(error),
+  });
 
-export const deprecatedExperimentalEnableSSGWarning = createDiagnosticMessage({
-  source: 'gt-next',
+export const deprecatedExperimentalEnableSSGWarning = createGtNextDiagnostic({
   whatHappened:
     'experimentalEnableSSG is deprecated and will be removed in a future version',
   fix: 'Move to experimentalLocaleResolution when you update your SSG configuration',

--- a/packages/next/src/request/utils/getRequestFunction.ts
+++ b/packages/next/src/request/utils/getRequestFunction.ts
@@ -5,7 +5,7 @@ import {
 } from '../../errors/ssg';
 import { getRootParam } from '@generaltranslation/next-internal';
 import { defaultExperimentalLocaleResolutionParam } from '../../utils/constants';
-import { experimentalLocaleResolutionError } from '../../errors/cacheComponents';
+import { createExperimentalLocaleResolutionError } from '../../errors/cacheComponents';
 import { getI18NConfig } from '../../config-dir/getI18NConfig';
 
 /**
@@ -68,7 +68,7 @@ function handleExperimentalLocaleResolution(
           ? unverifiedLocale
           : undefined;
       } catch (error) {
-        console.warn(experimentalLocaleResolutionError + error);
+        console.warn(createExperimentalLocaleResolutionError(error));
         return undefined;
       }
     };
@@ -109,9 +109,7 @@ function getModule(functionName: RequestFunctions):
       module,
     };
   } catch (error) {
-    console.warn(
-      createGetRequestFunctionWarning(functionName) + ' Error: ' + error
-    );
+    console.warn(createGetRequestFunctionWarning(functionName, error));
     return {
       error: true,
       module: undefined as never,
@@ -188,9 +186,7 @@ function extractCustomFunction(
     }
     throw new Error(undefinedNamespaceError);
   } catch (error) {
-    console.warn(
-      createCustomGetRequestFunctionWarning(functionName) + ' Error: ' + error
-    );
+    console.warn(createCustomGetRequestFunctionWarning(functionName, error));
     return {
       error: true,
       value: undefined as never,

--- a/packages/next/src/request/utils/isSSR.ts
+++ b/packages/next/src/request/utils/isSSR.ts
@@ -1,5 +1,5 @@
 import { PHASE_PRODUCTION_BUILD } from 'next/constants';
-import { ssrDetectionFailedWarning } from '../../errors/ssg';
+import { createSsrDetectionFailedWarning } from '../../errors/ssg';
 
 /**
  * @deprecated
@@ -22,7 +22,7 @@ export function isSSR() {
       return false;
     }
   } catch (error) {
-    console.warn(ssrDetectionFailedWarning + ' Error: ' + error);
+    console.warn(createSsrDetectionFailedWarning(error));
   }
   return isSSR;
 }

--- a/packages/next/src/request/utils/legacyGetRequestFunction.ts
+++ b/packages/next/src/request/utils/legacyGetRequestFunction.ts
@@ -109,9 +109,7 @@ function getModule(functionName: RequestFunctions | StaticRequestFunctions):
       module,
     };
   } catch (error) {
-    console.warn(
-      createGetRequestFunctionWarning(functionName) + ' Error: ' + error
-    );
+    console.warn(createGetRequestFunctionWarning(functionName, error));
     return {
       error: true,
       module: undefined as never,
@@ -202,9 +200,7 @@ function extractCustomFunction(
     }
     throw new Error(undefinedNamespaceError);
   } catch (error) {
-    console.warn(
-      createCustomGetRequestFunctionWarning(functionName) + ' Error: ' + error
-    );
+    console.warn(createCustomGetRequestFunctionWarning(functionName, error));
     return {
       error: true,
       value: undefined as never,

--- a/packages/next/src/server-dir/buildtime/getTranslationFunction.ts
+++ b/packages/next/src/server-dir/buildtime/getTranslationFunction.ts
@@ -118,15 +118,14 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
       return cutoffMessage;
     } catch (error) {
       if (process.env.NODE_ENV === 'production') {
-        console.warn(createStringRenderWarning(message, id), 'Error: ', error);
+        console.warn(createStringRenderWarning(message, id, error));
       } else {
         // (3) If no fallback, throw error (non-prod)
-        if (!fallback)
-          throw new Error(
-            `${createStringRenderError(message, id)} Error: ${error}`
-          );
+        if (!fallback) {
+          throw new Error(createStringRenderError(message, id, error));
+        }
 
-        console.error(createStringRenderError(message, id), 'Error: ', error);
+        console.error(createStringRenderError(message, id, error));
       }
 
       // (2) If format fails, format fallback

--- a/packages/react-core/src/errors-dir/createErrors.ts
+++ b/packages/react-core/src/errors-dir/createErrors.ts
@@ -1,65 +1,60 @@
 import { getLocaleProperties } from '@generaltranslation/format';
-import { createDiagnosticMessage } from 'generaltranslation/internal';
+import {
+  createReactCoreDiagnostic,
+  formatDiagnosticErrorDetails,
+} from './diagnostics';
 import { PACKAGE_NAME } from './constants';
 
 // ---- ERRORS ---- //
 
-export const projectIdMissingError = createDiagnosticMessage({
-  source: PACKAGE_NAME,
+export const projectIdMissingError = createReactCoreDiagnostic({
   severity: 'Error',
   whatHappened: 'Runtime translation needs a project ID',
   fix: 'Add projectId to your <GTProvider> configuration or set GT_PROJECT_ID in your environment',
   docsUrl: 'https://generaltranslation.com/dashboard',
 });
 
-export const devApiKeyProductionError = createDiagnosticMessage({
-  source: PACKAGE_NAME,
+export const devApiKeyProductionError = createReactCoreDiagnostic({
   severity: 'Error',
   whatHappened: 'Production environments cannot use a development API key',
   fix: 'Replace it with a production API key before deploying',
 });
 
-export const apiKeyInProductionError = createDiagnosticMessage({
-  source: PACKAGE_NAME,
+export const apiKeyInProductionError = createReactCoreDiagnostic({
   severity: 'Error',
   whatHappened: 'The API key is available to client-side production code',
   fix: 'Move translation credentials to a server-only environment before deploying',
 });
 
-export const createNoAuthError = createDiagnosticMessage({
-  source: PACKAGE_NAME,
+export const createNoAuthError = createReactCoreDiagnostic({
   severity: 'Error',
   whatHappened: 'Runtime translation is not configured',
   fix: 'Add projectId and devApiKey to your environment, or pass them to <GTProvider> directly',
 });
 
 export const createPluralMissingError = (children: unknown) =>
-  createDiagnosticMessage({
-    source: PACKAGE_NAME,
+  createReactCoreDiagnostic({
     severity: 'Error',
     whatHappened: `<Plural> could not choose a plural form for "${children}"`,
     fix: 'Pass the required "n" option to <Plural>',
   });
 
 export const createClientSideTDictionaryCollisionError = (id: string) =>
-  createDiagnosticMessage({
-    source: PACKAGE_NAME,
+  createReactCoreDiagnostic({
     severity: 'Error',
     whatHappened: `<T id="${id}"> conflicts with a dictionary entry using the same ID`,
     fix: 'Rename the <T> id or the dictionary key so each translation source has a unique ID',
   });
 
 export const createClientSideTHydrationError = (id: string) =>
-  createDiagnosticMessage({
-    source: PACKAGE_NAME,
+  createReactCoreDiagnostic({
     severity: 'Error',
     whatHappened: `<T id="${id}"> is rendering in a client component without a saved translation`,
     why: 'This can cause hydration mismatches',
     fix: 'Use a dictionary with useGT() or push translations from the command line before rendering this component on the client',
   });
 
-export const dynamicTranslationError = createDiagnosticMessage({
-  source: PACKAGE_NAME,
+export const dynamicTranslationError = createReactCoreDiagnostic({
   severity: 'Error',
   whatHappened: 'Runtime translations could not be loaded',
   wayOut: 'Source content will render as a fallback',
@@ -68,52 +63,40 @@ export const dynamicTranslationError = createDiagnosticMessage({
 
 export const createGenericRuntimeTranslationError = (
   id: string | undefined,
-  hash: string
-) => {
-  if (!id) {
-    return createDiagnosticMessage({
-      source: PACKAGE_NAME,
-      severity: 'Error',
-      whatHappened: `Translation could not be found for hash "${hash}"`,
-      wayOut: 'Source content will render as a fallback',
-      fix: 'Push translations again or check that runtime translation is configured',
-    });
-  } else {
-    return createDiagnosticMessage({
-      source: PACKAGE_NAME,
-      severity: 'Error',
-      whatHappened: `Translation could not be found for id "${id}" and hash "${hash}"`,
-      wayOut: 'Source content will render as a fallback',
-      fix: 'Push translations again or check that runtime translation is configured',
-    });
-  }
-};
+  hash: string,
+  error?: unknown
+) =>
+  createReactCoreDiagnostic({
+    severity: 'Error',
+    whatHappened: id
+      ? `Translation could not be found for id "${id}" and hash "${hash}"`
+      : `Translation could not be found for hash "${hash}"`,
+    wayOut: 'Source content will render as a fallback',
+    fix: 'Push translations again or check that runtime translation is configured',
+    details: formatDiagnosticErrorDetails(error),
+  });
 
-export const runtimeTranslationError = createDiagnosticMessage({
-  source: PACKAGE_NAME,
+export const runtimeTranslationError = createReactCoreDiagnostic({
   severity: 'Error',
   whatHappened: 'Runtime translation could not be completed',
 });
 
 export const customLoadTranslationsError = (locale: string = '') =>
-  createDiagnosticMessage({
-    source: PACKAGE_NAME,
+  createReactCoreDiagnostic({
     severity: 'Error',
     whatHappened: `Locally stored translations could not be loaded${locale ? ` for "${locale}"` : ''}`,
     fix: 'If you use loadTranslations(), make sure it returns translations for the requested locale',
   });
 
 export const customLoadDictionaryWarning = (locale: string = '') =>
-  createDiagnosticMessage({
-    source: PACKAGE_NAME,
+  createReactCoreDiagnostic({
     severity: 'Warning',
     whatHappened: `The local dictionary could not be loaded${locale ? ` for "${locale}"` : ''}`,
     fix: 'If you use loadDictionary(), make sure it returns a dictionary for the requested locale',
   });
 
 export const missingVariablesError = (variables: string[], message: string) =>
-  createDiagnosticMessage({
-    source: PACKAGE_NAME,
+  createReactCoreDiagnostic({
     severity: 'Error',
     whatHappened: `The message "${message}" is missing variables: "${variables.join('", "')}"`,
     fix: 'Provide values for these variables before rendering the translation',
@@ -121,13 +104,14 @@ export const missingVariablesError = (variables: string[], message: string) =>
 
 export const createStringRenderError = (
   message: string,
-  id: string | undefined
+  id: string | undefined,
+  error?: unknown
 ) =>
-  createDiagnosticMessage({
-    source: PACKAGE_NAME,
+  createReactCoreDiagnostic({
     severity: 'Error',
     whatHappened: `The string ${id ? `for id "${id}" ` : ''}could not be rendered`,
     fix: `Check the message syntax and variables for: "${message}"`,
+    details: formatDiagnosticErrorDetails(error),
   });
 
 export const createStringTranslationError = (
@@ -135,8 +119,7 @@ export const createStringTranslationError = (
   id?: string,
   functionName = 'tx'
 ) =>
-  createDiagnosticMessage({
-    source: PACKAGE_NAME,
+  createReactCoreDiagnostic({
     severity: 'Error',
     whatHappened: `${functionName}("${string}")${id ? ` with id "${id}"` : ''} could not find a translation`,
     wayOut: 'Source content will render as a fallback',
@@ -144,8 +127,7 @@ export const createStringTranslationError = (
   });
 
 export const invalidLocalesError = (locales: string[]) =>
-  createDiagnosticMessage({
-    source: PACKAGE_NAME,
+  createReactCoreDiagnostic({
     severity: 'Error',
     whatHappened: 'Invalid locale codes in your configuration',
     fix: 'Specify a list of valid locales or use "customMapping" to define aliases for the invalid locales',
@@ -153,8 +135,7 @@ export const invalidLocalesError = (locales: string[]) =>
   });
 
 export const invalidCanonicalLocalesError = (locales: string[]) =>
-  createDiagnosticMessage({
-    source: PACKAGE_NAME,
+  createReactCoreDiagnostic({
     severity: 'Error',
     whatHappened: 'Invalid canonical locale codes in your configuration',
     fix: 'Use valid BCP 47 locale codes before starting translation',
@@ -162,32 +143,28 @@ export const invalidCanonicalLocalesError = (locales: string[]) =>
   });
 
 export const createEmptyIdError = () =>
-  createDiagnosticMessage({
-    source: PACKAGE_NAME,
+  createReactCoreDiagnostic({
     severity: 'Error',
     whatHappened: 't.obj() received an empty id',
     fix: 'Pass a non-empty dictionary id',
   });
 
 export const createSubtreeNotFoundError = (id: string) =>
-  createDiagnosticMessage({
-    source: PACKAGE_NAME,
+  createReactCoreDiagnostic({
     severity: 'Error',
     whatHappened: `Dictionary subtree "${id}" could not be found`,
     fix: 'Check that the id matches your dictionary structure',
   });
 
 export const createDictionaryEntryError = () =>
-  createDiagnosticMessage({
-    source: PACKAGE_NAME,
+  createReactCoreDiagnostic({
     severity: 'Error',
     whatHappened: 'A dictionary entry cannot be injected as a subtree',
     fix: 'Pass a dictionary object instead',
   });
 
 export const createCannotInjectDictionaryEntryError = () =>
-  createDiagnosticMessage({
-    source: PACKAGE_NAME,
+  createReactCoreDiagnostic({
     severity: 'Error',
     whatHappened:
       'A dictionary entry cannot be merged into another dictionary entry',
@@ -195,8 +172,7 @@ export const createCannotInjectDictionaryEntryError = () =>
   });
 
 export const createInvalidIcuDictionaryEntryError = (id: string | undefined) =>
-  createDiagnosticMessage({
-    source: PACKAGE_NAME,
+  createReactCoreDiagnostic({
     severity: 'Error',
     whatHappened: `Dictionary entry "${id}" contains invalid ICU syntax`,
     fix: 'Fix the ICU message before rendering this translation',
@@ -204,8 +180,7 @@ export const createInvalidIcuDictionaryEntryError = (id: string | undefined) =>
 
 // ---- WARNINGS ---- //
 
-export const projectIdMissingWarning = createDiagnosticMessage({
-  source: PACKAGE_NAME,
+export const projectIdMissingWarning = createReactCoreDiagnostic({
   severity: 'Warning',
   whatHappened: 'Runtime translation needs a project ID',
   fix: 'Add projectId to <GTProvider> or set GT_PROJECT_ID in your environment',
@@ -213,24 +188,21 @@ export const projectIdMissingWarning = createDiagnosticMessage({
 });
 
 export const createNoEntryFoundWarning = (id: string) =>
-  createDiagnosticMessage({
-    source: PACKAGE_NAME,
+  createReactCoreDiagnostic({
     severity: 'Warning',
     whatHappened: `No valid dictionary entry was found for id "${id}"`,
     wayOut: 'Source content will render as a fallback',
   });
 
 export const createInvalidDictionaryEntryWarning = (id: string) =>
-  createDiagnosticMessage({
-    source: PACKAGE_NAME,
+  createReactCoreDiagnostic({
     severity: 'Warning',
     whatHappened: `Dictionary entry "${id}" is invalid`,
     wayOut: 'Source content will render as a fallback until the entry is fixed',
   });
 
 export const createInvalidIcuDictionaryEntryWarning = (id: string) =>
-  createDiagnosticMessage({
-    source: PACKAGE_NAME,
+  createReactCoreDiagnostic({
     severity: 'Warning',
     whatHappened: `Dictionary entry "${id}" contains invalid ICU syntax`,
     wayOut: 'Source content will render as a fallback until the entry is fixed',
@@ -240,8 +212,7 @@ export const createNoEntryTranslationWarning = (
   id: string,
   prefixedId: string
 ) =>
-  createDiagnosticMessage({
-    source: PACKAGE_NAME,
+  createReactCoreDiagnostic({
     severity: 'Warning',
     whatHappened: `t("${id}") could not find a translation for dictionary item "${prefixedId}"`,
     wayOut: 'Source content will render as a fallback',
@@ -251,8 +222,7 @@ export const createMismatchingHashWarning = (
   expectedHash: string,
   receivedHash: string
 ) =>
-  createDiagnosticMessage({
-    source: PACKAGE_NAME,
+  createReactCoreDiagnostic({
     severity: 'Warning',
     whatHappened: 'Translation hashes do not match',
     reassurance: 'The translation will still render',
@@ -260,8 +230,7 @@ export const createMismatchingHashWarning = (
     details: [`expected ${expectedHash}`, `received ${receivedHash}`],
   });
 
-export const APIKeyMissingWarn = createDiagnosticMessage({
-  source: PACKAGE_NAME,
+export const APIKeyMissingWarn = createReactCoreDiagnostic({
   severity: 'Warning',
   whatHappened: 'Runtime translation needs a development API key',
   fix: 'Find your development API key at generaltranslation.com/dashboard, or set runtimeUrl to an empty string to disable runtime translation',
@@ -275,8 +244,7 @@ export const createUnsupportedLocalesWarning = (locales: string[]) =>
     })
     .join(', ')}`;
 
-export const runtimeTranslationTimeoutWarning = createDiagnosticMessage({
-  source: PACKAGE_NAME,
+export const runtimeTranslationTimeoutWarning = createReactCoreDiagnostic({
   severity: 'Warning',
   whatHappened: 'Runtime translation timed out',
 });
@@ -293,8 +261,7 @@ export const createUnsupportedLocaleWarning = (
   );
 };
 
-export const dictionaryMissingWarning = createDiagnosticMessage({
-  source: PACKAGE_NAME,
+export const dictionaryMissingWarning = createReactCoreDiagnostic({
   severity: 'Warning',
   whatHappened: 'No dictionary was found',
   fix: 'Pass a dictionary to <GTProvider> or configure a dictionary loader before rendering translations',
@@ -302,14 +269,15 @@ export const dictionaryMissingWarning = createDiagnosticMessage({
 
 export const createStringRenderWarning = (
   message: string,
-  id: string | undefined
+  id: string | undefined,
+  error?: unknown
 ) =>
-  createDiagnosticMessage({
-    source: PACKAGE_NAME,
+  createReactCoreDiagnostic({
     severity: 'Warning',
     whatHappened: `The string ${id ? `for id "${id}" ` : ''}could not be rendered`,
     wayOut: 'Source content will render as a fallback',
     fix: `Check the message syntax and variables for: "${message}"`,
+    details: formatDiagnosticErrorDetails(error),
   });
 
 // Unlikely edge case: A <_T> component was injected outside of a <Derive> boundary. This would be caused by the compiler overeagerly injecting <_T> components.

--- a/packages/react-core/src/errors-dir/diagnostics.ts
+++ b/packages/react-core/src/errors-dir/diagnostics.ts
@@ -1,5 +1,6 @@
 import {
   createDiagnosticMessage,
+  formatDiagnosticErrorDetails,
   type DiagnosticMessageInput,
 } from 'generaltranslation/internal';
 import { PACKAGE_NAME } from './constants';
@@ -15,9 +16,4 @@ export function createReactCoreDiagnostic(
   });
 }
 
-export function formatDiagnosticErrorDetails(
-  error: unknown
-): string | undefined {
-  if (error == null) return undefined;
-  return String(error);
-}
+export { formatDiagnosticErrorDetails };

--- a/packages/react-core/src/errors-dir/diagnostics.ts
+++ b/packages/react-core/src/errors-dir/diagnostics.ts
@@ -1,0 +1,23 @@
+import {
+  createDiagnosticMessage,
+  type DiagnosticMessageInput,
+} from 'generaltranslation/internal';
+import { PACKAGE_NAME } from './constants';
+
+type ReactCoreDiagnosticInput = Omit<DiagnosticMessageInput, 'source'>;
+
+export function createReactCoreDiagnostic(
+  input: ReactCoreDiagnosticInput
+): string {
+  return createDiagnosticMessage({
+    source: PACKAGE_NAME,
+    ...input,
+  });
+}
+
+export function formatDiagnosticErrorDetails(
+  error: unknown
+): string | undefined {
+  if (error == null) return undefined;
+  return String(error);
+}

--- a/packages/react-core/src/provider/hooks/translation/useCreateInternalUseGTFunction.ts
+++ b/packages/react-core/src/provider/hooks/translation/useCreateInternalUseGTFunction.ts
@@ -104,15 +104,14 @@ export default function useCreateInternalUseGTFunction({
       return cutoffMessage;
     } catch (error) {
       if (environment === 'production') {
-        console.warn(createStringRenderWarning(message, id), 'Error: ', error);
+        console.warn(createStringRenderWarning(message, id, error));
       } else {
         // (3) If no fallback, throw error (non-prod)
-        if (!fallback)
-          throw new Error(
-            `${createStringRenderError(message, id)} Error: ${error}`
-          );
+        if (!fallback) {
+          throw new Error(createStringRenderError(message, id, error));
+        }
 
-        console.error(createStringRenderError(message, id), 'Error: ', error);
+        console.error(createStringRenderError(message, id, error));
       }
 
       // (2) If format fails, format fallback

--- a/packages/react-core/src/provider/hooks/useRuntimeTranslation.ts
+++ b/packages/react-core/src/provider/hooks/useRuntimeTranslation.ts
@@ -223,15 +223,24 @@ export default function useRuntimeTranslation({
             newTranslations[hash] = value;
             resultsMap.set(hash, value);
           } else if (result && result.error) {
-            const msg = createGenericRuntimeTranslationError(id, hash);
             console.warn(
-              `${msg} ${result.error || 'An upstream error occurred.'}`
+              createGenericRuntimeTranslationError(
+                id,
+                hash,
+                result.error || 'An upstream error occurred.'
+              )
             );
             newTranslations[hash] = null;
             resultsMap.set(hash, null);
           } else {
-            const msg = createGenericRuntimeTranslationError(id, hash);
-            console.warn(`${msg} Unknown response format.`, result);
+            console.warn(
+              createGenericRuntimeTranslationError(
+                id,
+                hash,
+                'Unknown response format'
+              ),
+              result
+            );
             newTranslations[hash] = null;
             resultsMap.set(hash, null);
           }

--- a/tests/apps/next/middleware/next.config.ts
+++ b/tests/apps/next/middleware/next.config.ts
@@ -1,31 +1,14 @@
-import { createRequire } from 'module';
-import { dirname, isAbsolute, relative, resolve } from 'path';
+import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { withGTConfig } from 'gt-next/config';
 import type { NextConfig } from 'next';
 
-const require = createRequire(import.meta.url);
 const appRoot = dirname(fileURLToPath(import.meta.url));
-const nextPackageRoot = dirname(require.resolve('next/package.json'));
-
-function getTurbopackRoot(): string {
-  let root = resolve(appRoot);
-
-  while (true) {
-    const diff = relative(root, nextPackageRoot);
-    if (diff === '' || (!diff.startsWith('..') && !isAbsolute(diff))) {
-      return root;
-    }
-
-    const parent = dirname(root);
-    if (parent === root) return parent;
-    root = parent;
-  }
-}
+const repoRoot = resolve(appRoot, '../../../..');
 
 const nextConfig: NextConfig = {
   turbopack: {
-    root: getTurbopackRoot(),
+    root: repoRoot,
   },
 };
 

--- a/tests/apps/next/middleware/next.config.ts
+++ b/tests/apps/next/middleware/next.config.ts
@@ -1,6 +1,32 @@
+import { createRequire } from 'module';
+import { dirname, isAbsolute, relative, resolve } from 'path';
+import { fileURLToPath } from 'url';
 import { withGTConfig } from 'gt-next/config';
 import type { NextConfig } from 'next';
 
-const nextConfig: NextConfig = {};
+const require = createRequire(import.meta.url);
+const appRoot = dirname(fileURLToPath(import.meta.url));
+const nextPackageRoot = dirname(require.resolve('next/package.json'));
+
+function getTurbopackRoot(): string {
+  let root = resolve(appRoot);
+
+  while (true) {
+    const diff = relative(root, nextPackageRoot);
+    if (diff === '' || (!diff.startsWith('..') && !isAbsolute(diff))) {
+      return root;
+    }
+
+    const parent = dirname(root);
+    if (parent === root) return parent;
+    root = parent;
+  }
+}
+
+const nextConfig: NextConfig = {
+  turbopack: {
+    root: getTurbopackRoot(),
+  },
+};
 
 export default withGTConfig(nextConfig, {});

--- a/tests/apps/next/middleware/runBenchE2E.mjs
+++ b/tests/apps/next/middleware/runBenchE2E.mjs
@@ -5,63 +5,114 @@ import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '../../../..');
-const GT_NEXT_DIR = join(ROOT, 'packages/next');
 const PKG_PATH = join(__dirname, 'package.json');
+const ROOT_PKG_PATH = join(ROOT, 'package.json');
 
-// --- Step 1: Build all packages ---
-console.log('\n=== Building packages ===\n');
-execSync('pnpm build', { cwd: ROOT, stdio: 'inherit' });
+const PACKED_WORKSPACE_DEPENDENCIES = [
+  ['@generaltranslation/compiler', 'packages/compiler'],
+  ['@generaltranslation/format', 'packages/format'],
+  ['generaltranslation', 'packages/core'],
+  ['@generaltranslation/next-internal', 'packages/next-internal'],
+  ['@generaltranslation/supported-locales', 'packages/supported-locales'],
+  ['gt-react', 'packages/react'],
+  ['@generaltranslation/react-core', 'packages/react-core'],
+  ['gt-i18n', 'packages/i18n'],
+];
 
-// --- Step 2: Pack gt-next ---
-console.log('\n=== Packing gt-next ===\n');
+function log(message) {
+  process.stdout.write(`${message}\n`);
+}
 
-for (const f of readdirSync(__dirname)) {
-  if (f.endsWith('.tgz')) {
-    unlinkSync(join(__dirname, f));
+function logSection(message) {
+  log(`\n=== ${message} ===\n`);
+}
+
+function packWorkspacePackage(name, dir) {
+  const packOutput = execSync(`pnpm pack --pack-destination ${__dirname}`, {
+    cwd: join(ROOT, dir),
+    encoding: 'utf-8',
+  }).trim();
+
+  const tarballName = packOutput.split('\n').pop()?.split('/').pop();
+  if (tarballName == null || tarballName.length === 0) {
+    throw new Error(`Failed to pack ${name}`);
+  }
+
+  log(`Packed: ${name} ${tarballName}`);
+  return tarballName;
+}
+
+function removePackedTarballs() {
+  for (const file of readdirSync(__dirname)) {
+    if (file.endsWith('.tgz')) {
+      unlinkSync(join(__dirname, file));
+    }
   }
 }
 
-const packOutput = execSync(`pnpm pack --pack-destination ${__dirname}`, {
-  cwd: GT_NEXT_DIR,
-  encoding: 'utf-8',
-}).trim();
+// --- Step 1: Build all packages ---
+logSection('Building packages');
+execSync('pnpm build', { cwd: ROOT, stdio: 'inherit' });
 
-const tarballPath = packOutput.split('\n').pop();
-const tarballName = tarballPath.split('/').pop();
-console.log('Packed:', tarballName);
+// --- Step 2: Pack gt-next and its local workspace dependency closure ---
+logSection('Packing gt-next workspace package closure');
 
-// --- Step 3: Swap dependency to tarball ---
+removePackedTarballs();
+
+const gtNextTarballName = packWorkspacePackage('gt-next', 'packages/next');
+const dependencyOverrides = Object.fromEntries(
+  PACKED_WORKSPACE_DEPENDENCIES.map(([name, dir]) => [
+    name,
+    `file:./tests/apps/next/middleware/${packWorkspacePackage(name, dir)}`,
+  ])
+);
+
+// --- Step 3: Swap dependency to tarball and pin local workspace deps ---
 const originalPkg = readFileSync(PKG_PATH, 'utf-8');
+const originalRootPkg = readFileSync(ROOT_PKG_PATH, 'utf-8');
 const pkg = JSON.parse(originalPkg);
-pkg.dependencies['gt-next'] = `file:./${tarballName}`;
+const rootPkg = JSON.parse(originalRootPkg);
+pkg.dependencies['gt-next'] = `file:./${gtNextTarballName}`;
 writeFileSync(PKG_PATH, JSON.stringify(pkg, null, 2) + '\n');
+
+rootPkg.pnpm = {
+  ...rootPkg.pnpm,
+  overrides: {
+    ...rootPkg.pnpm?.overrides,
+    ...dependencyOverrides,
+  },
+};
+writeFileSync(ROOT_PKG_PATH, JSON.stringify(rootPkg, null, 2) + '\n');
 
 try {
   // --- Step 4: Install with tarball ---
-  console.log('\n=== Installing with packed gt-next ===\n');
+  logSection('Installing with packed gt-next workspace package closure');
   execSync('pnpm install --no-frozen-lockfile', {
     cwd: ROOT,
     stdio: 'inherit',
   });
 
   // --- Step 5: Build + run benchmark ---
-  console.log('\n=== Building app ===\n');
+  logSection('Building app');
   execSync('NEXT_PUBLIC_USE_CASE=main pnpm build', {
     cwd: __dirname,
     stdio: 'inherit',
   });
 
-  console.log('\n=== Running e2e benchmarks ===\n');
+  logSection('Running e2e benchmarks');
   execSync('npx playwright test --config=benchmarks/playwright.config.ts', {
     cwd: __dirname,
     stdio: 'inherit',
   });
 } finally {
   // --- Step 6: Restore workspace dependency ---
-  console.log('\n=== Restoring workspace dependency ===\n');
+  logSection('Restoring workspace dependency');
   writeFileSync(PKG_PATH, originalPkg);
+  writeFileSync(ROOT_PKG_PATH, originalRootPkg);
   execSync('pnpm install --no-frozen-lockfile', {
     cwd: ROOT,
     stdio: 'inherit',
   });
+
+  removePackedTarballs();
 }

--- a/tests/apps/next/middleware/runBenchE2E.mjs
+++ b/tests/apps/next/middleware/runBenchE2E.mjs
@@ -7,6 +7,15 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '../../../..');
 const PKG_PATH = join(__dirname, 'package.json');
 const ROOT_PKG_PATH = join(ROOT, 'package.json');
+const INSTALL_ARGS = ['install', '--no-frozen-lockfile'];
+const FORCE_INSTALL_ARGS = process.env.CI ? [] : ['--force'];
+// Keep package realpaths under the repo while Turbopack uses the repo root.
+const PACKED_INSTALL_ARGS = [
+  ...INSTALL_ARGS,
+  ...FORCE_INSTALL_ARGS,
+  '--config.enable-global-virtual-store=false',
+];
+const RESTORE_INSTALL_ARGS = [...INSTALL_ARGS, ...FORCE_INSTALL_ARGS];
 
 const PACKED_WORKSPACE_DEPENDENCIES = [
   ['@generaltranslation/compiler', 'packages/compiler'],
@@ -98,7 +107,7 @@ try {
   // --- Step 4: Install with tarball ---
   logSection('Installing with packed gt-next workspace package closure');
   installNeedsRestore = true;
-  runPnpm(['install', '--no-frozen-lockfile'], {
+  runPnpm(PACKED_INSTALL_ARGS, {
     cwd: ROOT,
     stdio: 'inherit',
   });
@@ -126,12 +135,14 @@ try {
   if (pkgWasWritten) writeFileSync(PKG_PATH, originalPkg);
   if (rootPkgWasWritten) writeFileSync(ROOT_PKG_PATH, originalRootPkg);
 
-  if (installNeedsRestore) {
-    runPnpm(['install', '--no-frozen-lockfile'], {
-      cwd: ROOT,
-      stdio: 'inherit',
-    });
+  try {
+    if (installNeedsRestore) {
+      runPnpm(RESTORE_INSTALL_ARGS, {
+        cwd: ROOT,
+        stdio: 'inherit',
+      });
+    }
+  } finally {
+    removePackedTarballs();
   }
-
-  removePackedTarballs();
 }

--- a/tests/apps/next/middleware/runBenchE2E.mjs
+++ b/tests/apps/next/middleware/runBenchE2E.mjs
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { readFileSync, writeFileSync, readdirSync, unlinkSync } from 'fs';
 import { join, resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -27,8 +27,12 @@ function logSection(message) {
   log(`\n=== ${message} ===\n`);
 }
 
+function runPnpm(args, options) {
+  return execFileSync('pnpm', args, options);
+}
+
 function packWorkspacePackage(name, dir) {
-  const packOutput = execSync(`pnpm pack --pack-destination ${__dirname}`, {
+  const packOutput = runPnpm(['pack', '--pack-destination', __dirname], {
     cwd: join(ROOT, dir),
     encoding: 'utf-8',
   }).trim();
@@ -52,7 +56,7 @@ function removePackedTarballs() {
 
 // --- Step 1: Build all packages ---
 logSection('Building packages');
-execSync('pnpm build', { cwd: ROOT, stdio: 'inherit' });
+runPnpm(['build'], { cwd: ROOT, stdio: 'inherit' });
 
 // --- Step 2: Pack gt-next and its local workspace dependency closure ---
 logSection('Packing gt-next workspace package closure');
@@ -72,47 +76,62 @@ const originalPkg = readFileSync(PKG_PATH, 'utf-8');
 const originalRootPkg = readFileSync(ROOT_PKG_PATH, 'utf-8');
 const pkg = JSON.parse(originalPkg);
 const rootPkg = JSON.parse(originalRootPkg);
-pkg.dependencies['gt-next'] = `file:./${gtNextTarballName}`;
-writeFileSync(PKG_PATH, JSON.stringify(pkg, null, 2) + '\n');
-
-rootPkg.pnpm = {
-  ...rootPkg.pnpm,
-  overrides: {
-    ...rootPkg.pnpm?.overrides,
-    ...dependencyOverrides,
-  },
-};
-writeFileSync(ROOT_PKG_PATH, JSON.stringify(rootPkg, null, 2) + '\n');
+let pkgWasWritten = false;
+let rootPkgWasWritten = false;
+let installNeedsRestore = false;
 
 try {
+  pkg.dependencies['gt-next'] = `file:./${gtNextTarballName}`;
+  writeFileSync(PKG_PATH, JSON.stringify(pkg, null, 2) + '\n');
+  pkgWasWritten = true;
+
+  rootPkg.pnpm = {
+    ...rootPkg.pnpm,
+    overrides: {
+      ...rootPkg.pnpm?.overrides,
+      ...dependencyOverrides,
+    },
+  };
+  writeFileSync(ROOT_PKG_PATH, JSON.stringify(rootPkg, null, 2) + '\n');
+  rootPkgWasWritten = true;
+
   // --- Step 4: Install with tarball ---
   logSection('Installing with packed gt-next workspace package closure');
-  execSync('pnpm install --no-frozen-lockfile', {
+  installNeedsRestore = true;
+  runPnpm(['install', '--no-frozen-lockfile'], {
     cwd: ROOT,
     stdio: 'inherit',
   });
 
   // --- Step 5: Build + run benchmark ---
   logSection('Building app');
-  execSync('NEXT_PUBLIC_USE_CASE=main pnpm build', {
+  runPnpm(['build'], {
     cwd: __dirname,
+    env: { ...process.env, NEXT_PUBLIC_USE_CASE: 'main' },
     stdio: 'inherit',
   });
 
   logSection('Running e2e benchmarks');
-  execSync('npx playwright test --config=benchmarks/playwright.config.ts', {
-    cwd: __dirname,
-    stdio: 'inherit',
-  });
+  execFileSync(
+    'npx',
+    ['playwright', 'test', '--config=benchmarks/playwright.config.ts'],
+    {
+      cwd: __dirname,
+      stdio: 'inherit',
+    }
+  );
 } finally {
   // --- Step 6: Restore workspace dependency ---
   logSection('Restoring workspace dependency');
-  writeFileSync(PKG_PATH, originalPkg);
-  writeFileSync(ROOT_PKG_PATH, originalRootPkg);
-  execSync('pnpm install --no-frozen-lockfile', {
-    cwd: ROOT,
-    stdio: 'inherit',
-  });
+  if (pkgWasWritten) writeFileSync(PKG_PATH, originalPkg);
+  if (rootPkgWasWritten) writeFileSync(ROOT_PKG_PATH, originalRootPkg);
+
+  if (installNeedsRestore) {
+    runPnpm(['install', '--no-frozen-lockfile'], {
+      cwd: ROOT,
+      stdio: 'inherit',
+    });
+  }
 
   removePackedTarballs();
 }


### PR DESCRIPTION
## Summary
- add package-local diagnostic helpers for gt-next and react-core and route error detail formatting through them
- centralize repeated CLI workflow diagnostic text and omit empty diagnostic details
- update the benchmark harness to pack gt-next with its local workspace dependency closure and keep harness logging lint-clean
- add the changeset that was missed when #1412 was merged

## Tests
- `pnpm exec oxfmt --check <touched files>`
- `pnpm exec oxlint <touched files>`
- `pnpm --filter generaltranslation test -- diagnostics`
- `pnpm --filter generaltranslation typecheck`
- `pnpm --filter gt typecheck`
- `pnpm --filter @generaltranslation/react-core typecheck`
- `pnpm --filter gt-next typecheck`
- `pnpm --filter gt-next test -- getTranslationFunction getRequestFunction`
- `pnpm --filter @generaltranslation/react-core test -- useRuntimeTranslation useCreateInternalUseGTFunction`
- `BENCH_OUTPUT_NAME=e2e-latest node runBenchE2E.mjs` from `tests/apps/next/middleware`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors diagnostic helpers across `gt-next`, `react-core`, and the CLI to reduce boilerplate and improve error formatting. It also hardens the benchmark harness to correctly pack the full workspace dependency closure and guard against dirty-repo state on failure.

- **Package-local diagnostic wrappers** (`createGtNextDiagnostic`, `createReactCoreDiagnostic`) are introduced in each package, eliminating the repeated `source` field from every `createDiagnosticMessage` call and centralising the package name in one place.
- **Error details routing** is unified: `formatDiagnosticErrorDetails(error)` replaces the ad-hoc `+ ' Error: ' + error` string concatenation, and `formatDetails` now silently omits empty/whitespace-only detail strings.
- **Benchmark harness** (`runBenchE2E.mjs`) is extended to pack all workspace transitive dependencies (not just `gt-next`), track file-mutation state with flags before writing, and restore both `package.json` files unconditionally in the `finally` block.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all changes are mechanical refactoring with no behavioural regressions found.

The diagnostic wrapper extraction, error-detail routing, and benchmark harness refactor are all internally consistent. File mutations in the harness are now guarded by written-state flags and restored unconditionally in the finally block. No logic errors or data-loss paths were identified.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/logging/diagnostics.ts | Adds `formatDiagnosticErrorDetails` export and guards `formatDetails` against empty/whitespace strings; both changes are correct and covered by new tests. |
| packages/next/src/errors/diagnostics.ts | New file introducing `createGtNextDiagnostic` and `createGtNextPluginDiagnostic` wrappers that hardcode the source string, plus a re-export of `formatDiagnosticErrorDetails`. |
| packages/react-core/src/errors-dir/diagnostics.ts | New file introducing `createReactCoreDiagnostic` wrapper using the existing `PACKAGE_NAME` constant, mirroring the gt-next pattern cleanly. |
| packages/next/src/errors/createErrors.ts | Migrates all `createDiagnosticMessage` calls to `createGtNextDiagnostic`/`createGtNextPluginDiagnostic`; error parameter added to `createStringRenderError` and `createStringRenderWarning` with correct plumbing. |
| packages/react-core/src/errors-dir/createErrors.ts | Migrates all calls to `createReactCoreDiagnostic`; `createGenericRuntimeTranslationError` simplified from an if/else block to a single ternary, and gains an optional `error` parameter. |
| packages/cli/src/console/index.ts | Adds `branchResolutionError` constant and `withOriginalError` helper to centralise the repeated CLI error strings; logic is correct. |
| tests/apps/next/middleware/runBenchE2E.mjs | Significant refactor: packs the full workspace dependency closure, moves file mutations inside the try block guarded by written-flags, and restores both package.json files in the finally block. Minor: tarballs created before the try block during the packing phase are not cleaned up if `packWorkspacePackage` throws mid-loop, but they are removed at the start of the next run. |
| tests/apps/next/middleware/next.config.ts | Adds `turbopack.root` pointing to the monorepo root so Turbopack can resolve packed workspace packages correctly during the benchmark run. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Call site (e.g. console.warn)"] --> B["createGtNextDiagnostic / createReactCoreDiagnostic"]
    B --> C["createDiagnosticMessage (generaltranslation/internal)"]
    E["error: unknown"] --> F["formatDiagnosticErrorDetails(error)"]
    F -->|"null/undefined → undefined"| G["details field omitted"]
    F -->|"truthy → String(error)"| H["details: '...'"]
    H --> C
    G --> C
    C --> I["formatDetails(details)"]
    I -->|"empty/whitespace → ''"| J["detail omitted from message"]
    I -->|"non-empty → 'Details: ...'"| K["appended to message"]
    K --> L["Final diagnostic string"]
    J --> L
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix: scope benchmark turbopack root"](https://github.com/generaltranslation/gt/commit/b21fb01415daf92c954c8550fc08bf7cd02466c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31851390)</sub>

<!-- /greptile_comment -->