### PR TITLE
chore: enter odysseus prerelease mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,28 @@
+{
+  "mode": "pre",
+  "tag": "odysseus",
+  "initialVersions": {
+    "gt": "2.14.37",
+    "@generaltranslation/compiler": "1.3.23",
+    "generaltranslation": "8.2.15",
+    "@generaltranslation/format": "0.1.1",
+    "gtx-cli": "2.14.37",
+    "gt-i18n": "0.9.3",
+    "locadex": "1.0.172",
+    "@generaltranslation/mcp": "1.0.7",
+    "@generaltranslation/next-internal": "0.1.2",
+    "@generaltranslation/gt-next-lint": "14.0.28",
+    "gt-next": "6.16.28",
+    "gt-node": "0.7.3",
+    "@generaltranslation/python-extractor": "0.2.21",
+    "@generaltranslation/react-core-linter": "0.1.9",
+    "@generaltranslation/react-core": "1.8.19",
+    "gt-react-native": "10.19.17",
+    "gt-react": "10.19.17",
+    "gt-remark": "1.0.7",
+    "gt-sanity": "2.0.17",
+    "@generaltranslation/supported-locales": "2.0.73",
+    "gt-tanstack-start": "0.4.21"
+  },
+  "changesets": []
+}

--- a/.changeset/separate-external-store-conditions.md
+++ b/.changeset/separate-external-store-conditions.md
@@ -1,9 +1,0 @@
----
-"@generaltranslation/react-core": major
-"gt-react": major
-"gt-i18n": major
-"gt-tanstack-start": major
-"gt-next": major
----
-
-useSyncExternalStore refactor


### PR DESCRIPTION
## Summary
- remove the pending major changeset from this branch
- add Changesets prerelease state for the `odysseus` tag

## Notes
Merge first. This prepares the branch for prerelease versions like `x.y.z-odysseus.0` without publishing anything by itself.

## Testing
- Not run: local `pnpm`/`node` are not on PATH in this shell
- Validated `.changeset/pre.json` with `jq`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->