### PR TITLE
reexport the t function

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "scripts": {
     "build": "turbo run build --filter='./packages/*' --ui tui",
+    "build:watch": "turbo watch build --filter='./packages/*' --ui tui",
     "test": "turbo run test --filter='./packages/*'",
     "lint": "oxlint packages && pnpm --filter './examples/*' --filter './tests/apps/**/*' --if-present run lint && oxfmt --check .",
     "lint:fix": "oxlint packages --fix && pnpm --filter './examples/*' --filter './tests/apps/**/*' --if-present lint --fix && oxfmt .",

--- a/packages/i18n/src/i18n-manager/I18nManager.ts
+++ b/packages/i18n/src/i18n-manager/I18nManager.ts
@@ -35,12 +35,7 @@ import {
   createLocaleResolver,
   LocaleCandidates,
 } from "../condition-store/localeResolver";
-
-type RuntimeEnvironment = {
-  DEV?: boolean;
-  MODE?: string;
-  NODE_ENV?: string;
-};
+import { getRuntimeEnvironment } from "../utils/getRuntimeEnvironment";
 
 /**
  * Default translation timeout in milliseconds for a runtime translation request
@@ -856,27 +851,6 @@ function standardizeConfig<TranslationValue extends Translation>(
       ? standardizeLocales(dedupedLocales)
       : dedupedLocales),
   };
-}
-
-function getRuntimeEnvironment(): "development" | "production" {
-  const processEnv = typeof process === "undefined" ? undefined : process.env;
-  if (processEnv?.NODE_ENV === "development") {
-    return "development";
-  }
-
-  const importMetaEnv = (
-    import.meta as ImportMeta & {
-      env?: RuntimeEnvironment;
-    }
-  ).env;
-  if (importMetaEnv?.MODE) {
-    return importMetaEnv.MODE === "development" ? "development" : "production";
-  }
-  if (importMetaEnv?.DEV === true) {
-    return "development";
-  }
-
-  return "production";
 }
 
 /**

--- a/packages/i18n/src/internal.ts
+++ b/packages/i18n/src/internal.ts
@@ -26,3 +26,4 @@ export {
   setI18nManager,
 } from "./i18n-manager/singleton-operations";
 export { createConditionStoreSingleton } from "./condition-store/createConditionStoreSingleton";
+export { getRuntimeEnvironment } from "./utils/getRuntimeEnvironment";

--- a/packages/i18n/src/utils/getRuntimeEnvironment.ts
+++ b/packages/i18n/src/utils/getRuntimeEnvironment.ts
@@ -1,0 +1,26 @@
+export type RuntimeEnvironment = {
+  DEV?: boolean;
+  MODE?: string;
+  NODE_ENV?: string;
+};
+
+export function getRuntimeEnvironment(): "development" | "production" {
+  const processEnv = typeof process === "undefined" ? undefined : process.env;
+  if (processEnv?.NODE_ENV === "development") {
+    return "development";
+  }
+
+  const importMetaEnv = (
+    import.meta as ImportMeta & {
+      env?: RuntimeEnvironment;
+    }
+  ).env;
+  if (importMetaEnv?.MODE) {
+    return importMetaEnv.MODE === "development" ? "development" : "production";
+  }
+  if (importMetaEnv?.DEV === true) {
+    return "development";
+  }
+
+  return "production";
+}

--- a/packages/react-core/src/condition-store/singleton-operations.ts
+++ b/packages/react-core/src/condition-store/singleton-operations.ts
@@ -4,6 +4,7 @@ import type { WritableConditionStoreInterface } from "gt-i18n/internal/types";
 export const {
   getConditionStore: getWritableConditionStore,
   setConditionStore: setWritableConditionStore,
+  isConditionStoreInitialized: isWritableConditionStoreInitialized,
 } = createConditionStoreSingleton<WritableConditionStoreInterface>(
   "WritableConditionStore is not initialized.",
 );

--- a/packages/react-core/src/context.ts
+++ b/packages/react-core/src/context.ts
@@ -40,6 +40,7 @@ export {
   mFallback,
   gtFallback,
 } from "gt-i18n";
+export { t } from "./functions/translation/t";
 
 // ===== Internal ===== //
 export { InternalGTProvider } from "./context/InternalGTProvider";

--- a/packages/react-core/src/functions/translation/t.ts
+++ b/packages/react-core/src/functions/translation/t.ts
@@ -1,10 +1,15 @@
-import {
-  getLocale,
-  resolveTranslationSync,
-  resolveTranslationSyncWithFallback,
-} from 'gt-i18n/internal';
-import type { InlineTranslationOptions } from 'gt-i18n/types';
-import { getRenderStrategy } from '../../setup/globals';
+import { createLookupOptions, interpolateMessage } from "gt-i18n/internal";
+import type {
+  InlineTranslationOptions,
+  ResolutionOptions,
+} from "gt-i18n/types";
+import { getRenderStrategy } from "../../setup/globals";
+import { isWritableConditionStoreInitialized } from "../../condition-store/singleton-operations";
+import { StringContent } from "generaltranslation/types";
+import { getReactI18nManager } from "../../i18n-manager/singleton-operations";
+import { StringFormat } from "generaltranslation/types";
+import { getShouldTranslate } from "../../hooks/utils";
+import { getLocale } from "../../hooks/context-hooks";
 
 /**
  * NOTE: t() is the only function exported from the 'gt-react' entry point.
@@ -35,22 +40,14 @@ export const t: StringOrTemplateSyncResolutionFunction = (
   messageOrStrings: string | TemplateStringsArray,
   ...values: unknown[]
 ) => {
-  // Fail on SSR applications
-  if (getRenderStrategy() === 'server-render') {
-    console.warn(
-      createTranslationFailedDueToBrowserEnvironmentWarning(messageOrStrings)
-    );
-  }
+  // Warnings and errors
+  enforceSSRRules(messageOrStrings);
 
   //  t("Hello, {name}!", { name: "John" })
-  if (typeof messageOrStrings === 'string') {
+  if (typeof messageOrStrings === "string") {
     const options = values.at(0) as InlineTranslationOptions | undefined;
     const locale = options?.$locale ?? getLocale();
-    return resolveTranslationSyncWithFallback(
-      locale,
-      messageOrStrings,
-      options
-    );
+    return resolveStringContent(locale, messageOrStrings, options);
   }
 
   // t`Hello, ${name}`
@@ -58,6 +55,35 @@ export const t: StringOrTemplateSyncResolutionFunction = (
 };
 
 // ----- Helper Functions ----- //
+
+export function resolveStringContent(
+  locale: string,
+  content: StringContent,
+  options: ResolutionOptions<StringFormat> = {},
+): StringContent {
+  const i18nManager = getReactI18nManager();
+  const defaultLocale = i18nManager.getDefaultLocale();
+  if (!getShouldTranslate()) {
+    return interpolateMessage({
+      options,
+      source: content,
+      sourceLocale: defaultLocale,
+    });
+  }
+
+  const lookupOptions = createLookupOptions(locale, options, "ICU");
+  const translation = i18nManager.lookupTranslation(
+    lookupOptions.$locale,
+    content,
+    lookupOptions,
+  );
+  return interpolateMessage({
+    source: content,
+    target: translation,
+    options: lookupOptions,
+    sourceLocale: defaultLocale,
+  });
+}
 
 /**
  * Handle tagged template literal translation
@@ -72,27 +98,29 @@ export const t: StringOrTemplateSyncResolutionFunction = (
  */
 function handleTaggedTemplateLiteralTranslation(
   messageOrStrings: TemplateStringsArray,
-  values: unknown[]
+  values: unknown[],
 ): string {
   const locale = getLocale();
   // for tagged template literals, there has been no compiler transformation
   // (1) lookup interpolated template (aka derived message)
   const interpolatedTemplate = interpolateTemplateLiteral(
     messageOrStrings,
-    values
+    values,
   );
-  const translatedInterpolatedTemplate = resolveTranslationSync(
+  const i18nManager = getReactI18nManager();
+  const translatedInterpolatedTemplate = i18nManager.lookupTranslation(
     locale,
-    interpolatedTemplate
+    interpolatedTemplate,
+    { $format: "STRING" },
   );
   if (translatedInterpolatedTemplate) return translatedInterpolatedTemplate;
 
   // (2) resolve uninterpolated message
   const { message, variables } = extractInterpolatableValues(
     messageOrStrings,
-    values
+    values,
   );
-  return resolveTranslationSyncWithFallback(locale, message, variables);
+  return resolveStringContent(locale, message, variables);
 }
 
 /**
@@ -103,7 +131,7 @@ function handleTaggedTemplateLiteralTranslation(
  */
 function extractInterpolatableValues(
   strings: TemplateStringsArray,
-  values: unknown[]
+  values: unknown[],
 ): {
   message: string;
   variables: Record<string, unknown>;
@@ -128,7 +156,7 @@ function extractInterpolatableValues(
   }
 
   return {
-    message: parts.join(''),
+    message: parts.join(""),
     variables,
   };
 }
@@ -141,24 +169,54 @@ function extractInterpolatableValues(
  */
 function interpolateTemplateLiteral(
   strings: TemplateStringsArray,
-  values: unknown[]
+  values: unknown[],
 ): string {
   return strings
     .map((string, index) => {
-      return string + (values[index] ?? '');
+      return string + (values[index] ?? "");
     })
-    .join('');
+    .join("");
+}
+
+// ----- Warnings and errors ----- //
+
+/**
+ * If detect SSR + module level:
+ * - Build: Error
+ * - Dev: Error
+ * - Prod: Warn
+ */
+function enforceSSRRules(messageOrStrings: string | TemplateStringsArray) {
+  const ssrEnabled = getRenderStrategy() === "server-render";
+  const moduleLevel = !isWritableConditionStoreInitialized();
+  if (!ssrEnabled || !moduleLevel) return;
+
+  const message =
+    typeof messageOrStrings === "string"
+      ? messageOrStrings
+      : messageOrStrings.join("");
+  const errorMessage = createSSRRulesError(message);
+  // TODO: find a more runtime agnostic way to check this
+  if (process.env.NODE_ENV === "development") {
+    throw new Error(errorMessage);
+  } else {
+    console.warn(errorMessage);
+  }
 }
 
 // ----- Constants ----- //
+
+// SSR Rules Error
+const createSSRRulesError = (message: string) =>
+  `@generaltranslation/react-core Failed to translate "${message}" because it is being used in an SSR environment at the module level. Please use an msg() function instead, and translate with an m() function. See: https://generaltranslation.com/en-US/docs/react/api/strings/msg`;
 
 // TODO: for following three functions, resturcture them to be more organized
 
 // TODO: rename this
 const createTranslationFailedDueToBrowserEnvironmentWarning = (
-  message: string | TemplateStringsArray | undefined
+  message: string | TemplateStringsArray | undefined,
 ) =>
-  `@generaltranslation/react-core Warning: Translation failed for t("${typeof message === 'string' ? message : '`' + message?.join('${}') + '`'}") because it was used outside of a browser environment or your SPA did not initialize GT correctly. Falling back to original message.`;
+  `@generaltranslation/react-core Warning: Translation failed for t("${typeof message === "string" ? message : "`" + message?.join("${}") + "`"}") because it was used outside of a browser environment or your SPA did not initialize GT correctly. Falling back to original message.`;
 
 /**
  * Overloaded type for the `t` function.

--- a/packages/react-core/src/functions/translation/t.ts
+++ b/packages/react-core/src/functions/translation/t.ts
@@ -1,13 +1,16 @@
-import { createLookupOptions, interpolateMessage } from "gt-i18n/internal";
+import {
+  createLookupOptions,
+  getRuntimeEnvironment,
+  interpolateMessage,
+} from "gt-i18n/internal";
 import type {
   InlineTranslationOptions,
   ResolutionOptions,
 } from "gt-i18n/types";
 import { getRenderStrategy } from "../../setup/globals";
 import { isWritableConditionStoreInitialized } from "../../condition-store/singleton-operations";
-import { StringContent } from "generaltranslation/types";
+import { StringContent, StringFormat } from "generaltranslation/types";
 import { getReactI18nManager } from "../../i18n-manager/singleton-operations";
-import { StringFormat } from "generaltranslation/types";
 import { getShouldTranslate } from "../../hooks/utils";
 import { getLocale } from "../../hooks/context-hooks";
 
@@ -32,8 +35,6 @@ import { getLocale } from "../../hooks/context-hooks";
  *
  * @example
  * t`Hello, ${name}` // Translate via tagged template literal
- *
- * TODO: enforce enableI18n
  *
  */
 export const t: StringOrTemplateSyncResolutionFunction = (
@@ -178,8 +179,6 @@ function interpolateTemplateLiteral(
     .join("");
 }
 
-// ----- Warnings and errors ----- //
-
 /**
  * If detect SSR + module level:
  * - Build: Error
@@ -196,27 +195,16 @@ function enforceSSRRules(messageOrStrings: string | TemplateStringsArray) {
       ? messageOrStrings
       : messageOrStrings.join("");
   const errorMessage = createSSRRulesError(message);
-  // TODO: find a more runtime agnostic way to check this
-  if (process.env.NODE_ENV === "development") {
+  if (getRuntimeEnvironment() === "development") {
     throw new Error(errorMessage);
   } else {
     console.warn(errorMessage);
   }
 }
 
-// ----- Constants ----- //
-
 // SSR Rules Error
 const createSSRRulesError = (message: string) =>
   `@generaltranslation/react-core Failed to translate "${message}" because it is being used in an SSR environment at the module level. Please use an msg() function instead, and translate with an m() function. See: https://generaltranslation.com/en-US/docs/react/api/strings/msg`;
-
-// TODO: for following three functions, resturcture them to be more organized
-
-// TODO: rename this
-const createTranslationFailedDueToBrowserEnvironmentWarning = (
-  message: string | TemplateStringsArray | undefined,
-) =>
-  `@generaltranslation/react-core Warning: Translation failed for t("${typeof message === "string" ? message : "`" + message?.join("${}") + "`"}") because it was used outside of a browser environment or your SPA did not initialize GT correctly. Falling back to original message.`;
 
 /**
  * Overloaded type for the `t` function.

--- a/packages/react-core/src/functions/translation/t.ts
+++ b/packages/react-core/src/functions/translation/t.ts
@@ -15,17 +15,10 @@ import { getShouldTranslate } from "../../hooks/utils";
 import { getLocale } from "../../hooks/context-hooks";
 
 /**
- * NOTE: t() is the only function exported from the 'gt-react' entry point.
- * All other functions in i18n-context are exported from the 'gt-react/browser' entry point.
- */
-
-/**
  * Translate a message
  * @param {string} message - The message to translate.
  * @param {InlineTranslationOptions} [options] - The options for the translation.
  * @returns {string} The translated message.
- *
- * This is a BROWSER ONLY function.
  *
  * @example
  * t('Hello, world!'); // Translates 'Hello, world!'

--- a/packages/react-core/src/hooks/context-hooks.ts
+++ b/packages/react-core/src/hooks/context-hooks.ts
@@ -5,6 +5,7 @@ import { useContext } from "react";
 
 /**
  * @internal
+ * @deprecated use condition store directly instead
  */
 function useGTContext(property: keyof GTContextType): GTContextType {
   const conditionStore = useContext(GTContext);
@@ -27,7 +28,11 @@ function useGTContext(property: keyof GTContextType): GTContextType {
 }
 
 export function useLocale(): string {
-  return useGTContext("locale").locale;
+  return getLocale();
+}
+
+export function getLocale(): string {
+  return getWritableConditionStore().getLocale();
 }
 
 export function useSetLocale(): (locale: string) => void {

--- a/packages/react-core/src/hooks/utils.ts
+++ b/packages/react-core/src/hooks/utils.ts
@@ -2,9 +2,11 @@ import {
   useCustomMapping,
   useDefaultLocale,
   useLocales,
-} from './external-store-hooks';
-import { useEnableI18n, useLocale } from './context-hooks';
-import { requiresTranslation } from 'generaltranslation/core';
+} from "./external-store-hooks";
+import { useEnableI18n, useLocale } from "./context-hooks";
+import { requiresTranslation } from "generaltranslation/core";
+import { getWritableConditionStore } from "../condition-store/singleton-operations";
+import { getReactI18nManager } from "../i18n-manager/singleton-operations";
 
 export function useFormatLocales(localesProp: string[] = []): string[] {
   const locale = useLocale();
@@ -15,15 +17,22 @@ export function useFormatLocales(localesProp: string[] = []): string[] {
     : [defaultLocale];
 }
 
+export function useShouldTranslate(): boolean {
+  return getShouldTranslate();
+}
+
 /**
  * Returns true if (1) i18n enabled and (2) translation is required
  */
-export function useShouldTranslate(): boolean {
-  const enableI18n = useEnableI18n();
-  const defaultLocale = useDefaultLocale();
-  const locale = useLocale();
-  const locales = useLocales();
-  const customMapping = useCustomMapping();
+export function getShouldTranslate(): boolean {
+  const conditionStore = getWritableConditionStore();
+  const i18nManager = getReactI18nManager();
+
+  const enableI18n = conditionStore.getEnableI18n();
+  const locale = conditionStore.getLocale();
+  const defaultLocale = i18nManager.getDefaultLocale();
+  const locales = i18nManager.getLocales();
+  const customMapping = i18nManager.getCustomMapping();
   return (
     enableI18n &&
     requiresTranslation(defaultLocale, locale, [...locales], customMapping)

--- a/packages/react/src/context.client.ts
+++ b/packages/react/src/context.client.ts
@@ -40,6 +40,7 @@ export {
   getTranslationsSnapshot,
   getReactI18nManager,
   setReactI18nManager,
+  t,
   // ===== Setup ===== //
   internalInitializeGTSSR as initializeGT,
 } from "@generaltranslation/react-core/context";

--- a/packages/react/src/context.server.ts
+++ b/packages/react/src/context.server.ts
@@ -40,6 +40,7 @@ export {
   getTranslationsSnapshot,
   getReactI18nManager,
   setReactI18nManager,
+  t,
   // ===== Setup ===== //
   internalInitializeGTSSR as initializeGT,
   internalInitializeGTSPA,

--- a/packages/react/src/context.types.ts
+++ b/packages/react/src/context.types.ts
@@ -49,6 +49,7 @@ export {
   mFallback,
   gtFallback,
   getTranslationsSnapshot,
+  t,
   // ===== Setup ===== //
   internalInitializeGTSSR as initializeGT,
   getReactI18nManager,

--- a/packages/tanstack-start/src/index.client.ts
+++ b/packages/tanstack-start/src/index.client.ts
@@ -43,6 +43,7 @@ export {
   mFallback,
   gtFallback,
   getTranslationsSnapshot,
+  t,
   // ===== Setup ===== //
   initializeGT,
 } from "gt-react/context";

--- a/packages/tanstack-start/src/index.server.ts
+++ b/packages/tanstack-start/src/index.server.ts
@@ -34,6 +34,7 @@ export {
   mFallback,
   gtFallback,
   getTranslationsSnapshot,
+  t,
   // ===== Setup ===== //
   initializeGT,
 } from "gt-react/context";

--- a/packages/tanstack-start/src/index.types.ts
+++ b/packages/tanstack-start/src/index.types.ts
@@ -34,6 +34,7 @@ export {
   mFallback,
   gtFallback,
   getTranslationsSnapshot,
+  t,
   // ===== Setup ===== //
   initializeGT,
 } from "gt-react/context";


### PR DESCRIPTION
moving towards deprecating our string translation hooks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1452"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR re-exports the `t()` translation function from the server and client entry points of `gt-react` and `gt-tanstack-start`, marking a step toward deprecating the string translation hooks. Internally, `t()` is rewritten to use `i18nManager.lookupTranslation` and a new `resolveStringContent` helper, `getRuntimeEnvironment` is extracted into a shared utility module, and `getLocale`/`getShouldTranslate` are extracted as non-hook singletons that back their hook counterparts.

- **`t()` rewrite**: replaces `resolveTranslationSyncWithFallback` with a direct `i18nManager.lookupTranslation` path; adds `enforceSSRRules` to throw in dev and warn in prod when called at module level in an SSR app.
- **Non-reactive singletons**: `useLocale()` and `useShouldTranslate()` now delegate to `getLocale()`/`getShouldTranslate()` which read from the condition store singleton instead of React context — intentional as the team moves toward full-page reloads for locale changes.
- **Shared utility**: `getRuntimeEnvironment()` is extracted from `I18nManager.ts` into `packages/i18n/src/utils/getRuntimeEnvironment.ts` and re-exported via `gt-i18n/internal`.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with awareness that module-level SSR calls in production will emit a console.warn and then throw from the uninitialized condition store — an acknowledged intentional breaking change per prior discussion.

The functional changes are intentional and scoped: the new resolveStringContent path, the SSR enforcement logic, and the non-reactive singleton helpers all behave as the team designed them. The only concern is the stale JSDoc that could mislead library consumers about where t() is allowed. No unintended regressions were found in the changed paths.

packages/react-core/src/functions/translation/t.ts — the JSDoc description of valid environments should be updated to match the new server exports.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/functions/translation/t.ts | Core rewrite of t(): replaces resolveTranslationSyncWithFallback with new resolveStringContent backed by the i18nManager, adds enforceSSRRules for module-level SSR detection, and exports resolveStringContent for reuse. JSDoc still says "BROWSER ONLY" despite new server exports. |
| packages/react-core/src/hooks/context-hooks.ts | Extracts getLocale() as a non-hook function reading directly from the condition store singleton; useLocale() now delegates to it, losing React context reactivity intentionally. |
| packages/react-core/src/hooks/utils.ts | Splits useShouldTranslate into a hook wrapper and getShouldTranslate() reading from the condition store singleton directly; useShouldTranslate becomes non-reactive as a result. |
| packages/i18n/src/utils/getRuntimeEnvironment.ts | Extracted getRuntimeEnvironment() into its own utility module so it can be shared across packages; logic is unchanged from the removed inline version in I18nManager.ts. |
| packages/react-core/src/condition-store/singleton-operations.ts | Exports isWritableConditionStoreInitialized so enforceSSRRules in t.ts can check initialization state before calling the store. |
| packages/react/src/context.server.ts | Re-exports t from react-core context, making it available on the server entry point alongside the existing exports. |
| packages/tanstack-start/src/index.server.ts | Re-exports t through the tanstack-start server entry, mirroring the react package change. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["t(message | template)"] --> B["enforceSSRRules()"]
    B --> C{ssrEnabled AND moduleLevel?}
    C -- No --> D{typeof messageOrStrings}
    C -- "Yes + dev" --> E["throw Error"]
    C -- "Yes + prod" --> F["console.warn → continues"]
    F --> D
    D -- string --> G["getLocale()"]
    G --> H["getWritableConditionStore().getLocale()"]
    D -- TemplateStringsArray --> I["handleTaggedTemplateLiteralTranslation()"]
    I --> H
    H --> J["resolveStringContent()"]
    J --> K["getShouldTranslate()"]
    K --> L{shouldTranslate?}
    L -- No --> M["interpolateMessage (source only)"]
    L -- Yes --> N["i18nManager.lookupTranslation()"]
    N --> O["interpolateMessage (translated)"]
    M --> P["return string"]
    O --> P
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Freact-core%2Fsrc%2Ffunctions%2Ftranslation%2Ft.ts%3A17-29%0A**Stale%20%22BROWSER%20ONLY%22%20JSDoc**%0A%0AThe%20block%20comment%20still%20says%20%60This%20is%20a%20BROWSER%20ONLY%20function.%60%20and%20%60t%28%29%20is%20the%20only%20function%20exported%20from%20the%20'gt-react'%20entry%20point%60%2C%20but%20this%20PR%20adds%20%60t%60%20to%20%60context.server.ts%60%2C%20%60index.server.ts%60%2C%20and%20%60index.types.ts%60.%20A%20developer%20reading%20this%20JSDoc%20would%20incorrectly%20conclude%20it's%20unsafe%20to%20call%20from%20an%20SSR%20route%20handler%2C%20undermining%20the%20purpose%20of%20this%20PR.%0A%0A&repo=generaltranslation%2Fgt&pr=1452&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fremove-gtproviders%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fremove-gtproviders%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Freact-core%2Fsrc%2Ffunctions%2Ftranslation%2Ft.ts%3A17-29%0A**Stale%20%22BROWSER%20ONLY%22%20JSDoc**%0A%0AThe%20block%20comment%20still%20says%20%60This%20is%20a%20BROWSER%20ONLY%20function.%60%20and%20%60t%28%29%20is%20the%20only%20function%20exported%20from%20the%20'gt-react'%20entry%20point%60%2C%20but%20this%20PR%20adds%20%60t%60%20to%20%60context.server.ts%60%2C%20%60index.server.ts%60%2C%20and%20%60index.types.ts%60.%20A%20developer%20reading%20this%20JSDoc%20would%20incorrectly%20conclude%20it's%20unsafe%20to%20call%20from%20an%20SSR%20route%20handler%2C%20undermining%20the%20purpose%20of%20this%20PR.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/react-core/src/functions/translation/t.ts:17-29
**Stale "BROWSER ONLY" JSDoc**

The block comment still says `This is a BROWSER ONLY function.` and `t() is the only function exported from the 'gt-react' entry point`, but this PR adds `t` to `context.server.ts`, `index.server.ts`, and `index.types.ts`. A developer reading this JSDoc would incorrectly conclude it's unsafe to call from an SSR route handler, undermining the purpose of this PR.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["greptile issues"](https://github.com/generaltranslation/gt/commit/f9da7646cbd99f0bf919f4da99c20458e73270e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32742953)</sub>

<!-- /greptile_comment -->