### PR TITLE
feat: add Esperanto locale support

### DIFF
--- a/.changeset/add-esperanto-locale.md
+++ b/.changeset/add-esperanto-locale.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/supported-locales': minor
+---
+
+Add Esperanto to the supported locales list.

--- a/packages/supported-locales/src/__tests__/supportedLocales.test.ts
+++ b/packages/supported-locales/src/__tests__/supportedLocales.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { getSupportedLocale, listSupportedLocales } from '../index';
+
+describe('@generaltranslation/supported-locales', () => {
+  it('lists Esperanto as a supported locale', () => {
+    expect(listSupportedLocales()).toContain('eo');
+  });
+
+  it('matches Esperanto locale requests to the supported language code', () => {
+    expect(getSupportedLocale('eo')).toBe('eo');
+    expect(getSupportedLocale('eo-US')).toBe('eo');
+  });
+});

--- a/packages/supported-locales/src/supportedLocales.ts
+++ b/packages/supported-locales/src/supportedLocales.ts
@@ -39,6 +39,7 @@ const supportedLocales = {
     'en-NZ', // New Zealand
     'en-US', // United States
   ],
+  eo: ['eo'], // Esperanto
   es: [
     // Spanish
     'es',


### PR DESCRIPTION
## Summary
- Add Esperanto (`eo`) to `@generaltranslation/supported-locales`
- Add package tests covering list and fallback matching behavior
- Add a changeset for the supported locales package

## Tests
- `pnpm --filter @generaltranslation/supported-locales test`
- `pnpm --filter @generaltranslation/supported-locales typecheck`
- `pnpm --filter @generaltranslation/supported-locales build`
- `pnpm format -- packages/supported-locales/src/supportedLocales.ts packages/supported-locales/src/__tests__/supportedLocales.test.ts .changeset/add-esperanto-locale.md`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Esperanto (`eo`) to the `@generaltranslation/supported-locales` package, inserting it alphabetically between `en` and `es` in the locale map with a minor-version changeset.

- **`supportedLocales.ts`**: Adds `eo: ['eo']` in the correct alphabetical position; the single-entry array follows the same pattern used by other language-only locales (e.g., `af`, `am`, `bg`).
- **New test file**: Covers `listSupportedLocales` membership and `getSupportedLocale` resolution for both the bare code (`eo`) and a region-tagged variant (`eo-US`), verifying the fallback logic returns `eo` for unsupported regional variants.
- **Changeset**: Correctly classifies the addition as a `minor` bump.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, self-contained locale addition with no impact on existing locales or the lookup logic.

The addition touches only the locale data map and a new test file. The entry follows the exact same pattern as every other single-variant locale in the file, is placed in correct alphabetical order, and the tests cover both direct resolution and the regional-fallback path.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/supported-locales/src/supportedLocales.ts | Adds `eo: ['eo']` for Esperanto in correct alphabetical position between `en` and `es`; no issues. |
| packages/supported-locales/src/__tests__/supportedLocales.test.ts | New test file verifying `listSupportedLocales` contains `eo` and `getSupportedLocale` correctly resolves `eo` and falls back from `eo-US` to `eo`. |
| .changeset/add-esperanto-locale.md | Changeset correctly marks the `@generaltranslation/supported-locales` package as a `minor` bump for the new locale addition. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["getSupportedLocale(locale)"] --> B{"isValidLocale?"}
    B -- No --> C["return null"]
    B -- Yes --> D["standardizeLocale"]
    D --> E["getLocaleProperties → languageCode"]
    E --> F{"languageCode in supportedLocales?"}
    F -- No --> C
    F -- Yes --> G["getMatchingCode"]
    G --> H{"exact locale in list?"}
    H -- Yes --> I["return matched locale"]
    H -- No --> J{"languageCode-regionCode in list?"}
    J -- Yes --> I
    J -- No --> K{"minimizedCode in list?"}
    K -- Yes --> I
    K -- No --> L["retry with bare languageCode"]
    L --> M{"match found?"}
    M -- Yes --> I
    M -- No --> C
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add Esperanto locale support"](https://github.com/generaltranslation/gt/commit/138c026b57c35efa2391eee269d9e2ac41545e6b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32663175)</sub>

<!-- /greptile_comment -->