### PR TITLE
style: update ink cli accent color

### DIFF
--- a/packages/cli/src/console/inkFields.tsx
+++ b/packages/cli/src/console/inkFields.tsx
@@ -1,5 +1,6 @@
 import { Box, Text } from 'ink';
 import { getLocaleCodeWidth } from './inkLocaleData.js';
+import { INK_ACCENT_COLOR } from './inkTheme.js';
 import type { LocaleOption } from './inkTypes.js';
 import { stripAnsi, truncate } from './inkUtils.js';
 
@@ -23,7 +24,7 @@ export function OptionRow({
   }`;
 
   return active ? (
-    <Text color='cyan' bold>
+    <Text color={INK_ACCENT_COLOR} bold>
       {width ? truncate(text, width) : text}
     </Text>
   ) : (
@@ -52,7 +53,7 @@ export function SelectedTags({
         return (
           <Text key={locale}>
             <Text
-              backgroundColor={isActive ? 'cyanBright' : 'gray'}
+              backgroundColor={isActive ? INK_ACCENT_COLOR : 'gray'}
               color='black'
               bold={isActive}
             >{` ${locale} `}</Text>
@@ -118,7 +119,7 @@ function LocaleRow({
 
   if (active) {
     return (
-      <Text color='cyan' bold>
+      <Text color={INK_ACCENT_COLOR} bold>
         {`${marker} ${codeStr}  ${truncatedName}`}
         {sameName ? '' : `  ${truncatedNative}`}
       </Text>

--- a/packages/cli/src/console/inkLayout.tsx
+++ b/packages/cli/src/console/inkLayout.tsx
@@ -1,6 +1,7 @@
 import { Box, Text } from 'ink';
 import { PACKAGE_VERSION } from '../generated/version.js';
 import { useTerminalSize } from './inkTerminal.js';
+import { INK_ACCENT_COLOR } from './inkTheme.js';
 import type { PromptFrameProps } from './inkTypes.js';
 import {
   getContentWidth,
@@ -35,7 +36,7 @@ export function PromptFrame({ message, children, footer }: PromptFrameProps) {
   return (
     <Box width={columns} height={rows} flexDirection='column'>
       <Box width={columns}>
-        <Text bold color='black' backgroundColor='cyan'>
+        <Text bold color='black' backgroundColor={INK_ACCENT_COLOR}>
           {headerText}
         </Text>
       </Box>
@@ -48,7 +49,7 @@ export function PromptFrame({ message, children, footer }: PromptFrameProps) {
       >
         <Box width={width} flexDirection='column'>
           <Box justifyContent='center'>
-            <Text bold color='cyan'>
+            <Text bold color={INK_ACCENT_COLOR}>
               GT Wizard
             </Text>
           </Box>
@@ -65,7 +66,11 @@ export function PromptFrame({ message, children, footer }: PromptFrameProps) {
 
       <Box flexGrow={1} />
       <Box width={columns}>
-        <Text color='black' backgroundColor='cyan' wrap='truncate-end'>
+        <Text
+          color='black'
+          backgroundColor={INK_ACCENT_COLOR}
+          wrap='truncate-end'
+        >
           {footerLine}
         </Text>
       </Box>
@@ -112,7 +117,12 @@ export function InputBox({
     const visibleValue = truncate(value, Math.max(0, innerWidth - 1));
     const padding = Math.max(0, innerWidth - visibleValue.length - 1);
     return (
-      <Box width={width} borderStyle='round' borderColor='cyan' paddingX={1}>
+      <Box
+        width={width}
+        borderStyle='round'
+        borderColor={INK_ACCENT_COLOR}
+        paddingX={1}
+      >
         <Text>{visibleValue}</Text>
         <Text inverse> </Text>
         <Text>{' '.repeat(padding)}</Text>
@@ -128,7 +138,12 @@ export function InputBox({
   if (!placeholderText) {
     const padding = Math.max(0, innerWidth - 1);
     return (
-      <Box width={width} borderStyle='round' borderColor='cyan' paddingX={1}>
+      <Box
+        width={width}
+        borderStyle='round'
+        borderColor={INK_ACCENT_COLOR}
+        paddingX={1}
+      >
         <Text inverse> </Text>
         <Text>{' '.repeat(padding)}</Text>
       </Box>
@@ -137,7 +152,12 @@ export function InputBox({
 
   const padding = Math.max(0, innerWidth - placeholderText.length);
   return (
-    <Box width={width} borderStyle='round' borderColor='cyan' paddingX={1}>
+    <Box
+      width={width}
+      borderStyle='round'
+      borderColor={INK_ACCENT_COLOR}
+      paddingX={1}
+    >
       <Text inverse dimColor>
         {placeholderText.slice(0, 1)}
       </Text>

--- a/packages/cli/src/console/inkTheme.ts
+++ b/packages/cli/src/console/inkTheme.ts
@@ -1,0 +1,1 @@
+export const INK_ACCENT_COLOR = '#61A6FA';


### PR DESCRIPTION
## Summary
- Add a shared Ink accent color constant using #61A6FA
- Apply the accent to the Ink prompt header/footer, title, input borders, active rows, and selected locale tags
- Leave non-Ink Chalk logging colors unchanged

## Checks
- pnpm lint
- pnpm format
- pnpm --filter gt typecheck
- pnpm --filter gt exec vitest run --config=./vitest.config.ts src/console/__tests__/inkUtils.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralizes the Ink CLI accent color into a single shared constant (`INK_ACCENT_COLOR = '#61A6FA'`) in a new `inkTheme.ts` file, then replaces all hardcoded `'cyan'`/`'cyanBright'` color literals across `inkFields.tsx` and `inkLayout.tsx`.

- **`inkTheme.ts`**: New file exporting a single hex accent color constant, making future theme adjustments a one-line change.
- **`inkFields.tsx`**: Switches active `OptionRow` and `LocaleRow` text colors, and the `SelectedTags` active background, from named Ink colors to the new hex constant.
- **`inkLayout.tsx`**: Switches the `PromptFrame` header/footer backgrounds, the \"GT Wizard\" title color, and all three `InputBox` border color variants to the new hex constant.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This is a safe, purely cosmetic change that centralizes a color constant — no logic, data flow, or API behavior is affected.

All changes swap hardcoded named color strings for a single shared hex constant. The constant is correctly exported and imported, all call sites are updated consistently, and the hex value #61A6FA is a valid color supported by Chalk/Ink's color props. There are no logic changes, no new dependencies, and no behavioral side effects.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/console/inkTheme.ts | New file introducing a single shared accent color constant (#61A6FA) for the Ink CLI UI. |
| packages/cli/src/console/inkFields.tsx | Replaces hardcoded 'cyan'/'cyanBright' color literals with INK_ACCENT_COLOR for active rows and selected locale tags. |
| packages/cli/src/console/inkLayout.tsx | Replaces hardcoded 'cyan' color literals with INK_ACCENT_COLOR across header/footer backgrounds, title text, and input box borders. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[inkTheme.ts\nINK_ACCENT_COLOR = '#61A6FA'] --> B[inkFields.tsx]
    A --> C[inkLayout.tsx]
    B --> D[OptionRow\ncolor prop]
    B --> E[SelectedTags\nbackgroundColor prop]
    B --> F[LocaleRow\ncolor prop]
    C --> G[PromptFrame\nheader backgroundColor]
    C --> H[PromptFrame\ntitle color]
    C --> I[PromptFrame\nfooter backgroundColor]
    C --> J[InputBox\nborderColor - 3 branches]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["style: update ink cli accent color"](https://github.com/generaltranslation/gt/commit/a29ede18b8f6b7a982fb324a2628336e8f327a91) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32213067)</sub>

<!-- /greptile_comment -->