### PR TITLE
fix: resolve tsconfig alias barrels in CLI extraction

### DIFF
--- a/.changeset/fuzzy-buckets-resolve.md
+++ b/.changeset/fuzzy-buckets-resolve.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Resolve TypeScript path aliases that point to directory index barrel files during CLI extraction.

--- a/packages/cli/src/react/jsx/utils/__tests__/resolveImportPath.test.ts
+++ b/packages/cli/src/react/jsx/utils/__tests__/resolveImportPath.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { resolveImportPath } from '../resolveImportPath.js';
+import type { ParsingConfigOptions } from '../../../../types/parsing.js';
+
+const parsingOptions: ParsingConfigOptions = {
+  conditionNames: ['browser', 'module', 'import', 'require', 'default'],
+};
+
+let testDir: string | undefined;
+
+function createTestProject(paths: Record<string, string[]>) {
+  testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gt-resolve-import-'));
+  fs.writeFileSync(
+    path.join(testDir, 'tsconfig.json'),
+    JSON.stringify({
+      compilerOptions: {
+        baseUrl: '.',
+        paths,
+      },
+    })
+  );
+
+  const currentDir = path.join(testDir, 'screens', 'account');
+  fs.mkdirSync(currentDir, { recursive: true });
+  const currentFile = path.join(currentDir, 'AccountOverviewPage.tsx');
+  fs.writeFileSync(currentFile, "import { menuItems } from '@/util';");
+
+  return { currentFile, root: testDir };
+}
+
+function resolveImport(currentFile: string, importPath: string) {
+  return resolveImportPath(currentFile, importPath, parsingOptions, new Map());
+}
+
+afterEach(() => {
+  if (testDir) {
+    fs.rmSync(testDir, { recursive: true, force: true });
+    testDir = undefined;
+  }
+});
+
+describe('resolveImportPath', () => {
+  it('resolves tsconfig path aliases to directory index files', () => {
+    const { currentFile, root } = createTestProject({ '@/*': ['./*'] });
+    const utilDir = path.join(root, 'util');
+    fs.mkdirSync(utilDir, { recursive: true });
+
+    const indexFile = path.join(utilDir, 'index.ts');
+    fs.writeFileSync(indexFile, "export * from './accountMenuItems';");
+    fs.writeFileSync(
+      path.join(utilDir, 'accountMenuItems.tsx'),
+      "export const menuItems = ['View account details'];"
+    );
+
+    const resolved = resolveImport(currentFile, '@/util');
+
+    expect(resolved).toBe(indexFile);
+  });
+
+  it('resolves tsconfig path aliases to files without explicit import extensions', () => {
+    const { currentFile, root } = createTestProject({ '@/*': ['./*'] });
+    const utilDir = path.join(root, 'util');
+    fs.mkdirSync(utilDir, { recursive: true });
+
+    const helperFile = path.join(utilDir, 'accountMenuItems.tsx');
+    fs.writeFileSync(
+      helperFile,
+      "export const menuItems = ['View account details'];"
+    );
+
+    const resolved = resolveImport(currentFile, '@/util/accountMenuItems');
+
+    expect(resolved).toBe(helperFile);
+  });
+
+  it('resolves tsconfig path aliases to files with explicit import extensions', () => {
+    const { currentFile, root } = createTestProject({ '@/*': ['./*'] });
+    const utilDir = path.join(root, 'util');
+    fs.mkdirSync(utilDir, { recursive: true });
+
+    const helperFile = path.join(utilDir, 'accountMenuItems.tsx');
+    fs.writeFileSync(
+      helperFile,
+      "export const menuItems = ['View account details'];"
+    );
+
+    const resolved = resolveImport(currentFile, '@/util/accountMenuItems.tsx');
+
+    expect(resolved).toBe(helperFile);
+  });
+
+  it('resolves aliases that match after appending an import extension', () => {
+    const { currentFile, root } = createTestProject({
+      '@account-menu.ts': ['./util/accountMenuItems.ts'],
+    });
+    const utilDir = path.join(root, 'util');
+    fs.mkdirSync(utilDir, { recursive: true });
+
+    const helperFile = path.join(utilDir, 'accountMenuItems.ts');
+    fs.writeFileSync(
+      helperFile,
+      "export const menuItems = ['View account details'];"
+    );
+
+    const resolved = resolveImport(currentFile, '@account-menu');
+
+    expect(resolved).toBe(helperFile);
+  });
+
+  it('returns null for aliased directories without index files', () => {
+    const { currentFile, root } = createTestProject({ '@/*': ['./*'] });
+    fs.mkdirSync(path.join(root, 'util'), { recursive: true });
+
+    const resolved = resolveImport(currentFile, '@/util');
+
+    expect(resolved).toBeNull();
+  });
+
+  it('returns null when no resolver can match an import path', () => {
+    const { currentFile } = createTestProject({ '@/*': ['./*'] });
+
+    const resolved = resolveImport(currentFile, '@/missing');
+
+    expect(resolved).toBeNull();
+  });
+});

--- a/packages/cli/src/react/jsx/utils/resolveImportPath.ts
+++ b/packages/cli/src/react/jsx/utils/resolveImportPath.ts
@@ -1,11 +1,49 @@
 import { createMatchPath, loadConfig } from 'tsconfig-paths';
-import { ParsingConfigOptions } from '../../../types/parsing.js';
+import type { ParsingConfigOptions } from '../../../types/parsing.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import resolve from 'resolve';
 import enhancedResolve from 'enhanced-resolve';
 import type { FileSystem } from 'enhanced-resolve';
 const { ResolverFactory } = enhancedResolve;
+
+function resolveExistingPath(
+  filePath: string | undefined,
+  extensions: string[]
+): string | null {
+  if (!filePath) {
+    return null;
+  }
+
+  if (fs.existsSync(filePath)) {
+    const stats = fs.statSync(filePath);
+    if (stats.isFile()) {
+      return filePath;
+    }
+
+    if (stats.isDirectory()) {
+      for (const ext of extensions) {
+        const indexPath = path.join(filePath, `index${ext}`);
+        if (fs.existsSync(indexPath) && fs.statSync(indexPath).isFile()) {
+          return indexPath;
+        }
+      }
+      return null;
+    }
+  }
+
+  for (const ext of extensions) {
+    const resolvedWithExt = filePath + ext;
+    if (
+      fs.existsSync(resolvedWithExt) &&
+      fs.statSync(resolvedWithExt).isFile()
+    ) {
+      return resolvedWithExt;
+    }
+  }
+
+  return null;
+}
 
 /**
  * Resolves import paths to absolute file paths using battle-tested libraries.
@@ -44,27 +82,32 @@ export function resolveImportPath(
     );
 
     // First try without any extension
-    let tsResolved = matchPath(importPath);
-    if (tsResolved && fs.existsSync(tsResolved)) {
-      result = tsResolved;
+    let tsResolved = matchPath(importPath, undefined, undefined, extensions);
+    const resolvedTsPath = resolveExistingPath(tsResolved, extensions);
+    if (resolvedTsPath) {
+      result = resolvedTsPath;
       resolveImportPathCache.set(cacheKey, result);
       return result;
     }
 
     // Then try with each extension
+    const tsResolvedBase = matchPath(importPath);
     for (const ext of extensions) {
       tsResolved = matchPath(importPath + ext);
-      if (tsResolved && fs.existsSync(tsResolved)) {
-        result = tsResolved;
+      const resolvedPathWithExt = resolveExistingPath(tsResolved, extensions);
+      if (resolvedPathWithExt) {
+        result = resolvedPathWithExt;
         resolveImportPathCache.set(cacheKey, result);
         return result;
       }
 
       // Also try the resolved path with extension
-      tsResolved = matchPath(importPath);
-      if (tsResolved) {
-        const resolvedWithExt = tsResolved + ext;
-        if (fs.existsSync(resolvedWithExt)) {
+      if (tsResolvedBase) {
+        const resolvedWithExt = resolveExistingPath(
+          tsResolvedBase + ext,
+          extensions
+        );
+        if (resolvedWithExt) {
           result = resolvedWithExt;
           resolveImportPathCache.set(cacheKey, result);
           return result;


### PR DESCRIPTION
## Summary
- Resolve TypeScript path aliases that point to directory index barrel files during CLI extraction
- Add resolver coverage for an `@/*` alias importing through a directory `index.ts` barrel
- Add a patch changeset for `gt`

## Verification
- `PATH="/opt/homebrew/bin:$PATH" ./node_modules/.bin/vitest run --config=./vitest.config.ts src/react/jsx/utils/__tests__/resolveImportPath.test.ts`
- `PATH="/opt/homebrew/bin:$PATH" ./node_modules/.bin/tsc --noEmit`
- `PATH="/opt/homebrew/bin:$PATH" ./node_modules/.bin/oxfmt --check packages/cli/src/react/jsx/utils/resolveImportPath.ts packages/cli/src/react/jsx/utils/__tests__/resolveImportPath.test.ts .changeset/fuzzy-buckets-resolve.md`
- Full CLI Vitest suite passed earlier in this worktree
- Rebuilt linked `gt` package and verified Vite and Next Pages scratch apps no longer warn on `@/util` barrel resolution during `gt translate --dry-run`
- Next Pages scratch app build passes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes CLI extraction failures when a TypeScript path alias (e.g. `@/util`) resolves to a directory rather than a direct file, by adding a `resolveExistingPath` helper that checks for `index.*` barrel files inside matched directories. It also adds an integration test suite covering the new barrel scenario as well as several pre-existing resolution paths.

- **`resolveExistingPath`**: new helper centralises the \"file vs. directory vs. missing\" disambiguation; when `tsconfig-paths` returns a directory the helper now walks `index.{tsx,ts,jsx,js}` entries instead of falling through to extension-appending logic.
- **`matchPath` loop refactor**: `tsResolvedBase = matchPath(importPath)` is computed once before the loop instead of being re-evaluated on every iteration, eliminating redundant calls.
- **Tests**: 6 integration tests create temporary projects on disk and exercise barrel resolution, extension-less imports, explicit-extension imports, suffix-alias matching, and the two null-return paths.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is additive, scoped to CLI path resolution, and all resolution fallbacks remain intact.

The new resolveExistingPath helper correctly branches on file / directory / missing, the directory branch returns null explicitly instead of falling through, and the matchPath base result is now computed once before the loop. Integration tests cover the added barrel path and the main pre-existing paths. No correctness issues found.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/react/jsx/utils/resolveImportPath.ts | Adds resolveExistingPath helper to handle directory barrel files; refactors tsconfig-paths loop to call matchPath(importPath) once before the loop instead of per-iteration. |
| packages/cli/src/react/jsx/utils/__tests__/resolveImportPath.test.ts | New integration test file with 6 cases covering barrel-index resolution, extension variants, and null-return paths. |
| .changeset/fuzzy-buckets-resolve.md | Patch changeset entry for the gt package describing the barrel resolution fix. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["resolveImportPath(currentFile, importPath)"] --> B{tsconfig found?}
    B -- No --> E
    B -- Yes --> C["matchPath(importPath, ø, ø, extensions)"]
    C --> D["resolveExistingPath(tsResolved, extensions)"]
    D --> D1{filePath exists?}
    D1 -- "No (or undefined)" --> D4["Try filePath+ext for each ext"]
    D1 -- Yes --> D2{isFile?}
    D2 -- Yes --> RET1["return filePath ✓"]
    D2 -- No --> D3{isDirectory?}
    D3 -- Yes --> IDX["Look for index.{tsx,ts,jsx,js}"]
    IDX -- found --> RET2["return indexPath ✓"]
    IDX -- not found --> RNULL["return null"]
    D3 -- No --> D4
    D4 -- found --> RET3["return filePath+ext ✓"]
    D4 -- not found --> RNULL
    RNULL --> LOOP["Loop: matchPath(importPath+ext) for each ext"]
    LOOP --> D5["resolveExistingPath(tsResolved, extensions)"]
    D5 -- found --> RET4["return ✓"]
    D5 -- null --> D6["resolveExistingPath(tsResolvedBase+ext, extensions)"]
    D6 -- found --> RET5["return ✓"]
    D6 -- null --> LOOP
    LOOP -- exhausted --> E["enhanced-resolve"]
    E -- found --> RET6["return ✓"]
    E -- fail --> F["Node resolve.sync"]
    F -- found --> RET7["return ✓"]
    F -- fail --> FINAL["return null"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: resolve tsconfig alias barrels in C..."](https://github.com/generaltranslation/gt/commit/04d8e8bf7d9473133a39be1d7521e5e8fd77e688) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32064551)</sub>

<!-- /greptile_comment -->