### PR TITLE
fix: slash in url

### DIFF
--- a/.changeset/chilly-moons-mix.md
+++ b/.changeset/chilly-moons-mix.md
@@ -1,0 +1,5 @@
+---
+"gt": patch
+---
+
+Handling slash in Mint `url` fields

--- a/packages/cli/src/utils/__tests__/localizeMintlifyFrontmatterUrls.test.ts
+++ b/packages/cli/src/utils/__tests__/localizeMintlifyFrontmatterUrls.test.ts
@@ -8,7 +8,7 @@ import localizeMintlifyFrontmatterUrls, {
 import type { Settings } from '../../types/index.js';
 
 describe('localizeMintlifyFrontmatterUrlForContent', () => {
-  it('prefixes a root-relative Mintlify frontmatter url with the target locale', () => {
+  it('prefixes an absolute Mintlify frontmatter url with the target locale and preserves the leading slash', () => {
     const result = localizeMintlifyFrontmatterUrlForContent(
       [
         '---',
@@ -18,6 +18,17 @@ describe('localizeMintlifyFrontmatterUrlForContent', () => {
         '---',
         '',
       ].join('\n'),
+      'ja',
+      ['en', 'ja']
+    );
+
+    expect(result.changed).toBe(true);
+    expect(result.content).toContain('url: "/ja/sandboxes"');
+  });
+
+  it('prefixes a relative Mintlify frontmatter url without adding a leading slash', () => {
+    const result = localizeMintlifyFrontmatterUrlForContent(
+      ['---', 'url: "sandboxes"', '---', ''].join('\n'),
       'ja',
       ['en', 'ja']
     );
@@ -39,7 +50,7 @@ describe('localizeMintlifyFrontmatterUrlForContent', () => {
     );
 
     expect(result.changed).toBe(true);
-    expect(result.content).toContain('url: "ja/sandboxes"');
+    expect(result.content).toContain('url: "/ja/sandboxes"');
     expect(repeated.changed).toBe(false);
     expect(repeated.content).toBe(result.content);
   });
@@ -106,7 +117,7 @@ describe('localizeMintlifyFrontmatterUrls', () => {
     await localizeMintlifyFrontmatterUrls(settings);
 
     expect(fs.readFileSync(targetPath, 'utf8')).toContain(
-      'url: "ja/sandboxes"'
+      'url: "/ja/sandboxes"'
     );
   });
 });

--- a/packages/cli/src/utils/localizeMintlifyFrontmatterUrls.ts
+++ b/packages/cli/src/utils/localizeMintlifyFrontmatterUrls.ts
@@ -47,11 +47,12 @@ function normalizeMintlifyFrontmatterUrl(
 
   const leadingWhitespace = url.match(/^\s*/)?.[0] ?? '';
   const trailingWhitespace = url.match(/\s*$/)?.[0] ?? '';
+  const leadingSlash = trimmed.startsWith('/') ? '/' : '';
   const pathBody = trimmed.replace(/^\/+/, '');
   const [firstSegment, ...restSegments] = pathBody.split('/');
 
   if (firstSegment === targetLocale) {
-    const normalized = `${leadingWhitespace}${pathBody}${trailingWhitespace}`;
+    const normalized = `${leadingWhitespace}${leadingSlash}${pathBody}${trailingWhitespace}`;
     return normalized === url ? null : normalized;
   }
 
@@ -61,7 +62,7 @@ function normalizeMintlifyFrontmatterUrl(
   const localizedPath = unprefixedPath
     ? `${targetLocale}/${unprefixedPath}`
     : `${targetLocale}/`;
-  const normalized = `${leadingWhitespace}${localizedPath}${trailingWhitespace}`;
+  const normalized = `${leadingWhitespace}${leadingSlash}${localizedPath}${trailingWhitespace}`;
 
   return normalized === url ? null : normalized;
 }


### PR DESCRIPTION
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1456"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes URL localization for Mintlify frontmatter so that a leading `/` in the original URL is preserved after the locale prefix is injected (e.g. `/sandboxes` → `/ja/sandboxes` instead of `ja/sandboxes`). Relative URLs without a leading slash continue to be localized without adding one.

- Adds `leadingSlash` extraction in `normalizeMintlifyFrontmatterUrl` and threads it into both the "already-localized" and "needs-prefix" output paths.
- Splits the existing test into two cases (absolute vs. relative URLs) and updates the idempotency and integration test expectations to match the corrected output format.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a narrow, well-tested bug fix with no side effects on unrelated paths.

The fix captures one boolean (`leadingSlash`) and inserts it in exactly two string templates. Both branches — the already-localized no-op path and the locale-injection path — are covered by new or updated tests. Idempotency is preserved: a URL already starting with `/ja/...` re-enters the first branch, reconstructs the same string, and returns null (no-change). No other behavior is altered.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/utils/localizeMintlifyFrontmatterUrls.ts | Adds `leadingSlash` detection to preserve a URL's leading `/` through locale-prefix injection; both the "already-localized" and "needs-prefix" branches now include `leadingSlash` in the rebuilt string. |
| packages/cli/src/utils/__tests__/localizeMintlifyFrontmatterUrls.test.ts | Tests updated to expect `/ja/sandboxes` for absolute URLs; a new dedicated test for relative (non-slash-prefixed) URLs is added; idempotency and integration tests updated consistently. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["normalizeMintlifyFrontmatterUrl(url, targetLocale, knownLocales)"] --> B{trimmed empty\nor matches SKIPPABLE_URL_REGEX?}
    B -- yes --> C[return null]
    B -- no --> D["capture leadingWhitespace, trailingWhitespace\nleadingSlash = '/' if trimmed starts with '/'"]
    D --> E["pathBody = trimmed.replace(/^\/+/, '')"]
    E --> F["split into firstSegment + restSegments"]
    F --> G{firstSegment\n=== targetLocale?}
    G -- yes --> H["normalized = WS + leadingSlash + pathBody + WS\n(already-localized, no-op or whitespace fix)"]
    H --> I{normalized === url?}
    I -- yes --> C
    I -- no --> J[return normalized]
    G -- no --> K{knownLocales.has\nfirstSegment?}
    K -- yes --> L["unprefixedPath = restSegments.join('/')"]
    K -- no --> M["unprefixedPath = pathBody"]
    L --> N
    M --> N["localizedPath = targetLocale + '/' + unprefixedPath"]
    N --> O["normalized = WS + leadingSlash + localizedPath + WS"]
    O --> I
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: changeset"](https://github.com/generaltranslation/gt/commit/01f8015d74946174804caffcf8848b943d4e188b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32904829)</sub>

<!-- /greptile_comment -->