### PR TITLE
fix: cli openapi directory fix

### DIFF
--- a/.changeset/nasty-sides-pick.md
+++ b/.changeset/nasty-sides-pick.md
@@ -1,0 +1,5 @@
+---
+"gt": patch
+---
+
+Handle Mintlify `docs.json` `directory` field

--- a/packages/cli/src/cli/commands/__tests__/translate.test.ts
+++ b/packages/cli/src/cli/commands/__tests__/translate.test.ts
@@ -3,14 +3,14 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { postProcessTranslations } from '../translate.js';
 import type { Settings } from '../../../types/index.js';
 import flattenJsonFiles from '../../../utils/flattenJsonFiles.js';
-import processOpenApi from '../../../utils/processOpenApi.js';
+import { postprocessMintlify } from '../../../formats/files/postprocess/mintlify.js';
 import { persistPostProcessHashes } from '../../../utils/persistPostprocessHashes.js';
 
 vi.mock('../../../utils/flattenJsonFiles.js', () => ({
   default: vi.fn(),
 }));
-vi.mock('../../../utils/processOpenApi.js', () => ({
-  default: vi.fn(),
+vi.mock('../../../formats/files/postprocess/mintlify.js', () => ({
+  postprocessMintlify: vi.fn(),
 }));
 vi.mock('../../../utils/localizeStaticUrls.js', () => ({
   default: vi.fn(),
@@ -76,7 +76,7 @@ describe('postProcessTranslations', () => {
       new Set(['locales/fr/messages.po', 'locales/fr/messages.json'])
     );
 
-    expect(processOpenApi).toHaveBeenCalledWith(
+    expect(postprocessMintlify).toHaveBeenCalledWith(
       expect.anything(),
       new Set(['locales/fr/messages.json'])
     );

--- a/packages/cli/src/cli/commands/translate.ts
+++ b/packages/cli/src/cli/commands/translate.ts
@@ -11,8 +11,8 @@ import flattenJsonFiles from '../../utils/flattenJsonFiles.js';
 import localizeStaticUrls from '../../utils/localizeStaticUrls.js';
 import localizeRelativeAssets from '../../utils/localizeRelativeAssets.js';
 import processAnchorIds from '../../utils/processAnchorIds.js';
-import processOpenApi from '../../utils/processOpenApi.js';
 import localizeStaticImports from '../../utils/localizeStaticImports.js';
+import { postprocessMintlify } from '../../formats/files/postprocess/mintlify.js';
 import { BranchData } from '../../types/branch.js';
 import { getDownloadedMeta } from '../../state/recentDownloads.js';
 import { persistPostProcessHashes } from '../../utils/persistPostprocessHashes.js';
@@ -87,8 +87,7 @@ export async function postProcessTranslations(
   );
   if (includeFiles && postProcessIncludes?.size === 0) return;
 
-  // Mintlify OpenAPI localization (spec routing + validation)
-  await processOpenApi(settings, postProcessIncludes);
+  await postprocessMintlify(settings, postProcessIncludes);
 
   // Localize static urls (/docs -> /[locale]/docs) and preserve anchor IDs for non-default locales
   // Default locale is processed earlier in the flow in base.ts

--- a/packages/cli/src/formats/files/postprocess/__tests__/mintlify.test.ts
+++ b/packages/cli/src/formats/files/postprocess/__tests__/mintlify.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { postprocessMintlify } from '../mintlify.js';
+import processOpenApi from '../../../../utils/processOpenApi.js';
+import localizeMintlifyFrontmatterUrls from '../../../../utils/localizeMintlifyFrontmatterUrls.js';
+import type { Settings } from '../../../../types/index.js';
+
+vi.mock('../../../../utils/processOpenApi.js', () => ({
+  default: vi.fn(),
+}));
+vi.mock('../../../../utils/localizeMintlifyFrontmatterUrls.js', () => ({
+  default: vi.fn(),
+}));
+
+describe('postprocessMintlify', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('runs OpenAPI postprocessing for explicit Mintlify OpenAPI config', async () => {
+    const settings = {
+      options: {
+        mintlify: {
+          openapi: {
+            files: ['./openapi.json'],
+          },
+        },
+      },
+    } as Settings;
+
+    await postprocessMintlify(settings);
+
+    expect(processOpenApi).toHaveBeenCalledWith(settings, undefined);
+    expect(localizeMintlifyFrontmatterUrls).not.toHaveBeenCalled();
+  });
+
+  it('runs all Mintlify postprocessors for detected Mintlify projects', async () => {
+    const settings = {
+      framework: 'mintlify',
+    } as Settings;
+    const includeFiles = new Set(['ja/sandboxes.mdx']);
+
+    await postprocessMintlify(settings, includeFiles);
+
+    expect(processOpenApi).toHaveBeenCalledWith(settings, includeFiles);
+    expect(localizeMintlifyFrontmatterUrls).toHaveBeenCalledWith(
+      settings,
+      includeFiles
+    );
+  });
+
+  it('skips non-Mintlify projects without Mintlify OpenAPI config', async () => {
+    await postprocessMintlify({ framework: 'next-app' } as Settings);
+
+    expect(processOpenApi).not.toHaveBeenCalled();
+    expect(localizeMintlifyFrontmatterUrls).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/formats/files/postprocess/mintlify.ts
+++ b/packages/cli/src/formats/files/postprocess/mintlify.ts
@@ -1,0 +1,20 @@
+import type { Settings } from '../../../types/index.js';
+import localizeMintlifyFrontmatterUrls from '../../../utils/localizeMintlifyFrontmatterUrls.js';
+import processOpenApi from '../../../utils/processOpenApi.js';
+
+/**
+ * Runs all Mintlify-specific postprocessing on translated files.
+ */
+export async function postprocessMintlify(
+  settings: Settings,
+  includeFiles?: Set<string>
+) {
+  if (settings.framework !== 'mintlify' && !settings.options?.mintlify?.openapi)
+    return;
+
+  await processOpenApi(settings, includeFiles);
+
+  if (settings.framework !== 'mintlify') return;
+
+  await localizeMintlifyFrontmatterUrls(settings, includeFiles);
+}

--- a/packages/cli/src/utils/__tests__/localizeMintlifyFrontmatterUrls.test.ts
+++ b/packages/cli/src/utils/__tests__/localizeMintlifyFrontmatterUrls.test.ts
@@ -1,0 +1,112 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import localizeMintlifyFrontmatterUrls, {
+  localizeMintlifyFrontmatterUrlForContent,
+} from '../localizeMintlifyFrontmatterUrls.js';
+import type { Settings } from '../../types/index.js';
+
+describe('localizeMintlifyFrontmatterUrlForContent', () => {
+  it('prefixes a root-relative Mintlify frontmatter url with the target locale', () => {
+    const result = localizeMintlifyFrontmatterUrlForContent(
+      [
+        '---',
+        'title: "Serverless Sandboxes"',
+        'url: "/sandboxes"',
+        'tag: Preview',
+        '---',
+        '',
+      ].join('\n'),
+      'ja',
+      ['en', 'ja']
+    );
+
+    expect(result.changed).toBe(true);
+    expect(result.content).toContain('url: "ja/sandboxes"');
+  });
+
+  it('replaces an existing known locale prefix and stays idempotent', () => {
+    const content = ['---', 'url: "/en/sandboxes"', '---', ''].join('\n');
+    const result = localizeMintlifyFrontmatterUrlForContent(content, 'ja', [
+      'en',
+      'ja',
+    ]);
+    const repeated = localizeMintlifyFrontmatterUrlForContent(
+      result.content,
+      'ja',
+      ['en', 'ja']
+    );
+
+    expect(result.changed).toBe(true);
+    expect(result.content).toContain('url: "ja/sandboxes"');
+    expect(repeated.changed).toBe(false);
+    expect(repeated.content).toBe(result.content);
+  });
+
+  it('skips external and fragment-only urls', () => {
+    const external = localizeMintlifyFrontmatterUrlForContent(
+      ['---', 'url: "https://example.com/sandboxes"', '---', ''].join('\n'),
+      'ja',
+      ['en', 'ja']
+    );
+    const fragment = localizeMintlifyFrontmatterUrlForContent(
+      ['---', 'url: "#sandboxes"', '---', ''].join('\n'),
+      'ja',
+      ['en', 'ja']
+    );
+
+    expect(external.changed).toBe(false);
+    expect(fragment.changed).toBe(false);
+  });
+});
+
+describe('localizeMintlifyFrontmatterUrls', () => {
+  const originalCwd = process.cwd();
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gt-mintlify-url-'));
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('localizes translated mdx frontmatter url fields from file mappings', async () => {
+    const sourcePath = path.join(tmpDir, 'sandboxes.mdx');
+    const targetPath = path.join(tmpDir, 'ja', 'sandboxes.mdx');
+    fs.writeFileSync(sourcePath, '---\nurl: "/sandboxes"\n---\n');
+    fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+    fs.writeFileSync(targetPath, '---\nurl: "/sandboxes"\n---\n');
+
+    const settings = {
+      config: path.join(tmpDir, 'gt.config.json'),
+      configDirectory: path.join(tmpDir, '.gt'),
+      baseUrl: '',
+      dashboardUrl: '',
+      defaultLocale: 'en',
+      locales: ['ja'],
+      files: {
+        resolvedPaths: { mdx: [sourcePath] },
+        placeholderPaths: {
+          mdx: [path.join(tmpDir, '[locale]', 'sandboxes.mdx')],
+        },
+        transformPaths: {},
+        transformFormats: {},
+      },
+      stageTranslations: false,
+      framework: 'mintlify',
+      parsingOptions: { conditionNames: [] },
+      branchOptions: { enabled: false, remoteName: 'origin' },
+    } as Settings;
+
+    await localizeMintlifyFrontmatterUrls(settings);
+
+    expect(fs.readFileSync(targetPath, 'utf8')).toContain(
+      'url: "ja/sandboxes"'
+    );
+  });
+});

--- a/packages/cli/src/utils/__tests__/processOpenApi.test.ts
+++ b/packages/cli/src/utils/__tests__/processOpenApi.test.ts
@@ -130,7 +130,7 @@ describe('processOpenApi', () => {
     expect(updatedTranslated).toContain('/es/openapi.demo.yaml POST /foo');
   });
 
-  it('rewrites Mintlify docs.json openapi source and strips locale prefixes from openapi pages', async () => {
+  it('rewrites Mintlify docs.json openapi source, directory, and strips locale prefixes from openapi pages', async () => {
     const spec = { openapi: '3.0.0', paths: { '/foo': { get: {} } } };
     const specPath = path.join(tmpDir, 'openapi.json');
     fs.writeFileSync(specPath, JSON.stringify(spec));
@@ -206,9 +206,19 @@ describe('processOpenApi', () => {
     const enGroup = updatedDocs.navigation.languages[0].tabs[0].groups[0];
     const esGroup = updatedDocs.navigation.languages[1].tabs[0].groups[0];
     expect(enGroup.openapi.source).toBe('openapi.json');
+    expect(enGroup.openapi.directory).toBe('api');
     expect(enGroup.pages[0]).toBe('GET /foo');
     expect(esGroup.openapi.source).toBe('es/openapi.json');
+    expect(esGroup.openapi.directory).toBe('es/api');
     expect(esGroup.pages[0]).toBe('GET /foo');
+
+    await processOpenApi(settings);
+
+    const repeatedDocs = JSON.parse(fs.readFileSync(docsJsonPath, 'utf8'));
+    const repeatedEsGroup =
+      repeatedDocs.navigation.languages[1].tabs[0].groups[0];
+    expect(repeatedEsGroup.openapi.source).toBe('es/openapi.json');
+    expect(repeatedEsGroup.openapi.directory).toBe('es/api');
   });
 
   it('rewrites docs.json string openapi field with locale-specific spec path', async () => {

--- a/packages/cli/src/utils/localizeMintlifyFrontmatterUrls.ts
+++ b/packages/cli/src/utils/localizeMintlifyFrontmatterUrls.ts
@@ -1,0 +1,158 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkFrontmatter from 'remark-frontmatter';
+import YAML, { isMap, isScalar } from 'yaml';
+import type { Content, Root, Yaml } from 'mdast';
+import { createFileMapping } from '../formats/files/fileMapping.js';
+import type { Settings } from '../types/index.js';
+
+const SKIPPABLE_URL_REGEX = /^(?:[a-z][a-z0-9+.-]*:|\/\/|#|\.\/|\.\.\/)/i;
+
+function getYamlFrontmatter(content: string): Yaml | null {
+  let tree: Root;
+  try {
+    tree = unified()
+      .use(remarkParse)
+      .use(remarkFrontmatter, ['yaml'])
+      .parse(content) as Root;
+  } catch {
+    return null;
+  }
+
+  const yamlNode = (tree.children as Content[]).find(
+    (node): node is Yaml => (node as Yaml).type === 'yaml'
+  );
+  if (
+    !yamlNode ||
+    !yamlNode.position ||
+    yamlNode.position.start?.offset === undefined ||
+    yamlNode.position.end?.offset === undefined
+  ) {
+    return null;
+  }
+  return yamlNode;
+}
+
+function normalizeMintlifyFrontmatterUrl(
+  url: string,
+  targetLocale: string,
+  knownLocales: Set<string>
+): string | null {
+  const trimmed = url.trim();
+  if (!trimmed || SKIPPABLE_URL_REGEX.test(trimmed)) {
+    return null;
+  }
+
+  const leadingWhitespace = url.match(/^\s*/)?.[0] ?? '';
+  const trailingWhitespace = url.match(/\s*$/)?.[0] ?? '';
+  const pathBody = trimmed.replace(/^\/+/, '');
+  const [firstSegment, ...restSegments] = pathBody.split('/');
+
+  if (firstSegment === targetLocale) {
+    const normalized = `${leadingWhitespace}${pathBody}${trailingWhitespace}`;
+    return normalized === url ? null : normalized;
+  }
+
+  const unprefixedPath = knownLocales.has(firstSegment)
+    ? restSegments.join('/')
+    : pathBody;
+  const localizedPath = unprefixedPath
+    ? `${targetLocale}/${unprefixedPath}`
+    : `${targetLocale}/`;
+  const normalized = `${leadingWhitespace}${localizedPath}${trailingWhitespace}`;
+
+  return normalized === url ? null : normalized;
+}
+
+export function localizeMintlifyFrontmatterUrlForContent(
+  content: string,
+  targetLocale: string,
+  knownLocaleValues: string[]
+): { content: string; changed: boolean } {
+  const yamlNode = getYamlFrontmatter(content);
+  if (!yamlNode) {
+    return { content, changed: false };
+  }
+
+  const frontmatterRaw: string = yamlNode.value || '';
+  const doc = YAML.parseDocument(frontmatterRaw, {
+    prettyErrors: false,
+    keepSourceTokens: true,
+  });
+  if (doc.errors?.length || !isMap(doc.contents)) {
+    return { content, changed: false };
+  }
+
+  const urlNode = doc.get('url', true);
+  if (!isScalar(urlNode) || typeof urlNode.value !== 'string') {
+    return { content, changed: false };
+  }
+
+  const localizedUrl = normalizeMintlifyFrontmatterUrl(
+    urlNode.value,
+    targetLocale,
+    new Set(knownLocaleValues)
+  );
+  if (!localizedUrl) {
+    return { content, changed: false };
+  }
+
+  urlNode.value = localizedUrl;
+
+  const start = yamlNode.position!.start.offset as number;
+  const end = yamlNode.position!.end.offset as number;
+  const newline = content.includes('\r\n') ? '\r\n' : '\n';
+  const frontmatter = doc.toString().trimEnd().replace(/\n/g, newline);
+  return {
+    content: `${content.slice(0, start)}---${newline}${frontmatter}${newline}---${content.slice(end)}`,
+    changed: true,
+  };
+}
+
+function shouldProcessFile(filePath: string, includeFiles?: Set<string>) {
+  if (!includeFiles) return true;
+  return includeFiles.has(filePath) || includeFiles.has(path.resolve(filePath));
+}
+
+export default async function localizeMintlifyFrontmatterUrls(
+  settings: Settings,
+  includeFiles?: Set<string>
+) {
+  if (settings.framework !== 'mintlify' || !settings.files) return;
+
+  const fileMapping = createFileMapping(
+    settings.files.resolvedPaths,
+    settings.files.placeholderPaths,
+    settings.files.transformPaths ?? {},
+    settings.files.transformFormats ?? {},
+    settings.locales,
+    settings.defaultLocale
+  );
+  const knownLocaleValues = [settings.defaultLocale, ...settings.locales];
+
+  for (const [locale, filesMap] of Object.entries(fileMapping)) {
+    const targetFiles = Object.values(filesMap).filter(
+      (filePath) =>
+        (filePath.endsWith('.md') || filePath.endsWith('.mdx')) &&
+        shouldProcessFile(filePath, includeFiles)
+    );
+
+    await Promise.all(
+      targetFiles.map(async (filePath) => {
+        if (!fs.existsSync(filePath)) return;
+
+        const content = await fs.promises.readFile(filePath, 'utf8');
+        const result = localizeMintlifyFrontmatterUrlForContent(
+          content,
+          locale,
+          knownLocaleValues
+        );
+        if (result.changed) {
+          await fs.promises.writeFile(filePath, result.content, 'utf8');
+        }
+      })
+    );
+  }
+}

--- a/packages/cli/src/utils/processOpenApi.ts
+++ b/packages/cli/src/utils/processOpenApi.ts
@@ -290,6 +290,20 @@ function rewriteDocsJsonOpenApi(
           changed = true;
         }
       }
+
+      const directoryValue = openapiConfig.directory;
+      if (typeof directoryValue === 'string') {
+        const localizedDirectory = localizeDocsJsonDirectory(
+          directoryValue,
+          locale,
+          defaultLocale,
+          new Set([defaultLocale, ...Object.keys(fileMappingRel)])
+        );
+        if (localizedDirectory && localizedDirectory !== directoryValue) {
+          openapiConfig.directory = localizedDirectory;
+          changed = true;
+        }
+      }
     }
 
     if (Array.isArray(node.pages)) {
@@ -324,6 +338,39 @@ function stripLocaleFromOpenApiPage(value: string, locale: string): string {
   const parsed = parseOpenApiValue(candidate);
   if (!parsed) return value;
   return candidate;
+}
+
+function localizeDocsJsonDirectory(
+  directory: string,
+  locale: string,
+  defaultLocale: string,
+  knownLocales: Set<string>
+): string | null {
+  if (locale === defaultLocale) return null;
+
+  const trimmed = directory.trim();
+  if (!trimmed || /^(?:[a-z][a-z0-9+.-]*:|\/\/|#|\.\/|\.\.\/)/i.test(trimmed)) {
+    return null;
+  }
+
+  const leadingWhitespace = directory.match(/^\s*/)?.[0] ?? '';
+  const trailingWhitespace = directory.match(/\s*$/)?.[0] ?? '';
+  const leadingSlash = trimmed.startsWith('/') ? '/' : '';
+  const pathBody = trimmed.replace(/^\/+/, '');
+  const [firstSegment, ...restSegments] = pathBody.split('/');
+
+  if (firstSegment === locale) {
+    const normalized = `${leadingWhitespace}${leadingSlash}${pathBody}${trailingWhitespace}`;
+    return normalized === directory ? null : normalized;
+  }
+
+  const unprefixedPath = knownLocales.has(firstSegment)
+    ? restSegments.join('/')
+    : pathBody;
+  const localizedPath = unprefixedPath ? `${locale}/${unprefixedPath}` : locale;
+  const normalized = `${leadingWhitespace}${leadingSlash}${localizedPath}${trailingWhitespace}`;
+
+  return normalized === directory ? null : normalized;
 }
 
 function localizeDocsJsonSpecPath(


### PR DESCRIPTION
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1455"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces two improvements to Mintlify CLI postprocessing: it adds localization of the `directory` field inside `openapi` objects in `docs.json`, and introduces a new `localizeMintlifyFrontmatterUrls` utility that rewrites root-relative `url` fields in translated MDX/MD frontmatter. These are bundled under a new `postprocessMintlify` orchestration function that replaces the direct call to `processOpenApi` from the translate command.

- **`localizeDocsJsonDirectory`** (`processOpenApi.ts`): a new helper that prefixes the `directory` value with the target locale (e.g., `api` → `es/api`), skipping the default locale and handling idempotency when the prefix already matches the locale.
- **`localizeMintlifyFrontmatterUrls`** (new utility): parses YAML frontmatter in `.md`/`.mdx` files and rewrites the `url` field with a locale prefix, preserving the existing newline convention; idempotency is ensured by checking whether the first path segment already equals the target locale.
- **`postprocessMintlify`** (new postprocess module): replaces the old direct `processOpenApi` import in `translate.ts`, calling both the OpenAPI and frontmatter URL processors in sequence, with an early-return guard for non-Mintlify projects lacking explicit OpenAPI config.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the changes add well-tested functionality with no regressions to the existing translate pipeline.

The `directory` localization logic and `localizeMintlifyFrontmatterUrls` are both new code paths that haven't had production exposure. Idempotency is verified in tests, but certain edge cases in `normalizeMintlifyFrontmatterUrl` (empty path bodies yielding trailing-slash results, locale-only path segments being silently stripped) are not covered. The refactor from `processOpenApi` to `postprocessMintlify` in `translate.ts` is straightforward and the test mock was updated to match.

The two new utility files — `localizeMintlifyFrontmatterUrls.ts` and the directory-rewriting additions in `processOpenApi.ts` — are the only areas with non-trivial new logic worth a second look.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/utils/processOpenApi.ts | Adds `localizeDocsJsonDirectory` to localize the `directory` field in Mintlify docs.json openapi objects; idempotency is correctly handled and the default-locale bypass is in place. |
| packages/cli/src/utils/localizeMintlifyFrontmatterUrls.ts | New utility that rewrites the frontmatter `url` field in translated MDX/MD files with a locale prefix; strips the leading slash from root-relative URLs by design (tests confirm this). |
| packages/cli/src/formats/files/postprocess/mintlify.ts | New orchestration wrapper; logic is clean and properly guards against non-Mintlify projects. |
| packages/cli/src/cli/commands/translate.ts | Swaps `processOpenApi` for `postprocessMintlify`; straightforward refactor with no behavioral regression for the translate pipeline. |
| packages/cli/src/utils/__tests__/processOpenApi.test.ts | Test updated to assert `directory` rewriting and verifies idempotency with a second `processOpenApi` call. |
| packages/cli/src/utils/__tests__/localizeMintlifyFrontmatterUrls.test.ts | New tests cover locale prefixing, idempotency, and skipping of external/fragment URLs. |
| packages/cli/src/formats/files/postprocess/__tests__/mintlify.test.ts | New tests for `postprocessMintlify` correctly cover all three dispatch paths (explicit OpenAPI config, Mintlify framework, non-Mintlify). |
| packages/cli/src/cli/commands/__tests__/translate.test.ts | Test mock correctly updated from `processOpenApi` to `postprocessMintlify` to match the new import in translate.ts. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[postProcessTranslations] --> B[postprocessMintlify]
    B --> C{framework === mintlify\nOR has mintlify.openapi config?}
    C -- No --> D[return early]
    C -- Yes --> E[processOpenApi]
    E --> F{openapiConfig.files\nexists?}
    F -- No --> G[return early]
    F -- Yes --> H[Rewrite MDX/MD frontmatter\nopenapi fields]
    H --> I[Rewrite docs.json\nopenapi.source]
    I --> J[Rewrite docs.json\nopenapi.directory\nnew in this PR]
    J --> K[Strip locale prefix\nfrom openapi pages]
    K --> L{framework === mintlify?}
    B --> L
    L -- No --> M[done]
    L -- Yes --> N[localizeMintlifyFrontmatterUrls]
    N --> O[For each locale file mapping]
    O --> P[Parse YAML frontmatter]
    P --> Q{url field\npresent?}
    Q -- No --> R[skip file]
    Q -- Yes --> S[normalizeMintlifyFrontmatterUrl\nprefix with locale]
    S --> T[Write updated file]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: changeset"](https://github.com/generaltranslation/gt/commit/a617c6d3d8a6477472170c5c0d7357674924df82) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32885465)</sub>

<!-- /greptile_comment -->