### PR TITLE
fix: deprecate experimental locale resolution

### DIFF
--- a/.changeset/deprecate-experimental-locale-resolution.md
+++ b/.changeset/deprecate-experimental-locale-resolution.md
@@ -1,0 +1,5 @@
+---
+"gt-next": patch
+---
+
+Deprecate `experimentalLocaleResolution` and update cache components warnings to recommend explicit custom `getLocale.ts` and `getRegion.ts` request functions instead of automatic root parameter detection.

--- a/packages/next/src/config-dir/props/withGTConfigProps.ts
+++ b/packages/next/src/config-dir/props/withGTConfigProps.ts
@@ -91,8 +91,15 @@ export type withGTConfigProps = {
   _usingPlugin?: boolean;
   // SSG
   experimentalEnableSSG?: boolean;
-  // Using special server side locale resolution logic
+  /**
+   * @deprecated This option relies on unsupported Next.js internals. For
+   * cacheComponents support, define custom getLocale.ts and getRegion.ts files
+   * or configure getLocalePath and getRegionPath.
+   */
   experimentalLocaleResolution?: boolean;
+  /**
+   * @deprecated Only used by deprecated experimentalLocaleResolution.
+   */
   experimentalLocaleResolutionParam?: string;
   /** @deprecated */
   disableSSGWarnings?: boolean;

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -107,8 +107,8 @@ type WithGTConfigResult<TNextConfig extends object> = TNextConfig & NextConfig;
  * @param {string|undefined} [getStaticLocalePath="getStaticLocale"] - The path to the static getLocale function. (deprecated)
  * @param {string|undefined} [getStaticRegionPath="getStaticRegion"] - The path to the static getRegion function. (deprecated)
  * @param {string|undefined} [getStaticDomainPath="getStaticDomain"] - The path to the static getDomain function. (deprecated)
- * @param {boolean} [experimentalLocaleResolution=defaultWithGTConfigProps.experimentalLocaleResolution] - Whether to use special server side locale resolution logic (required for Cached Components).
- * @param {string|undefined} [experimentalLocaleResolutionParam=defaultWithGTConfigProps.experimentalLocaleResolutionParam] - The parameter to use for experimental locale resolution.
+ * @param {boolean} [experimentalLocaleResolution=defaultWithGTConfigProps.experimentalLocaleResolution] - Deprecated. Uses unsupported Next.js internals to infer locale from root params.
+ * @param {string|undefined} [experimentalLocaleResolutionParam=defaultWithGTConfigProps.experimentalLocaleResolutionParam] - Deprecated. Only used by experimentalLocaleResolution.
  * @param {object} metadata - Additional metadata that can be passed for extended configuration.
  *
  * @param {object} nextConfig - The Next.js configuration object to extend

--- a/packages/next/src/errors/cacheComponents.ts
+++ b/packages/next/src/errors/cacheComponents.ts
@@ -19,15 +19,38 @@ export const createExperimentalLocaleResolutionError = (error: unknown) =>
   });
 
 // ---- WARNINGS ---- //
-export const cacheComponentsMissingExperimentalLocaleResolutionWarning =
-  createGtNextDiagnostic({
-    whatHappened:
-      'cacheComponents is enabled, but experimentalLocaleResolution is not enabled',
-    fix: 'Enable experimentalLocaleResolution so i18n can work inside cached components',
-  });
+export type CacheComponentsRequestFunction = 'getLocale' | 'getRegion';
 
-export const cacheComponentsExperimentalFeatureWarning =
-  'gt-next: experimentalLocaleResolution is an experimental feature.';
+export const createCacheComponentsMissingRequestFunctionsWarning = (
+  requestFunctions: CacheComponentsRequestFunction[]
+) => {
+  const isPlural = requestFunctions.length > 1;
+  const functionNames = requestFunctions
+    .map((requestFunction) => `${requestFunction}()`)
+    .join(' and ');
+  const fileNames = requestFunctions
+    .map((requestFunction) => `${requestFunction}.ts`)
+    .join(' and ');
+  const configKeys = requestFunctions
+    .map((requestFunction) => `${requestFunction}Path`)
+    .join(' and ');
+
+  return createGtNextDiagnostic({
+    whatHappened: `cacheComponents is enabled, but custom ${functionNames} ${isPlural ? 'are' : 'is'} not configured`,
+    wayOut:
+      'Automatic root parameter detection is deprecated because it relies on unsupported Next.js internals',
+    fix: `Add ${fileNames} ${isPlural ? 'files' : 'file'}, or configure ${configKeys}`,
+  });
+};
+
+export const experimentalLocaleResolutionDeprecatedWarning =
+  createGtNextDiagnostic({
+    severity: 'Warning',
+    whatHappened: 'experimentalLocaleResolution is deprecated',
+    wayOut:
+      'This option relies on unsupported Next.js internals and may break in future Next.js releases',
+    fix: 'Remove experimentalLocaleResolution and define custom getLocale.ts and getRegion.ts files for cacheComponents support',
+  });
 
 export const cacheComponentsExperimentalFeatureDisableGetRequestFunctionWarning =
   'gt-next: experimentalLocaleResolution is enabled. getRegion and getDomain are disabled.';
@@ -46,4 +69,4 @@ export const cacheComponentsNonLocalTranslationsWarning =
   });
 
 export const experimentalLocaleResolutionWithoutCacheComponentsWarning =
-  'gt-next: experimentalLocaleResolution is enabled, but cacheComponents is disabled. experimentalLocaleResolution is meant to be used with cacheComponents. If this is intentional, ignore this warning.';
+  'gt-next: experimentalLocaleResolution is enabled, but cacheComponents is disabled. experimentalLocaleResolution is deprecated and should be removed.';

--- a/packages/next/src/errors/ssg.ts
+++ b/packages/next/src/errors/ssg.ts
@@ -83,7 +83,7 @@ export const createSsrDetectionFailedWarning = (error: unknown) =>
 export const deprecatedExperimentalEnableSSGWarning = createGtNextDiagnostic({
   whatHappened:
     'experimentalEnableSSG is deprecated and will be removed in a future version',
-  fix: 'Move to experimentalLocaleResolution when you update your SSG configuration',
+  fix: 'Define custom getLocalePath and getRegionPath request functions instead',
 });
 
 export const createDeprecatedGetStaticLocaleFunctionWarning = (

--- a/packages/next/src/plugin/checks/__tests__/cacheComponentsChecks.test.ts
+++ b/packages/next/src/plugin/checks/__tests__/cacheComponentsChecks.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { NextConfig } from 'next';
+import { cacheComponentsChecks } from '../cacheComponentsChecks';
+import {
+  createCacheComponentsMissingRequestFunctionsWarning,
+  experimentalLocaleResolutionDeprecatedWarning,
+} from '../../../errors/cacheComponents';
+import type { withGTConfigProps } from '../../../config-dir/props/withGTConfigProps';
+import type { RequestFunctionPaths } from '../../../config-dir/utils/resolveRequestFunctionPaths';
+
+function runCacheComponentsChecks({
+  mergedConfig = {},
+  nextConfig = {},
+  requestFunctionPaths = {},
+}: {
+  mergedConfig?: withGTConfigProps;
+  nextConfig?: NextConfig;
+  requestFunctionPaths?: RequestFunctionPaths;
+} = {}) {
+  cacheComponentsChecks({
+    mergedConfig,
+    nextConfig,
+    requestFunctionPaths,
+    localTranslationsEnabled: true,
+    localDictionaryEnabled: false,
+  });
+}
+
+describe('cacheComponentsChecks', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('warns when cacheComponents is enabled without custom getLocale and getRegion functions', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    runCacheComponentsChecks({
+      nextConfig: { cacheComponents: true },
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      createCacheComponentsMissingRequestFunctionsWarning([
+        'getLocale',
+        'getRegion',
+      ])
+    );
+  });
+
+  it('only warns about the missing request function when one is configured', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    runCacheComponentsChecks({
+      nextConfig: { cacheComponents: true },
+      requestFunctionPaths: {
+        getLocale: './getLocale.ts',
+      },
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      createCacheComponentsMissingRequestFunctionsWarning(['getRegion'])
+    );
+  });
+
+  it('does not warn about request functions when cacheComponents has custom getLocale and getRegion functions', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    runCacheComponentsChecks({
+      nextConfig: { cacheComponents: true },
+      requestFunctionPaths: {
+        getLocale: './getLocale.ts',
+        getRegion: './getRegion.ts',
+      },
+    });
+
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      createCacheComponentsMissingRequestFunctionsWarning([
+        'getLocale',
+        'getRegion',
+      ])
+    );
+  });
+
+  it('warns that experimentalLocaleResolution is deprecated when enabled', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    runCacheComponentsChecks({
+      mergedConfig: { experimentalLocaleResolution: true },
+      nextConfig: { cacheComponents: true },
+      requestFunctionPaths: {
+        getLocale: './getLocale.ts',
+        getRegion: './getRegion.ts',
+      },
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      experimentalLocaleResolutionDeprecatedWarning
+    );
+  });
+});

--- a/packages/next/src/plugin/checks/cacheComponentsChecks.ts
+++ b/packages/next/src/plugin/checks/cacheComponentsChecks.ts
@@ -1,8 +1,9 @@
 import { NextConfig } from 'next';
 import { type withGTConfigProps } from '../../config-dir/props/withGTConfigProps';
 import {
-  cacheComponentsExperimentalFeatureWarning,
-  cacheComponentsMissingExperimentalLocaleResolutionWarning,
+  experimentalLocaleResolutionDeprecatedWarning,
+  createCacheComponentsMissingRequestFunctionsWarning,
+  type CacheComponentsRequestFunction,
   cacheComponentsLegacySsgConflictError,
   cacheComponentsExperimentalLocaleResolutionDisableCustomGetLocaleWarning,
   cacheComponentsNonLocalTranslationsWarning,
@@ -24,7 +25,7 @@ export function cacheComponentsChecks({
   localTranslationsEnabled: boolean;
   localDictionaryEnabled: boolean;
 }) {
-  // Check: if cacheComponents is enabled, but no local translations or dictionary are enabled, error
+  // Check: if cacheComponents is enabled, but no local translations or dictionary are enabled, warn
   // this is necessary because it prevents executing a fetch when no local translations or dictionary are enabled
   if (
     nextConfig.cacheComponents &&
@@ -34,17 +35,29 @@ export function cacheComponentsChecks({
     console.warn(cacheComponentsNonLocalTranslationsWarning);
   }
 
-  // checks for disabled experimentalLocaleResolution
-  if (!mergedConfig.experimentalLocaleResolution) {
-    if (nextConfig.cacheComponents) {
-      // Warn that i18n wont work inside of cached components
-      console.warn(cacheComponentsMissingExperimentalLocaleResolutionWarning);
+  if (nextConfig.cacheComponents) {
+    const missingRequestFunctions: CacheComponentsRequestFunction[] = [];
+    if (!requestFunctionPaths.getLocale) {
+      missingRequestFunctions.push('getLocale');
     }
+    if (!requestFunctionPaths.getRegion) {
+      missingRequestFunctions.push('getRegion');
+    }
+
+    if (missingRequestFunctions.length) {
+      console.warn(
+        createCacheComponentsMissingRequestFunctionsWarning(
+          missingRequestFunctions
+        )
+      );
+    }
+  }
+
+  if (!mergedConfig.experimentalLocaleResolution) {
     return;
   }
 
-  // Warn that this is an experimental feature
-  console.warn(cacheComponentsExperimentalFeatureWarning);
+  console.warn(experimentalLocaleResolutionDeprecatedWarning);
 
   // Warn that getRegion and getDomain are disabled
   console.warn(

--- a/packages/next/src/request/utils/getRequestFunction.ts
+++ b/packages/next/src/request/utils/getRequestFunction.ts
@@ -48,7 +48,7 @@ export function getRequestFunction(
 
 /* ========== HELPERS ========== */
 /**
- * Special handler for when experimentalLocaleResolution is enabled
+ * Deprecated handler for when experimentalLocaleResolution is enabled.
  */
 function handleExperimentalLocaleResolution(
   functionName: RequestFunctions


### PR DESCRIPTION
## Summary
- deprecate `experimentalLocaleResolution` and its param in `gt-next` config docs/types
- update cache components warnings to recommend explicit `getLocale.ts` / `getRegion.ts` request functions
- warn when `experimentalLocaleResolution` is enabled because it relies on unsupported Next.js internals
- add focused cache components warning coverage

## Verification
- `git diff --check`
- `pnpm format`
- `pnpm --filter gt-next typecheck`
- `pnpm --filter gt-next test:js -- --runInBand`
- `pnpm --filter gt-next transpile`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1437"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR deprecates `experimentalLocaleResolution` (and its companion param) across types, JSDoc, and runtime warnings, and pivots the `cacheComponents` checks to recommend explicit `getLocale.ts` / `getRegion.ts` request functions instead.

- **`cacheComponentsChecks.ts`**: Detects missing `getLocale`/`getRegion` paths independently of `experimentalLocaleResolution`; when the deprecated flag is still present it emits a new deprecation warning before continuing through its existing guard rails.
- **`cacheComponents.ts` errors**: Old single warning replaced by a factory (`createCacheComponentsMissingRequestFunctionsWarning`) and a new `experimentalLocaleResolutionDeprecatedWarning` constant; the `wayOut` copy in the factory references \"Automatic root parameter detection\" even for users who never enabled the deprecated feature.
- **Tests**: New `cacheComponentsChecks.test.ts` covers the four main scenarios for the refactored check.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; changes are additive deprecation warnings with no removal of existing functionality.

The refactored check logic is correct and the new tests cover the main paths. The one rough edge is a wayOut message in createCacheComponentsMissingRequestFunctionsWarning that references automatic root parameter detection even for users who never opted into the deprecated feature, which could confuse first-time adopters of cacheComponents.

packages/next/src/errors/cacheComponents.ts — the warning copy for the factory function.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/plugin/checks/cacheComponentsChecks.ts | Logic refactored: missing-request-functions check is now independent of experimentalLocaleResolution, and the deprecated feature now emits a deprecation warning when present. Control flow is correct; users with both cacheComponents and experimentalLocaleResolution will receive multiple overlapping warnings, which appears intentional. |
| packages/next/src/errors/cacheComponents.ts | Old single warning replaced by a factory function plus a new deprecation constant; wayOut copy references the deprecated automatic detection path in a context that also surfaces to users who never enabled it. |
| packages/next/src/plugin/checks/__tests__/cacheComponentsChecks.test.ts | New test file with four focused cases covering missing-both, missing-one, both-present, and deprecated-flag scenarios. Good coverage for the changed paths. |
| packages/next/src/config-dir/props/withGTConfigProps.ts | Added @deprecated JSDoc annotations to experimentalLocaleResolution and experimentalLocaleResolutionParam with correct migration guidance. |
| packages/next/src/errors/ssg.ts | deprecatedExperimentalEnableSSGWarning fix message updated to point to getLocalePath/getRegionPath instead of the now-deprecated experimentalLocaleResolution. |
| packages/next/src/request/utils/getRequestFunction.ts | Comment-only change: 'Special handler' → 'Deprecated handler'. No functional change. |
| packages/next/src/config.ts | JSDoc param descriptions for the two deprecated options updated to reflect their deprecated status. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[cacheComponentsChecks called] --> B{cacheComponents enabled?}
    B -- No --> E
    B -- Yes --> C[Check missingRequestFunctions]
    C --> C1{getLocale path set?}
    C1 -- No --> C2[push getLocale]
    C1 -- Yes --> C3{getRegion path set?}
    C2 --> C3
    C3 -- No --> C4[push getRegion]
    C3 -- Yes --> D
    C4 --> D{missingRequestFunctions.length > 0?}
    D -- Yes --> D1[warn: createCacheComponentsMissingRequestFunctionsWarning]
    D -- No --> E
    D1 --> E{experimentalLocaleResolution enabled?}
    E -- No --> F[return early]
    E -- Yes --> G[warn: experimentalLocaleResolutionDeprecatedWarning]
    G --> H[warn: getRegion and getDomain disabled]
    H --> I{experimentalEnableSSG?}
    I -- Yes --> J[throw: cacheComponentsLegacySsgConflictError]
    I -- No --> K{getLocale path set?}
    K -- Yes --> L[warn: custom getLocale will be ignored]
    K -- No --> M
    L --> M{cacheComponents disabled?}
    M -- Yes --> N[warn: experimentalLocaleResolution without cacheComponents]
    M -- No --> O[done]
    N --> O
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fnext%2Fsrc%2Ferrors%2FcacheComponents.ts%3A40-43%0A**Misleading%20%60wayOut%60%20for%20users%20who%20never%20enabled%20%60experimentalLocaleResolution%60**%0A%0A%60createCacheComponentsMissingRequestFunctionsWarning%60%20is%20shown%20to%20any%20user%20who%20enables%20%60cacheComponents%60%20without%20configuring%20%60getLocale%60%2F%60getRegion%60%2C%20regardless%20of%20whether%20they%20ever%20touched%20%60experimentalLocaleResolution%60.%20For%20a%20brand-new%20user%20the%20%60wayOut%60%20message%20%E2%80%94%20%60%22Automatic%20root%20parameter%20detection%20is%20deprecated%20because%20it%20relies%20on%20unsupported%20Next.js%20internals%22%60%20%E2%80%94%20refers%20to%20a%20feature%20they%20never%20opted%20into%2C%20making%20the%20warning%20confusing%20and%20harder%20to%20act%20on.%20The%20%60fix%60%20line%20already%20gives%20the%20right%20action%3B%20the%20%60wayOut%60%20only%20adds%20noise%20for%20the%20common%20case.%0A%0A&repo=generaltranslation%2Fgt&pr=1437&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22bg%2Fdeprecate-experimental-locale-resolution%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22bg%2Fdeprecate-experimental-locale-resolution%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fnext%2Fsrc%2Ferrors%2FcacheComponents.ts%3A40-43%0A**Misleading%20%60wayOut%60%20for%20users%20who%20never%20enabled%20%60experimentalLocaleResolution%60**%0A%0A%60createCacheComponentsMissingRequestFunctionsWarning%60%20is%20shown%20to%20any%20user%20who%20enables%20%60cacheComponents%60%20without%20configuring%20%60getLocale%60%2F%60getRegion%60%2C%20regardless%20of%20whether%20they%20ever%20touched%20%60experimentalLocaleResolution%60.%20For%20a%20brand-new%20user%20the%20%60wayOut%60%20message%20%E2%80%94%20%60%22Automatic%20root%20parameter%20detection%20is%20deprecated%20because%20it%20relies%20on%20unsupported%20Next.js%20internals%22%60%20%E2%80%94%20refers%20to%20a%20feature%20they%20never%20opted%20into%2C%20making%20the%20warning%20confusing%20and%20harder%20to%20act%20on.%20The%20%60fix%60%20line%20already%20gives%20the%20right%20action%3B%20the%20%60wayOut%60%20only%20adds%20noise%20for%20the%20common%20case.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/next/src/errors/cacheComponents.ts:40-43
**Misleading `wayOut` for users who never enabled `experimentalLocaleResolution`**

`createCacheComponentsMissingRequestFunctionsWarning` is shown to any user who enables `cacheComponents` without configuring `getLocale`/`getRegion`, regardless of whether they ever touched `experimentalLocaleResolution`. For a brand-new user the `wayOut` message — `"Automatic root parameter detection is deprecated because it relies on unsupported Next.js internals"` — refers to a feature they never opted into, making the warning confusing and harder to act on. The `fix` line already gives the right action; the `wayOut` only adds noise for the common case.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: deprecate experimental locale resol..."](https://github.com/generaltranslation/gt/commit/7ebf31e148b479a878e4826198f9e29d34a5c854) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32417259)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->