### PR TITLE
fix: handle missing CLDR data in isValidLocale

### DIFF
--- a/packages/format/src/locales/isValidLocale.ts
+++ b/packages/format/src/locales/isValidLocale.ts
@@ -17,6 +17,26 @@ const isCustomLanguage = (language: string) => {
 };
 
 /**
+ * Checks whether Intl.DisplayNames has CLDR data available by testing a
+ * known-good code. Some browsers (embedded WebViews, privacy-focused
+ * browsers, stripped ICU builds) support the DisplayNames API but lack
+ * the underlying locale data, causing .of() to return the raw code
+ * instead of a human-readable name (due to the default fallback: "code").
+ */
+const _hasDisplayNamesData = (): boolean => {
+  try {
+    const dn = intlCache.get('DisplayNames', [libraryDefaultLocale], {
+      type: 'language',
+    });
+    // "en" should always resolve to "English" (or a localized equivalent)
+    // when CLDR data is present. If it returns "en", data is missing.
+    return dn.of('en') !== 'en';
+  } catch {
+    return false;
+  }
+};
+
+/**
  * Checks if a given BCP 47 language code is valid.
  * @param {string} code - The BCP 47 language code to validate.
  * @param {CustomMapping} [customMapping] - The custom mapping to use for validation.
@@ -34,6 +54,13 @@ export const _isValidLocale = (
     const { language, region, script } = intlCache.get('Locale', locale);
     const partCount = 1 + Number(Boolean(region)) + Number(Boolean(script));
     if (locale.split('-').length !== partCount) return false;
+
+    // If the runtime lacks CLDR data for Intl.DisplayNames, skip the
+    // display-name validation and rely solely on Intl.Locale parsing +
+    // the part-count check above. This prevents false negatives on
+    // browsers/WebViews with incomplete ICU data.
+    if (!_hasDisplayNamesData()) return true;
+
     const displayLanguageNames = intlCache.get(
       'DisplayNames',
       [libraryDefaultLocale],


### PR DESCRIPTION
## Problem

Some browsers and WebViews (embedded browsers, privacy-focused browsers, stripped ICU builds) support `Intl.DisplayNames` but lack the underlying CLDR locale data. This causes `DisplayNames.of()` to return the raw code (e.g. `"en"`) instead of the display name (`"English"`) due to the default `fallback: "code"` behavior.

This was causing `isValidLocale("en")` to return `false` on these environments, which then threw **"Invalid locale codes in your configuration"** in `useLocaleState`.

**Sentry data:** First seen 2026-04-29, 141 events, 110 users affected — consistent with WebView/in-app browser traffic.

## Root Cause

In `packages/format/src/locales/isValidLocale.ts`, the validation logic checks:

```js
const dn = new Intl.DisplayNames(["en"], { type: "language" });
if (dn.of(language) === language) return false;
```

The `Intl.DisplayNames` constructor defaults to `fallback: "code"` — meaning if the browser has the API but lacks CLDR data, `.of("en")` returns `"en"` instead of `"English"`. This trips the equality check and marks perfectly valid locales as invalid.

### Affected environments
- Embedded WebViews / in-app browsers (custom Chromium builds with stripped ICU data)
- Privacy-focused browsers in aggressive mode (Brave, Tor)
- Older iOS WebViews with incomplete CLDR data
- React Native WebViews with limited Intl support

## Fix

Added a `_hasDisplayNamesData()` probe that tests whether `Intl.DisplayNames` actually has CLDR data by checking if `.of("en")` returns something other than `"en"`. When CLDR data is missing, the function skips the DisplayNames validation entirely and falls back to `Intl.Locale` parsing + part-count validation, which don't depend on CLDR data.

This is a safe degradation — the Intl.Locale check still validates structural correctness of the BCP 47 code, and the part-count check catches malformed codes. We only lose the ability to reject codes that are structurally valid but not real locale codes (e.g. private-use codes), which is an acceptable tradeoff for not crashing on valid locales.

## Testing

All 245 existing tests in `@generaltranslation/format` continue to pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1464"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781892464&installation_id=127936663&pr_number=1464&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1464&signature=862903f066ed412e059861fbb4dc0b1a0a485eef904afc7703e0ea90f3e33671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a false-negative in `isValidLocale` that caused valid locales (e.g. `"en"`) to be rejected on WebViews and browsers with the `Intl.DisplayNames` API present but CLDR locale data stripped, resulting in a thrown "Invalid locale codes" error for 110 affected users.

- Introduces `_hasDisplayNamesData()`, which probes whether `DisplayNames.of('en')` returns something other than the raw code `\"en\"`, and short-circuits to `return true` (skipping the CLDR-dependent display-name checks) when data is absent.
- The fallback path still validates structural correctness via `Intl.Locale` parsing and part-count checks; only the ability to reject structurally-valid-but-nonexistent codes (e.g. private-use ranges outside `qaa\u2013qtz`) is relaxed on data-poor runtimes.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the fix correctly addresses the crash on no-CLDR environments and all existing tests pass; the two noted gaps are narrow edge cases that don’t affect the common scenario.

The probe logic is correct for the primary failure mode (no CLDR data at all). Two non-blocking concerns exist: the probe result is recomputed on every call rather than being evaluated once at module load, and the probe only covers language-type CLDR availability, leaving a theoretical gap for environments with partial CLDR data where region or script names are missing but language names are not — such an environment would still return false negatives for locales like `en-US`. Neither issue affects the 110 users described in the Sentry data.

Only `packages/format/src/locales/isValidLocale.ts` changed; pay attention to the probe coverage and memoization points noted in the comments.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/format/src/locales/isValidLocale.ts | Adds `_hasDisplayNamesData()` probe to skip DisplayNames CLDR validation on stripped-ICU environments; probe logic is sound for the common case but is re-evaluated on every call and only covers language-type CLDR data, leaving a rare partial-CLDR gap for locales with regions or scripts. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["_isValidLocale(locale)"] --> B["Intl.Locale parse + part-count check"]
    B -->|"parse fails or part mismatch"| C["return false"]
    B -->|"passes"| D["_hasDisplayNamesData()"]
    D -->|"dn.of('en') === 'en' no CLDR data"| E["return true (skip DisplayNames checks)"]
    D -->|"dn.of('en') not 'en' CLDR data present"| F["DisplayNames language check"]
    F -->|"language unrecognised & not custom"| C
    F -->|"recognised"| G{"region present?"}
    G -->|"yes"| H["DisplayNames region check"]
    H -->|"unrecognised"| C
    H -->|"recognised"| I{"script present?"}
    G -->|"no"| I
    I -->|"yes"| J["DisplayNames script check"]
    J -->|"unrecognised & not exception"| C
    J -->|"recognised"| K["return true"]
    I -->|"no"| K
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fformat%2Fsrc%2Flocales%2FisValidLocale.ts%3A26-37%0A**Probe%20result%20not%20memoized%20across%20calls**%0A%0A%60_hasDisplayNamesData%28%29%60%20is%20invoked%20on%20every%20call%20to%20%60_isValidLocale%60%2C%20but%20CLDR%20data%20availability%20is%20a%20fixed%20runtime%20property%20%E2%80%94%20it%20never%20changes%20mid-session.%20While%20the%20%60DisplayNames%60%20instance%20itself%20is%20served%20from%20%60intlCache%60%2C%20the%20probe%20still%20executes%20%60dn.of%28'en'%29%60%20on%20every%20locale%20validation.%20Hoisting%20the%20result%20to%20a%20module-level%20constant%20%28%60const%20HAS_DISPLAY_NAMES_DATA%20%3D%20_hasDisplayNamesData%28%29%60%29%20would%20avoid%20the%20repeated%20call%20entirely%20with%20no%20change%20in%20correctness.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fformat%2Fsrc%2Flocales%2FisValidLocale.ts%3A62%0A**Probe%20covers%20only%20language-type%20CLDR%20data%2C%20not%20region%20or%20script**%0A%0A%60_hasDisplayNamesData%28%29%60%20tests%20only%20%60DisplayNames%60%20with%20%60type%3A%20'language'%60.%20An%20environment%20with%20partial%20ICU%20data%20%E2%80%94%20language%20names%20present%20but%20region%20or%20script%20names%20stripped%20%E2%80%94%20would%20pass%20the%20probe%20%28%60true%60%29%20and%20proceed%20to%20the%20full%20validation%20path.%20On%20that%20path%2C%20%60displayRegionNames.of%28'US'%29%20%3D%3D%3D%20'US'%60%20or%20%60displayScriptNames.of%28'Latn'%29%20%3D%3D%3D%20'Latn'%60%20would%20each%20still%20fire%20a%20false-negative%20%60return%20false%60%20for%20an%20otherwise%20valid%20locale%20like%20%60en-US%60%20or%20%60sr-Latn%60.%20The%20tradeoff%20is%20real%20but%20narrow%3B%20the%20common%20real-world%20case%20%28no%20CLDR%20data%20at%20all%29%20is%20handled%20correctly.%20Adding%20a%20secondary%20probe%20for%20%60type%3A%20'region'%60%20alongside%20the%20language%20probe%20would%20close%20this%20gap.%0A%0A&repo=generaltranslation%2Fgt&pr=1464&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22fix%2FisValidLocale-cldr-fallback%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2FisValidLocale-cldr-fallback%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fformat%2Fsrc%2Flocales%2FisValidLocale.ts%3A26-37%0A**Probe%20result%20not%20memoized%20across%20calls**%0A%0A%60_hasDisplayNamesData%28%29%60%20is%20invoked%20on%20every%20call%20to%20%60_isValidLocale%60%2C%20but%20CLDR%20data%20availability%20is%20a%20fixed%20runtime%20property%20%E2%80%94%20it%20never%20changes%20mid-session.%20While%20the%20%60DisplayNames%60%20instance%20itself%20is%20served%20from%20%60intlCache%60%2C%20the%20probe%20still%20executes%20%60dn.of%28'en'%29%60%20on%20every%20locale%20validation.%20Hoisting%20the%20result%20to%20a%20module-level%20constant%20%28%60const%20HAS_DISPLAY_NAMES_DATA%20%3D%20_hasDisplayNamesData%28%29%60%29%20would%20avoid%20the%20repeated%20call%20entirely%20with%20no%20change%20in%20correctness.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fformat%2Fsrc%2Flocales%2FisValidLocale.ts%3A62%0A**Probe%20covers%20only%20language-type%20CLDR%20data%2C%20not%20region%20or%20script**%0A%0A%60_hasDisplayNamesData%28%29%60%20tests%20only%20%60DisplayNames%60%20with%20%60type%3A%20'language'%60.%20An%20environment%20with%20partial%20ICU%20data%20%E2%80%94%20language%20names%20present%20but%20region%20or%20script%20names%20stripped%20%E2%80%94%20would%20pass%20the%20probe%20%28%60true%60%29%20and%20proceed%20to%20the%20full%20validation%20path.%20On%20that%20path%2C%20%60displayRegionNames.of%28'US'%29%20%3D%3D%3D%20'US'%60%20or%20%60displayScriptNames.of%28'Latn'%29%20%3D%3D%3D%20'Latn'%60%20would%20each%20still%20fire%20a%20false-negative%20%60return%20false%60%20for%20an%20otherwise%20valid%20locale%20like%20%60en-US%60%20or%20%60sr-Latn%60.%20The%20tradeoff%20is%20real%20but%20narrow%3B%20the%20common%20real-world%20case%20%28no%20CLDR%20data%20at%20all%29%20is%20handled%20correctly.%20Adding%20a%20secondary%20probe%20for%20%60type%3A%20'region'%60%20alongside%20the%20language%20probe%20would%20close%20this%20gap.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/format/src/locales/isValidLocale.ts:26-37
**Probe result not memoized across calls**

`_hasDisplayNamesData()` is invoked on every call to `_isValidLocale`, but CLDR data availability is a fixed runtime property — it never changes mid-session. While the `DisplayNames` instance itself is served from `intlCache`, the probe still executes `dn.of('en')` on every locale validation. Hoisting the result to a module-level constant (`const HAS_DISPLAY_NAMES_DATA = _hasDisplayNamesData()`) would avoid the repeated call entirely with no change in correctness.

### Issue 2 of 2
packages/format/src/locales/isValidLocale.ts:62
**Probe covers only language-type CLDR data, not region or script**

`_hasDisplayNamesData()` tests only `DisplayNames` with `type: 'language'`. An environment with partial ICU data — language names present but region or script names stripped — would pass the probe (`true`) and proceed to the full validation path. On that path, `displayRegionNames.of('US') === 'US'` or `displayScriptNames.of('Latn') === 'Latn'` would each still fire a false-negative `return false` for an otherwise valid locale like `en-US` or `sr-Latn`. The tradeoff is real but narrow; the common real-world case (no CLDR data at all) is handled correctly. Adding a secondary probe for `type: 'region'` alongside the language probe would close this gap.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: handle missing CLDR data in isValid..."](https://github.com/generaltranslation/gt/commit/32546a887a933ef706caa5d39fc0369aa2354127) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33081460)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->