### PR TITLE
ci: add odysseus release workflow

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,7 +11,7 @@
   ],
   "linked": [],
   "access": "public",
-  "baseBranch": "main",
+  "baseBranch": "odysseus",
   "updateInternalDependencies": "minor",
   "ignore": [
     "base",

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,7 +11,7 @@
   ],
   "linked": [],
   "access": "public",
-  "baseBranch": "odysseus",
+  "baseBranch": "main",
   "updateInternalDependencies": "minor",
   "ignore": [
     "base",

--- a/.github/workflows/release-odysseus.yml
+++ b/.github/workflows/release-odysseus.yml
@@ -36,11 +36,6 @@ jobs:
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/release-odysseus.yml
+++ b/.github/workflows/release-odysseus.yml
@@ -1,0 +1,73 @@
+name: Odysseus Release
+
+on:
+  push:
+    branches:
+      - odysseus
+
+permissions:
+  id-token: write # Required for OIDC
+  contents: write
+  pull-requests: write
+  packages: write
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+env:
+  CI: true
+
+jobs:
+  release:
+    name: Odysseus Release
+    runs-on: ubuntu-latest
+    environment:
+      name: 'release'
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-wasip1
+
+      - name: Install Dependencies
+        # not frozen since we are using workspaces & package versions will change
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Build packages
+        run: pnpm run build:release
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+      - name: Verify Odysseus prerelease mode
+        run: |
+          test -f .changeset/pre.json
+          test "$(jq -r '.mode' .changeset/pre.json)" = "pre"
+          test "$(jq -r '.tag' .changeset/pre.json)" = "odysseus"
+
+      - name: Create Odysseus Release Pull Request or Publish to npm
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          version: pnpm run version-packages
+          publish: pnpm run release
+          commit: '[ci] odysseus release'
+          title: '[ci] odysseus release'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-odysseus.yml
+++ b/.github/workflows/release-odysseus.yml
@@ -50,6 +50,11 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
+      - name: Configure Changesets for Odysseus
+        run: |
+          jq '.baseBranch = "odysseus"' .changeset/config.json > .changeset/config.tmp.json
+          mv .changeset/config.tmp.json .changeset/config.json
+
       - name: Verify Odysseus prerelease mode
         run: |
           test -f .changeset/pre.json

--- a/.github/workflows/release-odysseus.yml
+++ b/.github/workflows/release-odysseus.yml
@@ -6,7 +6,6 @@ on:
       - odysseus
 
 permissions:
-  id-token: write # Required for OIDC
   contents: write
   pull-requests: write
   packages: write
@@ -25,6 +24,12 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+
+      - name: Verify Odysseus prerelease mode
+        run: |
+          test -f .changeset/pre.json
+          test "$(jq -r '.mode' .changeset/pre.json)" = "pre"
+          test "$(jq -r '.tag' .changeset/pre.json)" = "odysseus"
 
       - uses: pnpm/action-setup@v4
         name: Install pnpm
@@ -54,12 +59,6 @@ jobs:
         run: |
           jq '.baseBranch = "odysseus"' .changeset/config.json > .changeset/config.tmp.json
           mv .changeset/config.tmp.json .changeset/config.json
-
-      - name: Verify Odysseus prerelease mode
-        run: |
-          test -f .changeset/pre.json
-          test "$(jq -r '.mode' .changeset/pre.json)" = "pre"
-          test "$(jq -r '.tag' .changeset/pre.json)" = "odysseus"
 
       - name: Create Odysseus Release Pull Request or Publish to npm
         id: changesets


### PR DESCRIPTION
## Summary
- add a dedicated release workflow for pushes to `odysseus`
- set Changesets `baseBranch` to `odysseus`
- publish through `changeset publish` only, with no `@bin`, R2, or PyPI release steps
- fail early unless `.changeset/pre.json` is in `odysseus` prerelease mode

## Notes
Merge second, after #1441. This keeps the main release workflow unchanged.

## Testing
- Not run: local `pnpm`/`node` are not on PATH in this shell
- Reviewed workflow diff for binary/PyPI publish omissions

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a dedicated GitHub Actions workflow (`release-odysseus.yml`) that handles npm prerelease publishing for the `odysseus` branch, while leaving the existing `release.yml` untouched. It patches `baseBranch` in the Changesets config at runtime (via `jq`) rather than editing the shared `config.json`, which avoids the forward-merge hazard raised in earlier reviews.

- Adds `release-odysseus.yml` triggered on push to `odysseus`, with an early prerelease guard (`pre.json` mode/tag check immediately after checkout), skipping all `@bin`, R2, and PyPI steps.
- Patches `.changeset/config.json` at runtime to set `baseBranch = \"odysseus\"` so the Changesets action targets the correct branch.
- Missing `oven-sh/setup-bun@v2` setup step compared to `release.yml`; if `build:release` invokes `bun`, the build step will fail.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with one fix: the missing Bun setup step will cause build:release to fail if any package in the monorepo invokes bun during compilation.

The workflow is structurally sound — the early prerelease guard, runtime config patching, and omission of binary/PyPI steps are all correct. The one concrete gap is the absent oven-sh/setup-bun@v2 step that the main release.yml carries; without it, pnpm run build:release will break the odysseus workflow whenever bun is invoked.

.github/workflows/release-odysseus.yml — specifically the missing Bun setup before the build step.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-odysseus.yml | New CI workflow for odysseus prerelease publishing; mirrors release.yml but omits the Bun setup step that build:release likely requires |

</details>

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Frelease-odysseus.yml%3A44-49%0AThe%20main%20%60release.yml%60%20installs%20Bun%20%28%60oven-sh%2Fsetup-bun%40v2%60%29%20before%20running%20%60pnpm%20run%20build%3Arelease%60%2C%20but%20this%20step%20is%20absent%20here.%20If%20any%20package%20in%20the%20monorepo%20invokes%20%60bun%60%20during%20%60build%3Arelease%60%2C%20the%20step%20will%20fail%20with%20%60bun%3A%20command%20not%20found%60.%20Since%20the%20build%20matrix%20is%20shared%20between%20both%20workflows%2C%20a%20missing%20toolchain%20dependency%20will%20silently%20break%20the%20odysseus%20build.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20name%3A%20Setup%20Bun%0A%20%20%20%20%20%20%20%20uses%3A%20oven-sh%2Fsetup-bun%40v2%0A%20%20%20%20%20%20%20%20with%3A%0A%20%20%20%20%20%20%20%20%20%20bun-version%3A%20latest%0A%0A%20%20%20%20%20%20-%20name%3A%20Setup%20Rust%0A%20%20%20%20%20%20%20%20uses%3A%20dtolnay%2Frust-toolchain%40stable%0A%20%20%20%20%20%20%20%20with%3A%0A%20%20%20%20%20%20%20%20%20%20targets%3A%20wasm32-wasip1%0A%0A%20%20%20%20%20%20-%20name%3A%20Install%20Dependencies%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1442&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Frelease-ci%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Frelease-ci%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Frelease-odysseus.yml%3A44-49%0AThe%20main%20%60release.yml%60%20installs%20Bun%20%28%60oven-sh%2Fsetup-bun%40v2%60%29%20before%20running%20%60pnpm%20run%20build%3Arelease%60%2C%20but%20this%20step%20is%20absent%20here.%20If%20any%20package%20in%20the%20monorepo%20invokes%20%60bun%60%20during%20%60build%3Arelease%60%2C%20the%20step%20will%20fail%20with%20%60bun%3A%20command%20not%20found%60.%20Since%20the%20build%20matrix%20is%20shared%20between%20both%20workflows%2C%20a%20missing%20toolchain%20dependency%20will%20silently%20break%20the%20odysseus%20build.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20name%3A%20Setup%20Bun%0A%20%20%20%20%20%20%20%20uses%3A%20oven-sh%2Fsetup-bun%40v2%0A%20%20%20%20%20%20%20%20with%3A%0A%20%20%20%20%20%20%20%20%20%20bun-version%3A%20latest%0A%0A%20%20%20%20%20%20-%20name%3A%20Setup%20Rust%0A%20%20%20%20%20%20%20%20uses%3A%20dtolnay%2Frust-toolchain%40stable%0A%20%20%20%20%20%20%20%20with%3A%0A%20%20%20%20%20%20%20%20%20%20targets%3A%20wasm32-wasip1%0A%0A%20%20%20%20%20%20-%20name%3A%20Install%20Dependencies%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/release-odysseus.yml:44-49
The main `release.yml` installs Bun (`oven-sh/setup-bun@v2`) before running `pnpm run build:release`, but this step is absent here. If any package in the monorepo invokes `bun` during `build:release`, the step will fail with `bun: command not found`. Since the build matrix is shared between both workflows, a missing toolchain dependency will silently break the odysseus build.

```suggestion
      - name: Setup Bun
        uses: oven-sh/setup-bun@v2
        with:
          bun-version: latest

      - name: Setup Rust
        uses: dtolnay/rust-toolchain@stable
        with:
          targets: wasm32-wasip1

      - name: Install Dependencies
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["ci: tighten odysseus release workflow"](https://github.com/generaltranslation/gt/commit/9337e6660215c71d5a335170af59277a54b4f870) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32673772)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->