### PR TITLE
fix: skip source strings in condenseVars

### DIFF
--- a/.changeset/tough-ghosts-shop.md
+++ b/.changeset/tough-ghosts-shop.md
@@ -1,0 +1,5 @@
+---
+"generaltranslation": patch
+---
+
+fix: escape characters in declareVar() for source locale consumed by condenseVars()

--- a/packages/core/src/derive/__tests__/condenseVars.test.ts
+++ b/packages/core/src/derive/__tests__/condenseVars.test.ts
@@ -1,85 +1,73 @@
-import { describe, it, expect } from 'vitest';
-import { parse } from '@formatjs/icu-messageformat-parser';
-import { condenseVars } from '../condenseVars';
+import { describe, it, expect } from "vitest";
+import { parse } from "@formatjs/icu-messageformat-parser";
+import { condenseVars } from "../condenseVars";
 
 const expectParseableIcu = (icuString: string) => {
   expect(() => parse(icuString)).not.toThrow();
 };
 
-describe('static condenseVars', () => {
-  describe('source strings without indexed GT variables', () => {
+describe("static condenseVars", () => {
+  describe("source strings without indexed GT variables", () => {
     it.each([
-      ['empty string', ''],
-      ['plain text', 'Plain text without any variables'],
-      ['normal argument', 'Hello {name}'],
-      ['single unindexed declareVar', 'Hello {_gt_, select, other {Alice}}'],
+      ["empty string", ""],
+      ["plain text", "Plain text without any variables"],
+      ["normal argument", "Hello {name}"],
+      ["single unindexed declareVar", "Hello {_gt_, select, other {Alice}}"],
       [
-        'multiple unindexed declareVars',
-        'Hey {_gt_, select, other {Alice}}, {_gt_, select, other {Bob}}',
+        "multiple unindexed declareVars",
+        "Hey {_gt_, select, other {Alice}}, {_gt_, select, other {Bob}}",
       ],
       [
-        'source sms invite with trailing apostrophe',
+        "source sms invite with trailing apostrophe",
         "Hey {_gt_, select, other {Alice}}, {_gt_, select, other {Bob}} invited you to {_gt_, select, other {Haas''}}",
       ],
+      ["trailing apostrophe", "Join {_gt_, select, other {Haas''}}"],
+      ["internal apostrophe", "Hello {_gt_, select, other {O''Brien}}"],
       [
-        'trailing apostrophe',
-        "Join {_gt_, select, other {Haas''}}",
-      ],
-      ['internal apostrophe', "Hello {_gt_, select, other {O''Brien}}"],
-      [
-        'multiple internal apostrophes',
+        "multiple internal apostrophes",
         "Hello {_gt_, select, other {Bob''s and Alice''s party}}",
       ],
+      ["double trailing apostrophes", "Hello {_gt_, select, other {Haas''''}}"],
       [
-        'double trailing apostrophes',
-        "Hello {_gt_, select, other {Haas''''}}",
-      ],
-      [
-        'apostrophe before punctuation',
+        "apostrophe before punctuation",
         "Hello {_gt_, select, other {Haas''}}!",
       ],
       [
-        'apostrophe before comma',
+        "apostrophe before comma",
         "Hello {_gt_, select, other {Haas''}}, welcome",
       ],
-      ['empty unindexed declareVar', 'Hello {_gt_, select, other {}}'],
+      ["empty unindexed declareVar", "Hello {_gt_, select, other {}}"],
+      ["quoted braces", "Hello {_gt_, select, other {'{eventId}'}}"],
+      ["quoted angle text", "Hello {_gt_, select, other {'<event>'}}"],
       [
-        'quoted braces',
-        "Hello {_gt_, select, other {'{eventId}'}}",
+        "regular select plus unindexed declareVar",
+        "{name, select, other {Hello}} {_gt_, select, other {World}}",
       ],
       [
-        'quoted angle text',
-        "Hello {_gt_, select, other {'<event>'}}",
+        "regular plural plus unindexed declareVar",
+        "{count, plural, one {One} other {Many}} {_gt_, select, other {items}}",
       ],
       [
-        'regular select plus unindexed declareVar',
-        '{name, select, other {Hello}} {_gt_, select, other {World}}',
+        "nested unindexed declareVar inside plural",
+        "{count, plural, one {{_gt_, select, other {Alice}} invited you} other {No invites}}",
       ],
       [
-        'regular plural plus unindexed declareVar',
-        '{count, plural, one {One} other {Many}} {_gt_, select, other {items}}',
-      ],
-      [
-        'nested unindexed declareVar inside plural',
-        '{count, plural, one {{_gt_, select, other {Alice}} invited you} other {No invites}}',
-      ],
-      [
-        'nested unindexed trailing apostrophe inside plural',
+        "nested unindexed trailing apostrophe inside plural",
         "{count, plural, one {{_gt_, select, other {Haas''}} invited you} other {No invites}}",
       ],
       [
-        'deeply nested unindexed trailing apostrophe',
+        "deeply nested unindexed trailing apostrophe",
         "{count, plural, one {{status, select, yes {{_gt_, select, other {Haas''}}} other {none}}} other {No invites}}",
       ],
       [
-        'plain indexed-looking text',
-        'This literal mentions _gt_1 but has no ICU select',
+        "plain indexed-looking text",
+        "This literal mentions _gt_1 but has no ICU select",
       ],
       [
-        'plain indexed-looking argument',
-        'This literal mentions {_gt_1} but has no select',
+        "plain indexed-looking argument",
+        "This literal mentions {_gt_1} but has no select",
       ],
-    ])('returns the original source for %s', (_name, input) => {
+    ])("returns the original source for %s", (_name, input) => {
       const result = condenseVars(input);
 
       expect(result).toBe(input);
@@ -87,49 +75,41 @@ describe('static condenseVars', () => {
     });
   });
 
-  describe('strings that look indexed but have no indexed GT select', () => {
+  describe("strings that look indexed but have no indexed GT select", () => {
     it.each([
       [
-        'select without gt prefix',
-        '{gt_1, select, other {value}}',
-        '{gt_1, select, other {value}}',
+        "select without gt prefix",
+        "{gt_1, select, other {value}}",
+        "{gt_1, select, other {value}}",
       ],
       [
-        'invalid gt suffix',
-        '{_gt_a, select, other {value}}',
-        '{_gt_a, select, other {value}}',
+        "invalid gt suffix",
+        "{_gt_a, select, other {value}}",
+        "{_gt_a, select, other {value}}",
       ],
       [
-        'extra characters after gt index',
-        '{_gt_1x, select, other {value}}',
-        '{_gt_1x,select,other{value}}',
+        "extra characters after gt index",
+        "{_gt_1x, select, other {value}}",
+        "{_gt_1x,select,other{value}}",
+      ],
+      ["indexed argument only", "Hello {_gt_1}", "Hello {_gt_1}"],
+      [
+        "indexed plural",
+        "{_gt_1, plural, other {items}}",
+        "{_gt_1,plural,other{items}}",
       ],
       [
-        'indexed argument only',
-        'Hello {_gt_1}',
-        'Hello {_gt_1}',
+        "indexed selectordinal",
+        "{_gt_1, selectordinal, one {first} other {other}}",
+        "{_gt_1,selectordinal,one{first} other{other}}",
       ],
+      ["indexed number format", "{_gt_1, number}", "{_gt_1, number}"],
       [
-        'indexed plural',
-        '{_gt_1, plural, other {items}}',
-        '{_gt_1,plural,other{items}}',
+        "indexed select with non-literal other branch",
+        "{_gt_1, select, other {{count, plural, one {item} other {items}}}}",
+        "{_gt_1,select,other{{count,plural,one{item} other{items}}}}",
       ],
-      [
-        'indexed selectordinal',
-        '{_gt_1, selectordinal, one {first} other {other}}',
-        '{_gt_1,selectordinal,one{first} other{other}}',
-      ],
-      [
-        'indexed number format',
-        '{_gt_1, number}',
-        '{_gt_1, number}',
-      ],
-      [
-        'indexed select with non-literal other branch',
-        '{_gt_1, select, other {{count, plural, one {item} other {items}}}}',
-        '{_gt_1,select,other{{count,plural,one{item} other{items}}}}',
-      ],
-    ])('returns the expected string for %s', (_name, input, expected) => {
+    ])("returns the expected string for %s", (_name, input, expected) => {
       const result = condenseVars(input);
 
       expect(result).toBe(expected);
@@ -141,74 +121,62 @@ describe('static condenseVars', () => {
     // should not appear in the same real input.
   });
 
-  describe('indexed translation variables', () => {
+  describe("indexed translation variables", () => {
     it.each([
       [
-        'single empty indexed select',
-        'Hello {_gt_1, select, other {}}',
-        'Hello {_gt_1}',
+        "single empty indexed select",
+        "Hello {_gt_1, select, other {}}",
+        "Hello {_gt_1}",
       ],
       [
-        'multiple empty indexed selects',
-        'I play with {_gt_1, select, other {}} at the {_gt_2, select, other {}}',
-        'I play with {_gt_1} at the {_gt_2}',
+        "multiple empty indexed selects",
+        "I play with {_gt_1, select, other {}} at the {_gt_2, select, other {}}",
+        "I play with {_gt_1} at the {_gt_2}",
+      ],
+      ["single digit index", "{_gt_5, select, other {}}", "{_gt_5}"],
+      ["multi-digit index", "{_gt_123, select, other {}}", "{_gt_123}"],
+      ["zero index", "{_gt_0, select, other {}}", "{_gt_0}"],
+      [
+        "translation with regular argument",
+        "User {username} has {_gt_1, select, other {}} {count} tasks",
+        "User {username} has {_gt_1} {count} tasks",
       ],
       [
-        'single digit index',
-        '{_gt_5, select, other {}}',
-        '{_gt_5}',
+        "translation with regular select",
+        "{name, select, other {Hello}} {_gt_1, select, other {}}",
+        "{name,select,other{Hello}} {_gt_1}",
       ],
       [
-        'multi-digit index',
-        '{_gt_123, select, other {}}',
-        '{_gt_123}',
+        "translation with regular plural",
+        "{count, plural, one {One invite} other {Many invites}} {_gt_1, select, other {}}",
+        "{count,plural,one{One invite} other{Many invites}} {_gt_1}",
       ],
       [
-        'zero index',
-        '{_gt_0, select, other {}}',
-        '{_gt_0}',
+        "translation with date format",
+        "{date, date, short} {_gt_1, select, other {}}",
+        "{date, date, short} {_gt_1}",
       ],
       [
-        'translation with regular argument',
-        'User {username} has {_gt_1, select, other {}} {count} tasks',
-        'User {username} has {_gt_1} {count} tasks',
+        "translation with number format",
+        "{count, number} {_gt_1, select, other {}}",
+        "{count, number} {_gt_1}",
       ],
       [
-        'translation with regular select',
-        '{name, select, other {Hello}} {_gt_1, select, other {}}',
-        '{name,select,other{Hello}} {_gt_1}',
+        "translation with newline formatting",
+        "Line 1\nHas {_gt_1, select, other {}}\n  with spacing",
+        "Line 1\nHas {_gt_1}\n  with spacing",
       ],
       [
-        'translation with regular plural',
-        '{count, plural, one {One invite} other {Many invites}} {_gt_1, select, other {}}',
-        '{count,plural,one{One invite} other{Many invites}} {_gt_1}',
+        "translation with tag",
+        "{_gt_1, select, other {}} <b>bold</b>",
+        "{_gt_1} <b>bold</b>",
       ],
       [
-        'translation with date format',
-        '{date, date, short} {_gt_1, select, other {}}',
-        '{date, date, short} {_gt_1}',
+        "translation with multiple select options and empty other",
+        "{_gt_1, select, one {one} other {}}",
+        "{_gt_1}",
       ],
-      [
-        'translation with number format',
-        '{count, number} {_gt_1, select, other {}}',
-        '{count, number} {_gt_1}',
-      ],
-      [
-        'translation with newline formatting',
-        'Line 1\nHas {_gt_1, select, other {}}\n  with spacing',
-        'Line 1\nHas {_gt_1}\n  with spacing',
-      ],
-      [
-        'translation with tag',
-        '{_gt_1, select, other {}} <b>bold</b>',
-        '{_gt_1} <b>bold</b>',
-      ],
-      [
-        'translation with multiple select options and empty other',
-        '{_gt_1, select, one {one} other {}}',
-        '{_gt_1}',
-      ],
-    ])('condenses %s', (_name, input, expected) => {
+    ])("condenses %s", (_name, input, expected) => {
       const result = condenseVars(input);
 
       expect(result).toBe(expected);
@@ -216,54 +184,54 @@ describe('static condenseVars', () => {
     });
   });
 
-  describe('nested indexed translation variables', () => {
+  describe("nested indexed translation variables", () => {
     it.each([
       [
-        'indexed variable inside plural one branch',
-        '{count, plural, one {Invite {_gt_1, select, other {}}} other {Invites}}',
-        '{count,plural,one{Invite {_gt_1}} other{Invites}}',
+        "indexed variable inside plural one branch",
+        "{count, plural, one {Invite {_gt_1, select, other {}}} other {Invites}}",
+        "{count,plural,one{Invite {_gt_1}} other{Invites}}",
       ],
       [
-        'indexed variable inside plural other branch',
-        '{count, plural, one {Invite} other {Invites {_gt_1, select, other {}}}}',
-        '{count,plural,one{Invite} other{Invites {_gt_1}}}',
+        "indexed variable inside plural other branch",
+        "{count, plural, one {Invite} other {Invites {_gt_1, select, other {}}}}",
+        "{count,plural,one{Invite} other{Invites {_gt_1}}}",
       ],
       [
-        'indexed variables in multiple plural branches',
-        '{count, plural, one {{_gt_1, select, other {}} invite} other {{_gt_2, select, other {}} invites}}',
-        '{count,plural,one{{_gt_1} invite} other{{_gt_2} invites}}',
+        "indexed variables in multiple plural branches",
+        "{count, plural, one {{_gt_1, select, other {}} invite} other {{_gt_2, select, other {}} invites}}",
+        "{count,plural,one{{_gt_1} invite} other{{_gt_2} invites}}",
       ],
       [
-        'indexed variable inside select branch',
-        '{status, select, invited {{_gt_1, select, other {}} is invited} other {No invite}}',
-        '{status,select,invited{{_gt_1} is invited} other{No invite}}',
+        "indexed variable inside select branch",
+        "{status, select, invited {{_gt_1, select, other {}} is invited} other {No invite}}",
+        "{status,select,invited{{_gt_1} is invited} other{No invite}}",
       ],
       [
-        'indexed variables in nested select inside plural',
-        '{count, plural, one {{status, select, yes {{_gt_1, select, other {}}} other {none}}} other {{status, select, yes {{_gt_2, select, other {}}} other {none}}}}',
-        '{count,plural,one{{status,select,yes{{_gt_1}} other{none}}} other{{status,select,yes{{_gt_2}} other{none}}}}',
+        "indexed variables in nested select inside plural",
+        "{count, plural, one {{status, select, yes {{_gt_1, select, other {}}} other {none}}} other {{status, select, yes {{_gt_2, select, other {}}} other {none}}}}",
+        "{count,plural,one{{status,select,yes{{_gt_1}} other{none}}} other{{status,select,yes{{_gt_2}} other{none}}}}",
       ],
       [
-        'indexed variable inside tag in plural branch',
-        '{count, plural, one {<b>{_gt_1, select, other {}}</b>} other {<i>{_gt_2, select, other {}}</i>}}',
-        '{count,plural,one{<b>{_gt_1}</b>} other{<i>{_gt_2}</i>}}',
+        "indexed variable inside tag in plural branch",
+        "{count, plural, one {<b>{_gt_1, select, other {}}</b>} other {<i>{_gt_2, select, other {}}</i>}}",
+        "{count,plural,one{<b>{_gt_1}</b>} other{<i>{_gt_2}</i>}}",
       ],
       [
-        'nested plural with offset',
-        '{count, plural, offset:1 =0 {Nobody} one {{_gt_1, select, other {}}} other {{_gt_2, select, other {}}}}',
-        '{count,plural,offset:1 =0{Nobody} one{{_gt_1}} other{{_gt_2}}}',
+        "nested plural with offset",
+        "{count, plural, offset:1 =0 {Nobody} one {{_gt_1, select, other {}}} other {{_gt_2, select, other {}}}}",
+        "{count,plural,offset:1 =0{Nobody} one{{_gt_1}} other{{_gt_2}}}",
       ],
       [
-        'nested selectordinal',
-        '{place, selectordinal, one {{_gt_1, select, other {}}} two {{_gt_2, select, other {}}} other {{_gt_3, select, other {}}}}',
-        '{place,selectordinal,one{{_gt_1}} two{{_gt_2}} other{{_gt_3}}}',
+        "nested selectordinal",
+        "{place, selectordinal, one {{_gt_1, select, other {}}} two {{_gt_2, select, other {}}} other {{_gt_3, select, other {}}}}",
+        "{place,selectordinal,one{{_gt_1}} two{{_gt_2}} other{{_gt_3}}}",
       ],
       [
-        'nested pound in plural remains valid',
-        '{count, plural, one {# {_gt_1, select, other {}}} other {# {_gt_2, select, other {}}}}',
-        '{count,plural,one{# {_gt_1}} other{# {_gt_2}}}',
+        "nested pound in plural remains valid",
+        "{count, plural, one {# {_gt_1, select, other {}}} other {# {_gt_2, select, other {}}}}",
+        "{count,plural,one{# {_gt_1}} other{# {_gt_2}}}",
       ],
-    ])('condenses %s', (_name, input, expected) => {
+    ])("condenses %s", (_name, input, expected) => {
       const result = condenseVars(input);
 
       expect(result).toBe(expected);

--- a/packages/core/src/derive/__tests__/condenseVars.test.ts
+++ b/packages/core/src/derive/__tests__/condenseVars.test.ts
@@ -1,137 +1,273 @@
 import { describe, it, expect } from 'vitest';
+import { parse } from '@formatjs/icu-messageformat-parser';
 import { condenseVars } from '../condenseVars';
 
+const expectParseableIcu = (icuString: string) => {
+  expect(() => parse(icuString)).not.toThrow();
+};
+
 describe('static condenseVars', () => {
-  describe('basic functionality', () => {
-    it('should convert select elements to arguments', () => {
-      const input = 'Hello {_gt_1, select, other {World}}';
+  describe('source strings without indexed GT variables', () => {
+    it.each([
+      ['empty string', ''],
+      ['plain text', 'Plain text without any variables'],
+      ['normal argument', 'Hello {name}'],
+      ['single unindexed declareVar', 'Hello {_gt_, select, other {Alice}}'],
+      [
+        'multiple unindexed declareVars',
+        'Hey {_gt_, select, other {Alice}}, {_gt_, select, other {Bob}}',
+      ],
+      [
+        'source sms invite with trailing apostrophe',
+        "Hey {_gt_, select, other {Alice}}, {_gt_, select, other {Bob}} invited you to {_gt_, select, other {Haas''}}",
+      ],
+      [
+        'trailing apostrophe',
+        "Join {_gt_, select, other {Haas''}}",
+      ],
+      ['internal apostrophe', "Hello {_gt_, select, other {O''Brien}}"],
+      [
+        'multiple internal apostrophes',
+        "Hello {_gt_, select, other {Bob''s and Alice''s party}}",
+      ],
+      [
+        'double trailing apostrophes',
+        "Hello {_gt_, select, other {Haas''''}}",
+      ],
+      [
+        'apostrophe before punctuation',
+        "Hello {_gt_, select, other {Haas''}}!",
+      ],
+      [
+        'apostrophe before comma',
+        "Hello {_gt_, select, other {Haas''}}, welcome",
+      ],
+      ['empty unindexed declareVar', 'Hello {_gt_, select, other {}}'],
+      [
+        'quoted braces',
+        "Hello {_gt_, select, other {'{eventId}'}}",
+      ],
+      [
+        'quoted angle text',
+        "Hello {_gt_, select, other {'<event>'}}",
+      ],
+      [
+        'regular select plus unindexed declareVar',
+        '{name, select, other {Hello}} {_gt_, select, other {World}}',
+      ],
+      [
+        'regular plural plus unindexed declareVar',
+        '{count, plural, one {One} other {Many}} {_gt_, select, other {items}}',
+      ],
+      [
+        'nested unindexed declareVar inside plural',
+        '{count, plural, one {{_gt_, select, other {Alice}} invited you} other {No invites}}',
+      ],
+      [
+        'nested unindexed trailing apostrophe inside plural',
+        "{count, plural, one {{_gt_, select, other {Haas''}} invited you} other {No invites}}",
+      ],
+      [
+        'deeply nested unindexed trailing apostrophe',
+        "{count, plural, one {{status, select, yes {{_gt_, select, other {Haas''}}} other {none}}} other {No invites}}",
+      ],
+      [
+        'plain indexed-looking text',
+        'This literal mentions _gt_1 but has no ICU select',
+      ],
+      [
+        'plain indexed-looking argument',
+        'This literal mentions {_gt_1} but has no select',
+      ],
+    ])('returns the original source for %s', (_name, input) => {
       const result = condenseVars(input);
-      expect(result).toBe('Hello {_gt_1}');
-    });
 
-    it('should handle multiple indexed selects', () => {
-      const input =
-        'I play with {_gt_1, select, other {toys}} at the {_gt_2, select, other {park}}';
-      const result = condenseVars(input);
-      expect(result).toBe('I play with {_gt_1} at the {_gt_2}');
-    });
-
-    it('should preserve non-indexed selects', () => {
-      const input =
-        '{name, select, other {Hello}} {_gt_1, select, other {World}}';
-      const result = condenseVars(input);
-      expect(result).toBe('{name,select,other{Hello}} {_gt_1}');
-    });
-
-    it('should preserve plain text', () => {
-      const input = 'Plain text without any variables';
-      const result = condenseVars(input);
-      expect(result).toBe('Plain text without any variables');
-    });
-
-    it('should preserve non-select variables', () => {
-      const input = 'Hello {name}';
-      const result = condenseVars(input);
-      expect(result).toBe('Hello {name}');
-    });
-  });
-
-  describe('edge cases', () => {
-    it('should handle empty string', () => {
-      const input = '';
-      const result = condenseVars(input);
-      expect(result).toBe('');
-    });
-
-    it('should handle selects with multiple options', () => {
-      const input = '{_gt_1, select, one {book} other {books}}';
-      const result = condenseVars(input);
-      expect(result).toBe('{_gt_1}');
-    });
-
-    it('should handle nested selects within indexed select', () => {
-      const input =
-        '{_gt_1, select, other {I have {count, plural, one {book} other {books}}}}';
-      const result = condenseVars(input);
-      expect(result).toBe('{_gt_1}');
-    });
-
-    it('should handle mixed indexed and regular arguments', () => {
-      const input =
-        'User {username} has {_gt_1, select, other {completed}} {count} tasks';
-      const result = condenseVars(input);
-      expect(result).toBe('User {username} has {_gt_1} {count} tasks');
-    });
-  });
-
-  describe('number variations', () => {
-    it('should handle single digit indexes', () => {
-      const input = '{_gt_5, select, other {value}}';
-      const result = condenseVars(input);
-      expect(result).toBe('{_gt_5}');
-    });
-
-    it('should handle multi-digit indexes', () => {
-      const input = '{_gt_123, select, other {value}}';
-      const result = condenseVars(input);
-      expect(result).toBe('{_gt_123}');
-    });
-
-    it('should handle zero index', () => {
-      const input = '{_gt_0, select, other {value}}';
-      const result = condenseVars(input);
-      expect(result).toBe('{_gt_0}');
+      expect(result).toBe(input);
+      expectParseableIcu(result);
     });
   });
 
-  describe('invalid patterns should not be processed', () => {
-    it('should not process selects without _gt_ prefix', () => {
-      const input = '{gt_1, select, other {value}}';
+  describe('strings that look indexed but have no indexed GT select', () => {
+    it.each([
+      [
+        'select without gt prefix',
+        '{gt_1, select, other {value}}',
+        '{gt_1, select, other {value}}',
+      ],
+      [
+        'invalid gt suffix',
+        '{_gt_a, select, other {value}}',
+        '{_gt_a, select, other {value}}',
+      ],
+      [
+        'extra characters after gt index',
+        '{_gt_1x, select, other {value}}',
+        '{_gt_1x,select,other{value}}',
+      ],
+      [
+        'indexed argument only',
+        'Hello {_gt_1}',
+        'Hello {_gt_1}',
+      ],
+      [
+        'indexed plural',
+        '{_gt_1, plural, other {items}}',
+        '{_gt_1,plural,other{items}}',
+      ],
+      [
+        'indexed selectordinal',
+        '{_gt_1, selectordinal, one {first} other {other}}',
+        '{_gt_1,selectordinal,one{first} other{other}}',
+      ],
+      [
+        'indexed number format',
+        '{_gt_1, number}',
+        '{_gt_1, number}',
+      ],
+      [
+        'indexed select with non-literal other branch',
+        '{_gt_1, select, other {{count, plural, one {item} other {items}}}}',
+        '{_gt_1,select,other{{count,plural,one{item} other{items}}}}',
+      ],
+    ])('returns the expected string for %s', (_name, input, expected) => {
       const result = condenseVars(input);
-      expect(result).toBe('{gt_1, select, other {value}}');
+
+      expect(result).toBe(expected);
+      expectParseableIcu(result);
     });
 
-    it('should not process selects with invalid suffix', () => {
-      const input = '{_gt_a, select, other {value}}';
-      const result = condenseVars(input);
-      expect(result).toBe('{_gt_a,select,other{value}}');
-    });
+    // We intentionally do not test messages that mix `_gt_` and `_gt_#`.
+    // Source strings use `_gt_`; translated strings use `_gt_#`; the two forms
+    // should not appear in the same real input.
+  });
 
-    it('should not process selects with extra characters', () => {
-      const input = '{_gt_1x, select, other {value}}';
+  describe('indexed translation variables', () => {
+    it.each([
+      [
+        'single empty indexed select',
+        'Hello {_gt_1, select, other {}}',
+        'Hello {_gt_1}',
+      ],
+      [
+        'multiple empty indexed selects',
+        'I play with {_gt_1, select, other {}} at the {_gt_2, select, other {}}',
+        'I play with {_gt_1} at the {_gt_2}',
+      ],
+      [
+        'single digit index',
+        '{_gt_5, select, other {}}',
+        '{_gt_5}',
+      ],
+      [
+        'multi-digit index',
+        '{_gt_123, select, other {}}',
+        '{_gt_123}',
+      ],
+      [
+        'zero index',
+        '{_gt_0, select, other {}}',
+        '{_gt_0}',
+      ],
+      [
+        'translation with regular argument',
+        'User {username} has {_gt_1, select, other {}} {count} tasks',
+        'User {username} has {_gt_1} {count} tasks',
+      ],
+      [
+        'translation with regular select',
+        '{name, select, other {Hello}} {_gt_1, select, other {}}',
+        '{name,select,other{Hello}} {_gt_1}',
+      ],
+      [
+        'translation with regular plural',
+        '{count, plural, one {One invite} other {Many invites}} {_gt_1, select, other {}}',
+        '{count,plural,one{One invite} other{Many invites}} {_gt_1}',
+      ],
+      [
+        'translation with date format',
+        '{date, date, short} {_gt_1, select, other {}}',
+        '{date, date, short} {_gt_1}',
+      ],
+      [
+        'translation with number format',
+        '{count, number} {_gt_1, select, other {}}',
+        '{count, number} {_gt_1}',
+      ],
+      [
+        'translation with newline formatting',
+        'Line 1\nHas {_gt_1, select, other {}}\n  with spacing',
+        'Line 1\nHas {_gt_1}\n  with spacing',
+      ],
+      [
+        'translation with tag',
+        '{_gt_1, select, other {}} <b>bold</b>',
+        '{_gt_1} <b>bold</b>',
+      ],
+      [
+        'translation with multiple select options and empty other',
+        '{_gt_1, select, one {one} other {}}',
+        '{_gt_1}',
+      ],
+    ])('condenses %s', (_name, input, expected) => {
       const result = condenseVars(input);
-      expect(result).toBe('{_gt_1x,select,other{value}}');
-    });
 
-    it('should not process non-select elements with _gt_ pattern', () => {
-      const input = 'Hello {_gt_1}';
-      const result = condenseVars(input);
-      expect(result).toBe('Hello {_gt_1}');
+      expect(result).toBe(expected);
+      expectParseableIcu(result);
     });
   });
 
-  describe('complex scenarios', () => {
-    it('should handle the example from documentation', () => {
-      const input =
-        'I play with {_gt_1, select, other {toys}} at the {_gt_2, select, other {park}}';
+  describe('nested indexed translation variables', () => {
+    it.each([
+      [
+        'indexed variable inside plural one branch',
+        '{count, plural, one {Invite {_gt_1, select, other {}}} other {Invites}}',
+        '{count,plural,one{Invite {_gt_1}} other{Invites}}',
+      ],
+      [
+        'indexed variable inside plural other branch',
+        '{count, plural, one {Invite} other {Invites {_gt_1, select, other {}}}}',
+        '{count,plural,one{Invite} other{Invites {_gt_1}}}',
+      ],
+      [
+        'indexed variables in multiple plural branches',
+        '{count, plural, one {{_gt_1, select, other {}} invite} other {{_gt_2, select, other {}} invites}}',
+        '{count,plural,one{{_gt_1} invite} other{{_gt_2} invites}}',
+      ],
+      [
+        'indexed variable inside select branch',
+        '{status, select, invited {{_gt_1, select, other {}} is invited} other {No invite}}',
+        '{status,select,invited{{_gt_1} is invited} other{No invite}}',
+      ],
+      [
+        'indexed variables in nested select inside plural',
+        '{count, plural, one {{status, select, yes {{_gt_1, select, other {}}} other {none}}} other {{status, select, yes {{_gt_2, select, other {}}} other {none}}}}',
+        '{count,plural,one{{status,select,yes{{_gt_1}} other{none}}} other{{status,select,yes{{_gt_2}} other{none}}}}',
+      ],
+      [
+        'indexed variable inside tag in plural branch',
+        '{count, plural, one {<b>{_gt_1, select, other {}}</b>} other {<i>{_gt_2, select, other {}}</i>}}',
+        '{count,plural,one{<b>{_gt_1}</b>} other{<i>{_gt_2}</i>}}',
+      ],
+      [
+        'nested plural with offset',
+        '{count, plural, offset:1 =0 {Nobody} one {{_gt_1, select, other {}}} other {{_gt_2, select, other {}}}}',
+        '{count,plural,offset:1 =0{Nobody} one{{_gt_1}} other{{_gt_2}}}',
+      ],
+      [
+        'nested selectordinal',
+        '{place, selectordinal, one {{_gt_1, select, other {}}} two {{_gt_2, select, other {}}} other {{_gt_3, select, other {}}}}',
+        '{place,selectordinal,one{{_gt_1}} two{{_gt_2}} other{{_gt_3}}}',
+      ],
+      [
+        'nested pound in plural remains valid',
+        '{count, plural, one {# {_gt_1, select, other {}}} other {# {_gt_2, select, other {}}}}',
+        '{count,plural,one{# {_gt_1}} other{# {_gt_2}}}',
+      ],
+    ])('condenses %s', (_name, input, expected) => {
       const result = condenseVars(input);
-      expect(result).toBe('I play with {_gt_1} at the {_gt_2}');
-    });
 
-    it('should handle mixed content with text, selects, and arguments', () => {
-      const input =
-        'Welcome {username}! You have {_gt_1, select, one {message} other {messages}} and {count} notifications.';
-      const result = condenseVars(input);
-      expect(result).toBe(
-        'Welcome {username}! You have {_gt_1} and {count} notifications.'
-      );
-    });
-
-    it('should preserve formatting and whitespace', () => {
-      const input =
-        'Line 1\nHas {_gt_1, select, other {content}}\n  with spacing';
-      const result = condenseVars(input);
-      expect(result).toBe('Line 1\nHas {_gt_1}\n  with spacing');
+      expect(result).toBe(expected);
+      expectParseableIcu(result);
     });
   });
 });

--- a/packages/core/src/derive/__tests__/condenseVars.test.ts
+++ b/packages/core/src/derive/__tests__/condenseVars.test.ts
@@ -1,73 +1,73 @@
-import { describe, it, expect } from "vitest";
-import { parse } from "@formatjs/icu-messageformat-parser";
-import { condenseVars } from "../condenseVars";
+import { describe, it, expect } from 'vitest';
+import { parse } from '@formatjs/icu-messageformat-parser';
+import { condenseVars } from '../condenseVars';
 
 const expectParseableIcu = (icuString: string) => {
   expect(() => parse(icuString)).not.toThrow();
 };
 
-describe("static condenseVars", () => {
-  describe("source strings without indexed GT variables", () => {
+describe('static condenseVars', () => {
+  describe('source strings without indexed GT variables', () => {
     it.each([
-      ["empty string", ""],
-      ["plain text", "Plain text without any variables"],
-      ["normal argument", "Hello {name}"],
-      ["single unindexed declareVar", "Hello {_gt_, select, other {Alice}}"],
+      ['empty string', ''],
+      ['plain text', 'Plain text without any variables'],
+      ['normal argument', 'Hello {name}'],
+      ['single unindexed declareVar', 'Hello {_gt_, select, other {Alice}}'],
       [
-        "multiple unindexed declareVars",
-        "Hey {_gt_, select, other {Alice}}, {_gt_, select, other {Bob}}",
+        'multiple unindexed declareVars',
+        'Hey {_gt_, select, other {Alice}}, {_gt_, select, other {Bob}}',
       ],
       [
-        "source sms invite with trailing apostrophe",
+        'source sms invite with trailing apostrophe',
         "Hey {_gt_, select, other {Alice}}, {_gt_, select, other {Bob}} invited you to {_gt_, select, other {Haas''}}",
       ],
-      ["trailing apostrophe", "Join {_gt_, select, other {Haas''}}"],
-      ["internal apostrophe", "Hello {_gt_, select, other {O''Brien}}"],
+      ['trailing apostrophe', "Join {_gt_, select, other {Haas''}}"],
+      ['internal apostrophe', "Hello {_gt_, select, other {O''Brien}}"],
       [
-        "multiple internal apostrophes",
+        'multiple internal apostrophes',
         "Hello {_gt_, select, other {Bob''s and Alice''s party}}",
       ],
-      ["double trailing apostrophes", "Hello {_gt_, select, other {Haas''''}}"],
+      ['double trailing apostrophes', "Hello {_gt_, select, other {Haas''''}}"],
       [
-        "apostrophe before punctuation",
+        'apostrophe before punctuation',
         "Hello {_gt_, select, other {Haas''}}!",
       ],
       [
-        "apostrophe before comma",
+        'apostrophe before comma',
         "Hello {_gt_, select, other {Haas''}}, welcome",
       ],
-      ["empty unindexed declareVar", "Hello {_gt_, select, other {}}"],
-      ["quoted braces", "Hello {_gt_, select, other {'{eventId}'}}"],
-      ["quoted angle text", "Hello {_gt_, select, other {'<event>'}}"],
+      ['empty unindexed declareVar', 'Hello {_gt_, select, other {}}'],
+      ['quoted braces', "Hello {_gt_, select, other {'{eventId}'}}"],
+      ['quoted angle text', "Hello {_gt_, select, other {'<event>'}}"],
       [
-        "regular select plus unindexed declareVar",
-        "{name, select, other {Hello}} {_gt_, select, other {World}}",
+        'regular select plus unindexed declareVar',
+        '{name, select, other {Hello}} {_gt_, select, other {World}}',
       ],
       [
-        "regular plural plus unindexed declareVar",
-        "{count, plural, one {One} other {Many}} {_gt_, select, other {items}}",
+        'regular plural plus unindexed declareVar',
+        '{count, plural, one {One} other {Many}} {_gt_, select, other {items}}',
       ],
       [
-        "nested unindexed declareVar inside plural",
-        "{count, plural, one {{_gt_, select, other {Alice}} invited you} other {No invites}}",
+        'nested unindexed declareVar inside plural',
+        '{count, plural, one {{_gt_, select, other {Alice}} invited you} other {No invites}}',
       ],
       [
-        "nested unindexed trailing apostrophe inside plural",
+        'nested unindexed trailing apostrophe inside plural',
         "{count, plural, one {{_gt_, select, other {Haas''}} invited you} other {No invites}}",
       ],
       [
-        "deeply nested unindexed trailing apostrophe",
+        'deeply nested unindexed trailing apostrophe',
         "{count, plural, one {{status, select, yes {{_gt_, select, other {Haas''}}} other {none}}} other {No invites}}",
       ],
       [
-        "plain indexed-looking text",
-        "This literal mentions _gt_1 but has no ICU select",
+        'plain indexed-looking text',
+        'This literal mentions _gt_1 but has no ICU select',
       ],
       [
-        "plain indexed-looking argument",
-        "This literal mentions {_gt_1} but has no select",
+        'plain indexed-looking argument',
+        'This literal mentions {_gt_1} but has no select',
       ],
-    ])("returns the original source for %s", (_name, input) => {
+    ])('returns the original source for %s', (_name, input) => {
       const result = condenseVars(input);
 
       expect(result).toBe(input);
@@ -75,41 +75,41 @@ describe("static condenseVars", () => {
     });
   });
 
-  describe("strings that look indexed but have no indexed GT select", () => {
+  describe('strings that look indexed but have no indexed GT select', () => {
     it.each([
       [
-        "select without gt prefix",
-        "{gt_1, select, other {value}}",
-        "{gt_1, select, other {value}}",
+        'select without gt prefix',
+        '{gt_1, select, other {value}}',
+        '{gt_1, select, other {value}}',
       ],
       [
-        "invalid gt suffix",
-        "{_gt_a, select, other {value}}",
-        "{_gt_a, select, other {value}}",
+        'invalid gt suffix',
+        '{_gt_a, select, other {value}}',
+        '{_gt_a, select, other {value}}',
       ],
       [
-        "extra characters after gt index",
-        "{_gt_1x, select, other {value}}",
-        "{_gt_1x,select,other{value}}",
+        'extra characters after gt index',
+        '{_gt_1x, select, other {value}}',
+        '{_gt_1x,select,other{value}}',
       ],
-      ["indexed argument only", "Hello {_gt_1}", "Hello {_gt_1}"],
+      ['indexed argument only', 'Hello {_gt_1}', 'Hello {_gt_1}'],
       [
-        "indexed plural",
-        "{_gt_1, plural, other {items}}",
-        "{_gt_1,plural,other{items}}",
+        'indexed plural',
+        '{_gt_1, plural, other {items}}',
+        '{_gt_1,plural,other{items}}',
       ],
       [
-        "indexed selectordinal",
-        "{_gt_1, selectordinal, one {first} other {other}}",
-        "{_gt_1,selectordinal,one{first} other{other}}",
+        'indexed selectordinal',
+        '{_gt_1, selectordinal, one {first} other {other}}',
+        '{_gt_1,selectordinal,one{first} other{other}}',
       ],
-      ["indexed number format", "{_gt_1, number}", "{_gt_1, number}"],
+      ['indexed number format', '{_gt_1, number}', '{_gt_1, number}'],
       [
-        "indexed select with non-literal other branch",
-        "{_gt_1, select, other {{count, plural, one {item} other {items}}}}",
-        "{_gt_1,select,other{{count,plural,one{item} other{items}}}}",
+        'indexed select with non-literal other branch',
+        '{_gt_1, select, other {{count, plural, one {item} other {items}}}}',
+        '{_gt_1,select,other{{count,plural,one{item} other{items}}}}',
       ],
-    ])("returns the expected string for %s", (_name, input, expected) => {
+    ])('returns the expected string for %s', (_name, input, expected) => {
       const result = condenseVars(input);
 
       expect(result).toBe(expected);
@@ -121,62 +121,62 @@ describe("static condenseVars", () => {
     // should not appear in the same real input.
   });
 
-  describe("indexed translation variables", () => {
+  describe('indexed translation variables', () => {
     it.each([
       [
-        "single empty indexed select",
-        "Hello {_gt_1, select, other {}}",
-        "Hello {_gt_1}",
+        'single empty indexed select',
+        'Hello {_gt_1, select, other {}}',
+        'Hello {_gt_1}',
       ],
       [
-        "multiple empty indexed selects",
-        "I play with {_gt_1, select, other {}} at the {_gt_2, select, other {}}",
-        "I play with {_gt_1} at the {_gt_2}",
+        'multiple empty indexed selects',
+        'I play with {_gt_1, select, other {}} at the {_gt_2, select, other {}}',
+        'I play with {_gt_1} at the {_gt_2}',
       ],
-      ["single digit index", "{_gt_5, select, other {}}", "{_gt_5}"],
-      ["multi-digit index", "{_gt_123, select, other {}}", "{_gt_123}"],
-      ["zero index", "{_gt_0, select, other {}}", "{_gt_0}"],
+      ['single digit index', '{_gt_5, select, other {}}', '{_gt_5}'],
+      ['multi-digit index', '{_gt_123, select, other {}}', '{_gt_123}'],
+      ['zero index', '{_gt_0, select, other {}}', '{_gt_0}'],
       [
-        "translation with regular argument",
-        "User {username} has {_gt_1, select, other {}} {count} tasks",
-        "User {username} has {_gt_1} {count} tasks",
-      ],
-      [
-        "translation with regular select",
-        "{name, select, other {Hello}} {_gt_1, select, other {}}",
-        "{name,select,other{Hello}} {_gt_1}",
+        'translation with regular argument',
+        'User {username} has {_gt_1, select, other {}} {count} tasks',
+        'User {username} has {_gt_1} {count} tasks',
       ],
       [
-        "translation with regular plural",
-        "{count, plural, one {One invite} other {Many invites}} {_gt_1, select, other {}}",
-        "{count,plural,one{One invite} other{Many invites}} {_gt_1}",
+        'translation with regular select',
+        '{name, select, other {Hello}} {_gt_1, select, other {}}',
+        '{name,select,other{Hello}} {_gt_1}',
       ],
       [
-        "translation with date format",
-        "{date, date, short} {_gt_1, select, other {}}",
-        "{date, date, short} {_gt_1}",
+        'translation with regular plural',
+        '{count, plural, one {One invite} other {Many invites}} {_gt_1, select, other {}}',
+        '{count,plural,one{One invite} other{Many invites}} {_gt_1}',
       ],
       [
-        "translation with number format",
-        "{count, number} {_gt_1, select, other {}}",
-        "{count, number} {_gt_1}",
+        'translation with date format',
+        '{date, date, short} {_gt_1, select, other {}}',
+        '{date, date, short} {_gt_1}',
       ],
       [
-        "translation with newline formatting",
-        "Line 1\nHas {_gt_1, select, other {}}\n  with spacing",
-        "Line 1\nHas {_gt_1}\n  with spacing",
+        'translation with number format',
+        '{count, number} {_gt_1, select, other {}}',
+        '{count, number} {_gt_1}',
       ],
       [
-        "translation with tag",
-        "{_gt_1, select, other {}} <b>bold</b>",
-        "{_gt_1} <b>bold</b>",
+        'translation with newline formatting',
+        'Line 1\nHas {_gt_1, select, other {}}\n  with spacing',
+        'Line 1\nHas {_gt_1}\n  with spacing',
       ],
       [
-        "translation with multiple select options and empty other",
-        "{_gt_1, select, one {one} other {}}",
-        "{_gt_1}",
+        'translation with tag',
+        '{_gt_1, select, other {}} <b>bold</b>',
+        '{_gt_1} <b>bold</b>',
       ],
-    ])("condenses %s", (_name, input, expected) => {
+      [
+        'translation with multiple select options and empty other',
+        '{_gt_1, select, one {one} other {}}',
+        '{_gt_1}',
+      ],
+    ])('condenses %s', (_name, input, expected) => {
       const result = condenseVars(input);
 
       expect(result).toBe(expected);
@@ -184,54 +184,54 @@ describe("static condenseVars", () => {
     });
   });
 
-  describe("nested indexed translation variables", () => {
+  describe('nested indexed translation variables', () => {
     it.each([
       [
-        "indexed variable inside plural one branch",
-        "{count, plural, one {Invite {_gt_1, select, other {}}} other {Invites}}",
-        "{count,plural,one{Invite {_gt_1}} other{Invites}}",
+        'indexed variable inside plural one branch',
+        '{count, plural, one {Invite {_gt_1, select, other {}}} other {Invites}}',
+        '{count,plural,one{Invite {_gt_1}} other{Invites}}',
       ],
       [
-        "indexed variable inside plural other branch",
-        "{count, plural, one {Invite} other {Invites {_gt_1, select, other {}}}}",
-        "{count,plural,one{Invite} other{Invites {_gt_1}}}",
+        'indexed variable inside plural other branch',
+        '{count, plural, one {Invite} other {Invites {_gt_1, select, other {}}}}',
+        '{count,plural,one{Invite} other{Invites {_gt_1}}}',
       ],
       [
-        "indexed variables in multiple plural branches",
-        "{count, plural, one {{_gt_1, select, other {}} invite} other {{_gt_2, select, other {}} invites}}",
-        "{count,plural,one{{_gt_1} invite} other{{_gt_2} invites}}",
+        'indexed variables in multiple plural branches',
+        '{count, plural, one {{_gt_1, select, other {}} invite} other {{_gt_2, select, other {}} invites}}',
+        '{count,plural,one{{_gt_1} invite} other{{_gt_2} invites}}',
       ],
       [
-        "indexed variable inside select branch",
-        "{status, select, invited {{_gt_1, select, other {}} is invited} other {No invite}}",
-        "{status,select,invited{{_gt_1} is invited} other{No invite}}",
+        'indexed variable inside select branch',
+        '{status, select, invited {{_gt_1, select, other {}} is invited} other {No invite}}',
+        '{status,select,invited{{_gt_1} is invited} other{No invite}}',
       ],
       [
-        "indexed variables in nested select inside plural",
-        "{count, plural, one {{status, select, yes {{_gt_1, select, other {}}} other {none}}} other {{status, select, yes {{_gt_2, select, other {}}} other {none}}}}",
-        "{count,plural,one{{status,select,yes{{_gt_1}} other{none}}} other{{status,select,yes{{_gt_2}} other{none}}}}",
+        'indexed variables in nested select inside plural',
+        '{count, plural, one {{status, select, yes {{_gt_1, select, other {}}} other {none}}} other {{status, select, yes {{_gt_2, select, other {}}} other {none}}}}',
+        '{count,plural,one{{status,select,yes{{_gt_1}} other{none}}} other{{status,select,yes{{_gt_2}} other{none}}}}',
       ],
       [
-        "indexed variable inside tag in plural branch",
-        "{count, plural, one {<b>{_gt_1, select, other {}}</b>} other {<i>{_gt_2, select, other {}}</i>}}",
-        "{count,plural,one{<b>{_gt_1}</b>} other{<i>{_gt_2}</i>}}",
+        'indexed variable inside tag in plural branch',
+        '{count, plural, one {<b>{_gt_1, select, other {}}</b>} other {<i>{_gt_2, select, other {}}</i>}}',
+        '{count,plural,one{<b>{_gt_1}</b>} other{<i>{_gt_2}</i>}}',
       ],
       [
-        "nested plural with offset",
-        "{count, plural, offset:1 =0 {Nobody} one {{_gt_1, select, other {}}} other {{_gt_2, select, other {}}}}",
-        "{count,plural,offset:1 =0{Nobody} one{{_gt_1}} other{{_gt_2}}}",
+        'nested plural with offset',
+        '{count, plural, offset:1 =0 {Nobody} one {{_gt_1, select, other {}}} other {{_gt_2, select, other {}}}}',
+        '{count,plural,offset:1 =0{Nobody} one{{_gt_1}} other{{_gt_2}}}',
       ],
       [
-        "nested selectordinal",
-        "{place, selectordinal, one {{_gt_1, select, other {}}} two {{_gt_2, select, other {}}} other {{_gt_3, select, other {}}}}",
-        "{place,selectordinal,one{{_gt_1}} two{{_gt_2}} other{{_gt_3}}}",
+        'nested selectordinal',
+        '{place, selectordinal, one {{_gt_1, select, other {}}} two {{_gt_2, select, other {}}} other {{_gt_3, select, other {}}}}',
+        '{place,selectordinal,one{{_gt_1}} two{{_gt_2}} other{{_gt_3}}}',
       ],
       [
-        "nested pound in plural remains valid",
-        "{count, plural, one {# {_gt_1, select, other {}}} other {# {_gt_2, select, other {}}}}",
-        "{count,plural,one{# {_gt_1}} other{# {_gt_2}}}",
+        'nested pound in plural remains valid',
+        '{count, plural, one {# {_gt_1, select, other {}}} other {# {_gt_2, select, other {}}}}',
+        '{count,plural,one{# {_gt_1}} other{# {_gt_2}}}',
       ],
-    ])("condenses %s", (_name, input, expected) => {
+    ])('condenses %s', (_name, input, expected) => {
       const result = condenseVars(input);
 
       expect(result).toBe(expected);

--- a/packages/core/src/derive/condenseVars.ts
+++ b/packages/core/src/derive/condenseVars.ts
@@ -11,6 +11,8 @@ interface GTIndexedArgumentElement extends ArgumentElement {
   value: `${typeof VAR_IDENTIFIER}${number}`;
 }
 
+const GT_INDEXED_IDENTIFIER_REGEX = new RegExp(`${VAR_IDENTIFIER}\\d+`);
+
 /**
  * Given an indexed ICU string, condenses any select to an argument
  * indexVars('Hello {_gt_1, select, other {World}}') => 'Hello {_gt_1}'
@@ -18,8 +20,8 @@ interface GTIndexedArgumentElement extends ArgumentElement {
  * @returns {string} The condensed ICU string.
  */
 export function condenseVars(icuString: string): string {
-  // Check if the string contains _gt_
-  if (!icuString.includes(VAR_IDENTIFIER)) {
+  // Check if the string contains an indexed _gt_ identifier.
+  if (!GT_INDEXED_IDENTIFIER_REGEX.test(icuString)) {
     return icuString;
   }
 

--- a/packages/core/src/derive/condenseVars.ts
+++ b/packages/core/src/derive/condenseVars.ts
@@ -11,7 +11,7 @@ interface GTIndexedArgumentElement extends ArgumentElement {
   value: `${typeof VAR_IDENTIFIER}${number}`;
 }
 
-const GT_INDEXED_IDENTIFIER_REGEX = new RegExp(`${VAR_IDENTIFIER}\\d+`);
+const CONTAINS_INDEXED_GT_REGEX = new RegExp(`${VAR_IDENTIFIER}\\d+`);
 
 /**
  * Given an indexed ICU string, condenses any select to an argument
@@ -23,7 +23,7 @@ const GT_INDEXED_IDENTIFIER_REGEX = new RegExp(`${VAR_IDENTIFIER}\\d+`);
  */
 export function condenseVars(icuString: string): string {
   // Check if the string contains an indexed _gt_ identifier.
-  if (!GT_INDEXED_IDENTIFIER_REGEX.test(icuString)) {
+  if (!CONTAINS_INDEXED_GT_REGEX.test(icuString)) {
     return icuString;
   }
 

--- a/packages/core/src/derive/condenseVars.ts
+++ b/packages/core/src/derive/condenseVars.ts
@@ -15,6 +15,8 @@ const GT_INDEXED_IDENTIFIER_REGEX = new RegExp(`${VAR_IDENTIFIER}\\d+`);
 
 /**
  * Given an indexed ICU string, condenses any select to an argument
+ * Unindexed _gt_ source strings and indexed _gt_# translation strings
+ * are mutually exclusive.
  * indexVars('Hello {_gt_1, select, other {World}}') => 'Hello {_gt_1}'
  * @param {string} icuString - The ICU string to condense.
  * @returns {string} The condensed ICU string.


### PR DESCRIPTION
## Summary

- Skip `condenseVars()` parsing/printing unless the ICU string contains an indexed GT variable like `_gt_1`.
- Preserve source-locale `declareVar()` strings that use unindexed `_gt_`, including escaped trailing apostrophes like `Haas''`.
- Expand `condenseVars` regression coverage for source strings, indexed translation strings, nested ICU structures, and parser normalization behavior.
- Add a patch changeset for `generaltranslation`.

## Why

Source strings use unindexed `_gt_` variables, while translated strings use indexed `_gt_#` variables. Those forms are mutually exclusive in real inputs: source-locale strings should only contain `_gt_`, and translated strings should only contain `_gt_#`.

`condenseVars()` only needs to condense indexed translation variables, but the old guard ran the ICU parse/`printAST()` round trip for source strings too.

That round trip is not a no-op: it can normalize escaped apostrophes, turning a valid source fragment like `Haas''` into `Haas'`. Skipping source strings avoids breaking default-locale interpolation while preserving the existing translation condensing behavior.

## Tests

- `pnpm --filter generaltranslation test -- src/derive/__tests__/condenseVars.test.ts`
- `pnpm --filter generaltranslation typecheck`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where `condenseVars()` incorrectly ran an ICU parse/`printAST()` round-trip on source-locale strings that use unindexed `_gt_` variables, causing escaped apostrophes like `Haas''` to be collapsed to `Haas'`. The guard is tightened from a plain `includes('_gt_')` check to a regex test for `_gt_\d+` (indexed form only), so unindexed source strings are returned as-is.

- **`condenseVars.ts`**: Replaces the `VAR_IDENTIFIER` substring check with `CONTAINS_INDEXED_GT_REGEX` (`/_gt_\d+/`), ensuring only strings with indexed translation variables (`_gt_1`, `_gt_2`, …) proceed through the parse/`printAST` round-trip.
- **`condenseVars.test.ts`**: Full test suite rewrite with four describe blocks — source string preservation (including escaped-apostrophe edge cases), non-select indexed patterns, indexed translation condensing, and deeply nested structures.
- **`.changeset/tough-ghosts-shop.md`**: Patch changeset entry accurately describing the bug.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a focused guard tightening with comprehensive test coverage and no functional changes to the translation condensing path.

The one-line logic change is correct: `_gt_\d+` (unanchored substring) is the right predicate to detect indexed translation strings without false-positives against unindexed source strings or `_gt_var_name`. The downstream `isGTIndexedSelectElement` already uses the anchored `^_gt_\d+$` regex, so any string that passes the new guard but carries a non-select or non-exact identifier still goes through a benign parse/printAST round-trip without condensing. The extensive new test suite covers apostrophe preservation, nested structures, edge-case identifiers, and parser-normalization behavior.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/derive/condenseVars.ts | Guard changed from `includes('_gt_')` to a regex test for `_gt_\d+`, preventing source-locale strings from going through the lossy parse/printAST round-trip. |
| packages/core/src/derive/__tests__/condenseVars.test.ts | Full test rewrite with four focused describe blocks covering source strings (including escaped-apostrophe preservation), non-GT indexed selects, indexed translation variables, and deeply nested structures. |
| .changeset/tough-ghosts-shop.md | Patch changeset added for `generaltranslation` package with an accurate description of the bug fixed. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[condenseVars called with icuString] --> B{CONTAINS_INDEXED_GT_REGEX\nmatches _gt_\\d+ ?}
    B -- No --> C[Return icuString unchanged\ne.g. source strings with _gt_\napostrophes preserved]
    B -- Yes --> D[traverseIcu with\nisGTIndexedSelectElement predicate]
    D --> E{Node is TYPE.select\nwith ^_gt_\\d+$ value\nand valid other branch?}
    E -- No --> F[Leave node unchanged\ne.g. _gt_1 plural/number/argument]
    E -- Yes --> G[Convert to TYPE.argument\ndelete options]
    F --> H[printAST — serialize AST]
    G --> H
    H --> I[Return condensed ICU string]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test: format condense vars tests"](https://github.com/generaltranslation/gt/commit/da4174aa1673624264dc7c480dd46a742ba1023b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32914159)</sub>

<!-- /greptile_comment -->