### PR TITLE
fix: prioritize locale code search matches

### DIFF
--- a/packages/cli/src/console/__tests__/inkLocaleData.test.ts
+++ b/packages/cli/src/console/__tests__/inkLocaleData.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { getFilteredLocaleOptions } from '../inkLocaleData.js';
+
+describe('ink locale data', () => {
+  it('prioritizes exact locale code matches over substring matches', () => {
+    const options = getFilteredLocaleOptions('fr');
+
+    expect(options[0]?.code).toBe('fr');
+    expect(options[0]?.name).toBe('French');
+  });
+});

--- a/packages/cli/src/console/inkLocaleData.ts
+++ b/packages/cli/src/console/inkLocaleData.ts
@@ -38,7 +38,23 @@ export function getFilteredLocaleOptions(query: string) {
   const options = getLocaleOptions();
   if (!normalizedQuery) return options;
 
-  return options.filter((option) =>
-    option.searchable.includes(normalizedQuery)
-  );
+  return options
+    .filter((option) => option.searchable.includes(normalizedQuery))
+    .sort(
+      (left, right) =>
+        getLocaleSearchRank(left, normalizedQuery) -
+        getLocaleSearchRank(right, normalizedQuery)
+    );
+}
+
+function getLocaleSearchRank(option: LocaleOption, query: string) {
+  const code = option.code.toLowerCase();
+  const name = option.name.toLowerCase();
+  const nativeName = option.nativeName.toLowerCase();
+
+  if (code === query) return 0;
+  if (code.startsWith(query)) return 1;
+  if (name.startsWith(query)) return 2;
+  if (nativeName.startsWith(query)) return 3;
+  return 4;
 }


### PR DESCRIPTION
## Summary
- rank exact locale-code matches before code/name/native-name prefix matches
- keep substring matching as a fallback for fuzzy locale search
- add coverage that querying `fr` returns French before substring matches like Afrikaans

## Tests
- pnpm --filter gt typecheck
- pnpm exec oxfmt --check packages/cli/src/console/inkLocaleData.ts packages/cli/src/console/__tests__/inkLocaleData.test.ts
- pnpm exec oxlint packages/cli/src/console/inkLocaleData.ts packages/cli/src/console/__tests__/inkLocaleData.test.ts
- pnpm --filter gt test -- packages/cli/src/console/__tests__/inkLocaleData.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes locale search ranking in the CLI's interactive locale picker so that an exact locale code match (e.g. `fr`) always surfaces before substring or prefix matches (e.g. Afrikaans, whose display name "Afrikaans" contains "fr" as a substring).

- `getFilteredLocaleOptions` now chains `.sort()` after `.filter()`, delegating rank computation to the new `getLocaleSearchRank` helper, which returns 0 for exact code match, 1 for code prefix, 2 for name prefix, 3 for native-name prefix, and 4 for any remaining substring hit.
- A focused Vitest test is added to assert that querying `fr` surfaces French (`code: 'fr'`) as the first result.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrow and self-contained, touching only the locale filtering helper and its new test.

The ranking logic is straightforward and correct: filter runs first on a newly allocated array so the module-level cache is never mutated, and the sort delegate correctly handles case by lowercasing both sides before comparison. The test directly reproduces the described bug and verifies the fix.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/console/inkLocaleData.ts | Adds getLocaleSearchRank helper and wires it into getFilteredLocaleOptions; filter runs first on a new array so the cached localeOptionsCache is never mutated by the subsequent sort. |
| packages/cli/src/console/__tests__/inkLocaleData.test.ts | New test file; verifies exact code match for 'fr' is ranked first, directly covering the bug described in the PR. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["getFilteredLocaleOptions(query)"] --> B["normalize: trim + lowercase"]
    B --> C{empty query?}
    C -- yes --> D["return all options unfiltered"]
    C -- no --> E["filter: searchable.includes(normalizedQuery)"]
    E --> F["sort via getLocaleSearchRank"]
    F --> G{code == query?}
    G -- yes --> R0["rank 0 — exact code match"]
    G -- no --> H{code starts with query?}
    H -- yes --> R1["rank 1 — code prefix"]
    H -- no --> I{name starts with query?}
    I -- yes --> R2["rank 2 — name prefix"]
    I -- no --> J{nativeName starts with query?}
    J -- yes --> R3["rank 3 — nativeName prefix"]
    J -- no --> R4["rank 4 — substring fallback"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: prioritize locale code search match..."](https://github.com/generaltranslation/gt/commit/2f594582fed880970221480c5ed5638685e14fe4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32924981)</sub>

<!-- /greptile_comment -->