### PR TITLE
style: run format fix

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -37,8 +37,5 @@
     "general-cases": "0.1.0",
     "gt-next-middleware-e2e": "0.1.22"
   },
-  "changesets": [
-    "odysseus-sanity-followup",
-    "odysseus-sanity-release-test"
-  ]
+  "changesets": ["odysseus-sanity-followup", "odysseus-sanity-release-test"]
 }

--- a/packages/cli/src/react/jsx/utils/constants.ts
+++ b/packages/cli/src/react/jsx/utils/constants.ts
@@ -51,9 +51,7 @@ export const STRING_REGISTRATION_FUNCS = [
 ] as const;
 
 // Derive functions that are imported from GT
-export const GT_DERIVE_STRING_FUNCTIONS = [
-  DERIVE_FUNCTION,
-];
+export const GT_DERIVE_STRING_FUNCTIONS = [DERIVE_FUNCTION];
 
 // Valid variable components
 export const VARIABLE_COMPONENTS = [

--- a/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
@@ -782,8 +782,7 @@ function parseJSXElement({
       ? new Set(
           Object.values(config.importAliases).filter(
             (name) =>
-              VARIABLE_COMPONENTS.includes(name) &&
-              name !== DERIVE_COMPONENT
+              VARIABLE_COMPONENTS.includes(name) && name !== DERIVE_COMPONENT
           )
         )
       : undefined;

--- a/packages/compiler/src/utils/constants/gt/constants.ts
+++ b/packages/compiler/src/utils/constants/gt/constants.ts
@@ -81,9 +81,7 @@ export const GT_FUNCTIONS_TO_CALLBACKS: Record<
 /**
  * GT derive functions
  */
-export const GT_DERIVE_STRING_FUNCTIONS = [
-  GT_OTHER_FUNCTIONS.derive,
-] as const;
+export const GT_DERIVE_STRING_FUNCTIONS = [GT_OTHER_FUNCTIONS.derive] as const;
 
 /**
  * All gt functions (both regular and callback functions)

--- a/packages/i18n/src/condition-store/ReadonlyConditionStore.ts
+++ b/packages/i18n/src/condition-store/ReadonlyConditionStore.ts
@@ -1,8 +1,8 @@
 import type {
   LocaleResolverConfig,
   ReadonlyConditionStoreInterface as ReadonlyConditionStoreContract,
-} from "../i18n-manager/types";
-import { createLocaleResolver, type LocaleCandidates } from "./localeResolver";
+} from '../i18n-manager/types';
+import { createLocaleResolver, type LocaleCandidates } from './localeResolver';
 
 export type ReadonlyConditionStoreParams = LocaleResolverConfig & {
   locale: LocaleCandidates;

--- a/packages/i18n/src/condition-store/WritableConditionStore.ts
+++ b/packages/i18n/src/condition-store/WritableConditionStore.ts
@@ -1,9 +1,9 @@
-import type { LocaleCandidates } from "../i18n-manager";
-import type { WritableConditionStoreInterface as WritableConditionStoreContract } from "../i18n-manager/types";
+import type { LocaleCandidates } from '../i18n-manager';
+import type { WritableConditionStoreInterface as WritableConditionStoreContract } from '../i18n-manager/types';
 import {
   ReadonlyConditionStore,
   type ReadonlyConditionStoreParams,
-} from "./ReadonlyConditionStore";
+} from './ReadonlyConditionStore';
 
 export type WritableConditionStoreParams = ReadonlyConditionStoreParams;
 
@@ -12,7 +12,7 @@ export class WritableConditionStore
   implements WritableConditionStoreContract
 {
   setLocale = (locale: LocaleCandidates): void => {
-    console.log("WritableConditionStore.setLocale", locale);
+    console.log('WritableConditionStore.setLocale', locale);
     this.locale = this.resolveLocale(locale);
   };
 

--- a/packages/i18n/src/condition-store/createConditionStoreSingleton.ts
+++ b/packages/i18n/src/condition-store/createConditionStoreSingleton.ts
@@ -1,4 +1,4 @@
-import type { ReadonlyConditionStoreInterface } from "../i18n-manager/types";
+import type { ReadonlyConditionStoreInterface } from '../i18n-manager/types';
 
 let conditionStore: ReadonlyConditionStoreInterface | undefined;
 

--- a/packages/i18n/src/condition-store/localeResolver.ts
+++ b/packages/i18n/src/condition-store/localeResolver.ts
@@ -1,6 +1,6 @@
-import { LocaleConfig } from "@generaltranslation/format";
-import { libraryDefaultLocale } from "generaltranslation/internal";
-import type { LocaleResolverConfig } from "../i18n-manager/types";
+import { LocaleConfig } from '@generaltranslation/format';
+import { libraryDefaultLocale } from 'generaltranslation/internal';
+import type { LocaleResolverConfig } from '../i18n-manager/types';
 
 export type LocaleCandidates = string | string[] | undefined;
 
@@ -26,17 +26,17 @@ type NormalizedConditionStoreConfig = ReturnType<
  */
 export function determineSupportedLocale(
   candidates: LocaleCandidates,
-  config: LocaleResolverConfig = {},
+  config: LocaleResolverConfig = {}
 ): string | undefined {
   return determineSupportedLocaleWithConfig(
     candidates,
-    normalizeConditionStoreConfig(config),
+    normalizeConditionStoreConfig(config)
   );
 }
 
 function determineSupportedLocaleWithConfig(
   candidates: LocaleCandidates,
-  config: NormalizedConditionStoreConfig,
+  config: NormalizedConditionStoreConfig
 ): string | undefined {
   if (
     candidates == null ||
@@ -54,7 +54,7 @@ function determineSupportedLocaleWithConfig(
  */
 export function resolveSupportedLocale(
   candidates: LocaleCandidates,
-  config: LocaleResolverConfig = {},
+  config: LocaleResolverConfig = {}
 ): string {
   const normalizedConfig = normalizeConditionStoreConfig(config);
   return (

--- a/packages/i18n/src/condition-store/singleton-operations.ts
+++ b/packages/i18n/src/condition-store/singleton-operations.ts
@@ -1,9 +1,9 @@
-import { createConditionStoreSingleton } from "./createConditionStoreSingleton";
-import { WritableConditionStore } from "./WritableConditionStore";
+import { createConditionStoreSingleton } from './createConditionStoreSingleton';
+import { WritableConditionStore } from './WritableConditionStore';
 
 export const {
   getConditionStore: getWritableConditionStore,
   setConditionStore: setWritableConditionStore,
 } = createConditionStoreSingleton<WritableConditionStore>(
-  "WritableConditionStore is not initialized.",
+  'WritableConditionStore is not initialized.'
 );

--- a/packages/i18n/src/helpers/locale.ts
+++ b/packages/i18n/src/helpers/locale.ts
@@ -1,5 +1,5 @@
-import { getWritableConditionStore } from "../condition-store/singleton-operations";
-import { getI18nManager } from "../i18n-manager/singleton-operations";
+import { getWritableConditionStore } from '../condition-store/singleton-operations';
+import { getI18nManager } from '../i18n-manager/singleton-operations';
 
 /**
  * Get the current locale

--- a/packages/i18n/src/i18n-manager/I18nManager.ts
+++ b/packages/i18n/src/i18n-manager/I18nManager.ts
@@ -1,41 +1,41 @@
-import { publishValidationResults } from "./validation/publishValidationResults";
-import logger from "../logs/logger";
-import { I18nManagerConfig, I18nManagerConstructorParams } from "./types";
-import { validateConfig } from "./validation/validateConfig";
-import { Translation } from "./translations-manager/utils/types/translation-data";
-import { libraryDefaultLocale } from "generaltranslation/internal";
-import { GT } from "generaltranslation";
-import { LocaleConfig, standardizeLocale } from "@generaltranslation/format";
-import type { CustomMapping } from "@generaltranslation/format/types";
-import { LookupOptions } from "../translation-functions/types/options";
-import { getGTServicesEnabled } from "./utils/getGTServicesEnabled";
+import { publishValidationResults } from './validation/publishValidationResults';
+import logger from '../logs/logger';
+import { I18nManagerConfig, I18nManagerConstructorParams } from './types';
+import { validateConfig } from './validation/validateConfig';
+import { Translation } from './translations-manager/utils/types/translation-data';
+import { libraryDefaultLocale } from 'generaltranslation/internal';
+import { GT } from 'generaltranslation';
+import { LocaleConfig, standardizeLocale } from '@generaltranslation/format';
+import type { CustomMapping } from '@generaltranslation/format/types';
+import { LookupOptions } from '../translation-functions/types/options';
+import { getGTServicesEnabled } from './utils/getGTServicesEnabled';
 import {
   SafeTranslationsLoader,
   TranslationsLoader,
-} from "./translations-manager/translations-loaders/types";
-import { createTranslateManyFactory } from "./translations-manager/utils/createTranslateMany";
-import { routeCreateTranslationLoader } from "./translations-manager/translations-loaders/routeCreateTranslationLoader";
-import { getLoadTranslationsType } from "./utils/getLoadTranslationsType";
-import { LocalesCache } from "./translations-manager/LocalesCache";
-import type { Locale } from "./translations-manager/LocalesCache";
-import type { Hash } from "./translations-manager/TranslationsCache";
+} from './translations-manager/translations-loaders/types';
+import { createTranslateManyFactory } from './translations-manager/utils/createTranslateMany';
+import { routeCreateTranslationLoader } from './translations-manager/translations-loaders/routeCreateTranslationLoader';
+import { getLoadTranslationsType } from './utils/getLoadTranslationsType';
+import { LocalesCache } from './translations-manager/LocalesCache';
+import type { Locale } from './translations-manager/LocalesCache';
+import type { Hash } from './translations-manager/TranslationsCache';
 import type {
   Dictionary,
   DictionaryEntry,
   DictionaryObject,
-} from "./translations-manager/DictionaryCache";
-import { resolveDictionaryLookupOptions } from "./translations-manager/utils/dictionary-helpers";
-import { DictionarySourceNotFoundError } from "./translations-manager/utils/DictionarySourceNotFoundError";
-import { createLifecycleCallbacks } from "./lifecycle-hooks/createLifecycleCallbacks";
-import { EventEmitter } from "./event-subscription/EventEmitter";
-import { subscribeLifecycleCallbacks } from "./lifecycle-hooks/subscribeLifecycleCallbacks";
-import { TRANSLATIONS_CACHE_MISS_EVENT_NAME } from "./event-subscription/types";
-import type { I18nEvents } from "./event-subscription/types";
+} from './translations-manager/DictionaryCache';
+import { resolveDictionaryLookupOptions } from './translations-manager/utils/dictionary-helpers';
+import { DictionarySourceNotFoundError } from './translations-manager/utils/DictionarySourceNotFoundError';
+import { createLifecycleCallbacks } from './lifecycle-hooks/createLifecycleCallbacks';
+import { EventEmitter } from './event-subscription/EventEmitter';
+import { subscribeLifecycleCallbacks } from './lifecycle-hooks/subscribeLifecycleCallbacks';
+import { TRANSLATIONS_CACHE_MISS_EVENT_NAME } from './event-subscription/types';
+import type { I18nEvents } from './event-subscription/types';
 import {
   createLocaleResolver,
   LocaleCandidates,
-} from "../condition-store/localeResolver";
-import { getRuntimeEnvironment } from "../utils/getRuntimeEnvironment";
+} from '../condition-store/localeResolver';
+import { getRuntimeEnvironment } from '../utils/getRuntimeEnvironment';
 
 /**
  * Default translation timeout in milliseconds for a runtime translation request
@@ -53,7 +53,7 @@ type TranslationResolver<U extends Translation = Translation> = <
   T extends U = U,
 >(
   message: T,
-  options?: LookupOptions,
+  options?: LookupOptions
 ) => T | undefined;
 
 /**
@@ -100,7 +100,7 @@ class I18nManager<
 
     // Validation
     const validationResults = validateConfig(params);
-    publishValidationResults(validationResults, "I18nManager: ");
+    publishValidationResults(validationResults, 'I18nManager: ');
 
     // Setup
     this.config = standardizeConfig(params);
@@ -135,17 +135,17 @@ class I18nManager<
     const createTranslateMany = createTranslateManyFactory(
       this.getGTClassClean(),
       runtimeTranslationTimeout,
-      runtimeTranslationMetadata,
+      runtimeTranslationMetadata
     );
 
     // Subscribe lifecycle callbacks
     subscribeLifecycleCallbacks(params.lifecycle ?? {}, (...args) =>
-      this.subscribe(...args),
+      this.subscribe(...args)
     );
 
     const lifecycle = createLifecycleCallbacks<TranslationValue>(
       (...args) => this.emit(...args),
-      (eventName) => this.hasListeners(eventName),
+      (eventName) => this.hasListeners(eventName)
     );
 
     // Setup locale-scoped caches
@@ -176,10 +176,10 @@ class I18nManager<
    */
   subscribeToTranslationsCacheMiss(
     listener: (
-      event: I18nEvents<TranslationValue>[typeof TRANSLATIONS_CACHE_MISS_EVENT_NAME],
+      event: I18nEvents<TranslationValue>[typeof TRANSLATIONS_CACHE_MISS_EVENT_NAME]
     ) => void,
     locale: Locale,
-    hash: Hash,
+    hash: Hash
   ) {
     return this.subscribe(TRANSLATIONS_CACHE_MISS_EVENT_NAME, (event) => {
       if (event.locale !== locale || event.hash !== hash) {
@@ -226,7 +226,7 @@ class I18nManager<
    */
   getGTClass(locale?: string): GT {
     return this.getGTClassClean(
-      locale ? this._resolveLocale(locale) : undefined,
+      locale ? this._resolveLocale(locale) : undefined
     );
   }
 
@@ -247,14 +247,14 @@ class I18nManager<
       !!this.config.devApiKey &&
       !!this.config.projectId &&
       this.isRuntimeUrlEnabled() &&
-      this.config.environment === "development"
+      this.config.environment === 'development'
     );
   }
 
   // ========== Translation Updates ========== //
 
   updateTranslations(
-    translationsSnapshot: Record<Locale, Record<Hash, TranslationValue>>,
+    translationsSnapshot: Record<Locale, Record<Hash, TranslationValue>>
   ): void {
     this.localesCache.updateTranslations(translationsSnapshot);
   }
@@ -294,7 +294,7 @@ class I18nManager<
    * Edge case usage: access the translations object directly
    */
   async loadTranslations(
-    locale: string,
+    locale: string
   ): Promise<Record<Hash, TranslationValue>> {
     try {
       // Validate
@@ -359,7 +359,7 @@ class I18nManager<
    */
   lookupDictionaryObj(
     locale: string,
-    id: string,
+    id: string
   ): DictionaryObject | undefined {
     try {
       const dictionaryLocale = this.resolveDictionaryCacheLocale(locale);
@@ -376,7 +376,7 @@ class I18nManager<
    */
   async lookupDictionaryWithFallback(
     locale: string,
-    id: string,
+    id: string
   ): Promise<DictionaryEntry | undefined> {
     try {
       const dictionaryLocale = this.resolveCacheLocale(locale);
@@ -391,7 +391,7 @@ class I18nManager<
       if (dictionaryEntry === undefined) {
         dictionaryEntry = await dictionaryCache.materializeEntry(
           id,
-          this.getSourceDictionaryEntry(id),
+          this.getSourceDictionaryEntry(id)
         );
       }
       return dictionaryEntry;
@@ -407,7 +407,7 @@ class I18nManager<
    */
   async lookupDictionaryObjWithFallback(
     locale: string,
-    id: string,
+    id: string
   ): Promise<DictionaryObject | undefined> {
     try {
       const dictionaryLocale = this.resolveCacheLocale(locale);
@@ -432,7 +432,7 @@ class I18nManager<
       return await dictionaryCache.materializeValue(
         id,
         sourceObject,
-        targetObject,
+        targetObject
       );
     } catch (error) {
       this.handleError(error);
@@ -443,16 +443,16 @@ class I18nManager<
   private async translateDictionaryEntry(
     locale: Locale,
     id: string,
-    sourceEntry: DictionaryEntry,
+    sourceEntry: DictionaryEntry
   ): Promise<string> {
     const translation = await this.lookupTranslationWithFallbackResolved(
       locale,
       sourceEntry.entry as TranslationValue,
-      resolveDictionaryLookupOptions(sourceEntry.options),
+      resolveDictionaryLookupOptions(sourceEntry.options)
     );
-    if (typeof translation !== "string") {
+    if (typeof translation !== 'string') {
       throw new Error(
-        `Dictionary entry "${id}" could not be translated into a string. Check the source entry and translation loader output.`,
+        `Dictionary entry "${id}" could not be translated into a string. Check the source entry and translation loader output.`
       );
     }
     return translation;
@@ -468,7 +468,7 @@ class I18nManager<
 
   private getSourceDictionaryObject(
     id: string,
-    { throwOnMissing = true }: { throwOnMissing?: boolean } = {},
+    { throwOnMissing = true }: { throwOnMissing?: boolean } = {}
   ): DictionaryObject | undefined {
     const sourceObject = this.getDefaultDictionaryCache()?.getValue(id);
     if (sourceObject === undefined && throwOnMissing) {
@@ -491,7 +491,7 @@ class I18nManager<
   lookupTranslation<T extends TranslationValue = TranslationValue>(
     locale: string,
     message: T,
-    options: LookupOptions,
+    options: LookupOptions
   ): T | undefined {
     try {
       // Validate
@@ -524,13 +524,13 @@ class I18nManager<
   >(
     locale: string,
     message: T,
-    options: LookupOptions,
+    options: LookupOptions
   ): Promise<T | undefined> {
     try {
       return await this.lookupTranslationWithFallbackResolved(
         locale,
         message,
-        options,
+        options
       );
     } catch (error) {
       this.handleError(error);
@@ -552,7 +552,7 @@ class I18nManager<
     prefetchEntries: {
       message: TranslationValue;
       options: LookupOptions;
-    }[] = [],
+    }[] = []
   ): Promise<TranslationResolver<TranslationValue>> {
     try {
       // Validate
@@ -569,11 +569,11 @@ class I18nManager<
         translationLocale,
         (entryLocale) =>
           this.resolveCacheLocale(entryLocale) ??
-          this._resolveLocale(entryLocale),
+          this._resolveLocale(entryLocale)
       );
       if (resolvedPrefetchEntries.length !== prefetchEntries.length) {
         logger.warn(
-          `I18nManager: getLookupTranslation(): prefetchEntries must all be the same locale, ignoring all entries that are not for ${translationLocale}`,
+          `I18nManager: getLookupTranslation(): prefetchEntries must all be the same locale, ignoring all entries that are not for ${translationLocale}`
         );
       }
 
@@ -584,7 +584,7 @@ class I18nManager<
       await Promise.all(
         resolvedPrefetchEntries
           .filter((entry) => txCache.get(entry) == null)
-          .map((entry) => txCache.miss(entry)),
+          .map((entry) => txCache.miss(entry))
       );
 
       // Create translation resolver
@@ -613,7 +613,7 @@ class I18nManager<
   resolveTranslationSync = <T extends TranslationValue = TranslationValue>(
     locale: string,
     message: T,
-    options: LookupOptions,
+    options: LookupOptions
   ) => {
     return this.lookupTranslation(locale, message, options);
   };
@@ -625,7 +625,7 @@ class I18nManager<
    * @deprecated use loadTranslations instead
    */
   async getTranslations(
-    locale: string,
+    locale: string
   ): Promise<Record<Hash, TranslationValue>> {
     try {
       return this.loadTranslations(locale);
@@ -646,7 +646,7 @@ class I18nManager<
    * @deprecated use getLookupTranslation instead
    */
   async getTranslationResolver(
-    locale: string,
+    locale: string
   ): Promise<TranslationResolver<TranslationValue>> {
     return this.getLookupTranslation(locale);
   }
@@ -699,11 +699,11 @@ class I18nManager<
     }
 
     switch (this.config.environment) {
-      case "development":
+      case 'development':
         throw error;
-      case "production":
+      case 'production':
       default:
-        logger.error("I18nManager: " + error);
+        logger.error('I18nManager: ' + error);
         break;
     }
   }
@@ -712,7 +712,7 @@ class I18nManager<
     const resolvedLocale = this.localeConfig.determineLocale(locale);
     if (!this.localeConfig.isValidLocale(locale) || !resolvedLocale) {
       throw new Error(
-        `Locale "${locale}" is not valid. Use a valid BCP 47 locale code or add a custom mapping.`,
+        `Locale "${locale}" is not valid. Use a valid BCP 47 locale code or add a custom mapping.`
       );
     }
     return resolvedLocale;
@@ -730,7 +730,7 @@ class I18nManager<
     }
 
     const aliasLocale = this.localeConfig.resolveAliasLocale(
-      standardizeLocale(locale),
+      standardizeLocale(locale)
     );
     if (this.requiresTranslation(aliasLocale)) {
       return aliasLocale;
@@ -751,7 +751,7 @@ class I18nManager<
 
   private resolveLookupOptions(
     options: LookupOptions = {} as LookupOptions,
-    translationLocale?: string,
+    translationLocale?: string
   ) {
     if (!options.$locale) {
       return options;
@@ -766,7 +766,7 @@ class I18nManager<
   }
 
   private isRuntimeUrlEnabled(): boolean {
-    return this.config.runtimeUrl !== null && this.config.runtimeUrl !== "";
+    return this.config.runtimeUrl !== null && this.config.runtimeUrl !== '';
   }
 
   private async lookupTranslationWithFallbackResolved<
@@ -803,9 +803,9 @@ class I18nManager<
       locales: Array.from(
         new Set(
           this.config.locales.map((locale) =>
-            this.localeConfig.resolveCanonicalLocale(locale),
-          ),
-        ),
+            this.localeConfig.resolveCanonicalLocale(locale)
+          )
+        )
       ),
       customMapping: this.config.customMapping,
       projectId: this.config.projectId,
@@ -826,7 +826,7 @@ export { I18nManager };
  * @returns The standardized config
  */
 function standardizeConfig<TranslationValue extends Translation>(
-  config: I18nManagerConstructorParams<TranslationValue>,
+  config: I18nManagerConstructorParams<TranslationValue>
 ) {
   const gtServicesEnabled = getGTServicesEnabled(config);
 
@@ -885,7 +885,7 @@ function standardizeLocales(config: {
   const defaultLocale = standardizeLocale(config.defaultLocale);
   const locales = config.locales.map((locale) => {
     const mappedLocale =
-      typeof config.customMapping?.[locale] === "string"
+      typeof config.customMapping?.[locale] === 'string'
         ? config.customMapping?.[locale]
         : config.customMapping?.[locale]?.code;
     if (mappedLocale) {
@@ -899,13 +899,13 @@ function standardizeLocales(config: {
   const customMapping = Object.fromEntries(
     Object.entries(config.customMapping || {}).map(([key, value]) => [
       key,
-      typeof value === "string"
+      typeof value === 'string'
         ? standardizeLocale(value)
         : {
             ...value,
             ...(value.code ? { code: standardizeLocale(value.code) } : {}),
           },
-    ]),
+    ])
   );
 
   return {
@@ -925,7 +925,7 @@ function standardizeLocales(config: {
 function resolvePrefetchEntriesByLocale<TranslationType extends Translation>(
   prefetchEntries: PrefetchEntry<TranslationType>[],
   locale: string,
-  resolveLocale: (locale: string) => string,
+  resolveLocale: (locale: string) => string
 ) {
   return prefetchEntries.flatMap((entry) => {
     const entryLocale = entry.options.$locale;

--- a/packages/i18n/src/i18n-manager/index.ts
+++ b/packages/i18n/src/i18n-manager/index.ts
@@ -1,15 +1,15 @@
 // Classes
-export { I18nManager } from "./I18nManager";
-export { ReadonlyConditionStore } from "../condition-store/ReadonlyConditionStore";
-export type { ReadonlyConditionStoreParams } from "../condition-store/ReadonlyConditionStore";
-export { WritableConditionStore } from "../condition-store/WritableConditionStore";
-export type { WritableConditionStoreParams } from "../condition-store/WritableConditionStore";
+export { I18nManager } from './I18nManager';
+export { ReadonlyConditionStore } from '../condition-store/ReadonlyConditionStore';
+export type { ReadonlyConditionStoreParams } from '../condition-store/ReadonlyConditionStore';
+export { WritableConditionStore } from '../condition-store/WritableConditionStore';
+export type { WritableConditionStoreParams } from '../condition-store/WritableConditionStore';
 export {
   createLocaleResolver,
   determineSupportedLocale,
   resolveSupportedLocale,
-} from "../condition-store/localeResolver";
-export type { LocaleCandidates } from "../condition-store/localeResolver";
+} from '../condition-store/localeResolver';
+export type { LocaleCandidates } from '../condition-store/localeResolver';
 
 // Events
 export {
@@ -17,7 +17,7 @@ export {
   LOCALES_CACHE_MISS_EVENT_NAME,
   LOCALES_DICTIONARY_CACHE_MISS_EVENT_NAME,
   TRANSLATIONS_CACHE_MISS_EVENT_NAME,
-} from "./event-subscription/types";
+} from './event-subscription/types';
 
 // Functions
-export { getI18nManager, setI18nManager } from "./singleton-operations";
+export { getI18nManager, setI18nManager } from './singleton-operations';

--- a/packages/i18n/src/i18n-manager/singleton-operations.ts
+++ b/packages/i18n/src/i18n-manager/singleton-operations.ts
@@ -1,9 +1,9 @@
-import { libraryDefaultLocale } from "generaltranslation/internal";
-import { I18nManager } from "./I18nManager";
-import logger from "../logs/logger";
-import { Translation } from "./translations-manager/utils/types/translation-data";
-import { createConditionStoreSingleton } from "../condition-store/createConditionStoreSingleton";
-import { WritableConditionStoreInterface } from "./types";
+import { libraryDefaultLocale } from 'generaltranslation/internal';
+import { I18nManager } from './I18nManager';
+import logger from '../logs/logger';
+import { Translation } from './translations-manager/utils/types/translation-data';
+import { createConditionStoreSingleton } from '../condition-store/createConditionStoreSingleton';
+import { WritableConditionStoreInterface } from './types';
 
 // Singleton instance of I18nManager
 let i18nManager: I18nManager | undefined = undefined;
@@ -20,7 +20,7 @@ export function getI18nManager<U extends Translation = Translation>():
   | I18nManager<Translation> {
   if (!i18nManager) {
     logger.warn(
-      "getI18nManager(): I18nManager was not initialized. Falling back to the default locale until initializeGT() configures translations.",
+      'getI18nManager(): I18nManager was not initialized. Falling back to the default locale until initializeGT() configures translations.'
     );
     i18nManager = new I18nManager({
       defaultLocale: libraryDefaultLocale,
@@ -39,7 +39,7 @@ export function getI18nManager<U extends Translation = Translation>():
  * Note: should not be consumed by gt-react, consumers should use a wrapper
  */
 export function setI18nManager<TranslationValue extends Translation>(
-  i18nManagerInstance: I18nManager<TranslationValue>,
+  i18nManagerInstance: I18nManager<TranslationValue>
 ): void {
   i18nManager = i18nManagerInstance as unknown as I18nManager;
 }

--- a/packages/i18n/src/i18n-manager/translations-manager/LocalesCache.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/LocalesCache.ts
@@ -1,25 +1,25 @@
-import { DictionaryCache } from "./DictionaryCache";
+import { DictionaryCache } from './DictionaryCache';
 import type {
   Dictionary,
   DictionaryEntry,
   DictionaryKey,
   DictionaryLoader,
-} from "./DictionaryCache";
-import { ResourceCache } from "./ResourceCache";
-import { TranslationsCache } from "./TranslationsCache";
+} from './DictionaryCache';
+import { ResourceCache } from './ResourceCache';
+import { TranslationsCache } from './TranslationsCache';
 import type {
   Hash,
   TranslationBatchConfig,
   TranslationKey,
-} from "./TranslationsCache";
-import type { CreateTranslateMany } from "./utils/createTranslateMany";
-import type { Translation } from "./utils/types/translation-data";
-import type { SafeTranslationsLoader } from "./translations-loaders/types";
+} from './TranslationsCache';
+import type { CreateTranslateMany } from './utils/createTranslateMany';
+import type { Translation } from './utils/types/translation-data';
+import type { SafeTranslationsLoader } from './translations-loaders/types';
 import type {
   I18nManagerCacheLifecycleCallbacks,
   LifecycleCallback,
   LifecycleParam,
-} from "../lifecycle-hooks/types";
+} from '../lifecycle-hooks/types';
 
 /**
  * Just being explicit about the purpose of this type
@@ -29,7 +29,7 @@ export type Locale = string;
 type TranslateLocaleDictionaryEntry = (
   locale: Locale,
   key: DictionaryKey,
-  sourceEntry: DictionaryEntry,
+  sourceEntry: DictionaryEntry
 ) => Promise<string>;
 
 type LocalesCacheParams<TranslationValue extends Translation> = {
@@ -52,11 +52,11 @@ export class LocalesCache<TranslationValue extends Translation> {
   private readonly dictionaries: ResourceCache<Locale, DictionaryCache>;
   private readonly createTranslationsCache: (
     locale: Locale,
-    init: Record<Hash, TranslationValue>,
+    init: Record<Hash, TranslationValue>
   ) => TranslationsCache<TranslationValue>;
   private readonly createDictionaryCache: (
     locale: Locale,
-    init: Dictionary,
+    init: Dictionary
   ) => DictionaryCache;
 
   constructor({
@@ -105,18 +105,18 @@ export class LocalesCache<TranslationValue extends Translation> {
     this.dictionaries.set(
       defaultLocale,
       this.createDictionaryCache(defaultLocale, dictionary),
-      { expiresAt: -1 },
+      { expiresAt: -1 }
     );
   }
 
   public getTranslations(
-    locale: Locale,
+    locale: Locale
   ): TranslationsCache<TranslationValue> | undefined {
     return this.translations.get(locale);
   }
 
   public getOrLoadTranslations(
-    locale: Locale,
+    locale: Locale
   ): Promise<TranslationsCache<TranslationValue>> {
     return this.translations.getOrLoad(locale);
   }
@@ -130,7 +130,7 @@ export class LocalesCache<TranslationValue extends Translation> {
   }
 
   public updateTranslations(
-    translations: Record<Locale, Record<Hash, TranslationValue>>,
+    translations: Record<Locale, Record<Hash, TranslationValue>>
   ): void {
     for (const locale in translations) {
       const translationsCache = this.translations.get(locale);
@@ -139,7 +139,7 @@ export class LocalesCache<TranslationValue extends Translation> {
       } else {
         this.translations.set(
           locale,
-          this.createTranslationsCache(locale, translations[locale]),
+          this.createTranslationsCache(locale, translations[locale])
         );
       }
     }
@@ -153,7 +153,7 @@ export class LocalesCache<TranslationValue extends Translation> {
       } else {
         this.dictionaries.set(
           locale,
-          this.createDictionaryCache(locale, dictionaries[locale]),
+          this.createDictionaryCache(locale, dictionaries[locale])
         );
       }
     }
@@ -180,7 +180,7 @@ function createTranslationsCacheFactory<TranslationValue extends Translation>({
 
 function createTranslationsCacheLifecycle<TranslationValue extends Translation>(
   locale: Locale,
-  lifecycle: I18nManagerCacheLifecycleCallbacks<TranslationValue>,
+  lifecycle: I18nManagerCacheLifecycleCallbacks<TranslationValue>
 ): LifecycleParam<
   TranslationKey<TranslationValue>,
   Hash,
@@ -217,7 +217,7 @@ function createDictionaryCache<TranslationValue extends Translation>({
       onMiss: withLocale(locale, onDictionaryCacheMiss),
       onDictionaryObjectCacheHit: withLocale(
         locale,
-        onDictionaryObjectCacheHit,
+        onDictionaryObjectCacheHit
       ),
     },
   });
@@ -233,7 +233,7 @@ function withLocale<InputKey, CacheKey, CacheValue, OutputValue>(
         cacheValue: CacheValue;
         outputValue: OutputValue;
       }) => void)
-    | undefined,
+    | undefined
 ): LifecycleCallback<InputKey, CacheKey, CacheValue, OutputValue> | undefined {
   return callback ? (params) => callback({ locale, ...params }) : undefined;
 }

--- a/packages/i18n/src/i18n-manager/types.ts
+++ b/packages/i18n/src/i18n-manager/types.ts
@@ -1,14 +1,14 @@
-import type { RuntimeTranslateManyOptions } from "generaltranslation/internal";
-import type { CustomMapping } from "@generaltranslation/format/types";
-import type { GTConfig } from "../config/types";
-import type { TranslationsLoader } from "./translations-manager/translations-loaders/types";
-import type { Translation } from "./translations-manager/utils/types/translation-data";
-import type { LifecycleCallbacks } from "./lifecycle-hooks/types";
-import type { TranslationBatchConfig } from "./translations-manager/TranslationsCache";
+import type { RuntimeTranslateManyOptions } from 'generaltranslation/internal';
+import type { CustomMapping } from '@generaltranslation/format/types';
+import type { GTConfig } from '../config/types';
+import type { TranslationsLoader } from './translations-manager/translations-loaders/types';
+import type { Translation } from './translations-manager/utils/types/translation-data';
+import type { LifecycleCallbacks } from './lifecycle-hooks/types';
+import type { TranslationBatchConfig } from './translations-manager/TranslationsCache';
 import type {
   Dictionary,
   DictionaryLoader,
-} from "./translations-manager/DictionaryCache";
+} from './translations-manager/DictionaryCache';
 
 export type DictionaryConfig =
   | {
@@ -31,14 +31,14 @@ type RuntimeTranslationConfig = {
 export type I18nManagerConstructorParams<
   TranslationValue extends Translation = Translation,
 > = DictionaryConfig &
-  Omit<GTConfig, "cacheExpiryTime"> & {
+  Omit<GTConfig, 'cacheExpiryTime'> & {
     /**
      * Locale cache TTL in milliseconds. Undefined uses the default TTL, null
      * disables expiry, and a number sets an explicit TTL.
      */
     cacheExpiryTime?: number | null;
     loadTranslations?: TranslationsLoader;
-    environment?: "development" | "production";
+    environment?: 'development' | 'production';
     batchConfig?: TranslationBatchConfig;
     runtimeTranslation?: RuntimeTranslationConfig;
     // Cache lifecycle hooks
@@ -50,7 +50,7 @@ export type I18nManagerConstructorParams<
  * I18nManager class configuration
  */
 export type I18nManagerConfig = {
-  environment: "development" | "production";
+  environment: 'development' | 'production';
   defaultLocale: string;
   locales: string[];
   customMapping: CustomMapping;
@@ -108,8 +108,7 @@ export interface ReadonlyConditionStoreInterface {
 /**
  * Condition store contract for runtimes that can persist locale changes.
  */
-export interface WritableConditionStoreInterface
-  extends ReadonlyConditionStoreInterface {
+export interface WritableConditionStoreInterface extends ReadonlyConditionStoreInterface {
   setLocale(locale: string): void;
   setEnableI18n(enabled: boolean): void;
 }
@@ -117,8 +116,7 @@ export interface WritableConditionStoreInterface
 /**
  * Condition store contract for runtimes with scoped locale context.
  */
-export interface ScopedConditionStoreInterface
-  extends ReadonlyConditionStoreInterface {
+export interface ScopedConditionStoreInterface extends ReadonlyConditionStoreInterface {
   run<T>(locale: string, callback: () => T): T;
 }
 

--- a/packages/i18n/src/internal-types.ts
+++ b/packages/i18n/src/internal-types.ts
@@ -11,8 +11,8 @@ export type {
   Dictionary,
   DictionaryLoader,
   DictionaryConfig,
-} from "./i18n-manager/types";
-export type { LocaleCandidates } from "./condition-store/localeResolver";
+} from './i18n-manager/types';
+export type { LocaleCandidates } from './condition-store/localeResolver';
 export type {
   DictionaryValue,
   DictionaryEntry,
@@ -21,17 +21,17 @@ export type {
   DictionaryOptions,
   DictionaryPath,
   DictionaryKey,
-} from "./i18n-manager/translations-manager/DictionaryCache";
-export type { ReadonlyConditionStoreParams } from "./condition-store/ReadonlyConditionStore";
-export type { WritableConditionStoreParams } from "./condition-store/WritableConditionStore";
+} from './i18n-manager/translations-manager/DictionaryCache';
+export type { ReadonlyConditionStoreParams } from './condition-store/ReadonlyConditionStore';
+export type { WritableConditionStoreParams } from './condition-store/WritableConditionStore';
 
 // Translation Options (Function types exported by /types)
-export type * from "./translation-functions/types/options";
-export type { InlineTranslationOptionsFields } from "./translation-functions/types/options";
+export type * from './translation-functions/types/options';
+export type { InlineTranslationOptionsFields } from './translation-functions/types/options';
 
 // Config
-export type * from "./config/types";
+export type * from './config/types';
 
 // Internal types
-export type { Hash } from "./i18n-manager/translations-manager/TranslationsCache";
-export type { Locale } from "./i18n-manager/translations-manager/LocalesCache";
+export type { Hash } from './i18n-manager/translations-manager/TranslationsCache';
+export type { Locale } from './i18n-manager/translations-manager/LocalesCache';

--- a/packages/i18n/src/internal.ts
+++ b/packages/i18n/src/internal.ts
@@ -1,29 +1,29 @@
-export * from "./translation-functions/internal";
-export * from "./i18n-manager";
-export * from "./translation-functions/utils/interpolation/interpolateIcuMessage";
-export * from "./helpers";
-export { interpolateMessage } from "./translation-functions/utils/interpolation/interpolateMessage";
-export { createLookupOptions } from "./translation-functions/internal/helpers";
-export { isEncodedTranslationOptions } from "./translation-functions/utils/isEncodedTranslationOptions";
-export { extractVariables } from "./utils/extractVariables";
+export * from './translation-functions/internal';
+export * from './i18n-manager';
+export * from './translation-functions/utils/interpolation/interpolateIcuMessage';
+export * from './helpers';
+export { interpolateMessage } from './translation-functions/utils/interpolation/interpolateMessage';
+export { createLookupOptions } from './translation-functions/internal/helpers';
+export { isEncodedTranslationOptions } from './translation-functions/utils/isEncodedTranslationOptions';
+export { extractVariables } from './utils/extractVariables';
 export {
   getDictionaryListenerKey,
   getTranslateListenerKey,
-} from "./utils/listenerKeys";
+} from './utils/listenerKeys';
 export type {
   DictionaryListenerLookup,
   TranslateListenerLookup,
-} from "./utils/listenerKeys";
+} from './utils/listenerKeys';
 export {
   getDictionaryEntry,
   isDictionaryValue,
   getDictionaryValue,
   resolveDictionaryLookupOptions,
-} from "./i18n-manager/translations-manager/utils/dictionary-helpers";
+} from './i18n-manager/translations-manager/utils/dictionary-helpers';
 
 export {
   getI18nManager,
   setI18nManager,
-} from "./i18n-manager/singleton-operations";
-export { createConditionStoreSingleton } from "./condition-store/createConditionStoreSingleton";
-export { getRuntimeEnvironment } from "./utils/getRuntimeEnvironment";
+} from './i18n-manager/singleton-operations';
+export { createConditionStoreSingleton } from './condition-store/createConditionStoreSingleton';
+export { getRuntimeEnvironment } from './utils/getRuntimeEnvironment';

--- a/packages/i18n/src/translation-functions/derive/index.ts
+++ b/packages/i18n/src/translation-functions/derive/index.ts
@@ -1,5 +1,1 @@
-export {
-  derive,
-  declareVar,
-  decodeVars,
-} from 'generaltranslation/internal';
+export { derive, declareVar, decodeVars } from 'generaltranslation/internal';

--- a/packages/i18n/src/translation-functions/internal/getGT.ts
+++ b/packages/i18n/src/translation-functions/internal/getGT.ts
@@ -1,10 +1,10 @@
-import { getI18nManager } from "../../i18n-manager/singleton-operations";
-import { InlineTranslationOptions } from "../types/options";
-import { GTFunctionType } from "../types/functions";
-import { interpolateMessage } from "../utils/interpolation/interpolateMessage";
-import { createLookupOptions } from "./helpers";
-import type { StringFormat } from "@generaltranslation/format/types";
-import { getLocale } from "../../helpers/locale";
+import { getI18nManager } from '../../i18n-manager/singleton-operations';
+import { InlineTranslationOptions } from '../types/options';
+import { GTFunctionType } from '../types/functions';
+import { interpolateMessage } from '../utils/interpolation/interpolateMessage';
+import { createLookupOptions } from './helpers';
+import type { StringFormat } from '@generaltranslation/format/types';
+import { getLocale } from '../../helpers/locale';
 
 /**
  * Returns the gt function that registers a string at build time and resolves its translation at runtime.
@@ -39,20 +39,20 @@ export async function getGT(): Promise<GTFunctionType> {
    */
   const gt: GTFunctionType = (
     message: string,
-    options: InlineTranslationOptions = {},
+    options: InlineTranslationOptions = {}
   ) => {
     const targetLocale = options.$locale ?? locale;
     const lookupOptions = createLookupOptions<StringFormat>(
       targetLocale,
       options,
-      "ICU",
+      'ICU'
     );
 
     // Lookup translation
     const translation = i18nManager.lookupTranslation(
       lookupOptions.$locale,
       message,
-      lookupOptions,
+      lookupOptions
     );
 
     // Format result

--- a/packages/i18n/src/translation-functions/internal/getTranslations.ts
+++ b/packages/i18n/src/translation-functions/internal/getTranslations.ts
@@ -1,11 +1,11 @@
-import { getI18nManager } from "../../i18n-manager/singleton-operations";
-import { DictionaryTranslationOptions } from "../types/options";
-import { TFunctionType } from "../types/functions";
-import { renderDictionaryEntry } from "./renderDictionaryEntry";
-import { renderDictionaryObject } from "./renderDictionaryObject";
-import { resolveDictionaryLookupOptions } from "../../i18n-manager/translations-manager/utils/dictionary-helpers";
-import type { DictionaryObjectTranslation } from "../types/functions";
-import { getLocale } from "../../helpers/locale";
+import { getI18nManager } from '../../i18n-manager/singleton-operations';
+import { DictionaryTranslationOptions } from '../types/options';
+import { TFunctionType } from '../types/functions';
+import { renderDictionaryEntry } from './renderDictionaryEntry';
+import { renderDictionaryObject } from './renderDictionaryObject';
+import { resolveDictionaryLookupOptions } from '../../i18n-manager/translations-manager/utils/dictionary-helpers';
+import type { DictionaryObjectTranslation } from '../types/functions';
+import { getLocale } from '../../helpers/locale';
 
 /**
  * Returns the t function that translates a dictionary entry based on its id and options.
@@ -43,7 +43,7 @@ export async function getTranslations(): Promise<TFunctionType> {
    */
   const t = ((
     id: string,
-    options: DictionaryTranslationOptions = {},
+    options: DictionaryTranslationOptions = {}
   ): string => {
     const sourceEntry = i18nManager.lookupDictionary(sourceLocale, id);
     if (sourceEntry === undefined) {
@@ -51,14 +51,14 @@ export async function getTranslations(): Promise<TFunctionType> {
     }
     const targetEntry = i18nManager.lookupDictionary(locale, id);
     const dictionaryOptions = resolveDictionaryLookupOptions(
-      sourceEntry.options,
+      sourceEntry.options
     );
     const target =
       targetEntry?.entry ??
       i18nManager.lookupTranslation(
         locale,
         sourceEntry.entry,
-        dictionaryOptions,
+        dictionaryOptions
       );
     return renderDictionaryEntry({
       sourceLocale,
@@ -94,7 +94,7 @@ export async function getTranslations(): Promise<TFunctionType> {
         i18nManager.lookupTranslation(
           locale,
           sourceEntry.entry,
-          dictionaryOptions,
+          dictionaryOptions
         ),
     });
   };

--- a/packages/i18n/src/translation-functions/internal/tx.ts
+++ b/packages/i18n/src/translation-functions/internal/tx.ts
@@ -1,11 +1,11 @@
-import { RuntimeTranslationOptions } from "../types/options";
-import type { StringFormat } from "@generaltranslation/format/types";
-import { resolveStringContentWithRuntimeFallback } from "./helpers";
-import { getLocale } from "../../helpers/locale";
+import { RuntimeTranslationOptions } from '../types/options';
+import type { StringFormat } from '@generaltranslation/format/types';
+import { resolveStringContentWithRuntimeFallback } from './helpers';
+import { getLocale } from '../../helpers/locale';
 
 type RuntimeTranslationOptionsWithFormat = Omit<
   RuntimeTranslationOptions,
-  "$format"
+  '$format'
 > & {
   $format?: StringFormat;
 };
@@ -26,12 +26,12 @@ type RuntimeTranslationOptionsWithFormat = Omit<
  */
 export async function tx(
   content: string,
-  options: RuntimeTranslationOptionsWithFormat = {},
+  options: RuntimeTranslationOptionsWithFormat = {}
 ): Promise<string> {
   const locale =
-    typeof options.$locale === "string" ? options.$locale : getLocale();
+    typeof options.$locale === 'string' ? options.$locale : getLocale();
   return resolveStringContentWithRuntimeFallback(locale, content, {
-    $format: "STRING",
+    $format: 'STRING',
     ...options,
   });
 }

--- a/packages/i18n/src/translation-functions/t.ts
+++ b/packages/i18n/src/translation-functions/t.ts
@@ -1,6 +1,6 @@
-import { resolveStringContentWithFallback } from "./internal/helpers";
-import { InlineTranslationOptions } from "./types/options";
-import { getLocale } from "../helpers/locale";
+import { resolveStringContentWithFallback } from './internal/helpers';
+import { InlineTranslationOptions } from './types/options';
+import { getLocale } from '../helpers/locale';
 
 /**
  * Translate a message
@@ -11,7 +11,7 @@ import { getLocale } from "../helpers/locale";
 export function t(message: string, options: InlineTranslationOptions = {}) {
   const locale = options.$locale ?? getLocale();
   return resolveStringContentWithFallback(locale, message, {
-    $format: "ICU",
+    $format: 'ICU',
     ...options,
   });
 }

--- a/packages/i18n/src/utils/getRuntimeEnvironment.ts
+++ b/packages/i18n/src/utils/getRuntimeEnvironment.ts
@@ -4,10 +4,10 @@ export type RuntimeEnvironment = {
   NODE_ENV?: string;
 };
 
-export function getRuntimeEnvironment(): "development" | "production" {
-  const processEnv = typeof process === "undefined" ? undefined : process.env;
-  if (processEnv?.NODE_ENV === "development") {
-    return "development";
+export function getRuntimeEnvironment(): 'development' | 'production' {
+  const processEnv = typeof process === 'undefined' ? undefined : process.env;
+  if (processEnv?.NODE_ENV === 'development') {
+    return 'development';
   }
 
   const importMetaEnv = (
@@ -16,11 +16,11 @@ export function getRuntimeEnvironment(): "development" | "production" {
     }
   ).env;
   if (importMetaEnv?.MODE) {
-    return importMetaEnv.MODE === "development" ? "development" : "production";
+    return importMetaEnv.MODE === 'development' ? 'development' : 'production';
   }
   if (importMetaEnv?.DEV === true) {
-    return "development";
+    return 'development';
   }
 
-  return "production";
+  return 'production';
 }

--- a/packages/node/src/async-i18n-manager/AsyncConditionStore.ts
+++ b/packages/node/src/async-i18n-manager/AsyncConditionStore.ts
@@ -1,9 +1,9 @@
-import { AsyncLocalStorage } from "node:async_hooks";
+import { AsyncLocalStorage } from 'node:async_hooks';
 import type {
   LocaleResolverConfig,
   ScopedConditionStore,
-} from "gt-i18n/internal/types";
-import { getI18nManager } from "gt-i18n/internal";
+} from 'gt-i18n/internal/types';
+import { getI18nManager } from 'gt-i18n/internal';
 
 type Store = {
   locale: string;
@@ -11,10 +11,10 @@ type Store = {
 };
 
 const OUTSIDE_SCOPE_MESSAGE =
-  "AsyncConditionStore: getLocale() called outside of a withGT() scope.";
+  'AsyncConditionStore: getLocale() called outside of a withGT() scope.';
 
 const ENABLE_I18N_MESSAGE =
-  "AsyncConditionStore: getEnableI18n() called outside of a withGT() scope.";
+  'AsyncConditionStore: getEnableI18n() called outside of a withGT() scope.';
 
 type AsyncConditionStoreConstructorParams = LocaleResolverConfig & {
   store?: AsyncLocalStorage<Store>;
@@ -41,14 +41,14 @@ export class AsyncConditionStore implements ScopedConditionStore {
   run<T>(locale: string, callback: () => T): T {
     return this.store.run(
       { locale: getI18nManager().determineLocale(locale) },
-      callback,
+      callback
     );
   }
 
   getLocale(): string {
     const store = this.store.getStore();
     if (!store) {
-      if (process.env.NODE_ENV === "production") {
+      if (process.env.NODE_ENV === 'production') {
         console.warn(OUTSIDE_SCOPE_MESSAGE);
         return getI18nManager().determineLocale();
       }
@@ -63,7 +63,7 @@ export class AsyncConditionStore implements ScopedConditionStore {
   getEnableI18n(): boolean {
     const store = this.store.getStore();
     if (!store) {
-      if (process.env.NODE_ENV === "production") {
+      if (process.env.NODE_ENV === 'production') {
         console.warn(ENABLE_I18N_MESSAGE);
         return true;
       }

--- a/packages/node/src/async-i18n-manager/singleton-operations.ts
+++ b/packages/node/src/async-i18n-manager/singleton-operations.ts
@@ -1,9 +1,9 @@
-import { createConditionStoreSingleton } from "gt-i18n/internal";
-import type { AsyncConditionStore } from "./AsyncConditionStore";
+import { createConditionStoreSingleton } from 'gt-i18n/internal';
+import type { AsyncConditionStore } from './AsyncConditionStore';
 
 export const {
   getConditionStore: getAsyncConditionStore,
   setConditionStore: setAsyncConditionStore,
 } = createConditionStoreSingleton<AsyncConditionStore>(
-  "AsyncConditionStore not initialized. Invoke initializeGT() to initialize.",
+  'AsyncConditionStore not initialized. Invoke initializeGT() to initialize.'
 );

--- a/packages/python-extractor/src/parseStringExpression.ts
+++ b/packages/python-extractor/src/parseStringExpression.ts
@@ -3,10 +3,7 @@ import type { SyntaxNode } from './parser.js';
 import { getParser } from './parser.js';
 import type { StringNode } from './stringNode.js';
 import type { ImportAlias } from './extractImports.js';
-import {
-  PYTHON_DERIVE,
-  PYTHON_DECLARE_VAR,
-} from './constants.js';
+import { PYTHON_DERIVE, PYTHON_DECLARE_VAR } from './constants.js';
 import {
   resolveFunctionInCurrentFile,
   resolveFunctionInFile,
@@ -259,9 +256,7 @@ async function resolveDeclareStaticArg(
 ): Promise<StringNode | null> {
   const arg = getFirstPositionalArg(callNode);
   if (!arg) {
-    ctx.errors.push(
-      `${locationStr(callNode)}: derive() requires an argument`
-    );
+    ctx.errors.push(`${locationStr(callNode)}: derive() requires an argument`);
     return null;
   }
 

--- a/packages/react-core/src/components/branches/Plural.tsx
+++ b/packages/react-core/src/components/branches/Plural.tsx
@@ -1,6 +1,6 @@
-import getPluralBranch from "../../utils/plurals/getPluralBranch";
-import type { ReactNode } from "react";
-import { useFormatLocales } from "../../hooks/utils";
+import getPluralBranch from '../../utils/plurals/getPluralBranch';
+import type { ReactNode } from 'react';
+import { useFormatLocales } from '../../hooks/utils';
 
 // ===== Component ===== //
 
@@ -16,7 +16,7 @@ function Plural({
   [key: string]: ReactNode;
 }): ReactNode {
   const locales = useFormatLocales(localesProp);
-  if (typeof n !== "number") {
+  if (typeof n !== 'number') {
     return children;
   }
   return getPluralBranch(n, locales, branches) || children;
@@ -32,8 +32,8 @@ function GtInternalPlural(props: {
 }
 
 /** @internal _gtt - The GT transformation for the component. */
-Plural._gtt = "plural";
-GtInternalPlural._gtt = "plural-automatic";
+Plural._gtt = 'plural';
+GtInternalPlural._gtt = 'plural-automatic';
 
 // ===== Exports ===== //
 

--- a/packages/react-core/src/components/translation/T.tsx
+++ b/packages/react-core/src/components/translation/T.tsx
@@ -1,20 +1,20 @@
-import { useCallback, useMemo } from "react";
-import addGTIdentifier from "../../utils/internal/addGTIdentifier";
-import { removeInjectedT } from "../../utils/internal/removeInjectedT";
-import writeChildrenAsObjects from "../../utils/internal/writeChildrenAsObjects";
-import renderDefaultChildren from "../../utils/rendering/renderDefaultChildren";
-import renderTranslatedChildren from "../../utils/rendering/renderTranslatedChildren";
-import { renderVariable } from "../../utils/rendering/renderVariable";
-import { useLocale } from "../../hooks/context-hooks";
+import { useCallback, useMemo } from 'react';
+import addGTIdentifier from '../../utils/internal/addGTIdentifier';
+import { removeInjectedT } from '../../utils/internal/removeInjectedT';
+import writeChildrenAsObjects from '../../utils/internal/writeChildrenAsObjects';
+import renderDefaultChildren from '../../utils/rendering/renderDefaultChildren';
+import renderTranslatedChildren from '../../utils/rendering/renderTranslatedChildren';
+import { renderVariable } from '../../utils/rendering/renderVariable';
+import { useLocale } from '../../hooks/context-hooks';
 import {
   useDefaultLocale,
   useTranslate,
-} from "../../hooks/external-store-hooks";
-import type { JsxTranslationOptions as JsxTranslationOptionsWithSugar } from "gt-i18n/types";
-import type { JsxChildren } from "generaltranslation/types";
-import type { TaggedChildren } from "../../utils/types";
-import type { ReactNode } from "react";
-import { useShouldTranslate } from "../../hooks/utils";
+} from '../../hooks/external-store-hooks';
+import type { JsxTranslationOptions as JsxTranslationOptionsWithSugar } from 'gt-i18n/types';
+import type { JsxChildren } from 'generaltranslation/types';
+import type { TaggedChildren } from '../../utils/types';
+import type { ReactNode } from 'react';
+import { useShouldTranslate } from '../../hooks/utils';
 
 // ===== Component ===== //
 
@@ -24,13 +24,13 @@ import { useShouldTranslate } from "../../hooks/utils";
 function T(
   props: {
     children: ReactNode;
-  } & JsxTranslationOptions,
+  } & JsxTranslationOptions
 ): ReactNode {
   return useComputeT(props);
 }
 
 /** @internal _gtt - The GT transformation for the component. */
-T._gtt = "translate-client";
+T._gtt = 'translate-client';
 
 export { T };
 
@@ -99,7 +99,7 @@ function usePrepSourceRender({
   taggedSourceChildren: TaggedChildren;
   sourceJsxChildren: JsxChildren;
   targetOptions: JsxTranslationOptionsWithSugar & {
-    $format: "JSX";
+    $format: 'JSX';
     $locale: string;
   };
   shouldTranslate: boolean;
@@ -109,16 +109,16 @@ function usePrepSourceRender({
   const shouldTranslate = useShouldTranslate();
   const taggedSourceChildren = useMemo(
     () => addGTIdentifier(removeInjectedT(sourceChildren)),
-    [sourceChildren],
+    [sourceChildren]
   );
   const sourceJsxChildren = useMemo(
     () => writeChildrenAsObjects(taggedSourceChildren),
-    [taggedSourceChildren],
+    [taggedSourceChildren]
   );
   const options = useMemo(() => normalizeParameters(params), [params]);
   const targetOptions = useMemo(
     () => ({ ...options, $locale: locale }),
-    [locale, options],
+    [locale, options]
   );
 
   return {
@@ -138,11 +138,11 @@ function normalizeParameters(
     context?: string;
     id?: string;
     _hash?: string;
-  } & JsxTranslationOptions,
-): JsxTranslationOptionsWithSugar & { $format: "JSX" } {
+  } & JsxTranslationOptions
+): JsxTranslationOptionsWithSugar & { $format: 'JSX' } {
   return {
     ...parameters,
-    $format: "JSX",
+    $format: 'JSX',
     $context: parameters.$context ?? parameters.context,
     $id: parameters.$id ?? parameters.id,
     $_hash: parameters.$_hash ?? parameters._hash,

--- a/packages/react-core/src/condition-store/singleton-operations.ts
+++ b/packages/react-core/src/condition-store/singleton-operations.ts
@@ -1,10 +1,10 @@
-import { createConditionStoreSingleton } from "gt-i18n/internal";
-import type { WritableConditionStoreInterface } from "gt-i18n/internal/types";
+import { createConditionStoreSingleton } from 'gt-i18n/internal';
+import type { WritableConditionStoreInterface } from 'gt-i18n/internal/types';
 
 export const {
   getConditionStore: getWritableConditionStore,
   setConditionStore: setWritableConditionStore,
   isConditionStoreInitialized: isWritableConditionStoreInitialized,
 } = createConditionStoreSingleton<WritableConditionStoreInterface>(
-  "WritableConditionStore is not initialized.",
+  'WritableConditionStore is not initialized.'
 );

--- a/packages/react-core/src/context.ts
+++ b/packages/react-core/src/context.ts
@@ -1,14 +1,14 @@
 // ===== Components ===== //
-export { Branch } from "./components/branches/Branch";
-export { Plural } from "./components/branches/Plural";
-export { Derive } from "./components/derivation/Derive";
-export { LocaleSelector } from "./components/helpers/LocaleSelector";
-export { T } from "./components/translation/T";
-export { Currency } from "./components/variables/Currency";
-export { DateTime } from "./components/variables/DateTime";
-export { Num } from "./components/variables/Num";
-export { RelativeTime } from "./components/variables/RelativeTime";
-export { Var } from "./components/variables/Var";
+export { Branch } from './components/branches/Branch';
+export { Plural } from './components/branches/Plural';
+export { Derive } from './components/derivation/Derive';
+export { LocaleSelector } from './components/helpers/LocaleSelector';
+export { T } from './components/translation/T';
+export { Currency } from './components/variables/Currency';
+export { DateTime } from './components/variables/DateTime';
+export { Num } from './components/variables/Num';
+export { RelativeTime } from './components/variables/RelativeTime';
+export { Var } from './components/variables/Var';
 
 // ===== Hooks ===== //
 export {
@@ -16,20 +16,20 @@ export {
   useSetLocale,
   useEnableI18n,
   useSetEnableI18n,
-} from "./hooks/context-hooks";
+} from './hooks/context-hooks';
 export {
   useCustomMapping,
   useDefaultLocale,
   useLocales,
-} from "./hooks/external-store-hooks";
-export { useGT } from "./hooks/useGT";
-export { useMessages } from "./hooks/useMessages";
-export { useTranslations } from "./hooks/useTranslations";
-export { useLocaleSelector } from "./hooks/useLocaleSelector";
-export { useFormatLocales } from "./hooks/utils";
+} from './hooks/external-store-hooks';
+export { useGT } from './hooks/useGT';
+export { useMessages } from './hooks/useMessages';
+export { useTranslations } from './hooks/useTranslations';
+export { useLocaleSelector } from './hooks/useLocaleSelector';
+export { useFormatLocales } from './hooks/utils';
 
 // ===== Functions ===== //
-export { getTranslationsSnapshot } from "./functions/helpers/getTranslationsSnapshot";
+export { getTranslationsSnapshot } from './functions/helpers/getTranslationsSnapshot';
 export {
   msg,
   decodeMsg,
@@ -39,34 +39,34 @@ export {
   decodeVars,
   mFallback,
   gtFallback,
-} from "gt-i18n";
-export { t } from "./functions/translation/t";
+} from 'gt-i18n';
+export { t } from './functions/translation/t';
 
 // ===== Internal ===== //
-export { InternalGTProvider } from "./context/InternalGTProvider";
-export { internalInitializeGTSPA } from "./setup/initializeGTSPA";
-export { internalInitializeGTSSR } from "./setup/initializeGTSSR";
-export { getI18nStore, setI18nStore } from "./i18n-store/singleton-operations";
+export { InternalGTProvider } from './context/InternalGTProvider';
+export { internalInitializeGTSPA } from './setup/initializeGTSPA';
+export { internalInitializeGTSSR } from './setup/initializeGTSSR';
+export { getI18nStore, setI18nStore } from './i18n-store/singleton-operations';
 export {
   setRenderStrategy,
   getRenderStrategy,
   setStoresInitialized,
-} from "./setup/globals";
+} from './setup/globals';
 export {
   getWritableConditionStore as getConditionStore,
   setWritableConditionStore as setConditionStore,
-} from "./condition-store/singleton-operations";
-export { WritableConditionStore } from "gt-i18n/internal";
-export type { WritableConditionStoreParams } from "gt-i18n/internal";
+} from './condition-store/singleton-operations';
+export { WritableConditionStore } from 'gt-i18n/internal';
+export type { WritableConditionStoreParams } from 'gt-i18n/internal';
 export {
   getReactI18nManager,
   setReactI18nManager,
-} from "./i18n-manager/singleton-operations";
-export { I18nStore } from "./i18n-store/I18nStore";
-export type { I18nStoreParams } from "./i18n-store/I18nStore";
-export type { InternalGTProviderProps } from "./deprecated/types-dir/config";
-export type { ReloadLocaleType } from "./i18n-store/storeTypes";
+} from './i18n-manager/singleton-operations';
+export { I18nStore } from './i18n-store/I18nStore';
+export type { I18nStoreParams } from './i18n-store/I18nStore';
+export type { InternalGTProviderProps } from './deprecated/types-dir/config';
+export type { ReloadLocaleType } from './i18n-store/storeTypes';
 export type {
   ReactI18nManager,
   ReactI18nManagerParams,
-} from "./i18n-manager/ReactI18nManager";
+} from './i18n-manager/ReactI18nManager';

--- a/packages/react-core/src/context/InternalGTProvider.tsx
+++ b/packages/react-core/src/context/InternalGTProvider.tsx
@@ -1,18 +1,18 @@
-import { GTContext, GTContextType } from "./GTContext";
+import { GTContext, GTContextType } from './GTContext';
 import {
   useCallback,
   useMemo,
   useSyncExternalStore,
   type ReactNode,
-} from "react";
-import { getI18nStore, setI18nStore } from "../i18n-store/singleton-operations";
-import { type WritableConditionStoreParams } from "gt-i18n/internal";
-import type { ReloadLocaleType } from "../i18n-store/storeTypes";
+} from 'react';
+import { getI18nStore, setI18nStore } from '../i18n-store/singleton-operations';
+import { type WritableConditionStoreParams } from 'gt-i18n/internal';
+import type { ReloadLocaleType } from '../i18n-store/storeTypes';
 import {
   setStoresInitialized,
   getI18nStoreInitialized,
-} from "../setup/globals";
-import { I18nStore, I18nStoreParams } from "../i18n-store/I18nStore";
+} from '../setup/globals';
+import { I18nStore, I18nStoreParams } from '../i18n-store/I18nStore';
 
 export type InternalGTProviderProps = WritableConditionStoreParams &
   I18nStoreParams & {
@@ -58,7 +58,7 @@ export function InternalGTProvider({
   const locale = useSyncExternalStore(
     getI18nStore().subscribeToLocale,
     getI18nStore().getLocaleSnapshot,
-    getI18nStore().getLocaleSnapshot,
+    getI18nStore().getLocaleSnapshot
   );
   const setLocale = useCallback((locale: string) => {
     getI18nStore().setLocale(locale);
@@ -66,7 +66,7 @@ export function InternalGTProvider({
   const enableI18n = useSyncExternalStore(
     getI18nStore().subscribeToEnableI18n,
     getI18nStore().getEnableI18nSnapshot,
-    getI18nStore().getEnableI18nSnapshot,
+    getI18nStore().getEnableI18nSnapshot
   );
   const setEnableI18n = useCallback((enableI18n: boolean) => {
     getI18nStore().setEnableI18n(enableI18n);
@@ -74,7 +74,7 @@ export function InternalGTProvider({
   const { status } = useSyncExternalStore(
     getI18nStore().subscribeToTranslationStatus,
     getI18nStore().getTranslationStatusSnapshot,
-    getI18nStore().getTranslationStatusSnapshot,
+    getI18nStore().getTranslationStatusSnapshot
   );
 
   const context: GTContextType = useMemo(
@@ -84,14 +84,14 @@ export function InternalGTProvider({
       setLocale,
       setEnableI18n,
     }),
-    [locale, enableI18n, setLocale, setEnableI18n],
+    [locale, enableI18n, setLocale, setEnableI18n]
   );
 
   // ------ Rendering ------ //
 
   // Show fallback when translations are loading (client only) from a locale change
   // locale will not be updated until the translations are loaded
-  const display = !(status === "loading" && !config.reloadLocale);
+  const display = !(status === 'loading' && !config.reloadLocale);
 
   return (
     <GTContext.Provider value={context}>

--- a/packages/react-core/src/deprecated/__tests__/react-core-package.test.ts
+++ b/packages/react-core/src/deprecated/__tests__/react-core-package.test.ts
@@ -69,7 +69,10 @@ function isWorkspaceSubpath(specifier: string): boolean {
   );
 }
 
-function isAllowedExternalizedSubpath(file: string, specifier: string): boolean {
+function isAllowedExternalizedSubpath(
+  file: string,
+  specifier: string
+): boolean {
   return file.startsWith('context.') && specifier.startsWith('gt-i18n/');
 }
 

--- a/packages/react-core/src/deprecated/branches/plurals/Plural.tsx
+++ b/packages/react-core/src/deprecated/branches/plurals/Plural.tsx
@@ -1,8 +1,8 @@
-import { ReactNode, useContext } from "react";
-import { getPluralBranch } from "../../../internal";
-import { createPluralMissingError } from "../../errors-dir/createErrors";
-import { libraryDefaultLocale } from "generaltranslation/internal";
-import { GTContext } from "../../provider/GTContext";
+import { ReactNode, useContext } from 'react';
+import { getPluralBranch } from '../../../internal';
+import { createPluralMissingError } from '../../errors-dir/createErrors';
+import { libraryDefaultLocale } from 'generaltranslation/internal';
+import { GTContext } from '../../provider/GTContext';
 
 /**
  * The `<Plural>` component dynamically renders content based on the plural form of the given number (`n`).
@@ -52,11 +52,11 @@ function Plural({
     ...(locales ? [locales] : []),
     defaultLocale || libraryDefaultLocale,
   ];
-  if (typeof n !== "number")
+  if (typeof n !== 'number')
     throw new Error(createPluralMissingError(children));
   return <>{getPluralBranch(n, providerLocales, branches) || children}</>;
 }
 
-Plural._gtt = "plural";
+Plural._gtt = 'plural';
 
 export default Plural;

--- a/packages/react-core/src/deprecated/errors-dir/createErrors.ts
+++ b/packages/react-core/src/deprecated/errors-dir/createErrors.ts
@@ -1,115 +1,115 @@
-import { getLocaleProperties } from "@generaltranslation/format";
+import { getLocaleProperties } from '@generaltranslation/format';
 import {
   createReactCoreDiagnostic,
   formatDiagnosticErrorDetails,
-} from "./diagnostics";
-import { PACKAGE_NAME } from "./constants";
+} from './diagnostics';
+import { PACKAGE_NAME } from './constants';
 
 // ---- ERRORS ---- //
 
 export const projectIdMissingError = createReactCoreDiagnostic({
-  severity: "Error",
-  whatHappened: "Runtime translation needs a project ID",
-  fix: "Add projectId to your <GTProvider> configuration or set GT_PROJECT_ID in your environment",
-  docsUrl: "https://generaltranslation.com/dashboard",
+  severity: 'Error',
+  whatHappened: 'Runtime translation needs a project ID',
+  fix: 'Add projectId to your <GTProvider> configuration or set GT_PROJECT_ID in your environment',
+  docsUrl: 'https://generaltranslation.com/dashboard',
 });
 
 export const devApiKeyProductionError = createReactCoreDiagnostic({
-  severity: "Error",
-  whatHappened: "Production environments cannot use a development API key",
-  fix: "Replace it with a production API key before deploying",
+  severity: 'Error',
+  whatHappened: 'Production environments cannot use a development API key',
+  fix: 'Replace it with a production API key before deploying',
 });
 
 export const apiKeyInProductionError = createReactCoreDiagnostic({
-  severity: "Error",
-  whatHappened: "The API key is available to client-side production code",
-  fix: "Move translation credentials to a server-only environment before deploying",
+  severity: 'Error',
+  whatHappened: 'The API key is available to client-side production code',
+  fix: 'Move translation credentials to a server-only environment before deploying',
 });
 
 export const createNoAuthError = createReactCoreDiagnostic({
-  severity: "Error",
-  whatHappened: "Runtime translation is not configured",
-  fix: "Add projectId and devApiKey to your environment, or pass them to <GTProvider> directly",
+  severity: 'Error',
+  whatHappened: 'Runtime translation is not configured',
+  fix: 'Add projectId and devApiKey to your environment, or pass them to <GTProvider> directly',
 });
 
 export const createPluralMissingError = (children: unknown) =>
   createReactCoreDiagnostic({
-    severity: "Error",
+    severity: 'Error',
     whatHappened: `<Plural> could not choose a plural form for "${children}"`,
     fix: 'Pass the required "n" option to <Plural>',
   });
 
 export const createClientSideTDictionaryCollisionError = (id: string) =>
   createReactCoreDiagnostic({
-    severity: "Error",
+    severity: 'Error',
     whatHappened: `<T id="${id}"> conflicts with a dictionary entry using the same ID`,
-    fix: "Rename the <T> id or the dictionary key so each translation source has a unique ID",
+    fix: 'Rename the <T> id or the dictionary key so each translation source has a unique ID',
   });
 
 export const createClientSideTHydrationError = (id: string) =>
   createReactCoreDiagnostic({
-    severity: "Error",
+    severity: 'Error',
     whatHappened: `<T id="${id}"> is rendering in a client component without a saved translation`,
-    why: "This can cause hydration mismatches",
-    fix: "Use a dictionary with useGT() or push translations from the command line before rendering this component on the client",
+    why: 'This can cause hydration mismatches',
+    fix: 'Use a dictionary with useGT() or push translations from the command line before rendering this component on the client',
   });
 
 export const dynamicTranslationError = createReactCoreDiagnostic({
-  severity: "Error",
-  whatHappened: "Runtime translations could not be loaded",
-  wayOut: "Source content will render as a fallback",
-  fix: "Check your runtime translation configuration and try again",
+  severity: 'Error',
+  whatHappened: 'Runtime translations could not be loaded',
+  wayOut: 'Source content will render as a fallback',
+  fix: 'Check your runtime translation configuration and try again',
 });
 
 export const createGenericRuntimeTranslationError = (
   id: string | undefined,
   hash: string,
-  error?: unknown,
+  error?: unknown
 ) =>
   createReactCoreDiagnostic({
-    severity: "Error",
+    severity: 'Error',
     whatHappened: id
       ? `Translation could not be found for id "${id}" and hash "${hash}"`
       : `Translation could not be found for hash "${hash}"`,
-    wayOut: "Source content will render as a fallback",
-    fix: "Push translations again or check that runtime translation is configured",
+    wayOut: 'Source content will render as a fallback',
+    fix: 'Push translations again or check that runtime translation is configured',
     details: formatDiagnosticErrorDetails(error),
   });
 
 export const runtimeTranslationError = createReactCoreDiagnostic({
-  severity: "Error",
-  whatHappened: "Runtime translation could not be completed",
+  severity: 'Error',
+  whatHappened: 'Runtime translation could not be completed',
 });
 
-export const customLoadTranslationsError = (locale: string = "") =>
+export const customLoadTranslationsError = (locale: string = '') =>
   createReactCoreDiagnostic({
-    severity: "Error",
-    whatHappened: `Locally stored translations could not be loaded${locale ? ` for "${locale}"` : ""}`,
-    fix: "If you use loadTranslations(), make sure it returns translations for the requested locale",
+    severity: 'Error',
+    whatHappened: `Locally stored translations could not be loaded${locale ? ` for "${locale}"` : ''}`,
+    fix: 'If you use loadTranslations(), make sure it returns translations for the requested locale',
   });
 
-export const customLoadDictionaryWarning = (locale: string = "") =>
+export const customLoadDictionaryWarning = (locale: string = '') =>
   createReactCoreDiagnostic({
-    severity: "Warning",
-    whatHappened: `The local dictionary could not be loaded${locale ? ` for "${locale}"` : ""}`,
-    fix: "If you use loadDictionary(), make sure it returns a dictionary for the requested locale",
+    severity: 'Warning',
+    whatHappened: `The local dictionary could not be loaded${locale ? ` for "${locale}"` : ''}`,
+    fix: 'If you use loadDictionary(), make sure it returns a dictionary for the requested locale',
   });
 
 export const missingVariablesError = (variables: string[], message: string) =>
   createReactCoreDiagnostic({
-    severity: "Error",
+    severity: 'Error',
     whatHappened: `The message "${message}" is missing variables: "${variables.join('", "')}"`,
-    fix: "Provide values for these variables before rendering the translation",
+    fix: 'Provide values for these variables before rendering the translation',
   });
 
 export const createStringRenderError = (
   message: string,
   id: string | undefined,
-  error?: unknown,
+  error?: unknown
 ) =>
   createReactCoreDiagnostic({
-    severity: "Error",
-    whatHappened: `The string ${id ? `for id "${id}" ` : ""}could not be rendered`,
+    severity: 'Error',
+    whatHappened: `The string ${id ? `for id "${id}" ` : ''}could not be rendered`,
     fix: `Check the message syntax and variables for: "${message}"`,
     details: formatDiagnosticErrorDetails(error),
   });
@@ -117,123 +117,123 @@ export const createStringRenderError = (
 export const createStringTranslationError = (
   string: string,
   id?: string,
-  functionName = "tx",
+  functionName = 'tx'
 ) =>
   createReactCoreDiagnostic({
-    severity: "Error",
-    whatHappened: `${functionName}("${string}")${id ? ` with id "${id}"` : ""} could not find a translation`,
-    wayOut: "Source content will render as a fallback",
-    fix: "Push translations again or check your dictionary/runtime translation configuration",
+    severity: 'Error',
+    whatHappened: `${functionName}("${string}")${id ? ` with id "${id}"` : ''} could not find a translation`,
+    wayOut: 'Source content will render as a fallback',
+    fix: 'Push translations again or check your dictionary/runtime translation configuration',
   });
 
 export const invalidLocalesError = (locales: string[]) =>
   createReactCoreDiagnostic({
-    severity: "Error",
-    whatHappened: "Invalid locale codes in your configuration",
+    severity: 'Error',
+    whatHappened: 'Invalid locale codes in your configuration',
     fix: 'Specify a list of valid locales or use "customMapping" to define aliases for the invalid locales',
     details: locales,
   });
 
 export const invalidCanonicalLocalesError = (locales: string[]) =>
   createReactCoreDiagnostic({
-    severity: "Error",
-    whatHappened: "Invalid canonical locale codes in your configuration",
-    fix: "Use valid BCP 47 locale codes before starting translation",
+    severity: 'Error',
+    whatHappened: 'Invalid canonical locale codes in your configuration',
+    fix: 'Use valid BCP 47 locale codes before starting translation',
     details: locales,
   });
 
 export const createEmptyIdError = () =>
   createReactCoreDiagnostic({
-    severity: "Error",
-    whatHappened: "t.obj() received an empty id",
-    fix: "Pass a non-empty dictionary id",
+    severity: 'Error',
+    whatHappened: 't.obj() received an empty id',
+    fix: 'Pass a non-empty dictionary id',
   });
 
 export const createSubtreeNotFoundError = (id: string) =>
   createReactCoreDiagnostic({
-    severity: "Error",
+    severity: 'Error',
     whatHappened: `Dictionary subtree "${id}" could not be found`,
-    fix: "Check that the id matches your dictionary structure",
+    fix: 'Check that the id matches your dictionary structure',
   });
 
 export const createDictionaryEntryError = () =>
   createReactCoreDiagnostic({
-    severity: "Error",
-    whatHappened: "A dictionary entry cannot be injected as a subtree",
-    fix: "Pass a dictionary object instead",
+    severity: 'Error',
+    whatHappened: 'A dictionary entry cannot be injected as a subtree',
+    fix: 'Pass a dictionary object instead',
   });
 
 export const createCannotInjectDictionaryEntryError = () =>
   createReactCoreDiagnostic({
-    severity: "Error",
+    severity: 'Error',
     whatHappened:
-      "A dictionary entry cannot be merged into another dictionary entry",
-    fix: "Pass a dictionary subtree instead",
+      'A dictionary entry cannot be merged into another dictionary entry',
+    fix: 'Pass a dictionary subtree instead',
   });
 
 export const createInvalidIcuDictionaryEntryError = (id: string | undefined) =>
   createReactCoreDiagnostic({
-    severity: "Error",
+    severity: 'Error',
     whatHappened: `Dictionary entry "${id}" contains invalid ICU syntax`,
-    fix: "Fix the ICU message before rendering this translation",
+    fix: 'Fix the ICU message before rendering this translation',
   });
 
 // ---- WARNINGS ---- //
 
 export const projectIdMissingWarning = createReactCoreDiagnostic({
-  severity: "Warning",
-  whatHappened: "Runtime translation needs a project ID",
-  fix: "Add projectId to <GTProvider> or set GT_PROJECT_ID in your environment",
-  docsUrl: "https://generaltranslation.com/dashboard",
+  severity: 'Warning',
+  whatHappened: 'Runtime translation needs a project ID',
+  fix: 'Add projectId to <GTProvider> or set GT_PROJECT_ID in your environment',
+  docsUrl: 'https://generaltranslation.com/dashboard',
 });
 
 export const createNoEntryFoundWarning = (id: string) =>
   createReactCoreDiagnostic({
-    severity: "Warning",
+    severity: 'Warning',
     whatHappened: `No valid dictionary entry was found for id "${id}"`,
-    wayOut: "Source content will render as a fallback",
+    wayOut: 'Source content will render as a fallback',
   });
 
 export const createInvalidDictionaryEntryWarning = (id: string) =>
   createReactCoreDiagnostic({
-    severity: "Warning",
+    severity: 'Warning',
     whatHappened: `Dictionary entry "${id}" is invalid`,
-    wayOut: "Source content will render as a fallback until the entry is fixed",
+    wayOut: 'Source content will render as a fallback until the entry is fixed',
   });
 
 export const createInvalidIcuDictionaryEntryWarning = (id: string) =>
   createReactCoreDiagnostic({
-    severity: "Warning",
+    severity: 'Warning',
     whatHappened: `Dictionary entry "${id}" contains invalid ICU syntax`,
-    wayOut: "Source content will render as a fallback until the entry is fixed",
+    wayOut: 'Source content will render as a fallback until the entry is fixed',
   });
 
 export const createNoEntryTranslationWarning = (
   id: string,
-  prefixedId: string,
+  prefixedId: string
 ) =>
   createReactCoreDiagnostic({
-    severity: "Warning",
+    severity: 'Warning',
     whatHappened: `t("${id}") could not find a translation for dictionary item "${prefixedId}"`,
-    wayOut: "Source content will render as a fallback",
+    wayOut: 'Source content will render as a fallback',
   });
 
 export const createMismatchingHashWarning = (
   expectedHash: string,
-  receivedHash: string,
+  receivedHash: string
 ) =>
   createReactCoreDiagnostic({
-    severity: "Warning",
-    whatHappened: "Translation hashes do not match",
-    reassurance: "The translation will still render",
-    fix: "Update your translations to the newest version to avoid stale content",
+    severity: 'Warning',
+    whatHappened: 'Translation hashes do not match',
+    reassurance: 'The translation will still render',
+    fix: 'Update your translations to the newest version to avoid stale content',
     details: [`expected ${expectedHash}`, `received ${receivedHash}`],
   });
 
 export const APIKeyMissingWarn = createReactCoreDiagnostic({
-  severity: "Warning",
-  whatHappened: "Runtime translation needs a development API key",
-  fix: "Find your development API key at generaltranslation.com/dashboard, or set runtimeUrl to an empty string to disable runtime translation",
+  severity: 'Warning',
+  whatHappened: 'Runtime translation needs a development API key',
+  fix: 'Find your development API key at generaltranslation.com/dashboard, or set runtimeUrl to an empty string to disable runtime translation',
 });
 
 export const createUnsupportedLocalesWarning = (locales: string[]) =>
@@ -242,17 +242,17 @@ export const createUnsupportedLocalesWarning = (locales: string[]) =>
       const { name } = getLocaleProperties(locale);
       return `${locale} (${name})`;
     })
-    .join(", ")}`;
+    .join(', ')}`;
 
 export const runtimeTranslationTimeoutWarning = createReactCoreDiagnostic({
-  severity: "Warning",
-  whatHappened: "Runtime translation timed out",
+  severity: 'Warning',
+  whatHappened: 'Runtime translation timed out',
 });
 
 export const createUnsupportedLocaleWarning = (
   validatedLocale: string,
   newLocale: string,
-  packageName: string = PACKAGE_NAME,
+  packageName: string = PACKAGE_NAME
 ) => {
   return (
     `${packageName} Warning: "${newLocale}" is not a supported locale. ` +
@@ -262,20 +262,20 @@ export const createUnsupportedLocaleWarning = (
 };
 
 export const dictionaryMissingWarning = createReactCoreDiagnostic({
-  severity: "Warning",
-  whatHappened: "No dictionary was found",
-  fix: "Pass a dictionary to <GTProvider> or configure a dictionary loader before rendering translations",
+  severity: 'Warning',
+  whatHappened: 'No dictionary was found',
+  fix: 'Pass a dictionary to <GTProvider> or configure a dictionary loader before rendering translations',
 });
 
 export const createStringRenderWarning = (
   message: string,
   id: string | undefined,
-  error?: unknown,
+  error?: unknown
 ) =>
   createReactCoreDiagnostic({
-    severity: "Warning",
-    whatHappened: `The string ${id ? `for id "${id}" ` : ""}could not be rendered`,
-    wayOut: "Source content will render as a fallback",
+    severity: 'Warning',
+    whatHappened: `The string ${id ? `for id "${id}" ` : ''}could not be rendered`,
+    wayOut: 'Source content will render as a fallback',
     fix: `Check the message syntax and variables for: "${message}"`,
     details: formatDiagnosticErrorDetails(error),
   });

--- a/packages/react-core/src/deprecated/provider/GTContext.ts
+++ b/packages/react-core/src/deprecated/provider/GTContext.ts
@@ -1,13 +1,13 @@
-import { createContext, useContext } from "react";
-import { GTContextType } from "../types-dir/context";
+import { createContext, useContext } from 'react';
+import { GTContextType } from '../types-dir/context';
 
 export const GTContext = createContext<GTContextType | undefined>(undefined);
 
 export default function useGTContext(
-  errorString = "useGTContext() must be used within a <GTProvider>!",
+  errorString = 'useGTContext() must be used within a <GTProvider>!'
 ): GTContextType {
   const context = useContext(GTContext);
-  if (typeof context === "undefined") {
+  if (typeof context === 'undefined') {
     throw new Error(errorString);
   }
   return context;

--- a/packages/react-core/src/deprecated/provider/__tests__/i18n-store.test.ts
+++ b/packages/react-core/src/deprecated/provider/__tests__/i18n-store.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { I18nManager, WritableConditionStore } from 'gt-i18n/internal';
-import {
-  setWritableConditionStore as setConditionStore,
-} from '../../../condition-store/singleton-operations';
+import { setWritableConditionStore as setConditionStore } from '../../../condition-store/singleton-operations';
 import { setReactI18nManager } from '../../../i18n-manager/singleton-operations';
 import { I18nStore } from '../../../i18n-store/I18nStore';
 

--- a/packages/react-core/src/deprecated/rendering/renderDefaultChildren.tsx
+++ b/packages/react-core/src/deprecated/rendering/renderDefaultChildren.tsx
@@ -1,16 +1,16 @@
-import React, { ReactNode } from "react";
+import React, { ReactNode } from 'react';
 import getVariableProps, {
   isVariableElementProps,
-} from "../variables/_getVariableProps";
-import { libraryDefaultLocale } from "generaltranslation/internal";
-import getPluralBranch from "../branches/plurals/getPluralBranch";
+} from '../variables/_getVariableProps';
+import { libraryDefaultLocale } from 'generaltranslation/internal';
+import getPluralBranch from '../branches/plurals/getPluralBranch';
 import {
   RenderVariable,
   TaggedChild,
   TaggedChildren,
   TaggedElement,
-} from "../types-dir/types";
-import getGTTag from "./getGTTag";
+} from '../types-dir/types';
+import getGTTag from './getGTTag';
 
 export default function renderDefaultChildren({
   children,
@@ -38,9 +38,9 @@ export default function renderDefaultChildren({
     }
 
     // Plural
-    if (generaltranslation?.transformation === "plural") {
+    if (generaltranslation?.transformation === 'plural') {
       const branches = generaltranslation.branches || {};
-      if (typeof child.props.n !== "number") {
+      if (typeof child.props.n !== 'number') {
         return child.props.children != null
           ? handleChildren(child.props.children)
           : null;
@@ -48,30 +48,30 @@ export default function renderDefaultChildren({
       const resolvedBranch = getPluralBranch(
         child.props.n,
         [defaultLocale],
-        branches,
+        branches
       );
       return handleChildren(
         (resolvedBranch !== null
           ? resolvedBranch
-          : child.props.children) as TaggedChildren,
+          : child.props.children) as TaggedChildren
       );
     }
 
     // Branch
-    if (generaltranslation?.transformation === "branch") {
+    if (generaltranslation?.transformation === 'branch') {
       const { children, branch } = child.props;
       const branches = generaltranslation.branches || {};
       const branchKey =
-        branch == null || branch === "" ? undefined : branch.toString();
+        branch == null || branch === '' ? undefined : branch.toString();
       return handleChildren(
         branchKey && branches[branchKey] !== undefined
           ? branches[branchKey]
-          : children,
+          : children
       );
     }
 
     // Fragment
-    if (generaltranslation?.transformation === "fragment") {
+    if (generaltranslation?.transformation === 'fragment') {
       return React.createElement(React.Fragment, {
         key: child.props.key,
         children: handleChildren(child.props.children),
@@ -82,11 +82,11 @@ export default function renderDefaultChildren({
     if (child.props.children) {
       return React.cloneElement(child, {
         ...child.props,
-        "data-_gt": undefined,
+        'data-_gt': undefined,
         children: handleChildren(child.props.children) as TaggedChildren,
       });
     }
-    return React.cloneElement(child, { ...child.props, "data-_gt": undefined });
+    return React.cloneElement(child, { ...child.props, 'data-_gt': undefined });
   };
 
   const handleSingleChild = (child: TaggedChild): ReactNode => {

--- a/packages/react-core/src/deprecated/rendering/renderTranslatedChildren.tsx
+++ b/packages/react-core/src/deprecated/rendering/renderTranslatedChildren.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react";
+import React, { ReactNode } from 'react';
 import {
   TaggedChildren,
   TaggedElement,
@@ -6,18 +6,18 @@ import {
   RenderVariable,
   TranslatedElement,
   VariableProps,
-} from "../types-dir/types";
+} from '../types-dir/types';
 import getVariableProps, {
   isVariableElementProps,
-} from "../variables/_getVariableProps";
-import renderDefaultChildren from "./renderDefaultChildren";
-import { isVariable, libraryDefaultLocale } from "generaltranslation/internal";
-import getPluralBranch from "../branches/plurals/getPluralBranch";
+} from '../variables/_getVariableProps';
+import renderDefaultChildren from './renderDefaultChildren';
+import { isVariable, libraryDefaultLocale } from 'generaltranslation/internal';
+import getPluralBranch from '../branches/plurals/getPluralBranch';
 import {
   HTML_CONTENT_PROPS,
   HtmlContentPropValuesRecord,
-} from "@generaltranslation/format/types";
-import getGTTag from "./getGTTag";
+} from '@generaltranslation/format/types';
+import getGTTag from './getGTTag';
 
 function renderTranslatedElement({
   sourceElement,
@@ -32,7 +32,7 @@ function renderTranslatedElement({
 }): React.ReactNode {
   // Get props and generaltranslation
   const { props: sourceProps } = sourceElement;
-  const sourceGT = sourceProps["data-_gt"];
+  const sourceGT = sourceProps['data-_gt'];
   const transformation = sourceGT?.transformation;
 
   // Get translated props
@@ -51,9 +51,9 @@ function renderTranslatedElement({
   }
 
   // plural (choose a branch)
-  if (transformation === "plural") {
+  if (transformation === 'plural') {
     const n = sourceElement.props.n;
-    if (typeof n !== "number") {
+    if (typeof n !== 'number') {
       return renderDefaultChildren({
         children: sourceElement,
         defaultLocale: locales[0],
@@ -79,10 +79,10 @@ function renderTranslatedElement({
   }
 
   // branch (choose a branch)
-  if (transformation === "branch") {
+  if (transformation === 'branch') {
     const { branch, children } = sourceProps;
     const branchKey =
-      branch == null || branch === "" ? undefined : branch.toString();
+      branch == null || branch === '' ? undefined : branch.toString();
     const sourceBranches = sourceGT.branches || {};
     const targetBranches = targetElement.d?.b || {};
     const sourceBranch =
@@ -102,7 +102,7 @@ function renderTranslatedElement({
   }
 
   // fragment (create a valid fragment)
-  if (transformation === "fragment" && targetElement.c) {
+  if (transformation === 'fragment' && targetElement.c) {
     return React.createElement(React.Fragment, {
       key: sourceElement.props.key,
       children: renderTranslatedChildren({
@@ -119,7 +119,7 @@ function renderTranslatedElement({
     return React.cloneElement(sourceElement, {
       ...sourceProps,
       ...translatedProps,
-      "data-_gt": undefined,
+      'data-_gt': undefined,
       children: renderTranslatedChildren({
         source: sourceProps.children as TaggedChildren,
         target: targetElement.c,
@@ -149,13 +149,13 @@ export default function renderTranslatedChildren({
   renderVariable: RenderVariable;
 }): ReactNode {
   // Most straightforward case, return a valid React node
-  if ((target === null || typeof target === "undefined") && source)
+  if ((target === null || typeof target === 'undefined') && source)
     return renderDefaultChildren({
       children: source,
       defaultLocale: locales[0],
       renderVariable,
     });
-  if (typeof target === "string") return target;
+  if (typeof target === 'string') return target;
 
   // Convert source to an array in case target has multiple children where source only has one
   if (Array.isArray(target) && !Array.isArray(source) && source)
@@ -164,12 +164,12 @@ export default function renderTranslatedChildren({
   // Multiple children
   if (Array.isArray(source) && Array.isArray(target)) {
     // Track the variables
-    const variables: Record<string, VariableProps["variableValue"]> = {};
-    const variablesOptions: Record<string, VariableProps["variableOptions"]> =
+    const variables: Record<string, VariableProps['variableValue']> = {};
+    const variablesOptions: Record<string, VariableProps['variableOptions']> =
       {};
     const variableInjectionTypes: Record<
       string,
-      VariableProps["injectionType"]
+      VariableProps['injectionType']
     > = {};
 
     // Extract source elements
@@ -193,17 +193,17 @@ export default function renderTranslatedChildren({
           }
         }
         return false;
-      },
+      }
     );
 
     // TODO: pre-index these to avoid O(n/2) lookups
     const findMatchingSourceElement = (
-      targetElement: TranslatedElement,
+      targetElement: TranslatedElement
     ): TaggedElement | undefined => {
       return (
         sourceElements.find((sourceChild): sourceChild is TaggedElement => {
           const generaltranslation = getGTTag(sourceChild);
-          if (typeof generaltranslation?.id !== "undefined") {
+          if (typeof generaltranslation?.id !== 'undefined') {
             const sourceId = generaltranslation.id;
             const targetId = targetElement.i;
             return sourceId === targetId;
@@ -215,7 +215,7 @@ export default function renderTranslatedChildren({
 
     // map target to source
     return target.map((targetChild, index) => {
-      if (typeof targetChild === "string")
+      if (typeof targetChild === 'string')
         return (
           <React.Fragment key={`string_${index}`}>{targetChild}</React.Fragment>
         );
@@ -225,11 +225,11 @@ export default function renderTranslatedChildren({
         return (
           <React.Fragment key={`var_${index}`}>
             {renderVariable({
-              variableType: targetChild.v || "v",
+              variableType: targetChild.v || 'v',
               variableValue: variables[targetChild.k],
               variableOptions: variablesOptions[targetChild.k],
               locales,
-              injectionType: variableInjectionTypes[targetChild.k] || "manual",
+              injectionType: variableInjectionTypes[targetChild.k] || 'manual',
             })}
           </React.Fragment>
         );
@@ -237,7 +237,7 @@ export default function renderTranslatedChildren({
 
       // Render element (targetChild is a TranslatedElement)
       const matchingSourceElement = findMatchingSourceElement(
-        targetChild as TranslatedElement,
+        targetChild as TranslatedElement
       );
       if (!matchingSourceElement) return null;
       return (
@@ -254,13 +254,13 @@ export default function renderTranslatedChildren({
   }
 
   // Single child
-  if (target && typeof target === "object" && !Array.isArray(target)) {
-    const targetType: "variable" | "element" = isVariable(target)
-      ? "variable"
-      : "element";
+  if (target && typeof target === 'object' && !Array.isArray(target)) {
+    const targetType: 'variable' | 'element' = isVariable(target)
+      ? 'variable'
+      : 'element';
 
     if (React.isValidElement(source)) {
-      if (targetType === "element") {
+      if (targetType === 'element') {
         return renderTranslatedElement({
           sourceElement: source,
           targetElement: target as TranslatedElement,

--- a/packages/react-core/src/deprecated/translation/T.tsx
+++ b/packages/react-core/src/deprecated/translation/T.tsx
@@ -1,15 +1,15 @@
-import React, { Suspense } from "react";
-import renderDefaultChildren from "../rendering/renderDefaultChildren";
-import { addGTIdentifier, writeChildrenAsObjects } from "../../internal";
-import useGTContext from "../provider/GTContext";
-import renderTranslatedChildren from "../rendering/renderTranslatedChildren";
-import { useMemo } from "react";
-import renderVariable from "../rendering/renderVariable";
-import { hashSource } from "generaltranslation/id";
-import renderSkeleton from "../rendering/renderSkeleton";
-import { TranslatedChildren } from "../types-dir/types";
-import { useable } from "../promises/dangerouslyUsable";
-import reactUse from "../utils/use";
+import React, { Suspense } from 'react';
+import renderDefaultChildren from '../rendering/renderDefaultChildren';
+import { addGTIdentifier, writeChildrenAsObjects } from '../../internal';
+import useGTContext from '../provider/GTContext';
+import renderTranslatedChildren from '../rendering/renderTranslatedChildren';
+import { useMemo } from 'react';
+import renderVariable from '../rendering/renderVariable';
+import { hashSource } from 'generaltranslation/id';
+import renderSkeleton from '../rendering/renderSkeleton';
+import { TranslatedChildren } from '../types-dir/types';
+import { useable } from '../promises/dangerouslyUsable';
+import reactUse from '../utils/use';
 
 /**
  * Build-time translation component that renders its children in the user's given locale.
@@ -62,7 +62,7 @@ function T({
   id = id ?? options?.$id;
   context = context ?? options?.$context;
   const maxChars =
-    typeof options?.$maxChars === "number" ? options.$maxChars : undefined;
+    typeof options?.$maxChars === 'number' ? options.$maxChars : undefined;
 
   const {
     translations,
@@ -87,7 +87,7 @@ function T({
     translationEntry = translations?.[id];
   }
 
-  if (typeof translationEntry === "undefined" && _hash) {
+  if (typeof translationEntry === 'undefined' && _hash) {
     translationEntry = translations?.[_hash];
   }
 
@@ -98,7 +98,7 @@ function T({
       !translationRequired || // Translation not required
       translationEntry // Translation already exists under the id
     ) {
-      return [undefined, ""];
+      return [undefined, ''];
     }
     // calculate hash
     const childrenAsObjects = writeChildrenAsObjects(taggedChildren);
@@ -107,7 +107,7 @@ function T({
       ...(context && { context }),
       ...(maxChars != null && { maxChars: Math.abs(maxChars) }),
       ...(id && { id }),
-      dataFormat: "JSX",
+      dataFormat: 'JSX',
     });
     return [childrenAsObjects, hash];
   }, [
@@ -120,7 +120,7 @@ function T({
   ]);
 
   // get translation entry on hash
-  if (typeof translationEntry === "undefined") {
+  if (typeof translationEntry === 'undefined') {
     translationEntry = translations?.[hash];
   }
 
@@ -195,7 +195,7 @@ function T({
     const resolvedTranslation = reactUse(
       useable(
         [
-          "getTranslationPromise", // prefix key
+          'getTranslationPromise', // prefix key
           developmentApiEnabled,
           JSON.stringify(childrenAsObjects),
           locale,
@@ -204,8 +204,8 @@ function T({
           context,
           maxChars,
         ],
-        () => getTranslationPromise(),
-      ),
+        () => getTranslationPromise()
+      )
     );
     return (
       <Suspense fallback={resolvedTranslation}>{resolvedTranslation}</Suspense>
@@ -213,9 +213,9 @@ function T({
   }
 
   let loadingFallback;
-  if (renderSettings.method === "skeleton") {
+  if (renderSettings.method === 'skeleton') {
     loadingFallback = renderSkeleton();
-  } else if (renderSettings.method === "replace") {
+  } else if (renderSettings.method === 'replace') {
     loadingFallback = renderDefault();
   } else {
     // default
@@ -229,6 +229,6 @@ function T({
   );
 }
 /** @internal _gtt - The GT transformation for the component. */
-T._gtt = "translate-client";
+T._gtt = 'translate-client';
 
 export default T;

--- a/packages/react-core/src/deprecated/utils/cookies.ts
+++ b/packages/react-core/src/deprecated/utils/cookies.ts
@@ -2,15 +2,15 @@
  * Cookie name for tracking the referrer locale
  * @deprecated move to gt-react
  */
-export const defaultLocaleCookieName = "generaltranslation.locale";
+export const defaultLocaleCookieName = 'generaltranslation.locale';
 /**
  * Cookie name for tracking the user's selected region
  * @deprecated move to gt-react
  */
-export const defaultRegionCookieName = "generaltranslation.region";
+export const defaultRegionCookieName = 'generaltranslation.region';
 /**
  * Cookie name for persisting the enableI18n feature flag
  * "true" or "false"
  * @deprecated move to gt-react
  */
-export const defaultEnableI18nCookieName = "generaltranslation.enable-i18n";
+export const defaultEnableI18nCookieName = 'generaltranslation.enable-i18n';

--- a/packages/react-core/src/errors.ts
+++ b/packages/react-core/src/errors.ts
@@ -1,3 +1,3 @@
-import { createUnsupportedLocaleWarning } from "./deprecated/errors-dir/createErrors";
+import { createUnsupportedLocaleWarning } from './deprecated/errors-dir/createErrors';
 
 export { createUnsupportedLocaleWarning };

--- a/packages/react-core/src/functions/translation/t.ts
+++ b/packages/react-core/src/functions/translation/t.ts
@@ -2,17 +2,17 @@ import {
   createLookupOptions,
   getRuntimeEnvironment,
   interpolateMessage,
-} from "gt-i18n/internal";
+} from 'gt-i18n/internal';
 import type {
   InlineTranslationOptions,
   ResolutionOptions,
-} from "gt-i18n/types";
-import { getRenderStrategy } from "../../setup/globals";
-import { isWritableConditionStoreInitialized } from "../../condition-store/singleton-operations";
-import { StringContent, StringFormat } from "generaltranslation/types";
-import { getReactI18nManager } from "../../i18n-manager/singleton-operations";
-import { getShouldTranslate } from "../../hooks/utils";
-import { getLocale } from "../../hooks/context-hooks";
+} from 'gt-i18n/types';
+import { getRenderStrategy } from '../../setup/globals';
+import { isWritableConditionStoreInitialized } from '../../condition-store/singleton-operations';
+import { StringContent, StringFormat } from 'generaltranslation/types';
+import { getReactI18nManager } from '../../i18n-manager/singleton-operations';
+import { getShouldTranslate } from '../../hooks/utils';
+import { getLocale } from '../../hooks/context-hooks';
 
 /**
  * Translate a message
@@ -38,7 +38,7 @@ export const t: StringOrTemplateSyncResolutionFunction = (
   enforceSSRRules(messageOrStrings);
 
   //  t("Hello, {name}!", { name: "John" })
-  if (typeof messageOrStrings === "string") {
+  if (typeof messageOrStrings === 'string') {
     const options = values.at(0) as InlineTranslationOptions | undefined;
     const locale = options?.$locale ?? getLocale();
     return resolveStringContent(locale, messageOrStrings, options);
@@ -53,7 +53,7 @@ export const t: StringOrTemplateSyncResolutionFunction = (
 export function resolveStringContent(
   locale: string,
   content: StringContent,
-  options: ResolutionOptions<StringFormat> = {},
+  options: ResolutionOptions<StringFormat> = {}
 ): StringContent {
   const i18nManager = getReactI18nManager();
   const defaultLocale = i18nManager.getDefaultLocale();
@@ -65,11 +65,11 @@ export function resolveStringContent(
     });
   }
 
-  const lookupOptions = createLookupOptions(locale, options, "ICU");
+  const lookupOptions = createLookupOptions(locale, options, 'ICU');
   const translation = i18nManager.lookupTranslation(
     lookupOptions.$locale,
     content,
-    lookupOptions,
+    lookupOptions
   );
   return interpolateMessage({
     source: content,
@@ -92,27 +92,27 @@ export function resolveStringContent(
  */
 function handleTaggedTemplateLiteralTranslation(
   messageOrStrings: TemplateStringsArray,
-  values: unknown[],
+  values: unknown[]
 ): string {
   const locale = getLocale();
   // for tagged template literals, there has been no compiler transformation
   // (1) lookup interpolated template (aka derived message)
   const interpolatedTemplate = interpolateTemplateLiteral(
     messageOrStrings,
-    values,
+    values
   );
   const i18nManager = getReactI18nManager();
   const translatedInterpolatedTemplate = i18nManager.lookupTranslation(
     locale,
     interpolatedTemplate,
-    { $format: "STRING" },
+    { $format: 'STRING' }
   );
   if (translatedInterpolatedTemplate) return translatedInterpolatedTemplate;
 
   // (2) resolve uninterpolated message
   const { message, variables } = extractInterpolatableValues(
     messageOrStrings,
-    values,
+    values
   );
   return resolveStringContent(locale, message, variables);
 }
@@ -125,7 +125,7 @@ function handleTaggedTemplateLiteralTranslation(
  */
 function extractInterpolatableValues(
   strings: TemplateStringsArray,
-  values: unknown[],
+  values: unknown[]
 ): {
   message: string;
   variables: Record<string, unknown>;
@@ -150,7 +150,7 @@ function extractInterpolatableValues(
   }
 
   return {
-    message: parts.join(""),
+    message: parts.join(''),
     variables,
   };
 }
@@ -163,13 +163,13 @@ function extractInterpolatableValues(
  */
 function interpolateTemplateLiteral(
   strings: TemplateStringsArray,
-  values: unknown[],
+  values: unknown[]
 ): string {
   return strings
     .map((string, index) => {
-      return string + (values[index] ?? "");
+      return string + (values[index] ?? '');
     })
-    .join("");
+    .join('');
 }
 
 /**
@@ -179,16 +179,16 @@ function interpolateTemplateLiteral(
  * - Prod: Warn
  */
 function enforceSSRRules(messageOrStrings: string | TemplateStringsArray) {
-  const ssrEnabled = getRenderStrategy() === "server-render";
+  const ssrEnabled = getRenderStrategy() === 'server-render';
   const moduleLevel = !isWritableConditionStoreInitialized();
   if (!ssrEnabled || !moduleLevel) return;
 
   const message =
-    typeof messageOrStrings === "string"
+    typeof messageOrStrings === 'string'
       ? messageOrStrings
-      : messageOrStrings.join("");
+      : messageOrStrings.join('');
   const errorMessage = createSSRRulesError(message);
-  if (getRuntimeEnvironment() === "development") {
+  if (getRuntimeEnvironment() === 'development') {
     throw new Error(errorMessage);
   } else {
     console.warn(errorMessage);

--- a/packages/react-core/src/hooks/context-hooks.ts
+++ b/packages/react-core/src/hooks/context-hooks.ts
@@ -1,7 +1,7 @@
-import { GTContext, GTContextType } from "../context/GTContext";
-import { getRenderStrategy } from "../setup/globals";
-import { getWritableConditionStore } from "../condition-store/singleton-operations";
-import { useContext } from "react";
+import { GTContext, GTContextType } from '../context/GTContext';
+import { getRenderStrategy } from '../setup/globals';
+import { getWritableConditionStore } from '../condition-store/singleton-operations';
+import { useContext } from 'react';
 
 /**
  * @internal
@@ -10,7 +10,7 @@ import { useContext } from "react";
 function useGTContext(property: keyof GTContextType): GTContextType {
   const conditionStore = useContext(GTContext);
   if (!conditionStore) {
-    if (getRenderStrategy() === "SPA") {
+    if (getRenderStrategy() === 'SPA') {
       // No need for useSyncExternalStore for SPA apps as reload will always trigger a re-render
       const conditionStore = getWritableConditionStore();
       return {
@@ -21,7 +21,7 @@ function useGTContext(property: keyof GTContextType): GTContextType {
       };
     }
     throw new Error(
-      `use${(property as string).charAt(0).toUpperCase() + (property as string).slice(1)}() is being accessed outside of a <GTProvider>. Make sure to add a <GTProvider> to the top of your component tree.`,
+      `use${(property as string).charAt(0).toUpperCase() + (property as string).slice(1)}() is being accessed outside of a <GTProvider>. Make sure to add a <GTProvider> to the top of your component tree.`
     );
   }
   return conditionStore;
@@ -36,13 +36,13 @@ export function getLocale(): string {
 }
 
 export function useSetLocale(): (locale: string) => void {
-  return useGTContext("setLocale").setLocale;
+  return useGTContext('setLocale').setLocale;
 }
 
 export function useEnableI18n(): boolean {
-  return useGTContext("enableI18n").enableI18n;
+  return useGTContext('enableI18n').enableI18n;
 }
 
 export function useSetEnableI18n(): (enableI18n: boolean) => void {
-  return useGTContext("setEnableI18n").setEnableI18n;
+  return useGTContext('setEnableI18n').setEnableI18n;
 }

--- a/packages/react-core/src/hooks/external-store-hooks.ts
+++ b/packages/react-core/src/hooks/external-store-hooks.ts
@@ -1,5 +1,5 @@
-import { useMemo, useSyncExternalStore } from "react";
-import type { Translation } from "gt-i18n/types";
+import { useMemo, useSyncExternalStore } from 'react';
+import type { Translation } from 'gt-i18n/types';
 import type {
   TranslateLookup,
   TranslateManySnapshot,
@@ -7,24 +7,24 @@ import type {
   DictionaryLookup,
   DictionaryEntrySnapshot,
   DictionaryObjectSnapshot,
-} from "../i18n-store/storeTypes";
-import type { CustomMapping } from "generaltranslation/types";
-import { getI18nStore } from "../i18n-store/singleton-operations";
-import type { RuntimeTranslationScope } from "../i18n-store/RuntimeTranslationScope";
-import type { RuntimeDictionaryScope } from "../i18n-store/RuntimeDictionaryScope";
-import { getReactI18nManager } from "../i18n-manager/singleton-operations";
+} from '../i18n-store/storeTypes';
+import type { CustomMapping } from 'generaltranslation/types';
+import { getI18nStore } from '../i18n-store/singleton-operations';
+import type { RuntimeTranslationScope } from '../i18n-store/RuntimeTranslationScope';
+import type { RuntimeDictionaryScope } from '../i18n-store/RuntimeDictionaryScope';
+import { getReactI18nManager } from '../i18n-manager/singleton-operations';
 
 /**
  * @internal
  */
 export function useTranslate<T extends Translation>(
-  lookup: TranslateLookup<T>,
+  lookup: TranslateLookup<T>
 ): TranslateSnapshot<T> {
   const store = getI18nStore();
   const translation = useSyncExternalStore(
     (listener) => store.subscribeToTranslate(lookup, listener),
     () => store.getTranslateSnapshot(lookup),
-    () => store.getTranslateSnapshot(lookup),
+    () => store.getTranslateSnapshot(lookup)
   );
   if (translation == null && getReactI18nManager().isDevHotReloadEnabled()) {
     store.translate(lookup);
@@ -36,13 +36,13 @@ export function useTranslate<T extends Translation>(
  * @internal
  */
 export function useTranslateMany<T extends Translation>(
-  lookups: readonly TranslateLookup<T>[],
+  lookups: readonly TranslateLookup<T>[]
 ): TranslateManySnapshot<T> {
   const store = getI18nStore();
   const translations = useSyncExternalStore(
     (listener) => store.subscribeToTranslateMany(lookups, listener),
     () => store.getTranslateManySnapshot(lookups),
-    () => store.getTranslateManySnapshot(lookups),
+    () => store.getTranslateManySnapshot(lookups)
   );
   const devHotReloadEnabled = getReactI18nManager().isDevHotReloadEnabled();
   translations.forEach((translation, index) => {
@@ -57,13 +57,13 @@ export function useTranslateMany<T extends Translation>(
  * @internal
  */
 export function useDictionaryEntry(
-  lookup: DictionaryLookup,
+  lookup: DictionaryLookup
 ): DictionaryEntrySnapshot {
   const store = getI18nStore();
   const dictionaryEntry = useSyncExternalStore(
     (listener) => store.subscribeToDictionaryEntry(lookup, listener),
     () => store.getDictionaryEntrySnapshot(lookup),
-    () => store.getDictionaryEntrySnapshot(lookup),
+    () => store.getDictionaryEntrySnapshot(lookup)
   );
   if (
     dictionaryEntry == null &&
@@ -78,13 +78,13 @@ export function useDictionaryEntry(
  * @internal
  */
 export function useDictionaryObject(
-  lookup: DictionaryLookup,
+  lookup: DictionaryLookup
 ): DictionaryObjectSnapshot {
   const store = getI18nStore();
   const dictionaryObject = useSyncExternalStore(
     (listener) => store.subscribeToDictionaryObject(lookup, listener),
     () => store.getDictionaryObjectSnapshot(lookup),
-    () => store.getDictionaryObjectSnapshot(lookup),
+    () => store.getDictionaryObjectSnapshot(lookup)
   );
   if (
     dictionaryObject == null &&
@@ -100,7 +100,7 @@ export function useCustomMapping(): CustomMapping {
   return useSyncExternalStore(
     store.subscribeToCustomMapping,
     store.getCustomMappingSnapshot,
-    store.getCustomMappingSnapshot,
+    store.getCustomMappingSnapshot
   );
 }
 
@@ -109,7 +109,7 @@ export function useDefaultLocale(): string {
   return useSyncExternalStore(
     store.subscribeToDefaultLocale,
     store.getDefaultLocaleSnapshot,
-    store.getDefaultLocaleSnapshot,
+    store.getDefaultLocaleSnapshot
   );
 }
 
@@ -118,7 +118,7 @@ export function useLocales(): readonly string[] {
   return useSyncExternalStore(
     store.subscribeToLocales,
     store.getLocalesSnapshot,
-    store.getLocalesSnapshot,
+    store.getLocalesSnapshot
   );
 }
 

--- a/packages/react-core/src/hooks/useGT.ts
+++ b/packages/react-core/src/hooks/useGT.ts
@@ -1,18 +1,18 @@
-import { useCallback, useMemo } from "react";
-import { createLookupOptions } from "gt-i18n/internal";
-import type { InlineTranslationOptionsFields } from "gt-i18n/internal/types";
+import { useCallback, useMemo } from 'react';
+import { createLookupOptions } from 'gt-i18n/internal';
+import type { InlineTranslationOptionsFields } from 'gt-i18n/internal/types';
 import {
   useDefaultLocale,
   useRuntimeTranslationScope,
   useTranslateMany,
-} from "./external-store-hooks";
-import { useLocale } from "./context-hooks";
-import { useShouldTranslate } from "./utils";
-import { getReactI18nManager } from "../i18n-manager/singleton-operations";
-import type { TranslateLookup } from "../i18n-store/storeTypes";
-import type { GTFunctionType, InlineTranslationOptions } from "gt-i18n/types";
-import type { StringFormat } from "@generaltranslation/format/types";
-import { interpolateMessage } from "gt-i18n/internal";
+} from './external-store-hooks';
+import { useLocale } from './context-hooks';
+import { useShouldTranslate } from './utils';
+import { getReactI18nManager } from '../i18n-manager/singleton-operations';
+import type { TranslateLookup } from '../i18n-store/storeTypes';
+import type { GTFunctionType, InlineTranslationOptions } from 'gt-i18n/types';
+import type { StringFormat } from '@generaltranslation/format/types';
+import { interpolateMessage } from 'gt-i18n/internal';
 
 const EMPTY_TRANSLATE_LOOKUPS: TranslateLookup<string>[] = [];
 
@@ -34,7 +34,7 @@ export function useGT(_messages?: Message[]): GTFunctionType {
     locale,
     shouldTranslate,
     devHotReloadEnabled,
-    _messages ?? [],
+    _messages ?? []
   );
 
   /**
@@ -53,12 +53,12 @@ export function useGT(_messages?: Message[]): GTFunctionType {
       const lookupOptions = createLookupOptions<StringFormat>(
         options.$locale ?? locale,
         options,
-        "ICU",
+        'ICU'
       );
       const translation = getReactI18nManager().lookupTranslation(
         lookupOptions.$locale,
         message,
-        lookupOptions,
+        lookupOptions
       );
 
       if (translation == null && devHotReloadEnabled) {
@@ -76,7 +76,7 @@ export function useGT(_messages?: Message[]): GTFunctionType {
         sourceLocale: defaultLocale,
       });
     },
-    [defaultLocale, devHotReloadEnabled, locale, scope, shouldTranslate],
+    [defaultLocale, devHotReloadEnabled, locale, scope, shouldTranslate]
   );
 }
 
@@ -86,7 +86,7 @@ function useSubscribeToExtractedMessages(
   locale: string,
   shouldTranslate: boolean,
   devHotReloadEnabled: boolean,
-  messages: Message[],
+  messages: Message[]
 ) {
   const lookups = useMemo(() => {
     if (!messages?.length || !shouldTranslate || !devHotReloadEnabled) {
@@ -97,7 +97,7 @@ function useSubscribeToExtractedMessages(
       const lookupOptions = createLookupOptions<StringFormat>(
         targetLocale,
         options,
-        "ICU",
+        'ICU'
       );
       return {
         locale: targetLocale,

--- a/packages/react-core/src/hooks/useMessages.ts
+++ b/packages/react-core/src/hooks/useMessages.ts
@@ -1,9 +1,9 @@
-import { useCallback } from "react";
-import { decodeOptions } from "gt-i18n";
-import { useGT } from "./useGT";
-import type { _Messages } from "../utils/types";
-import type { InlineResolveOptions, MFunctionType } from "gt-i18n/types";
-import { isEncodedTranslationOptions } from "gt-i18n/internal";
+import { useCallback } from 'react';
+import { decodeOptions } from 'gt-i18n';
+import { useGT } from './useGT';
+import type { _Messages } from '../utils/types';
+import type { InlineResolveOptions, MFunctionType } from 'gt-i18n/types';
+import { isEncodedTranslationOptions } from 'gt-i18n/internal';
 
 // ===== Hook ===== //
 
@@ -13,7 +13,7 @@ export function useMessages(_messages?: _Messages): MFunctionType {
   return useCallback(
     <T extends string | null | undefined>(
       encodedMsg: T,
-      options: InlineResolveOptions = {},
+      options: InlineResolveOptions = {}
     ): T extends string ? string : T => {
       if (encodedMsg == null) {
         return encodedMsg as T extends string ? string : T;
@@ -28,6 +28,6 @@ export function useMessages(_messages?: _Messages): MFunctionType {
 
       return gt(encodedMsg, options) as T extends string ? string : T;
     },
-    [gt],
+    [gt]
   );
 }

--- a/packages/react-core/src/hooks/utils.ts
+++ b/packages/react-core/src/hooks/utils.ts
@@ -2,11 +2,11 @@ import {
   useCustomMapping,
   useDefaultLocale,
   useLocales,
-} from "./external-store-hooks";
-import { useEnableI18n, useLocale } from "./context-hooks";
-import { requiresTranslation } from "generaltranslation/core";
-import { getWritableConditionStore } from "../condition-store/singleton-operations";
-import { getReactI18nManager } from "../i18n-manager/singleton-operations";
+} from './external-store-hooks';
+import { useEnableI18n, useLocale } from './context-hooks';
+import { requiresTranslation } from 'generaltranslation/core';
+import { getWritableConditionStore } from '../condition-store/singleton-operations';
+import { getReactI18nManager } from '../i18n-manager/singleton-operations';
 
 export function useFormatLocales(localesProp: string[] = []): string[] {
   const locale = useLocale();

--- a/packages/react-core/src/i18n-manager/singleton-operations.ts
+++ b/packages/react-core/src/i18n-manager/singleton-operations.ts
@@ -10,7 +10,5 @@ export function getReactI18nManager(): ReactI18nManager {
 }
 
 export function setReactI18nManager(i18nManager: ReactI18nManager): void {
-  i18nInternal.setI18nManager(
-    i18nManager as I18nManager<Translation>
-  );
+  i18nInternal.setI18nManager(i18nManager as I18nManager<Translation>);
 }

--- a/packages/react-core/src/i18n-store/I18nStore.ts
+++ b/packages/react-core/src/i18n-store/I18nStore.ts
@@ -1,8 +1,8 @@
 import {
   getDictionaryListenerKey,
   getTranslateListenerKey,
-} from "gt-i18n/internal";
-import type { CustomMapping } from "generaltranslation/types";
+} from 'gt-i18n/internal';
+import type { CustomMapping } from 'generaltranslation/types';
 import type {
   DictionaryEntrySnapshot,
   DictionaryLookup,
@@ -14,17 +14,17 @@ import type {
   TranslateSnapshot,
   Unsubscribe,
   ReloadLocaleType,
-} from "./storeTypes";
-import type { Translation } from "gt-i18n/types";
-import type { Hash, Locale, LocaleCandidates } from "gt-i18n/internal/types";
-import { getWritableConditionStore } from "../condition-store/singleton-operations";
-import { getReactI18nManager } from "../i18n-manager/singleton-operations";
-import { RuntimeTranslationScope } from "./RuntimeTranslationScope";
-import { RuntimeDictionaryScope } from "./RuntimeDictionaryScope";
+} from './storeTypes';
+import type { Translation } from 'gt-i18n/types';
+import type { Hash, Locale, LocaleCandidates } from 'gt-i18n/internal/types';
+import { getWritableConditionStore } from '../condition-store/singleton-operations';
+import { getReactI18nManager } from '../i18n-manager/singleton-operations';
+import { RuntimeTranslationScope } from './RuntimeTranslationScope';
+import { RuntimeDictionaryScope } from './RuntimeDictionaryScope';
 
 type TranslationStatusType =
-  | { status: "loading"; locale: string }
-  | { status: "ready" };
+  | { status: 'loading'; locale: string }
+  | { status: 'ready' };
 
 type EntryCacheEvent = {
   locale: string;
@@ -71,7 +71,7 @@ export class I18nStore {
   private localeListeners: ListenerSet = new Set();
 
   private translationStatusListeners: ListenerSet = new Set();
-  private translationStatus: TranslationStatusType = { status: "ready" };
+  private translationStatus: TranslationStatusType = { status: 'ready' };
 
   private reloadLocale?: ReloadLocaleType;
 
@@ -83,7 +83,7 @@ export class I18nStore {
       getWritableConditionStore();
       getReactI18nManager();
     } catch (error) {
-      throw new Error("Failed to initialize I18nStore. Reason: " + error);
+      throw new Error('Failed to initialize I18nStore. Reason: ' + error);
     }
     this.reloadLocale = reloadLocale;
   }
@@ -116,7 +116,7 @@ export class I18nStore {
 
   subscribeToTranslate<T extends Translation>(
     lookup: TranslateLookup<T>,
-    listener: StoreListener,
+    listener: StoreListener
   ): Unsubscribe {
     const lookupKey = getTranslateListenerKey(lookup);
     const wrappedListener: TranslateStoreListener = (lookup) => {
@@ -129,10 +129,10 @@ export class I18nStore {
 
   subscribeToTranslateMany<T extends Translation>(
     lookups: readonly TranslateLookup<T>[],
-    listener: StoreListener,
+    listener: StoreListener
   ): Unsubscribe {
     const unsubscribes = lookups.map((lookup) =>
-      this.subscribeToTranslate(lookup, listener),
+      this.subscribeToTranslate(lookup, listener)
     );
     return () => {
       unsubscribes.forEach((unsubscribe) => unsubscribe());
@@ -141,7 +141,7 @@ export class I18nStore {
 
   subscribeToDictionaryEntry(
     lookup: DictionaryLookup,
-    listener: StoreListener,
+    listener: StoreListener
   ): Unsubscribe {
     const lookupKey = getDictionaryListenerKey(lookup);
     const wrappedListener: DictionaryStoreListener = (event) => {
@@ -151,13 +151,13 @@ export class I18nStore {
     };
     return this.subscribeToDictionarySet(
       this.dictionaryEntryListeners,
-      wrappedListener,
+      wrappedListener
     );
   }
 
   subscribeToDictionaryObject(
     lookup: DictionaryLookup,
-    listener: StoreListener,
+    listener: StoreListener
   ): Unsubscribe {
     const lookupKey = getDictionaryListenerKey(lookup);
     const wrappedListener: DictionaryStoreListener = (event) => {
@@ -167,7 +167,7 @@ export class I18nStore {
     };
     return this.subscribeToDictionarySet(
       this.dictionaryObjectListeners,
-      wrappedListener,
+      wrappedListener
     );
   }
 
@@ -206,17 +206,17 @@ export class I18nStore {
   };
 
   getTranslateManySnapshot = <T extends Translation>(
-    lookups: readonly TranslateLookup<T>[],
+    lookups: readonly TranslateLookup<T>[]
   ): TranslateManySnapshot<T> => {
     const nextSnapshot = lookups.map((lookup) =>
-      this.getTranslateSnapshot(lookup),
+      this.getTranslateSnapshot(lookup)
     );
     const previousSnapshot = this.translateManySnapshotCache.get(lookups);
     if (
       previousSnapshot &&
       previousSnapshot.length === nextSnapshot.length &&
       previousSnapshot.every((value, index) =>
-        Object.is(value, nextSnapshot[index]),
+        Object.is(value, nextSnapshot[index])
       )
     ) {
       return previousSnapshot as TranslateManySnapshot<T>;
@@ -247,7 +247,7 @@ export class I18nStore {
       .lookupTranslationWithFallback(
         lookup.locale,
         lookup.message,
-        lookup.options,
+        lookup.options
       )
       .then((translation) => {
         if (translation == null) {
@@ -323,25 +323,25 @@ export class I18nStore {
       !i18nManager.requiresTranslation(locale) ||
       i18nManager.hasTranslations(locale)
     ) {
-      this.updateTranslationStatus({ status: "ready" });
+      this.updateTranslationStatus({ status: 'ready' });
       getWritableConditionStore().setLocale(locale);
       this.localeListeners.forEach((listener) => listener());
       return;
     }
 
     // Load new translations and update status and locale
-    this.updateTranslationStatus({ status: "loading", locale });
+    this.updateTranslationStatus({ status: 'loading', locale });
     getReactI18nManager()
       .loadTranslations(locale)
       .then(() => {
         // dedupe update
         if (
-          this.translationStatus.status === "ready" ||
+          this.translationStatus.status === 'ready' ||
           this.translationStatus.locale !== locale
         ) {
           return;
         }
-        this.updateTranslationStatus({ status: "ready" });
+        this.updateTranslationStatus({ status: 'ready' });
         getWritableConditionStore().setLocale(locale);
         this.localeListeners.forEach((listener) => listener());
       });
@@ -353,7 +353,7 @@ export class I18nStore {
    */
   setEnableI18n = (enableI18n: boolean): void => {
     getWritableConditionStore().setEnableI18n(enableI18n);
-    this.updateTranslationStatus({ status: "ready" });
+    this.updateTranslationStatus({ status: 'ready' });
     this.enableI18nListeners.forEach((listener) => listener());
   };
 
@@ -367,17 +367,17 @@ export class I18nStore {
 
   private updateTranslationStatus = (txStatus: TranslationStatusType): void => {
     // Need to create a new object, otherwise rerender will not trigger
-    if (txStatus.status === "loading") {
-      this.translationStatus = { status: "loading", locale: txStatus.locale };
+    if (txStatus.status === 'loading') {
+      this.translationStatus = { status: 'loading', locale: txStatus.locale };
     } else {
-      this.translationStatus = { status: "ready" };
+      this.translationStatus = { status: 'ready' };
     }
     this.translationStatusListeners.forEach((listener) => listener());
   };
 
   private subscribeToStaticSet(
     listenerSet: ListenerSet,
-    listener: StoreListener,
+    listener: StoreListener
   ): Unsubscribe {
     listenerSet.add(listener);
     return () => {
@@ -386,7 +386,7 @@ export class I18nStore {
   }
 
   private subscribeToTranslateSet(
-    listener: TranslateStoreListener,
+    listener: TranslateStoreListener
   ): Unsubscribe {
     this.translateListeners.add(listener);
     return () => {
@@ -396,7 +396,7 @@ export class I18nStore {
 
   private subscribeToDictionarySet(
     listenerSet: Set<DictionaryStoreListener>,
-    listener: DictionaryStoreListener,
+    listener: DictionaryStoreListener
   ): Unsubscribe {
     listenerSet.add(listener);
     return () => {
@@ -421,7 +421,7 @@ export class I18nStore {
 // ===== Lookup Keys ===== //
 
 function getDictionaryLookupFromKey(lookupKey: string): DictionaryLookup {
-  const separatorIndex = lookupKey.indexOf(":");
+  const separatorIndex = lookupKey.indexOf(':');
   return {
     locale: lookupKey.slice(0, separatorIndex),
     id: lookupKey.slice(separatorIndex + 1),
@@ -432,18 +432,18 @@ function getDictionaryLookupFromKey(lookupKey: string): DictionaryLookup {
 
 function dictionaryEntryEventMatchesLookup(
   event: DictionaryStoreEvent,
-  lookupKey: string,
+  lookupKey: string
 ): boolean {
   return getDictionaryListenerKey(event) === lookupKey;
 }
 
 function dictionaryObjectEventMatchesLookup(
   event: DictionaryStoreEvent,
-  lookupKey: string,
+  lookupKey: string
 ): boolean {
   const { locale, id } = getDictionaryLookupFromKey(lookupKey);
   if (locale !== event.locale) {
     return false;
   }
-  return id === "" || event.id === id || event.id.startsWith(`${id}.`);
+  return id === '' || event.id === id || event.id.startsWith(`${id}.`);
 }

--- a/packages/react-core/src/i18n-store/storeTypes.ts
+++ b/packages/react-core/src/i18n-store/storeTypes.ts
@@ -3,7 +3,7 @@ import type {
   DictionaryObject,
   LookupOptions,
   Translation,
-} from "gt-i18n/types";
+} from 'gt-i18n/types';
 
 // ----- Listeners ----- //
 

--- a/packages/react-core/src/index.ts
+++ b/packages/react-core/src/index.ts
@@ -1,43 +1,43 @@
-import T from "./deprecated/translation/T";
-import useGT from "./deprecated/translation/hooks/useGT";
-import useTranslations from "./deprecated/translation/hooks/useTranslations";
-import useDefaultLocale from "./deprecated/hooks/useDefaultLocale";
-import useLocale from "./deprecated/hooks/useLocale";
-import useVersionId from "./deprecated/hooks/useVersionId";
-import useRegion from "./deprecated/hooks/useRegion";
-import GTProvider from "./deprecated/provider/GTProvider";
-import Var from "./deprecated/variables/Var";
-import Num from "./deprecated/variables/Num";
-import Currency from "./deprecated/variables/Currency";
-import DateTime from "./deprecated/variables/DateTime";
-import RelativeTime from "./deprecated/variables/RelativeTime";
-import { Derive } from "./deprecated/variables/Derive";
-import Plural from "./deprecated/branches/plurals/Plural";
-import Branch from "./deprecated/branches/Branch";
-import useLocales from "./deprecated/hooks/useLocales";
-import useSetLocale from "./deprecated/hooks/useSetLocale";
-import LocaleSelector from "./deprecated/ui/LocaleSelector";
-import useLocaleSelector from "./deprecated/hooks/useLocaleSelector";
-import RegionSelector from "./deprecated/ui/RegionSelector";
+import T from './deprecated/translation/T';
+import useGT from './deprecated/translation/hooks/useGT';
+import useTranslations from './deprecated/translation/hooks/useTranslations';
+import useDefaultLocale from './deprecated/hooks/useDefaultLocale';
+import useLocale from './deprecated/hooks/useLocale';
+import useVersionId from './deprecated/hooks/useVersionId';
+import useRegion from './deprecated/hooks/useRegion';
+import GTProvider from './deprecated/provider/GTProvider';
+import Var from './deprecated/variables/Var';
+import Num from './deprecated/variables/Num';
+import Currency from './deprecated/variables/Currency';
+import DateTime from './deprecated/variables/DateTime';
+import RelativeTime from './deprecated/variables/RelativeTime';
+import { Derive } from './deprecated/variables/Derive';
+import Plural from './deprecated/branches/plurals/Plural';
+import Branch from './deprecated/branches/Branch';
+import useLocales from './deprecated/hooks/useLocales';
+import useSetLocale from './deprecated/hooks/useSetLocale';
+import LocaleSelector from './deprecated/ui/LocaleSelector';
+import useLocaleSelector from './deprecated/hooks/useLocaleSelector';
+import RegionSelector from './deprecated/ui/RegionSelector';
 import type {
   DictionaryTranslationOptions,
   InlineTranslationOptions,
   RuntimeTranslationOptions,
-} from "./deprecated/types-dir/types";
-import { useGTClass, useLocaleProperties } from "./deprecated/hooks/useGTClass";
-import { useRegionSelector } from "./deprecated/hooks/useRegionSelector";
-import { useLocaleDirection } from "./deprecated/hooks/useLocaleDirection";
-import { msg, decodeMsg, decodeOptions } from "./deprecated/messages/messages";
-import useMessages from "./deprecated/translation/hooks/useMessages";
-import { GTContext } from "./deprecated/provider/GTContext";
-import useRuntimeTranslation from "./deprecated/provider/hooks/useRuntimeTranslation";
-import useCreateInternalUseGTFunction from "./deprecated/provider/hooks/translation/useCreateInternalUseGTFunction";
-import useCreateInternalUseTranslationsFunction from "./deprecated/provider/hooks/translation/useCreateInternalUseTranslationsFunction";
-import { useCreateInternalUseTranslationsObjFunction } from "./deprecated/provider/hooks/translation/useCreateInternalUseTranslationsObjFunction";
+} from './deprecated/types-dir/types';
+import { useGTClass, useLocaleProperties } from './deprecated/hooks/useGTClass';
+import { useRegionSelector } from './deprecated/hooks/useRegionSelector';
+import { useLocaleDirection } from './deprecated/hooks/useLocaleDirection';
+import { msg, decodeMsg, decodeOptions } from './deprecated/messages/messages';
+import useMessages from './deprecated/translation/hooks/useMessages';
+import { GTContext } from './deprecated/provider/GTContext';
+import useRuntimeTranslation from './deprecated/provider/hooks/useRuntimeTranslation';
+import useCreateInternalUseGTFunction from './deprecated/provider/hooks/translation/useCreateInternalUseGTFunction';
+import useCreateInternalUseTranslationsFunction from './deprecated/provider/hooks/translation/useCreateInternalUseTranslationsFunction';
+import { useCreateInternalUseTranslationsObjFunction } from './deprecated/provider/hooks/translation/useCreateInternalUseTranslationsObjFunction';
 
-export * from "gt-i18n/fallbacks";
+export * from 'gt-i18n/fallbacks';
 
-export { derive, declareVar, decodeVars } from "gt-i18n";
+export { derive, declareVar, decodeVars } from 'gt-i18n';
 
 export {
   Var,

--- a/packages/react-core/src/internal.ts
+++ b/packages/react-core/src/internal.ts
@@ -1,46 +1,46 @@
 // No useContext related exports should go through here!
 
-import flattenDictionary from "./deprecated/internal/flattenDictionary";
-import addGTIdentifier from "./deprecated/internal/addGTIdentifier";
-import { removeInjectedT } from "./deprecated/internal/removeInjectedT";
-import writeChildrenAsObjects from "./deprecated/internal/writeChildrenAsObjects";
-import getPluralBranch from "./deprecated/branches/plurals/getPluralBranch";
+import flattenDictionary from './deprecated/internal/flattenDictionary';
+import addGTIdentifier from './deprecated/internal/addGTIdentifier';
+import { removeInjectedT } from './deprecated/internal/removeInjectedT';
+import writeChildrenAsObjects from './deprecated/internal/writeChildrenAsObjects';
+import getPluralBranch from './deprecated/branches/plurals/getPluralBranch';
 import {
   getDictionaryEntry,
   isValidDictionaryEntry,
-} from "./deprecated/dictionaries/getDictionaryEntry";
-import getEntryAndMetadata from "./deprecated/dictionaries/getEntryAndMetadata";
-import getVariableProps from "./deprecated/variables/_getVariableProps";
-import isVariableObject from "./deprecated/rendering/isVariableObject";
-import getVariableName from "./deprecated/variables/getVariableName";
-import renderDefaultChildren from "./deprecated/rendering/renderDefaultChildren";
-import renderTranslatedChildren from "./deprecated/rendering/renderTranslatedChildren";
-import { getDefaultRenderSettings } from "./deprecated/rendering/getDefaultRenderSettings";
-import renderSkeleton from "./deprecated/rendering/renderSkeleton";
+} from './deprecated/dictionaries/getDictionaryEntry';
+import getEntryAndMetadata from './deprecated/dictionaries/getEntryAndMetadata';
+import getVariableProps from './deprecated/variables/_getVariableProps';
+import isVariableObject from './deprecated/rendering/isVariableObject';
+import getVariableName from './deprecated/variables/getVariableName';
+import renderDefaultChildren from './deprecated/rendering/renderDefaultChildren';
+import renderTranslatedChildren from './deprecated/rendering/renderTranslatedChildren';
+import { getDefaultRenderSettings } from './deprecated/rendering/getDefaultRenderSettings';
+import renderSkeleton from './deprecated/rendering/renderSkeleton';
 import {
   defaultLocaleCookieName,
   defaultRegionCookieName,
   defaultEnableI18nCookieName,
-} from "./deprecated/utils/cookies";
-import mergeDictionaries from "./deprecated/dictionaries/mergeDictionaries";
-import { reactHasUse } from "./deprecated/promises/reactHasUse";
+} from './deprecated/utils/cookies';
+import mergeDictionaries from './deprecated/dictionaries/mergeDictionaries';
+import { reactHasUse } from './deprecated/promises/reactHasUse';
 import {
   getSubtree,
   getSubtreeWithCreation,
-} from "./deprecated/dictionaries/getSubtree";
-import { injectEntry } from "./deprecated/dictionaries/injectEntry";
-import { isDictionaryEntry } from "./deprecated/dictionaries/isDictionaryEntry";
-import { stripMetadataFromEntries } from "./deprecated/dictionaries/stripMetadataFromEntries";
-import { injectHashes } from "./deprecated/dictionaries/injectHashes";
-import { injectTranslations } from "./deprecated/dictionaries/injectTranslations";
-import { injectFallbacks } from "./deprecated/dictionaries/injectFallbacks";
-import { injectAndMerge } from "./deprecated/dictionaries/injectAndMerge";
-import { collectUntranslatedEntries } from "./deprecated/dictionaries/collectUntranslatedEntries";
-import { msg, decodeMsg, decodeOptions } from "./deprecated/messages/messages";
-import { Derive } from "./deprecated/variables/Derive";
+} from './deprecated/dictionaries/getSubtree';
+import { injectEntry } from './deprecated/dictionaries/injectEntry';
+import { isDictionaryEntry } from './deprecated/dictionaries/isDictionaryEntry';
+import { stripMetadataFromEntries } from './deprecated/dictionaries/stripMetadataFromEntries';
+import { injectHashes } from './deprecated/dictionaries/injectHashes';
+import { injectTranslations } from './deprecated/dictionaries/injectTranslations';
+import { injectFallbacks } from './deprecated/dictionaries/injectFallbacks';
+import { injectAndMerge } from './deprecated/dictionaries/injectAndMerge';
+import { collectUntranslatedEntries } from './deprecated/dictionaries/collectUntranslatedEntries';
+import { msg, decodeMsg, decodeOptions } from './deprecated/messages/messages';
+import { Derive } from './deprecated/variables/Derive';
 
-export * from "gt-i18n/fallbacks";
-export { derive, declareVar, decodeVars } from "gt-i18n";
+export * from 'gt-i18n/fallbacks';
+export { derive, declareVar, decodeVars } from 'gt-i18n';
 
 export {
   addGTIdentifier,

--- a/packages/react-core/src/setup/globals.ts
+++ b/packages/react-core/src/setup/globals.ts
@@ -3,7 +3,7 @@
  * - server-rendered apps must use context
  * - SPA apps can synchronously access the locale
  */
-export type RenderStrategy = "SPA" | "server-render";
+export type RenderStrategy = 'SPA' | 'server-render';
 
 declare global {
   var __generaltranslation: {
@@ -23,7 +23,7 @@ globalThis.__generaltranslation = {
 export function getRenderStrategy(): RenderStrategy {
   if (!globalThis.__generaltranslation.renderStrategy) {
     throw new Error(
-      "Cannot access render strategy. GT has not been initialized.",
+      'Cannot access render strategy. GT has not been initialized.'
     );
   }
   return globalThis.__generaltranslation.renderStrategy;

--- a/packages/react-core/src/setup/initializeGTSPA.ts
+++ b/packages/react-core/src/setup/initializeGTSPA.ts
@@ -1,12 +1,12 @@
-import { I18nManager, WritableConditionStore } from "gt-i18n/internal";
-import type { WritableConditionStoreParams } from "gt-i18n/internal";
-import type { Translation } from "gt-i18n/types";
-import { setReactI18nManager } from "../i18n-manager/singleton-operations";
-import type { ReactI18nManagerParams } from "../i18n-manager/ReactI18nManager";
-import { I18nStore, I18nStoreParams } from "../i18n-store/I18nStore";
-import { setRenderStrategy, setStoresInitialized } from "./globals";
-import { setWritableConditionStore } from "../condition-store/singleton-operations";
-import { setI18nStore } from "../i18n-store/singleton-operations";
+import { I18nManager, WritableConditionStore } from 'gt-i18n/internal';
+import type { WritableConditionStoreParams } from 'gt-i18n/internal';
+import type { Translation } from 'gt-i18n/types';
+import { setReactI18nManager } from '../i18n-manager/singleton-operations';
+import type { ReactI18nManagerParams } from '../i18n-manager/ReactI18nManager';
+import { I18nStore, I18nStoreParams } from '../i18n-store/I18nStore';
+import { setRenderStrategy, setStoresInitialized } from './globals';
+import { setWritableConditionStore } from '../condition-store/singleton-operations';
+import { setI18nStore } from '../i18n-store/singleton-operations';
 
 /**
  * Initialize GT for an SPA
@@ -19,9 +19,9 @@ import { setI18nStore } from "../i18n-store/singleton-operations";
 export function internalInitializeGTSPA(
   config: I18nStoreParams &
     ReactI18nManagerParams &
-    WritableConditionStoreParams,
+    WritableConditionStoreParams
 ): void {
-  setRenderStrategy("SPA");
+  setRenderStrategy('SPA');
 
   const i18nManager = new I18nManager<Translation>(config);
   setReactI18nManager(i18nManager);

--- a/packages/react-core/src/setup/initializeGTSSR.ts
+++ b/packages/react-core/src/setup/initializeGTSSR.ts
@@ -1,8 +1,8 @@
-import { I18nManager } from "gt-i18n/internal";
-import type { Translation } from "gt-i18n/types";
-import type { ReactI18nManagerParams } from "../i18n-manager/ReactI18nManager";
-import { setRenderStrategy } from "./globals";
-import { setReactI18nManager } from "../i18n-manager/singleton-operations";
+import { I18nManager } from 'gt-i18n/internal';
+import type { Translation } from 'gt-i18n/types';
+import type { ReactI18nManagerParams } from '../i18n-manager/ReactI18nManager';
+import { setRenderStrategy } from './globals';
+import { setReactI18nManager } from '../i18n-manager/singleton-operations';
 
 /**
  * Initialize GT for a server-side rendered application
@@ -12,7 +12,7 @@ import { setReactI18nManager } from "../i18n-manager/singleton-operations";
  * TODO: auto detect if can find gt.config.json files
  */
 export function internalInitializeGTSSR(config: ReactI18nManagerParams): void {
-  setRenderStrategy("server-render");
+  setRenderStrategy('server-render');
 
   const i18nManager = new I18nManager<Translation>(config);
   setReactI18nManager(i18nManager);

--- a/packages/react-core/src/types.ts
+++ b/packages/react-core/src/types.ts
@@ -1,7 +1,7 @@
 import type {
   MFunctionType,
   GTFunctionType,
-} from "./deprecated/types-dir/types";
+} from './deprecated/types-dir/types';
 import type {
   Dictionary,
   RenderMethod,
@@ -23,34 +23,34 @@ import type {
   _Message,
   _Messages,
   TaggedChildren,
-} from "./deprecated/types-dir/types";
-import type { GTContextType } from "./deprecated/types-dir/context";
+} from './deprecated/types-dir/types';
+import type { GTContextType } from './deprecated/types-dir/context';
 
 import type {
   AuthFromEnvParams,
   AuthFromEnvReturn,
-} from "./deprecated/utils/types";
+} from './deprecated/utils/types';
 import type {
   UseDetermineLocaleParams,
   UseDetermineLocaleReturn,
-} from "./deprecated/provider/hooks/locales/types";
+} from './deprecated/provider/hooks/locales/types';
 import type {
   UseRegionStateParams,
   UseRegionStateReturn,
   UseEnableI18nParams,
   UseEnableI18nReturn,
-} from "./deprecated/provider/hooks/types";
+} from './deprecated/provider/hooks/types';
 import type {
   LocaleSelectorProps,
   RegionSelectorProps,
-} from "./deprecated/ui/types";
+} from './deprecated/ui/types';
 
-import type { GTProp } from "@generaltranslation/format/types";
+import type { GTProp } from '@generaltranslation/format/types';
 
 import type {
   InternalGTProviderProps,
   GTConfig,
-} from "./deprecated/types-dir/config";
+} from './deprecated/types-dir/config';
 
 export type {
   Dictionary,

--- a/packages/react-core/src/utils/internal/removeInjectedT.ts
+++ b/packages/react-core/src/utils/internal/removeInjectedT.ts
@@ -1,12 +1,12 @@
-import { isAcceptedPluralForm } from "generaltranslation/internal";
-import { InjectionType, TransformationPrefix } from "generaltranslation/types";
+import { isAcceptedPluralForm } from 'generaltranslation/internal';
+import { InjectionType, TransformationPrefix } from 'generaltranslation/types';
 import {
   ReactNode,
   ReactElement,
   isValidElement,
   cloneElement,
   Children,
-} from "react";
+} from 'react';
 
 /**
  * Remove injected _T components at runtime. This is only for i18n-context T components to use.
@@ -39,12 +39,12 @@ export function removeInjectedT(children: ReactNode): ReactNode {
  */
 function handleSingleChildElement(
   child: ReactElement,
-  derivationDepth: number,
+  derivationDepth: number
 ): ReactNode {
   const { type: elementType, props: elementProps } = child;
   const transformation = getTransformation(elementType);
   // unlikely edge case: encountered an element with props that cannot be processed
-  if (typeof elementProps !== "object" || elementProps === null) {
+  if (typeof elementProps !== 'object' || elementProps === null) {
     return child;
   }
 
@@ -52,17 +52,17 @@ function handleSingleChildElement(
     const { componentType, injectionType } = transformation;
 
     // (1) If the element is a variable component, hands off
-    if (componentType === "variable") {
+    if (componentType === 'variable') {
       return child;
     }
 
     // (2) If the element is a branching component, explore respective branches
-    else if (componentType === "branch") {
+    else if (componentType === 'branch') {
       // Traverse into each branch (this also includes the children property)
       const newProps = Object.entries(elementProps).reduce<
         Record<string, unknown>
       >((acc, [branchName, branch]) => {
-        if (branchName !== "branch" && !branchName.startsWith("data-")) {
+        if (branchName !== 'branch' && !branchName.startsWith('data-')) {
           acc[branchName] = handleSingleChild(branch, derivationDepth);
         } else {
           // Skip recursion on non-translated branches
@@ -74,12 +74,12 @@ function handleSingleChildElement(
       return cloneElement(child, {
         ...newProps,
       });
-    } else if (componentType === "plural") {
+    } else if (componentType === 'plural') {
       // Traverse into each branch (this also includes the children property)
       const newProps = Object.entries(elementProps).reduce<
         Record<string, unknown>
       >((acc, [branchName, branch]) => {
-        if (isAcceptedPluralForm(branchName) || branchName === "children") {
+        if (isAcceptedPluralForm(branchName) || branchName === 'children') {
           acc[branchName] = handleSingleChild(branch, derivationDepth);
         } else {
           // Skip Recursion on non-translated branches
@@ -94,13 +94,13 @@ function handleSingleChildElement(
     }
 
     // (3) If the element is a derivation component, add/remove derivation depth
-    else if (componentType === "derive") {
+    else if (componentType === 'derive') {
       return cloneElement(child, {
         ...elementProps,
-        ...("children" in elementProps && {
+        ...('children' in elementProps && {
           children: handleChildren(
             elementProps.children as ReactNode,
-            derivationDepth + 1,
+            derivationDepth + 1
           ),
         }),
       });
@@ -108,17 +108,17 @@ function handleSingleChildElement(
 
     // (4) If the element is a translation component, remove _T if within a derivation context, just return the children
     else if (
-      componentType === "translate" &&
-      injectionType === "automatic" &&
+      componentType === 'translate' &&
+      injectionType === 'automatic' &&
       derivationDepth > 0
     ) {
-      return "children" in elementProps
+      return 'children' in elementProps
         ? handleChildren(elementProps.children as ReactNode, derivationDepth)
         : undefined;
     }
 
     // Note: componentType === 'translate': means that there is a <_T> inside of a <T>/<_T>
-    else if (componentType === "translate" && injectionType === "automatic") {
+    else if (componentType === 'translate' && injectionType === 'automatic') {
       console.warn(warnNestedInternalTComponent);
     }
   }
@@ -126,10 +126,10 @@ function handleSingleChildElement(
   // (5) Recurse into children
   return cloneElement(child, {
     ...elementProps,
-    ...("children" in elementProps && {
+    ...('children' in elementProps && {
       children: handleChildren(
         elementProps.children as ReactNode,
-        derivationDepth,
+        derivationDepth
       ),
     }),
   });
@@ -142,7 +142,7 @@ function handleSingleChildElement(
  */
 function handleSingleChild(
   child: ReactNode,
-  derivationDepth: number,
+  derivationDepth: number
 ): ReactNode {
   if (isValidElement(child)) {
     return handleSingleChildElement(child, derivationDepth);
@@ -156,11 +156,11 @@ function handleSingleChild(
  */
 function handleChildren(
   children: ReactNode,
-  derivationDepth: number,
+  derivationDepth: number
 ): ReactNode {
   if (Array.isArray(children)) {
     return Children.map(children, (child) =>
-      handleSingleChild(child, derivationDepth),
+      handleSingleChild(child, derivationDepth)
     );
   }
   return handleSingleChild(children, derivationDepth);
@@ -173,7 +173,7 @@ function handleChildren(
  * @param elementType - The element type to extract the transformation from.
  * @returns The transformation.
  */
-function getTransformation(elementType: ReactElement["type"]):
+function getTransformation(elementType: ReactElement['type']):
   | {
       componentType: TransformationPrefix;
       injectionType: InjectionType;
@@ -181,19 +181,19 @@ function getTransformation(elementType: ReactElement["type"]):
   | undefined {
   // Extract transformation string
   const transformation =
-    typeof elementType === "function" && "_gtt" in elementType
+    typeof elementType === 'function' && '_gtt' in elementType
       ? elementType._gtt
       : undefined;
-  if (transformation == null || typeof transformation !== "string")
+  if (transformation == null || typeof transformation !== 'string')
     return undefined;
 
   // Extract metadata from transformation string
-  const parts = transformation.split("-");
+  const parts = transformation.split('-');
   const componentType = parts[0] as TransformationPrefix;
   const injectionType =
-    parts[1] === "automatic" || parts[2] === "automatic"
-      ? "automatic"
-      : "manual";
+    parts[1] === 'automatic' || parts[2] === 'automatic'
+      ? 'automatic'
+      : 'manual';
 
   return {
     componentType,

--- a/packages/react-core/src/utils/internal/writeChildrenAsObjects.ts
+++ b/packages/react-core/src/utils/internal/writeChildrenAsObjects.ts
@@ -1,7 +1,7 @@
-import getVariableName from "../variables/getVariableName";
-import { TaggedChild, TaggedChildren, TaggedElement } from "../../utils/types";
-import { isValidTaggedElement } from "../../utils/utils";
-import { minifyVariableType } from "generaltranslation/internal";
+import getVariableName from '../variables/getVariableName';
+import { TaggedChild, TaggedChildren, TaggedElement } from '../../utils/types';
+import { isValidTaggedElement } from '../../utils/utils';
+import { minifyVariableType } from 'generaltranslation/internal';
 import {
   GTProp,
   HTML_CONTENT_PROPS,
@@ -10,8 +10,8 @@ import {
   JsxChildren,
   JsxElement,
   Variable,
-} from "@generaltranslation/format/types";
-import type { Transformation } from "generaltranslation/types";
+} from '@generaltranslation/format/types';
+import type { Transformation } from 'generaltranslation/types';
 
 /**
  * Gets the tag name of a React element.
@@ -19,58 +19,58 @@ import type { Transformation } from "generaltranslation/types";
  * @returns {string} - The tag name of the React element.
  */
 const getTagName = (child: TaggedElement): string => {
-  if (!child) return "";
+  if (!child) return '';
   const { type, props } = child;
-  if (type && typeof type === "function") {
+  if (type && typeof type === 'function') {
     if (
-      "displayName" in type &&
-      typeof type.displayName === "string" &&
+      'displayName' in type &&
+      typeof type.displayName === 'string' &&
       type.displayName
     )
       return type.displayName;
-    if ("name" in type && typeof type.name === "string" && type.name)
+    if ('name' in type && typeof type.name === 'string' && type.name)
       return type.name;
   }
-  if (type && typeof type === "string") return type;
-  if (props.href) return "a";
-  if (props["data-_gt"]?.id) return `C${props["data-_gt"].id}`;
-  return "function";
+  if (type && typeof type === 'string') return type;
+  if (props.href) return 'a';
+  if (props['data-_gt']?.id) return `C${props['data-_gt'].id}`;
+  return 'function';
 };
 const createGTProp = (
   transformation: Transformation,
   props: Record<string, unknown>,
-  branches?: Record<string, TaggedChildren>,
+  branches?: Record<string, TaggedChildren>
 ): GTProp | undefined => {
   // Add translatable HTML content props
   let newGTProp: GTProp = Object.entries(HTML_CONTENT_PROPS).reduce<GTProp>(
     (acc, [minifiedName, fullName]) => {
       const value = props[fullName];
-      if (typeof value === "string") {
+      if (typeof value === 'string') {
         acc[minifiedName as keyof HtmlContentPropKeysRecord] = value;
       }
       return acc;
     },
-    {},
+    {}
   );
 
   // Check if plural
-  if (transformation === "plural" && branches) {
+  if (transformation === 'plural' && branches) {
     const newBranches: Record<string, JsxChildren> = {};
     Object.entries(branches).forEach(
       ([key, value]: [string, TaggedChildren]) => {
         newBranches[key] = writeChildrenAsObjects(value);
-      },
+      }
     );
-    newGTProp = { ...newGTProp, b: newBranches, t: "p" };
+    newGTProp = { ...newGTProp, b: newBranches, t: 'p' };
   }
-  if (transformation === "branch" && branches) {
+  if (transformation === 'branch' && branches) {
     const newBranches: Record<string, JsxChildren> = {};
     Object.entries(branches).forEach(
       ([key, value]: [string, TaggedChildren]) => {
         newBranches[key] = writeChildrenAsObjects(value);
-      },
+      }
     );
-    newGTProp = { ...newGTProp, b: newBranches, t: "b" };
+    newGTProp = { ...newGTProp, b: newBranches, t: 'b' };
   }
 
   return Object.keys(newGTProp).length ? newGTProp : undefined;
@@ -82,20 +82,20 @@ const createGTProp = (
  * @returns {JsxElement | Variable} The minified element.
  */
 const handleSingleChildElement = (
-  child: TaggedElement,
+  child: TaggedElement
 ): JsxElement | Variable => {
   const { props } = child;
   const minifiedElement: JsxElement = {
     t: getTagName(child),
   };
-  if (props["data-_gt"]) {
+  if (props['data-_gt']) {
     // Get generaltranslation props
-    const generaltranslation = props["data-_gt"];
+    const generaltranslation = props['data-_gt'];
 
     // Check if variable
     const transformation = generaltranslation.transformation;
-    if (transformation === "variable") {
-      const variableType = generaltranslation.variableType || "variable";
+    if (transformation === 'variable') {
+      const variableType = generaltranslation.variableType || 'variable';
       const variableName = getVariableName(props, variableType);
       const minifiedVariableType = minifyVariableType(variableType);
       return {
@@ -112,39 +112,39 @@ const handleSingleChildElement = (
     minifiedElement.d = createGTProp(
       transformation as Transformation,
       props,
-      generaltranslation.branches,
+      generaltranslation.branches
     );
 
     // Add translatable HTML content props
     let newGTProp: GTProp = Object.entries(HTML_CONTENT_PROPS).reduce<GTProp>(
       (acc, [minifiedName, fullName]) => {
         const value = props[fullName];
-        if (typeof value === "string") {
+        if (typeof value === 'string') {
           acc[minifiedName as keyof HtmlContentPropKeysRecord] = value;
         }
         return acc;
       },
-      {},
+      {}
     );
 
     // Check if plural
-    if (transformation === "plural" && generaltranslation.branches) {
+    if (transformation === 'plural' && generaltranslation.branches) {
       const newBranches: Record<string, JsxChildren> = {};
       Object.entries(generaltranslation.branches).forEach(
         ([key, value]: [string, TaggedChildren]) => {
           newBranches[key] = writeChildrenAsObjects(value);
-        },
+        }
       );
-      newGTProp = { ...newGTProp, b: newBranches, t: "p" };
+      newGTProp = { ...newGTProp, b: newBranches, t: 'p' };
     }
-    if (transformation === "branch" && generaltranslation.branches) {
+    if (transformation === 'branch' && generaltranslation.branches) {
       const newBranches: Record<string, JsxChildren> = {};
       Object.entries(generaltranslation.branches).forEach(
         ([key, value]: [string, TaggedChildren]) => {
           newBranches[key] = writeChildrenAsObjects(value);
-        },
+        }
       );
-      newGTProp = { ...newGTProp, b: newBranches, t: "b" };
+      newGTProp = { ...newGTProp, b: newBranches, t: 'b' };
     }
 
     minifiedElement.d = Object.keys(newGTProp).length ? newGTProp : undefined;
@@ -159,7 +159,7 @@ const handleSingleChild = (child: TaggedChild): JsxChild => {
   if (isValidTaggedElement(child)) {
     return handleSingleChildElement(child);
   }
-  if (typeof child === "number") return child.toString();
+  if (typeof child === 'number') return child.toString();
   return child as JsxChild;
 };
 
@@ -170,7 +170,7 @@ const handleSingleChild = (child: TaggedChild): JsxChild => {
  * @returns {object} The processed children as objects.
  */
 export default function writeChildrenAsObjects(
-  children: TaggedChildren,
+  children: TaggedChildren
 ): JsxChildren {
   const result = Array.isArray(children)
     ? children.map(handleSingleChild)

--- a/packages/react-core/src/utils/rendering/getGTTag.ts
+++ b/packages/react-core/src/utils/rendering/getGTTag.ts
@@ -1,8 +1,8 @@
-import { TaggedElement, GTTag } from "../types";
+import { TaggedElement, GTTag } from '../types';
 
 export default function getGTTag(child: TaggedElement): GTTag | null {
-  if (child && child.props && child.props["data-_gt"]) {
-    return child.props["data-_gt"];
+  if (child && child.props && child.props['data-_gt']) {
+    return child.props['data-_gt'];
   }
   return null;
 }

--- a/packages/react-core/src/utils/rendering/renderDefaultChildren.tsx
+++ b/packages/react-core/src/utils/rendering/renderDefaultChildren.tsx
@@ -1,16 +1,16 @@
-import React, { ReactNode } from "react";
+import React, { ReactNode } from 'react';
 import getVariableProps, {
   isVariableElementProps,
-} from "../variables/_getVariableProps";
-import { libraryDefaultLocale } from "generaltranslation/internal";
+} from '../variables/_getVariableProps';
+import { libraryDefaultLocale } from 'generaltranslation/internal';
 import {
   RenderVariable,
   TaggedChild,
   TaggedChildren,
   TaggedElement,
-} from "../types";
-import getGTTag from "./getGTTag";
-import getPluralBranch from "../plurals/getPluralBranch";
+} from '../types';
+import getGTTag from './getGTTag';
+import getPluralBranch from '../plurals/getPluralBranch';
 
 export default function renderDefaultChildren({
   children,
@@ -38,9 +38,9 @@ export default function renderDefaultChildren({
     }
 
     // Plural
-    if (generaltranslation?.transformation === "plural") {
+    if (generaltranslation?.transformation === 'plural') {
       const branches = generaltranslation.branches || {};
-      if (typeof child.props.n !== "number") {
+      if (typeof child.props.n !== 'number') {
         return child.props.children != null
           ? handleChildren(child.props.children)
           : null;
@@ -48,30 +48,30 @@ export default function renderDefaultChildren({
       const resolvedBranch = getPluralBranch(
         child.props.n,
         [defaultLocale],
-        branches,
+        branches
       );
       return handleChildren(
         (resolvedBranch !== null
           ? resolvedBranch
-          : child.props.children) as TaggedChildren,
+          : child.props.children) as TaggedChildren
       );
     }
 
     // Branch
-    if (generaltranslation?.transformation === "branch") {
+    if (generaltranslation?.transformation === 'branch') {
       const { children, branch } = child.props;
       const branches = generaltranslation.branches || {};
       const branchKey =
-        branch == null || branch === "" ? undefined : branch.toString();
+        branch == null || branch === '' ? undefined : branch.toString();
       return handleChildren(
         branchKey && branches[branchKey] !== undefined
           ? branches[branchKey]
-          : children,
+          : children
       );
     }
 
     // Fragment
-    if (generaltranslation?.transformation === "fragment") {
+    if (generaltranslation?.transformation === 'fragment') {
       return React.createElement(React.Fragment, {
         key: child.props.key,
         children: handleChildren(child.props.children),
@@ -82,11 +82,11 @@ export default function renderDefaultChildren({
     if (child.props.children) {
       return React.cloneElement(child, {
         ...child.props,
-        "data-_gt": undefined,
+        'data-_gt': undefined,
         children: handleChildren(child.props.children) as TaggedChildren,
       });
     }
-    return React.cloneElement(child, { ...child.props, "data-_gt": undefined });
+    return React.cloneElement(child, { ...child.props, 'data-_gt': undefined });
   };
 
   const handleSingleChild = (child: TaggedChild): ReactNode => {

--- a/packages/react-core/src/utils/rendering/renderTranslatedChildren.tsx
+++ b/packages/react-core/src/utils/rendering/renderTranslatedChildren.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react";
+import React, { ReactNode } from 'react';
 import {
   TaggedChildren,
   TaggedElement,
@@ -6,18 +6,18 @@ import {
   RenderVariable,
   TranslatedElement,
   VariableProps,
-} from "../types";
+} from '../types';
 import getVariableProps, {
   isVariableElementProps,
-} from "../variables/_getVariableProps";
-import renderDefaultChildren from "./renderDefaultChildren";
-import { isVariable, libraryDefaultLocale } from "generaltranslation/internal";
-import getPluralBranch from "../plurals/getPluralBranch";
+} from '../variables/_getVariableProps';
+import renderDefaultChildren from './renderDefaultChildren';
+import { isVariable, libraryDefaultLocale } from 'generaltranslation/internal';
+import getPluralBranch from '../plurals/getPluralBranch';
 import {
   HTML_CONTENT_PROPS,
   HtmlContentPropValuesRecord,
-} from "@generaltranslation/format/types";
-import getGTTag from "./getGTTag";
+} from '@generaltranslation/format/types';
+import getGTTag from './getGTTag';
 
 function renderTranslatedElement({
   sourceElement,
@@ -32,7 +32,7 @@ function renderTranslatedElement({
 }): React.ReactNode {
   // Get props and generaltranslation
   const { props: sourceProps } = sourceElement;
-  const sourceGT = sourceProps["data-_gt"];
+  const sourceGT = sourceProps['data-_gt'];
   const transformation = sourceGT?.transformation;
 
   // Get translated props
@@ -51,9 +51,9 @@ function renderTranslatedElement({
   }
 
   // plural (choose a branch)
-  if (transformation === "plural") {
+  if (transformation === 'plural') {
     const n = sourceElement.props.n;
-    if (typeof n !== "number") {
+    if (typeof n !== 'number') {
       return renderDefaultChildren({
         children: sourceElement,
         defaultLocale: locales[0],
@@ -79,10 +79,10 @@ function renderTranslatedElement({
   }
 
   // branch (choose a branch)
-  if (transformation === "branch") {
+  if (transformation === 'branch') {
     const { branch, children } = sourceProps;
     const branchKey =
-      branch == null || branch === "" ? undefined : branch.toString();
+      branch == null || branch === '' ? undefined : branch.toString();
     const sourceBranches = sourceGT.branches || {};
     const targetBranches = targetElement.d?.b || {};
     const sourceBranch =
@@ -102,7 +102,7 @@ function renderTranslatedElement({
   }
 
   // fragment (create a valid fragment)
-  if (transformation === "fragment" && targetElement.c) {
+  if (transformation === 'fragment' && targetElement.c) {
     return React.createElement(React.Fragment, {
       key: sourceElement.props.key,
       children: renderTranslatedChildren({
@@ -119,7 +119,7 @@ function renderTranslatedElement({
     return React.cloneElement(sourceElement, {
       ...sourceProps,
       ...translatedProps,
-      "data-_gt": undefined,
+      'data-_gt': undefined,
       children: renderTranslatedChildren({
         source: sourceProps.children as TaggedChildren,
         target: targetElement.c,
@@ -149,13 +149,13 @@ export default function renderTranslatedChildren({
   renderVariable: RenderVariable;
 }): ReactNode {
   // Most straightforward case, return a valid React node
-  if ((target === null || typeof target === "undefined") && source)
+  if ((target === null || typeof target === 'undefined') && source)
     return renderDefaultChildren({
       children: source,
       defaultLocale: locales[0],
       renderVariable,
     });
-  if (typeof target === "string") return target;
+  if (typeof target === 'string') return target;
 
   // Convert source to an array in case target has multiple children where source only has one
   if (Array.isArray(target) && !Array.isArray(source) && source)
@@ -164,12 +164,12 @@ export default function renderTranslatedChildren({
   // Multiple children
   if (Array.isArray(source) && Array.isArray(target)) {
     // Track the variables
-    const variables: Record<string, VariableProps["variableValue"]> = {};
-    const variablesOptions: Record<string, VariableProps["variableOptions"]> =
+    const variables: Record<string, VariableProps['variableValue']> = {};
+    const variablesOptions: Record<string, VariableProps['variableOptions']> =
       {};
     const variableInjectionTypes: Record<
       string,
-      VariableProps["injectionType"]
+      VariableProps['injectionType']
     > = {};
 
     // Extract source elements
@@ -193,17 +193,17 @@ export default function renderTranslatedChildren({
           }
         }
         return false;
-      },
+      }
     );
 
     // TODO: pre-index these to avoid O(n/2) lookups
     const findMatchingSourceElement = (
-      targetElement: TranslatedElement,
+      targetElement: TranslatedElement
     ): TaggedElement | undefined => {
       return (
         sourceElements.find((sourceChild): sourceChild is TaggedElement => {
           const generaltranslation = getGTTag(sourceChild);
-          if (typeof generaltranslation?.id !== "undefined") {
+          if (typeof generaltranslation?.id !== 'undefined') {
             const sourceId = generaltranslation.id;
             const targetId = targetElement.i;
             return sourceId === targetId;
@@ -215,7 +215,7 @@ export default function renderTranslatedChildren({
 
     // map target to source
     return target.map((targetChild, index) => {
-      if (typeof targetChild === "string")
+      if (typeof targetChild === 'string')
         return (
           <React.Fragment key={`string_${index}`}>{targetChild}</React.Fragment>
         );
@@ -225,11 +225,11 @@ export default function renderTranslatedChildren({
         return (
           <React.Fragment key={`var_${index}`}>
             {renderVariable({
-              variableType: targetChild.v || "v",
+              variableType: targetChild.v || 'v',
               variableValue: variables[targetChild.k],
               variableOptions: variablesOptions[targetChild.k],
               locales,
-              injectionType: variableInjectionTypes[targetChild.k] || "manual",
+              injectionType: variableInjectionTypes[targetChild.k] || 'manual',
             })}
           </React.Fragment>
         );
@@ -237,7 +237,7 @@ export default function renderTranslatedChildren({
 
       // Render element (targetChild is a TranslatedElement)
       const matchingSourceElement = findMatchingSourceElement(
-        targetChild as TranslatedElement,
+        targetChild as TranslatedElement
       );
       if (!matchingSourceElement) return null;
       return (
@@ -254,13 +254,13 @@ export default function renderTranslatedChildren({
   }
 
   // Single child
-  if (target && typeof target === "object" && !Array.isArray(target)) {
-    const targetType: "variable" | "element" = isVariable(target)
-      ? "variable"
-      : "element";
+  if (target && typeof target === 'object' && !Array.isArray(target)) {
+    const targetType: 'variable' | 'element' = isVariable(target)
+      ? 'variable'
+      : 'element';
 
     if (React.isValidElement(source)) {
-      if (targetType === "element") {
+      if (targetType === 'element') {
         return renderTranslatedElement({
           sourceElement: source,
           targetElement: target as TranslatedElement,

--- a/packages/react-core/src/utils/rendering/renderVariable.tsx
+++ b/packages/react-core/src/utils/rendering/renderVariable.tsx
@@ -1,25 +1,25 @@
 import {
   GtInternalCurrency,
   Currency as GtExternalCurrency,
-} from "../../components/variables/Currency";
+} from '../../components/variables/Currency';
 import {
   GtInternalDateTime,
   DateTime as GtExternalDateTime,
-} from "../../components/variables/DateTime";
+} from '../../components/variables/DateTime';
 import {
   GtInternalNum,
   Num as GtExternalNum,
-} from "../../components/variables/Num";
+} from '../../components/variables/Num';
 import {
   GtInternalRelativeTime,
   RelativeTime as GtExternalRelativeTime,
-} from "../../components/variables/RelativeTime";
+} from '../../components/variables/RelativeTime';
 import {
   computeVar,
   Var as GtExternalVar,
-} from "../../components/variables/Var";
-import type { RelativeTimeFormatOptions, RenderVariable } from "../types";
-import { ReactNode } from "react";
+} from '../../components/variables/Var';
+import type { RelativeTimeFormatOptions, RenderVariable } from '../types';
+import { ReactNode } from 'react';
 
 // ===== Renderer ===== //
 
@@ -29,8 +29,8 @@ const renderVariable: RenderVariable = ({
   variableOptions,
   injectionType,
 }) => {
-  if (variableType === "n") {
-    const Num = injectionType === "automatic" ? GtExternalNum : GtInternalNum;
+  if (variableType === 'n') {
+    const Num = injectionType === 'automatic' ? GtExternalNum : GtInternalNum;
     const numOptions = variableOptions as Intl.NumberFormatOptions | undefined;
     return (
       <Num options={numOptions}>
@@ -38,9 +38,9 @@ const renderVariable: RenderVariable = ({
       </Num>
     );
   }
-  if (variableType === "d") {
+  if (variableType === 'd') {
     const DateTime =
-      injectionType === "automatic" ? GtExternalDateTime : GtInternalDateTime;
+      injectionType === 'automatic' ? GtExternalDateTime : GtInternalDateTime;
     const dateTimeOptions = variableOptions as
       | Intl.DateTimeFormatOptions
       | undefined;
@@ -50,9 +50,9 @@ const renderVariable: RenderVariable = ({
       </DateTime>
     );
   }
-  if (variableType === "c") {
+  if (variableType === 'c') {
     const Currency =
-      injectionType === "automatic" ? GtExternalCurrency : GtInternalCurrency;
+      injectionType === 'automatic' ? GtExternalCurrency : GtInternalCurrency;
     const currencyOptions = variableOptions as
       | Intl.NumberFormatOptions
       | undefined;
@@ -62,15 +62,15 @@ const renderVariable: RenderVariable = ({
       </Currency>
     );
   }
-  if (variableType === "rt") {
+  if (variableType === 'rt') {
     const RelativeTime =
-      injectionType === "automatic"
+      injectionType === 'automatic'
         ? GtExternalRelativeTime
         : GtInternalRelativeTime;
     const relativeTimeOptions = variableOptions as
       | RelativeTimeFormatOptions
       | undefined;
-    if (typeof variableValue === "number" && relativeTimeOptions?.unit) {
+    if (typeof variableValue === 'number' && relativeTimeOptions?.unit) {
       return (
         <RelativeTime
           value={variableValue}
@@ -83,7 +83,7 @@ const renderVariable: RenderVariable = ({
     const dateValue =
       variableValue instanceof Date
         ? variableValue
-        : typeof variableValue === "string" || typeof variableValue === "number"
+        : typeof variableValue === 'string' || typeof variableValue === 'number'
           ? new Date(variableValue)
           : undefined;
     return (
@@ -94,7 +94,7 @@ const renderVariable: RenderVariable = ({
       />
     );
   }
-  return injectionType === "automatic" ? (
+  return injectionType === 'automatic' ? (
     computeVar({ children: variableValue as ReactNode })
   ) : (
     <GtExternalVar>{variableValue as ReactNode}</GtExternalVar>

--- a/packages/react-core/src/utils/utils.tsx
+++ b/packages/react-core/src/utils/utils.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { TaggedElement, TaggedElementProps } from "./types";
+import React from 'react';
+import { TaggedElement, TaggedElementProps } from './types';
 
 export function isValidTaggedElement(target: unknown): target is TaggedElement {
   return React.isValidElement<TaggedElementProps>(target);

--- a/packages/react-core/tsdown.config.mts
+++ b/packages/react-core/tsdown.config.mts
@@ -17,34 +17,21 @@ const deps = {
 };
 
 const contextDeps = {
-  neverBundle: [
-    ...deps.neverBundle,
-    /^gt-i18n$/,
-    /^gt-i18n\//,
-  ],
-  alwaysBundle: [
-    /^@generaltranslation\/format\//,
-    /^generaltranslation\//,
-  ],
+  neverBundle: [...deps.neverBundle, /^gt-i18n$/, /^gt-i18n\//],
+  alwaysBundle: [/^@generaltranslation\/format\//, /^generaltranslation\//],
 };
 
-const bundledEntries = [
-  'src/index.ts',
-  'src/internal.ts',
-  'src/errors.ts',
-];
+const bundledEntries = ['src/index.ts', 'src/internal.ts', 'src/errors.ts'];
 
-export default defineConfig(
-  [
-    ...createTsdownMinifiedDualFormatConfig({
-      entries: bundledEntries,
-      deps,
-    }),
-    ...createTsdownMinifiedDualFormatConfig({
-      entries: ['src/context.ts'],
-      deps: contextDeps,
-      clean: false,
-      typeEntry: false,
-    }),
-  ]
-);
+export default defineConfig([
+  ...createTsdownMinifiedDualFormatConfig({
+    entries: bundledEntries,
+    deps,
+  }),
+  ...createTsdownMinifiedDualFormatConfig({
+    entries: ['src/context.ts'],
+    deps: contextDeps,
+    clean: false,
+    typeEntry: false,
+  }),
+]);

--- a/packages/react-native/src/provider/hooks/locale/useDetermineLocale.ts
+++ b/packages/react-native/src/provider/hooks/locale/useDetermineLocale.ts
@@ -1,25 +1,25 @@
-import { useEffect, useState } from "react";
-import type { Dispatch, SetStateAction } from "react";
+import { useEffect, useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
 import {
   determineLocale,
   resolveAliasLocale,
-} from "@generaltranslation/format";
-import { libraryDefaultLocale } from "generaltranslation/internal";
-import type { CustomMapping } from "@generaltranslation/format/types";
+} from '@generaltranslation/format';
+import { libraryDefaultLocale } from 'generaltranslation/internal';
+import type { CustomMapping } from '@generaltranslation/format/types';
 import type {
   UseDetermineLocaleParams,
   UseDetermineLocaleReturn,
-} from "@generaltranslation/react-core/types";
-import { createUnsupportedLocaleWarning } from "@generaltranslation/react-core/errors";
-import { PACKAGE_NAME } from "../../../errors-dir/constants";
-import { getNativeLocales } from "../../../utils/getNativeLocales";
-import { nativeStoreGet, nativeStoreSet } from "../../../utils/nativeStore";
+} from '@generaltranslation/react-core/types';
+import { createUnsupportedLocaleWarning } from '@generaltranslation/react-core/errors';
+import { PACKAGE_NAME } from '../../../errors-dir/constants';
+import { getNativeLocales } from '../../../utils/getNativeLocales';
+import { nativeStoreGet, nativeStoreSet } from '../../../utils/nativeStore';
 
 export function useDetermineLocale({
-  locale: _locale = "",
+  locale: _locale = '',
   defaultLocale = libraryDefaultLocale,
   locales = [],
-  localeCookieName = "generaltranslation.locale",
+  localeCookieName = 'generaltranslation.locale',
   ssr = false, // not relevant
   customMapping,
   enableI18n,
@@ -35,8 +35,8 @@ export function useDetermineLocale({
     const result = resolveAliasLocale(
       ssr
         ? _locale
-          ? determineLocale(_locale, locales, customMapping) || ""
-          : ""
+          ? determineLocale(_locale, locales, customMapping) || ''
+          : ''
         : getNewLocale({
             _locale,
             locale: _locale,
@@ -46,7 +46,7 @@ export function useDetermineLocale({
             customMapping,
             enableI18n,
           }),
-      customMapping,
+      customMapping
     );
     return result;
   };
@@ -139,7 +139,7 @@ function getNewLocale({
   let preferredLocales = getNativeLocales();
   if (preferredLocales.length === 0) preferredLocales = [defaultLocale];
   preferredLocales = preferredLocales.map((l) =>
-    resolveAliasLocale(l, customMapping),
+    resolveAliasLocale(l, customMapping)
   );
 
   // determine locale
@@ -151,7 +151,7 @@ function getNewLocale({
         ...preferredLocales, // then prefer browser locale
       ],
       locales,
-      customMapping,
+      customMapping
     ) || defaultLocale;
   if (newLocale) {
     newLocale = resolveAliasLocale(newLocale, customMapping);
@@ -194,15 +194,11 @@ function createSetLocale({
       determineLocale(newLocale, locales, customMapping) ||
         locale ||
         defaultLocale,
-      customMapping,
+      customMapping
     );
     if (validatedLocale !== newLocale) {
       console.warn(
-        createUnsupportedLocaleWarning(
-          validatedLocale,
-          newLocale,
-          PACKAGE_NAME,
-        ),
+        createUnsupportedLocaleWarning(validatedLocale, newLocale, PACKAGE_NAME)
       );
     }
     // persist locale

--- a/packages/react/src/condition-store/BrowserConditionStore.ts
+++ b/packages/react/src/condition-store/BrowserConditionStore.ts
@@ -2,14 +2,14 @@ import {
   getReactI18nManager,
   WritableConditionStore,
   WritableConditionStoreParams,
-} from "@generaltranslation/react-core/context";
-import { getCookieValue, setCookieValue } from "./cookies";
-import { readBrowserLocale } from "./readBrowserLocale";
-import { GetEnableI18n, GetLocale } from "../i18n-manager/types";
+} from '@generaltranslation/react-core/context';
+import { getCookieValue, setCookieValue } from './cookies';
+import { readBrowserLocale } from './readBrowserLocale';
+import { GetEnableI18n, GetLocale } from '../i18n-manager/types';
 import {
   LocaleCandidates,
   WritableConditionStoreInterface,
-} from "gt-i18n/internal/types";
+} from 'gt-i18n/internal/types';
 
 /**
  * The configuration for the BrowserConditionStore
@@ -64,13 +64,13 @@ export class BrowserConditionStore implements WritableConditionStoreInterface {
     if (cookieEnableI18n === undefined) {
       return this.customGetEnableI18n?.() ?? true;
     }
-    return cookieEnableI18n === "true";
+    return cookieEnableI18n === 'true';
   };
 
   setEnableI18n = (enableI18n: boolean): void => {
     setCookieValue({
       cookieName: this.enableI18nCookieName,
-      value: enableI18n ? "true" : "false",
+      value: enableI18n ? 'true' : 'false',
     });
   };
 }

--- a/packages/react/src/condition-store/createBrowserConditionStore.ts
+++ b/packages/react/src/condition-store/createBrowserConditionStore.ts
@@ -1,19 +1,19 @@
-import { getReactI18nManager } from "@generaltranslation/react-core/context";
-import type { LocaleCandidates } from "gt-i18n/internal";
+import { getReactI18nManager } from '@generaltranslation/react-core/context';
+import type { LocaleCandidates } from 'gt-i18n/internal';
 import {
   BrowserConditionStore,
   BrowserConditionStoreParams,
-} from "./BrowserConditionStore";
-import { readBrowserLocale } from "./readBrowserLocale";
+} from './BrowserConditionStore';
+import { readBrowserLocale } from './readBrowserLocale';
 import {
   defaultEnableI18nCookieName,
   defaultLocaleCookieName,
-} from "@generaltranslation/react-core/internal";
-import { getCookieValue } from "./cookies";
+} from '@generaltranslation/react-core/internal';
+import { getCookieValue } from './cookies';
 
 export type CreateBrowserConditionStoreParams = Omit<
   BrowserConditionStoreParams,
-  "locale" | "enableI18n" | "localeCookieName" | "enableI18nCookieName"
+  'locale' | 'enableI18n' | 'localeCookieName' | 'enableI18nCookieName'
 > & {
   locale?: LocaleCandidates;
   enableI18n?: boolean;
@@ -30,7 +30,7 @@ export type CreateBrowserConditionStoreParams = Omit<
  * persists state across page reloads
  */
 export function createBrowserConditionStore(
-  config: CreateBrowserConditionStoreParams,
+  config: CreateBrowserConditionStoreParams
 ): BrowserConditionStore {
   return new BrowserConditionStore({
     ...config,
@@ -64,5 +64,5 @@ function determineEnableI18n({
   if (cookieEnableI18n === undefined) {
     return getEnableI18n?.() ?? enableI18n ?? true;
   }
-  return cookieEnableI18n === "true";
+  return cookieEnableI18n === 'true';
 }

--- a/packages/react/src/condition-store/readBrowserLocale.ts
+++ b/packages/react/src/condition-store/readBrowserLocale.ts
@@ -1,4 +1,4 @@
-import { getCookieValue } from "./cookies";
+import { getCookieValue } from './cookies';
 
 export function readBrowserLocale(localeCookieName: string): string[] {
   const candidates = [];

--- a/packages/react/src/condition-store/singleton-operations.ts
+++ b/packages/react/src/condition-store/singleton-operations.ts
@@ -1,14 +1,14 @@
 import {
   createConditionStoreSingleton,
   ReadonlyConditionStore,
-} from "gt-i18n/internal";
-import { BrowserConditionStore } from "./BrowserConditionStore";
+} from 'gt-i18n/internal';
+import { BrowserConditionStore } from './BrowserConditionStore';
 
 export const {
   setConditionStore: setReadonlyConditionStore,
   isConditionStoreInitialized: isReadonlyConditionStoreInitialized,
 } = createConditionStoreSingleton<ReadonlyConditionStore>(
-  "ReadonlyConditionStore is not initialized.",
+  'ReadonlyConditionStore is not initialized.'
 );
 
 export const {
@@ -16,5 +16,5 @@ export const {
   setConditionStore: setBrowserConditionStore,
   isConditionStoreInitialized: isBrowserConditionStoreInitialized,
 } = createConditionStoreSingleton<BrowserConditionStore>(
-  "BrowserConditionStore is not initialized.",
+  'BrowserConditionStore is not initialized.'
 );

--- a/packages/react/src/context.client.ts
+++ b/packages/react/src/context.client.ts
@@ -1,7 +1,7 @@
-"use client";
+'use client';
 
-export { CSRGTProvider as GTProvider } from "./provider/CSRGTProvider";
-export { initializeGTSPA } from "./setup/initializeGTSPA";
+export { CSRGTProvider as GTProvider } from './provider/CSRGTProvider';
+export { initializeGTSPA } from './setup/initializeGTSPA';
 
 export {
   // ===== Components ===== //
@@ -43,4 +43,4 @@ export {
   t,
   // ===== Setup ===== //
   internalInitializeGTSSR as initializeGT,
-} from "@generaltranslation/react-core/context";
+} from '@generaltranslation/react-core/context';

--- a/packages/react/src/context.server.ts
+++ b/packages/react/src/context.server.ts
@@ -1,7 +1,7 @@
-"server-only";
+'server-only';
 
-export { SSRGTProvider as GTProvider } from "./provider/SSRGTProvider";
-export { initializeGTSPA } from "./setup/initializeGTSPA";
+export { SSRGTProvider as GTProvider } from './provider/SSRGTProvider';
+export { initializeGTSPA } from './setup/initializeGTSPA';
 
 export {
   // ===== Components ===== //
@@ -44,4 +44,4 @@ export {
   // ===== Setup ===== //
   internalInitializeGTSSR as initializeGT,
   internalInitializeGTSPA,
-} from "@generaltranslation/react-core/context";
+} from '@generaltranslation/react-core/context';

--- a/packages/react/src/context.types.ts
+++ b/packages/react/src/context.types.ts
@@ -1,15 +1,15 @@
-import { CSRGTProvider } from "./provider/CSRGTProvider";
+import { CSRGTProvider } from './provider/CSRGTProvider';
 
 /**
  * Wrap GTProvider around the content that you want to translate
  */
 export const GTProvider: typeof CSRGTProvider = () => {
   throw new Error(
-    "gt-react: You have imported a function from the dedicated types entrypoint. If you are seeing this error, it means something has gone wrong.",
+    'gt-react: You have imported a function from the dedicated types entrypoint. If you are seeing this error, it means something has gone wrong.'
   );
 };
 
-export { initializeGTSPA } from "./setup/initializeGTSPA";
+export { initializeGTSPA } from './setup/initializeGTSPA';
 
 /**
  * TODO: throw error if any of these functions are called
@@ -54,4 +54,4 @@ export {
   internalInitializeGTSSR as initializeGT,
   getReactI18nManager,
   setReactI18nManager,
-} from "@generaltranslation/react-core/context";
+} from '@generaltranslation/react-core/context';

--- a/packages/react/src/deprecated/__tests__/react-package.test.ts
+++ b/packages/react/src/deprecated/__tests__/react-package.test.ts
@@ -52,7 +52,10 @@ function node(args: string[]): void {
   execFileSync(process.execPath, args, { cwd: packageRoot, stdio: 'pipe' });
 }
 
-function isAllowedExternalizedSubpath(file: string, specifier: string): boolean {
+function isAllowedExternalizedSubpath(
+  file: string,
+  specifier: string
+): boolean {
   return (
     file.startsWith('context.') &&
     (specifier.startsWith('@generaltranslation/react-core/') ||

--- a/packages/react/src/i18n-manager/BrowserI18nManager.ts
+++ b/packages/react/src/i18n-manager/BrowserI18nManager.ts
@@ -1,13 +1,13 @@
 import type {
   I18nManagerConstructorParams,
   TranslationsLoader,
-} from "gt-i18n/internal/types";
-import { I18nManager } from "gt-i18n/internal";
-import type { HtmlTagOptions } from "./types";
-import type { Translation } from "gt-i18n/types";
-import { DEFAULT_HTML_TAG_OPTIONS } from "./constants";
-import { LocalStorageTranslationCache } from "./LocalStorageTranslationCache";
-import { createDiagnosticMessage } from "generaltranslation/internal";
+} from 'gt-i18n/internal/types';
+import { I18nManager } from 'gt-i18n/internal';
+import type { HtmlTagOptions } from './types';
+import type { Translation } from 'gt-i18n/types';
+import { DEFAULT_HTML_TAG_OPTIONS } from './constants';
+import { LocalStorageTranslationCache } from './LocalStorageTranslationCache';
+import { createDiagnosticMessage } from 'generaltranslation/internal';
 
 /**
  * The configuration for the BrowserI18nManager
@@ -39,7 +39,7 @@ export class BrowserI18nManager extends I18nManager<Translation> {
       ? wrapLoaderWithLocalStorage(
           config.loadTranslations!,
           config.projectId!,
-          localStorageCaches,
+          localStorageCaches
         )
       : config.loadTranslations;
 
@@ -60,7 +60,7 @@ export class BrowserI18nManager extends I18nManager<Translation> {
     // For dev hot reload, we need to write the translations to the localStorage cache
     if (devHotReloadEnabled) {
       this.subscribe(
-        "translations-cache-miss",
+        'translations-cache-miss',
         ({ locale, hash, translation }) => {
           const cache = localStorageCaches[locale];
           if (cache) {
@@ -72,7 +72,7 @@ export class BrowserI18nManager extends I18nManager<Translation> {
               init: { [hash]: translation },
             });
           }
-        },
+        }
       );
     }
   }
@@ -91,7 +91,7 @@ export class BrowserI18nManager extends I18nManager<Translation> {
    */
   getLocalStorageTranslationCache(
     locale: string,
-    init?: Record<string, Translation>,
+    init?: Record<string, Translation>
   ): LocalStorageTranslationCache | undefined {
     if (!import.meta.env?.DEV) return undefined;
 
@@ -113,7 +113,7 @@ export class BrowserI18nManager extends I18nManager<Translation> {
    */
   updateHtmlTag(
     locale: string,
-    htmlTagOptions?: { lang?: string; dir?: "ltr" | "rtl" } & HtmlTagOptions,
+    htmlTagOptions?: { lang?: string; dir?: 'ltr' | 'rtl' } & HtmlTagOptions
   ): void {
     // Get parameters
     const htmlLocale = htmlTagOptions?.lang || locale;
@@ -158,7 +158,7 @@ export class BrowserI18nManager extends I18nManager<Translation> {
 function wrapLoaderWithLocalStorage(
   originalLoader: TranslationsLoader,
   projectId: string,
-  localStorageCaches: Record<string, LocalStorageTranslationCache>,
+  localStorageCaches: Record<string, LocalStorageTranslationCache>
 ) {
   return async (locale: string) => {
     const loaderTranslations = await originalLoader(locale);
@@ -189,8 +189,8 @@ function isDevHotReloadEnabled(config: BrowserI18nManagerParams) {
 
 const createInvalidLocaleWarning = (locale: string) =>
   createDiagnosticMessage({
-    source: "gt-react",
-    severity: "Warning",
+    source: 'gt-react',
+    severity: 'Warning',
     whatHappened: `Locale "${locale}" is not valid`,
-    fix: "Use a valid BCP 47 locale code or add a custom mapping",
+    fix: 'Use a valid BCP 47 locale code or add a custom mapping',
   });

--- a/packages/react/src/provider/CSRGTProvider.tsx
+++ b/packages/react/src/provider/CSRGTProvider.tsx
@@ -1,14 +1,14 @@
 import {
   getReactI18nManager,
   InternalGTProvider,
-} from "@generaltranslation/react-core/context";
-import type { SharedGTProviderProps } from "./SharedGTProviderProps";
+} from '@generaltranslation/react-core/context';
+import type { SharedGTProviderProps } from './SharedGTProviderProps';
 import {
   getBrowserConditionStore,
   isBrowserConditionStoreInitialized,
   setBrowserConditionStore,
-} from "../condition-store/singleton-operations";
-import { createBrowserConditionStore } from "../condition-store/createBrowserConditionStore";
+} from '../condition-store/singleton-operations';
+import { createBrowserConditionStore } from '../condition-store/createBrowserConditionStore';
 
 /**
  * Client side GTProvider, this is different from server side

--- a/packages/react/src/provider/SSRGTProvider.tsx
+++ b/packages/react/src/provider/SSRGTProvider.tsx
@@ -1,13 +1,13 @@
-import { ReadonlyConditionStore } from "gt-i18n/internal";
+import { ReadonlyConditionStore } from 'gt-i18n/internal';
 import {
   isReadonlyConditionStoreInitialized,
   setReadonlyConditionStore,
-} from "../condition-store/singleton-operations";
-import type { SharedGTProviderProps } from "./SharedGTProviderProps";
+} from '../condition-store/singleton-operations';
+import type { SharedGTProviderProps } from './SharedGTProviderProps';
 import {
   getReactI18nManager,
   InternalGTProvider,
-} from "@generaltranslation/react-core/context";
+} from '@generaltranslation/react-core/context';
 
 /**
  * For the server side GTProvider, we don't need to synchronize translations

--- a/packages/react/src/provider/SharedGTProviderProps.ts
+++ b/packages/react/src/provider/SharedGTProviderProps.ts
@@ -1,10 +1,10 @@
-import type { InternalGTProviderProps } from "@generaltranslation/react-core/context";
-import type { Dictionary, Translation } from "gt-i18n/types";
+import type { InternalGTProviderProps } from '@generaltranslation/react-core/context';
+import type { Dictionary, Translation } from 'gt-i18n/types';
 import type {
   Locale,
   Hash,
   ReadonlyConditionStoreParams,
-} from "gt-i18n/internal/types";
+} from 'gt-i18n/internal/types';
 
 /**
  * We force the user to pass translations so they can be synchronously accessed

--- a/packages/react/src/setup/initializeGTSPA.ts
+++ b/packages/react/src/setup/initializeGTSPA.ts
@@ -7,13 +7,13 @@ import {
   setStoresInitialized,
   setConditionStore,
   setReactI18nManager,
-} from "@generaltranslation/react-core/context";
-import { BrowserI18nManager } from "../i18n-manager/BrowserI18nManager";
-import type { BrowserI18nManagerParams } from "../i18n-manager/BrowserI18nManager";
+} from '@generaltranslation/react-core/context';
+import { BrowserI18nManager } from '../i18n-manager/BrowserI18nManager';
+import type { BrowserI18nManagerParams } from '../i18n-manager/BrowserI18nManager';
 import {
   createBrowserConditionStore,
   CreateBrowserConditionStoreParams,
-} from "../condition-store/createBrowserConditionStore";
+} from '../condition-store/createBrowserConditionStore';
 
 /**
  * Initialize GT for an SPA
@@ -26,9 +26,9 @@ import {
 export async function initializeGTSPA(
   config: I18nStoreParams &
     BrowserI18nManagerParams &
-    CreateBrowserConditionStoreParams,
+    CreateBrowserConditionStoreParams
 ) {
-  setRenderStrategy("SPA");
+  setRenderStrategy('SPA');
 
   const i18nManager = new BrowserI18nManager(config);
   setReactI18nManager(i18nManager);

--- a/packages/react/tsdown.config.mts
+++ b/packages/react/tsdown.config.mts
@@ -24,10 +24,7 @@ const contextDeps = {
     /^gt-i18n$/,
     /^gt-i18n\//,
   ],
-  alwaysBundle: [
-    /^@generaltranslation\/format\//,
-    /^generaltranslation\//,
-  ],
+  alwaysBundle: [/^@generaltranslation\/format\//, /^generaltranslation\//],
 };
 
 const entries = [

--- a/packages/tanstack-start/src/condition-store/WritableConditionStore.ts
+++ b/packages/tanstack-start/src/condition-store/WritableConditionStore.ts
@@ -1,11 +1,11 @@
 import {
   createConditionStoreSingleton,
   WritableConditionStore,
-} from "gt-i18n/internal";
+} from 'gt-i18n/internal';
 
 export const {
   getConditionStore: getWritableConditionStore,
   setConditionStore: setWritableConditionStore,
 } = createConditionStoreSingleton<WritableConditionStore>(
-  "WritableConditionStore is not initialized.",
+  'WritableConditionStore is not initialized.'
 );

--- a/packages/tanstack-start/src/index.client.ts
+++ b/packages/tanstack-start/src/index.client.ts
@@ -1,11 +1,11 @@
-"use client";
+'use client';
 
-import { I18nManager } from "gt-i18n/internal";
-import type { Translation } from "gt-i18n/types";
+import { I18nManager } from 'gt-i18n/internal';
+import type { Translation } from 'gt-i18n/types';
 import {
   setReactI18nManager,
   type ReactI18nManagerParams,
-} from "@generaltranslation/react-core/context";
+} from '@generaltranslation/react-core/context';
 
 export {
   // ===== Components ===== //
@@ -46,4 +46,4 @@ export {
   t,
   // ===== Setup ===== //
   initializeGT,
-} from "gt-react/context";
+} from 'gt-react/context';

--- a/packages/tanstack-start/src/index.server.ts
+++ b/packages/tanstack-start/src/index.server.ts
@@ -37,4 +37,4 @@ export {
   t,
   // ===== Setup ===== //
   initializeGT,
-} from "gt-react/context";
+} from 'gt-react/context';

--- a/packages/tanstack-start/src/index.types.ts
+++ b/packages/tanstack-start/src/index.types.ts
@@ -37,4 +37,4 @@ export {
   t,
   // ===== Setup ===== //
   initializeGT,
-} from "gt-react/context";
+} from 'gt-react/context';

--- a/packages/tanstack-start/src/provider/types.ts
+++ b/packages/tanstack-start/src/provider/types.ts
@@ -1,4 +1,4 @@
-import { GTProviderProps as GTReactProviderProps } from "gt-react/internal";
+import { GTProviderProps as GTReactProviderProps } from 'gt-react/internal';
 
 /**
  * Props for the GTProvider component
@@ -8,4 +8,4 @@ import { GTProviderProps as GTReactProviderProps } from "gt-react/internal";
  *
  * TODO: use Pick<> syntax
  */
-export type GTProviderProps = Omit<GTReactProviderProps, "ssr">;
+export type GTProviderProps = Omit<GTReactProviderProps, 'ssr'>;


### PR DESCRIPTION
## Summary
- Run `pnpm format:fix` on latest `origin/odysseus`

## Verification
- `pnpm format:fix`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1454"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR applies `pnpm format:fix` across 84 files on the `odysseus` branch, standardizing quote style (double → single), removing trailing commas in function parameter and argument lists, and condensing single-element arrays to one-liners. No logic is changed.

- **Quote style normalization**: All import paths and string literals are converted from double quotes to single quotes across the entire monorepo.
- **Trailing comma removal**: Function signatures, call sites, and type parameter lists have trailing commas removed to match the formatter's configured style.
- **Leftover debug log**: `packages/i18n/src/condition-store/WritableConditionStore.ts` contains a `console.log` debug statement that was pre-existing and is now formatted but not removed — it will fire on every locale update in production.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with one pre-existing debug log that should be cleaned up before reaching production.

All 84 files contain only cosmetic formatter output with zero logic changes. The one concern is a console.log statement in WritableConditionStore.ts that was already present but reformatted and not removed — it will fire on every locale change in production environments.

packages/i18n/src/condition-store/WritableConditionStore.ts — contains an unconditional console.log debug statement on the hot setLocale path.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/condition-store/WritableConditionStore.ts | Formatting only, but carries a leftover console.log debug statement inside setLocale that will pollute production logs. |
| packages/i18n/src/i18n-manager/I18nManager.ts | Formatting only — double quotes to single quotes, trailing comma removal; no logic changes. |
| packages/react-core/src/deprecated/errors-dir/createErrors.ts | Formatting only; large file reformatted with single quotes and condensed arrays. |
| packages/react-core/src/i18n-store/I18nStore.ts | Formatting only — quote style and trailing comma changes with no logic modifications. |
| packages/react-core/src/utils/rendering/renderTranslatedChildren.tsx | Formatting only — quote style and trailing comma changes. |
| .changeset/pre.json | Changeset array condensed to a single line; no content changes. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pnpm format:fix] --> B[Prettier reformats 84 files]
    B --> C[Double quotes to Single quotes]
    B --> D[Trailing commas removed]
    B --> E[Single-element arrays condensed]
    C & D & E --> F[Formatted output committed]
    F --> G{Any side effects?}
    G -->|Yes| H[console.log in WritableConditionStore.setLocale still present]
    G -->|No| I[All other files: purely cosmetic]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fi18n%2Fsrc%2Fcondition-store%2FWritableConditionStore.ts%3A15%0A**Debug%20%60console.log%60%20in%20production%20code**%0A%0A%60console.log%28'WritableConditionStore.setLocale'%2C%20locale%29%60%20is%20a%20debug%20statement%20left%20in%20the%20%60setLocale%60%20method%2C%20which%20is%20called%20on%20every%20locale%20update.%20This%20will%20spam%20the%20browser%2FNode%20console%20in%20production%20for%20every%20locale%20change.%0A%0A&repo=generaltranslation%2Fgt&pr=1454&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22bg%2Fformat-fix-odysseus%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22bg%2Fformat-fix-odysseus%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fi18n%2Fsrc%2Fcondition-store%2FWritableConditionStore.ts%3A15%0A**Debug%20%60console.log%60%20in%20production%20code**%0A%0A%60console.log%28'WritableConditionStore.setLocale'%2C%20locale%29%60%20is%20a%20debug%20statement%20left%20in%20the%20%60setLocale%60%20method%2C%20which%20is%20called%20on%20every%20locale%20update.%20This%20will%20spam%20the%20browser%2FNode%20console%20in%20production%20for%20every%20locale%20change.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/i18n/src/condition-store/WritableConditionStore.ts:15
**Debug `console.log` in production code**

`console.log('WritableConditionStore.setLocale', locale)` is a debug statement left in the `setLocale` method, which is called on every locale update. This will spam the browser/Node console in production for every locale change.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["style: run format fix"](https://github.com/generaltranslation/gt/commit/c878fb3a7ce68e42a5a3b7a11de4d7eadf989b37) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32855602)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - Remove console.log statements and debug logging fr... ([source](https://app.greptile.com/review/custom-context?memory=ea076fa4-7856-4d31-9266-35f86e49f4b6))

**Learned From**
[generaltranslation/gt-cloud#1266](https://github.com/generaltranslation/gt-cloud/pull/1266)
[generaltranslation/gt-cloud#1240](https://github.com/generaltranslation/gt-cloud/pull/1240)

<!-- /greptile_comment -->