### PR TITLE
refactor: standardize react-core component wrappers

### DIFF
--- a/packages/react-core/src/components/branches/Branch.tsx
+++ b/packages/react-core/src/components/branches/Branch.tsx
@@ -1,19 +1,21 @@
 import type { ReactNode } from 'react';
 
+type BranchProps = {
+  children?: ReactNode;
+  branch?: string | number | boolean;
+  [key: string]: ReactNode;
+};
+
 // ===== Component ===== //
 
 /**
  * External-store version of the `<Branch>` component.
  */
-function Branch({
+function GtInternalBranch({
   children,
   branch,
   ...branches
-}: {
-  children?: ReactNode;
-  branch?: string | number | boolean;
-  [key: string]: ReactNode;
-}): ReactNode {
+}: BranchProps): ReactNode {
   let branchKey = branch?.toString();
   if (typeof branchKey === 'string' && branchKey.startsWith('data-')) {
     branchKey = undefined;
@@ -23,12 +25,8 @@ function Branch({
     : children;
 }
 
-function GtInternalBranch(props: {
-  children?: ReactNode;
-  branch?: string | number | boolean;
-  [key: string]: ReactNode;
-}): ReactNode {
-  return Branch(props);
+function Branch(props: BranchProps): React.JSX.Element {
+  return <GtInternalBranch {...props} />;
 }
 
 /** @internal _gtt - The GT transformation for the component. */

--- a/packages/react-core/src/components/branches/Plural.tsx
+++ b/packages/react-core/src/components/branches/Plural.tsx
@@ -2,19 +2,21 @@ import getPluralBranch from '../../utils/plurals/getPluralBranch';
 import type { ReactNode } from 'react';
 import { useFormatLocales } from '../../hooks/utils';
 
-// ===== Component ===== //
-
-function Plural({
-  children,
-  n,
-  locales: localesProp = [],
-  ...branches
-}: {
+type PluralProps = {
   children?: ReactNode;
   n: number;
   locales?: string[];
   [key: string]: ReactNode;
-}): ReactNode {
+};
+
+// ===== Component ===== //
+
+function GtInternalPlural({
+  children,
+  n,
+  locales: localesProp = [],
+  ...branches
+}: PluralProps): ReactNode {
   const locales = useFormatLocales(localesProp);
   if (typeof n !== 'number') {
     return children;
@@ -22,13 +24,8 @@ function Plural({
   return getPluralBranch(n, locales, branches) || children;
 }
 
-function GtInternalPlural(props: {
-  children?: ReactNode;
-  n: number;
-  locales?: string[];
-  [key: string]: ReactNode;
-}): ReactNode {
-  return Plural(props);
+function Plural(props: PluralProps): React.JSX.Element {
+  return <GtInternalPlural {...props} />;
 }
 
 /** @internal _gtt - The GT transformation for the component. */

--- a/packages/react-core/src/components/derivation/Derive.tsx
+++ b/packages/react-core/src/components/derivation/Derive.tsx
@@ -1,17 +1,19 @@
 import type { ReactNode } from 'react';
 
-// ===== Component ===== //
+type DeriveProps<T extends ReactNode> = {
+  children: T;
+};
 
-function Derive<T extends ReactNode>({ children }: { children: T }): T {
-  return children;
-}
+// ===== Component ===== //
 
 function GtInternalDerive<T extends ReactNode>({
   children,
-}: {
-  children: T;
-}): T {
+}: DeriveProps<T>): T {
   return children;
+}
+
+function Derive<T extends ReactNode>(props: DeriveProps<T>): React.JSX.Element {
+  return <GtInternalDerive {...props} />;
 }
 
 /** @internal _gtt - The GT transformation for the component. */

--- a/packages/react-core/src/components/variables/Currency.tsx
+++ b/packages/react-core/src/components/variables/Currency.tsx
@@ -1,6 +1,14 @@
 import { getReactI18nManager } from '../../i18n-manager/singleton-operations';
 import { useFormatLocales } from '../../hooks/utils';
 
+type CurrencyProps = {
+  children: number | string | null | undefined;
+  currency?: string;
+  options?: Intl.NumberFormatOptions;
+  locales?: string[];
+  name?: string;
+};
+
 // ===== Component ===== //
 
 function GtInternalCurrency({
@@ -8,13 +16,7 @@ function GtInternalCurrency({
   currency = 'USD',
   options = {},
   locales: localesProp = [],
-}: {
-  children: number | string | null | undefined;
-  currency?: string;
-  options?: Intl.NumberFormatOptions;
-  locales?: string[];
-  name?: string;
-}): string | null {
+}: CurrencyProps): string | null {
   const locales = useFormatLocales(localesProp);
   const gt = getReactI18nManager().getGTClass();
   if (children == null) return null;
@@ -26,14 +28,8 @@ function GtInternalCurrency({
   });
 }
 
-function Currency(props: {
-  children: number | string | null | undefined;
-  currency?: string;
-  options?: Intl.NumberFormatOptions;
-  locales?: string[];
-  name?: string;
-}): string | null {
-  return GtInternalCurrency(props);
+function Currency(props: CurrencyProps): React.JSX.Element {
+  return <GtInternalCurrency {...props} />;
 }
 
 /** @internal _gtt - The GT transformation for the component. */

--- a/packages/react-core/src/components/variables/DateTime.tsx
+++ b/packages/react-core/src/components/variables/DateTime.tsx
@@ -1,18 +1,20 @@
 import { getReactI18nManager } from '../../i18n-manager/singleton-operations';
 import { useFormatLocales } from '../../hooks/utils';
 
+type DateTimeProps = {
+  children: Date | null | undefined;
+  locales?: string[];
+  options?: Intl.DateTimeFormatOptions;
+  name?: string;
+};
+
 // ===== Component ===== //
 
 function GtInternalDateTime({
   children,
   options = {},
   locales: localesProp = [],
-}: {
-  children: Date | null | undefined;
-  locales?: string[];
-  options?: Intl.DateTimeFormatOptions;
-  name?: string;
-}): string | null {
+}: DateTimeProps): string | null {
   const locales = useFormatLocales(localesProp);
   // TODO: theres a world in which we don't need the i18n manager, if user passes their own params
   const gt = getReactI18nManager().getGTClass();
@@ -22,13 +24,8 @@ function GtInternalDateTime({
     .replace(/[\u200F\u202B\u202E]/g, '');
 }
 
-function DateTime(props: {
-  children: Date | null | undefined;
-  locales?: string[];
-  options?: Intl.DateTimeFormatOptions;
-  name?: string;
-}): string | null {
-  return GtInternalDateTime(props);
+function DateTime(props: DateTimeProps): React.JSX.Element {
+  return <GtInternalDateTime {...props} />;
 }
 
 /** @internal _gtt - The GT transformation for the component. */

--- a/packages/react-core/src/components/variables/Num.tsx
+++ b/packages/react-core/src/components/variables/Num.tsx
@@ -1,18 +1,20 @@
 import { getReactI18nManager } from '../../i18n-manager/singleton-operations';
 import { useFormatLocales } from '../../hooks/utils';
 
+type NumProps = {
+  children: number | string | null | undefined;
+  options?: Intl.NumberFormatOptions;
+  locales?: string[];
+  name?: string;
+};
+
 // ===== Component ===== //
 
 function GtInternalNum({
   children,
   options = {},
   locales: localesProp = [],
-}: {
-  children: number | string | null | undefined;
-  options?: Intl.NumberFormatOptions;
-  locales?: string[];
-  name?: string;
-}): string | null {
+}: NumProps): string | null {
   const locales = useFormatLocales(localesProp);
   const gt = getReactI18nManager().getGTClass();
   if (children == null) return null;
@@ -21,13 +23,8 @@ function GtInternalNum({
   return gt.formatNum(parsedNumber, { locales, ...options });
 }
 
-function Num(props: {
-  children: number | string | null | undefined;
-  options?: Intl.NumberFormatOptions;
-  locales?: string[];
-  name?: string;
-}): string | null {
-  return GtInternalNum(props);
+function Num(props: NumProps): React.JSX.Element {
+  return <GtInternalNum {...props} />;
 }
 
 /** @internal _gtt - The GT transformation for the component. */

--- a/packages/react-core/src/components/variables/RelativeTime.tsx
+++ b/packages/react-core/src/components/variables/RelativeTime.tsx
@@ -1,6 +1,17 @@
 import { getReactI18nManager } from '../../i18n-manager/singleton-operations';
 import { useFormatLocales } from '../../hooks/utils';
 
+type RelativeTimeProps = {
+  date?: Date | null | undefined;
+  children?: Date | null | undefined;
+  name?: string;
+  value?: number;
+  unit?: Intl.RelativeTimeFormatUnit;
+  baseDate?: Date;
+  locales?: string[];
+  options?: Intl.RelativeTimeFormatOptions;
+};
+
 // ===== Component ===== //
 
 function GtInternalRelativeTime({
@@ -11,16 +22,7 @@ function GtInternalRelativeTime({
   baseDate,
   locales: localesProp = [],
   options = {},
-}: {
-  date?: Date | null | undefined;
-  children?: Date | null | undefined;
-  name?: string;
-  value?: number;
-  unit?: Intl.RelativeTimeFormatUnit;
-  baseDate?: Date;
-  locales?: string[];
-  options?: Intl.RelativeTimeFormatOptions;
-}): string | null {
+}: RelativeTimeProps): string | null {
   const locales = useFormatLocales(localesProp);
   const gt = getReactI18nManager().getGTClass();
   const resolvedDate = date ?? children;
@@ -54,16 +56,8 @@ function GtInternalRelativeTime({
   return null;
 }
 
-function RelativeTime(props: {
-  date?: Date | null | undefined;
-  children?: Date | null | undefined;
-  value?: number;
-  unit?: Intl.RelativeTimeFormatUnit;
-  baseDate?: Date;
-  locales?: string[];
-  options?: Intl.RelativeTimeFormatOptions;
-}): string | null {
-  return GtInternalRelativeTime(props);
+function RelativeTime(props: RelativeTimeProps): React.JSX.Element {
+  return <GtInternalRelativeTime {...props} />;
 }
 
 /** @internal _gtt - The GT transformation for the component. */

--- a/packages/react-core/src/components/variables/Var.tsx
+++ b/packages/react-core/src/components/variables/Var.tsx
@@ -1,5 +1,10 @@
 import type { ReactNode } from 'react';
 
+type VarProps<T extends ReactNode> = {
+  children: T;
+  name?: string;
+};
+
 // ===== Shared Logic ===== //
 
 function computeVar<T extends ReactNode>({ children }: { children: T }): T {
@@ -11,22 +16,14 @@ function computeVar<T extends ReactNode>({ children }: { children: T }): T {
 /**
  * External-store version of the `<Var>` component.
  */
-function Var<T extends ReactNode>({
+function GtInternalVar<T extends ReactNode>({
   children,
-}: {
-  children: T;
-  name?: string;
-}): T {
+}: VarProps<T>): T {
   return computeVar({ children });
 }
 
-function GtInternalVar<T extends ReactNode>({
-  children,
-}: {
-  children: T;
-  name?: string;
-}): T {
-  return computeVar({ children });
+function Var<T extends ReactNode>(props: VarProps<T>): React.JSX.Element {
+  return <GtInternalVar {...props} />;
 }
 
 /** @internal _gtt - The GT transformation for the component. */


### PR DESCRIPTION
## Summary
- Route public react-core components through their GtInternal counterparts via JSX
- Standardize public wrapper return types as React.JSX.Element
- Extract shared prop types for the wrapper/internal pairs

## Verification
- pnpm --filter @generaltranslation/react-core build

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR standardizes the public/internal component wrapper pattern across `react-core` by inverting the caller relationship — the `GtInternal*` variants now own the implementation logic, and the public wrappers (`Branch`, `Plural`, `Currency`, etc.) delegate to them via JSX rather than direct function calls. Shared prop types (`BranchProps`, `PluralProps`, `CurrencyProps`, etc.) are extracted to eliminate duplication between the wrapper and internal pairs.

- **Wrapper inversion**: In all eight files the public component now renders `<GtInternal* {...props} />` via JSX, making the React component lifecycle (hooks, reconciliation) work correctly in the internal variants rather than bypassing it through direct function invocation.
- **Return type standardisation**: Public wrapper return types are uniformly declared as `React.JSX.Element`; internal implementations continue to return their natural types (`ReactNode`, `string | null`, or generic `T`).
- **Shared prop types**: A single named type per component pair replaces duplicated inline object types, reducing divergence risk if props need to evolve.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — this is a pure structural refactor with no changes to business logic or rendering output.

All eight files follow a uniform mechanical transformation: extract a shared props type, move the implementation body into the GtInternal* function, and have the public wrapper render it via JSX. No conditional logic, hook calls, or data paths were altered. The build passes, _gtt markers are preserved, and the only observable API differences were already surfaced in the previous review round.

No files require special attention — the changes are consistent and mechanical across all eight components.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/components/branches/Branch.tsx | Inverted public/internal relationship — GtInternalBranch is now the implementation, Branch wraps it via JSX; shared BranchProps type extracted; _gtt markers unchanged. |
| packages/react-core/src/components/branches/Plural.tsx | Same inversion as Branch — GtInternalPlural holds the hook call and logic, Plural delegates via JSX; PluralProps shared; no behavioural change. |
| packages/react-core/src/components/derivation/Derive.tsx | Public Derive<T> now returns React.JSX.Element instead of T; the generic return type is effectively dropped on the public wrapper (noted in previous review). |
| packages/react-core/src/components/variables/Currency.tsx | Public Currency now returns React.JSX.Element instead of string | null; CurrencyProps extracted and shared; no React import but uses React.JSX.Element (relies on UMD global from @types/react). |
| packages/react-core/src/components/variables/RelativeTime.tsx | name prop now included in shared RelativeTimeProps, expanding the public API surface; public wrapper return type changed to React.JSX.Element. |
| packages/react-core/src/components/variables/Var.tsx | computeVar helper preserved and still exported; GtInternalVar is now the sole caller of computeVar; Var<T> wraps via JSX losing the generic return type on the public API. |
| packages/react-core/src/components/variables/DateTime.tsx | DateTimeProps extracted; public DateTime return type changed from string | null to React.JSX.Element; straightforward refactor with no logic changes. |
| packages/react-core/src/components/variables/Num.tsx | NumProps extracted; public Num return type changed from string | null to React.JSX.Element; straightforward refactor with no logic changes. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Before
        B1["Branch (implementation)"] -->|"direct call: Branch(props)"| B2["GtInternalBranch (wrapper)"]
        C1["Currency (implementation)\nreturns string | null"] -->|"direct call"| C2["GtInternalCurrency (wrapper)\nreturns string | null"]
    end

    subgraph After
        A1["GtInternalBranch (implementation)\nreturns ReactNode"] -->|"rendered via JSX"| A2["Branch (public wrapper)\nreturns React.JSX.Element"]
        D1["GtInternalCurrency (implementation)\nreturns string | null"] -->|"rendered via JSX"| D2["Currency (public wrapper)\nreturns React.JSX.Element"]
    end

    style Before fill:#f9f0e8,stroke:#ccc
    style After fill:#e8f4f9,stroke:#ccc
```
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor: standardize react-core compone..."](https://github.com/generaltranslation/gt/commit/93836ad3ab9ade1dc0916a5d045e910480bfa28c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32723020)</sub>

<!-- /greptile_comment -->