### PR TITLE
chore: add odysseus sanity release test

### DIFF
--- a/.changeset/odysseus-sanity-release-test.md
+++ b/.changeset/odysseus-sanity-release-test.md
@@ -1,0 +1,5 @@
+---
+"gt-sanity": patch
+---
+
+Test the odysseus prerelease publishing flow with gt-sanity.


### PR DESCRIPTION
## Summary
- add a patch changeset for `gt-sanity`
- use `gt-sanity` as the low-risk package to test odysseus prerelease publishing

## Notes
Merge third, after #1441 and #1442. The resulting release PR should show a `gt-sanity` prerelease version with the `odysseus` suffix before publishing.

## Testing
- Not run: changeset-only PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1443"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->