### PR TITLE
feat: add gt-polyfills package with unplugin for Intl polyfill injection

### DIFF
--- a/.changeset/gt-polyfills-initial.md
+++ b/.changeset/gt-polyfills-initial.md
@@ -1,0 +1,10 @@
+---
+'gt-polyfills': minor
+---
+
+feat: add gt-polyfills package with unplugin for Intl polyfill injection
+
+New package that provides `@formatjs/intl-*` polyfill injection via unplugin, supporting Vite, Rollup, webpack, esbuild, Rspack, and more.
+
+- `import 'gt-polyfills'` loads all base Intl polyfills
+- `gt-polyfills/plugin` exports an unplugin that reads locales from `gt.config.json` and injects polyfill + locale-data imports into the entry module

--- a/packages/polyfills/package.json
+++ b/packages/polyfills/package.json
@@ -1,0 +1,99 @@
+{
+  "name": "gt-polyfills",
+  "version": "0.1.0",
+  "description": "Intl polyfill injection as an unplugin for General Translation",
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.cts",
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "sideEffects": [
+    "./dist/index.cjs",
+    "./dist/index.mjs",
+    "./src/index.ts"
+  ],
+  "scripts": {
+    "build:release": "pnpm run build:clean",
+    "build:clean": "sh ../../scripts/clean.sh && pnpm run build",
+    "build": "tsdown",
+    "lint": "eslint \"src/**/*.{js,ts}\"",
+    "lint:fix": "eslint \"src/**/*.{js,ts}\" --fix",
+    "release": "pnpm run build:clean && pnpm publish",
+    "release:alpha": "pnpm run build:clean && pnpm publish --tag alpha",
+    "release:beta": "pnpm run build:clean && pnpm publish --tag beta",
+    "release:latest": "pnpm run build:clean && pnpm publish --tag latest"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/generaltranslation/gt.git"
+  },
+  "keywords": [
+    "polyfill",
+    "intl",
+    "internationalization",
+    "localization",
+    "i18n",
+    "formatjs",
+    "unplugin",
+    "vite",
+    "webpack",
+    "rollup",
+    "esbuild",
+    "metro"
+  ],
+  "author": "General Translation, Inc.",
+  "license": "FSL-1.1-ALv2",
+  "bugs": {
+    "url": "https://github.com/generaltranslation/gt/issues"
+  },
+  "homepage": "https://generaltranslation.com/",
+  "dependencies": {
+    "@formatjs/intl-datetimeformat": "^6.18.2",
+    "@formatjs/intl-displaynames": "^6.8.13",
+    "@formatjs/intl-getcanonicallocales": "^2.5.6",
+    "@formatjs/intl-listformat": "^7.7.13",
+    "@formatjs/intl-locale": "^4.2.13",
+    "@formatjs/intl-numberformat": "^8.15.6",
+    "@formatjs/intl-pluralrules": "^5.4.6",
+    "@formatjs/intl-relativetimeformat": "^11.4.13",
+    "@generaltranslation/supported-locales": "workspace:*",
+    "generaltranslation": "workspace:*",
+    "unplugin": "^2.3.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.9",
+    "tsdown": "catalog:",
+    "typescript": "catalog:"
+  },
+  "exports": {
+    ".": {
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      },
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      }
+    },
+    "./plugin": {
+      "require": {
+        "types": "./dist/plugin.d.cts",
+        "default": "./dist/plugin.cjs"
+      },
+      "import": {
+        "types": "./dist/plugin.d.mts",
+        "default": "./dist/plugin.mjs"
+      }
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "plugin": [
+        "./dist/plugin.d.cts"
+      ]
+    }
+  }
+}

--- a/packages/polyfills/src/errors.ts
+++ b/packages/polyfills/src/errors.ts
@@ -1,0 +1,19 @@
+const PREFIX = 'gt-polyfills:';
+
+// ---- Warnings ----
+
+export function couldNotLocateConfigWarning(filePath: string): string {
+  return `${PREFIX} Could not locate config file at "${filePath}".`;
+}
+
+export function invalidLocalesWarning(locales: string[]): string {
+  return `${PREFIX} The following locales are not supported and will be skipped: ${locales.join(', ')}`;
+}
+
+export const resolveLocalesFailedWarning = `${PREFIX} Could not resolve any locales from config. Falling back to library default locale.`;
+
+// ---- Errors ----
+
+export function failedToReadConfigFileError(filePath: string): string {
+  return `${PREFIX} Failed to read config file at "${filePath}".`;
+}

--- a/packages/polyfills/src/index.ts
+++ b/packages/polyfills/src/index.ts
@@ -1,0 +1,11 @@
+// Base Intl polyfills — side-effect imports
+// Import 'gt-polyfills' to load all base polyfills
+import '@formatjs/intl-getcanonicallocales/polyfill';
+import '@formatjs/intl-locale/polyfill';
+import '@formatjs/intl-displaynames/polyfill';
+import '@formatjs/intl-listformat/polyfill';
+import '@formatjs/intl-pluralrules/polyfill-force'; // https://github.com/formatjs/formatjs/issues/4463
+import '@formatjs/intl-numberformat/polyfill';
+import '@formatjs/intl-relativetimeformat/polyfill';
+import '@formatjs/intl-datetimeformat/polyfill';
+import '@formatjs/intl-datetimeformat/add-all-tz';

--- a/packages/polyfills/src/plugin.ts
+++ b/packages/polyfills/src/plugin.ts
@@ -1,0 +1,79 @@
+import { createUnplugin } from 'unplugin';
+import { LOCALE_POLYFILLS } from './polyfills';
+import { resolveLocales } from './resolveLocales';
+
+export interface GtPolyfillsOptions {
+  /** List of locales to polyfill */
+  locales?: string[];
+  /** GT config object */
+  config?: { defaultLocale: string; locales: string[] } & Record<string, any>;
+  /** Path to the gt config file */
+  configFilePath?: string;
+  /** Module ID of the entry point to inject into. If omitted, injects into the first module transformed. */
+  entry?: string;
+}
+
+const gtPolyfillsPlugin = createUnplugin((options: GtPolyfillsOptions = {}) => {
+  const { locales, config, configFilePath, entry } = options;
+
+  const resolvedLocales = resolveLocales({ locales, config, configFilePath });
+
+  // Build the import statements to prepend
+  const localeImports = resolvedLocales.flatMap((locale) =>
+    LOCALE_POLYFILLS.map(
+      (localeData) => `import '${localeData}/${locale}';`
+    )
+  );
+
+  const injectedCode = [
+    `import 'gt-polyfills';`,
+    ...localeImports,
+    '',
+  ].join('\n');
+
+  let injected = false;
+
+  return {
+    name: 'gt-polyfills',
+    enforce: 'pre' as const,
+
+    transformInclude(id: string) {
+      // If entry is specified, only match that
+      if (entry) {
+        return id.includes(entry);
+      }
+      // Otherwise match common entry patterns
+      return /\.[jt]sx?$/.test(id);
+    },
+
+    transform(code: string, id: string) {
+      // Only inject once
+      if (injected) return;
+
+      // If entry is specified, only inject into that file
+      if (entry && !id.includes(entry)) return;
+
+      // Skip node_modules
+      if (id.includes('node_modules')) return;
+
+      // Don't inject into files that already have gt-polyfills
+      if (code.includes("'gt-polyfills'") || code.includes('"gt-polyfills"')) {
+        return;
+      }
+
+      injected = true;
+
+      return {
+        code: injectedCode + code,
+        map: null,
+      };
+    },
+  };
+});
+
+export default gtPolyfillsPlugin;
+export const vite = gtPolyfillsPlugin.vite;
+export const webpack = gtPolyfillsPlugin.webpack;
+export const rollup = gtPolyfillsPlugin.rollup;
+export const esbuild = gtPolyfillsPlugin.esbuild;
+export const rspack = gtPolyfillsPlugin.rspack;

--- a/packages/polyfills/src/polyfills.ts
+++ b/packages/polyfills/src/polyfills.ts
@@ -1,0 +1,20 @@
+export const POLYFILLS = [
+  '@formatjs/intl-getcanonicallocales/polyfill',
+  '@formatjs/intl-locale/polyfill',
+  '@formatjs/intl-displaynames/polyfill',
+  '@formatjs/intl-listformat/polyfill',
+  '@formatjs/intl-pluralrules/polyfill-force', // https://github.com/formatjs/formatjs/issues/4463
+  '@formatjs/intl-numberformat/polyfill',
+  '@formatjs/intl-relativetimeformat/polyfill',
+  '@formatjs/intl-datetimeformat/polyfill',
+  '@formatjs/intl-datetimeformat/add-all-tz',
+] as const;
+
+export const LOCALE_POLYFILLS = [
+  '@formatjs/intl-displaynames/locale-data',
+  '@formatjs/intl-listformat/locale-data',
+  '@formatjs/intl-pluralrules/locale-data',
+  '@formatjs/intl-numberformat/locale-data',
+  '@formatjs/intl-relativetimeformat/locale-data',
+  '@formatjs/intl-datetimeformat/locale-data',
+] as const;

--- a/packages/polyfills/src/resolveLocales.ts
+++ b/packages/polyfills/src/resolveLocales.ts
@@ -1,0 +1,94 @@
+import fs from 'fs';
+import path from 'path';
+import { libraryDefaultLocale } from 'generaltranslation/internal';
+import { getSupportedLocale } from '@generaltranslation/supported-locales';
+import {
+  couldNotLocateConfigWarning,
+  invalidLocalesWarning,
+  resolveLocalesFailedWarning,
+  failedToReadConfigFileError,
+} from './errors';
+
+const DEFAULT_CONFIG_FILE_PATHS = [
+  path.join(process.cwd(), 'gt.config.json'),
+  path.join(process.cwd(), '.locadex', 'gt.config.json'),
+];
+
+/**
+ * Given a list of locales or a config object or a path to a config file,
+ * return a list of locales to polyfill.
+ * Preference order: locales > config > configFilePaths > library default locale
+ */
+export function resolveLocales({
+  locales,
+  config,
+  configFilePath,
+}: {
+  locales?: string[];
+  config?: { defaultLocale: string; locales: string[] } & Record<string, any>;
+  configFilePath?: string;
+}): string[] {
+  let result: string[] = [];
+
+  if (locales) {
+    result = Array.from(new Set(locales));
+  } else if (config) {
+    result = Array.from(new Set([config.defaultLocale, ...config.locales]));
+  } else {
+    result = resolveLocalesFromConfig(configFilePath);
+  }
+
+  // Validate the result
+  const invalidLocales = result.filter((locale) => !getSupportedLocale(locale));
+  if (invalidLocales.length) {
+    console.warn(invalidLocalesWarning(invalidLocales));
+    result = result.filter((locale) => !invalidLocales.includes(locale));
+  }
+
+  // Fallback to default locale if no locales were found
+  if (result.length === 0) {
+    console.warn(resolveLocalesFailedWarning);
+    result = [libraryDefaultLocale];
+  }
+
+  return result;
+}
+
+/**
+ * Resolve locales from a config file.
+ */
+function resolveLocalesFromConfig(configFilePath: string | undefined) {
+  const configFilePaths = [
+    ...(configFilePath ? [configFilePath] : []),
+    ...DEFAULT_CONFIG_FILE_PATHS,
+  ];
+  let result: string[] = [];
+
+  for (const filePath of configFilePaths) {
+    try {
+      if (!fs.existsSync(filePath)) {
+        console.warn(couldNotLocateConfigWarning(filePath));
+        continue;
+      }
+
+      const resolvedConfig = JSON.parse(fs.readFileSync(filePath, 'utf8')) as {
+        defaultLocale?: string;
+        locales?: string[];
+      };
+
+      result = Array.from(
+        new Set([
+          ...(resolvedConfig.defaultLocale
+            ? [resolvedConfig.defaultLocale]
+            : []),
+          ...(resolvedConfig.locales || []),
+        ])
+      );
+      break;
+    } catch (error) {
+      console.error(failedToReadConfigFileError(filePath), error);
+      break;
+    }
+  }
+  return result;
+}

--- a/packages/polyfills/tsconfig.json
+++ b/packages/polyfills/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "strict": true,
+    "composite": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationDir": "./dist",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "removeComments": false,
+    "stripInternal": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "baseUrl": "./",
+    "lib": ["ES2023"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"],
+  "references": [
+    {
+      "path": "../supported-locales"
+    }
+  ]
+}

--- a/packages/polyfills/tsdown.config.ts
+++ b/packages/polyfills/tsdown.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'tsdown';
+import { createTsdownConfig } from '../../tsdown.preset.ts';
+
+export default defineConfig(
+  createTsdownConfig(['src/index.ts', 'src/plugin.ts'])
+);


### PR DESCRIPTION
## Summary

New `gt-polyfills` package at `packages/polyfills/` that provides `@formatjs/intl-*` polyfill injection via [unplugin](https://github.com/unjs/unplugin), supporting Vite, Rollup, webpack, esbuild, Rspack, and more.

### What's included

- **`import 'gt-polyfills'`** — loads all base Intl polyfills (side-effect imports)
- **`gt-polyfills/plugin`** — exports an unplugin that:
  - Reads locales from `gt.config.json` (or `.locadex/gt.config.json`)
  - Injects `import 'gt-polyfills'` + per-locale `@formatjs/intl-*/locale-data` imports into the entry module
  - Exports framework-specific plugins: `vite`, `webpack`, `rollup`, `esbuild`, `rspack`

### Usage

```ts
// vite.config.ts
import { vite as gtPolyfills } from 'gt-polyfills/plugin';

export default defineConfig({
  plugins: [gtPolyfills()],
});
```

### Notes
- Based on the Babel plugin in `gt-react-native`, adapted to work across bundlers
- Changeset included
- No CI changes needed — turbo picks up the new package automatically

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781898358&installation_id=127936663&pr_number=1465&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1465&signature=98b6880f8bfd85880180db7ce0d65bcd6080cb94912fd584c9dea99db21c987b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a new `gt-polyfills` package that injects `@formatjs/intl-*` polyfills via [unplugin](https://github.com/unjs/unplugin), supporting Vite, Rollup, webpack, esbuild, and Rspack. The package provides both a side-effect import (`gt-polyfills`) and a bundler plugin (`gt-polyfills/plugin`) that reads locales from `gt.config.json` and prepends polyfill imports into the app's entry module.

- **`plugin.ts`** has two interrelated logic bugs in the `transform` hook: the early-return guard for already-present `gt-polyfills` does not set `injected = true`, causing a second injection into an unrelated file; and the single `injected` flag prevents polyfill injection into more than one entry point in multi-entry builds.
- **`resolveLocales.ts`** uses `break` on JSON parse errors, silently skipping the remaining fallback config paths instead of continuing to the next candidate.
- **`polyfills.ts`** exports a `POLYFILLS` constant that is never imported; `src/index.ts` duplicates the same list manually, creating a drift risk.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Two correctness bugs in the transform hook warrant fixes before this ships to users.

The double-injection bug (missing `injected = true` when a file already has the import) and the single-`injected`-flag limitation for multi-entry builds are both observable defects that users are likely to hit in real projects. They produce subtly wrong behavior—polyfills injected into the wrong module, or absent from all-but-one entry chunk—without any warning.

packages/polyfills/src/plugin.ts needs the most attention—both transform-hook bugs live there. packages/polyfills/src/resolveLocales.ts has the fallback break issue.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/polyfills/src/plugin.ts | Core unplugin factory — has two logic bugs: the early-return guard for already-present `gt-polyfills` does not set `injected = true`, enabling a second injection into an unrelated file; and the `injected` flag prevents polyfill injection into any entry point beyond the first in multi-entry builds. |
| packages/polyfills/src/resolveLocales.ts | Config resolution logic is sound; minor bug where a JSON parse failure breaks the fallback loop instead of continuing to the next candidate path. |
| packages/polyfills/src/polyfills.ts | Defines `POLYFILLS` and `LOCALE_POLYFILLS` constants; `POLYFILLS` is never imported, leaving it out of sync with the duplicate list in `src/index.ts`. |
| packages/polyfills/src/index.ts | Side-effect-only polyfill entry; list duplicates `POLYFILLS` in polyfills.ts instead of reusing it. |
| packages/polyfills/package.json | Package manifest with correct dual CJS/ESM exports, `sideEffects` array, and dependency declarations — looks correct. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Plugin instantiated via createUnplugin] --> B[resolveLocales from options or config file]
    B --> C[Build injectedCode: import gt-polyfills + locale-data imports]
    C --> D[transformInclude hook called per file]
    D -->|entry specified| E{id includes entry?}
    D -->|no entry| F{file matches jt sx extension?}
    E -->|yes| G[transform hook]
    E -->|no| Z[skip file]
    F -->|yes| G
    F -->|no| Z
    G --> H{injected is true?}
    H -->|true| Z
    H -->|false| I{id in node_modules?}
    I -->|yes| Z
    I -->|no| J{code has gt-polyfills?}
    J -->|yes, bug: injected stays false| Z2[return without setting injected]
    J -->|no| K[prepend injectedCode and set injected = true]
    K --> L[emit transformed module]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Apackages%2Fpolyfills%2Fsrc%2Fplugin.ts%3A59-62%0A**Double-injection%20when%20%60gt-polyfills%60%20already%20exists%20in%20a%20file**%0A%0AWhen%20a%20file%20already%20contains%20%60'gt-polyfills'%60%2C%20the%20guard%20returns%20early%20*without*%20setting%20%60injected%20%3D%20true%60.%20This%20means%20the%20plugin%20keeps%20scanning%20and%20will%20inject%20into%20the%20very%20next%20non-%60node_modules%60%20JS%2FTS%20file%20it%20encounters.%20A%20user%20who%20manually%20adds%20%60import%20'gt-polyfills'%60%20to%20their%20entry%20AND%20uses%20this%20plugin%20will%20end%20up%20with%20the%20injection%20appearing%20in%20an%20unrelated%20second%20file%20%28e.g.%2C%20%60App.tsx%60%29.%20The%20bundler%20deduplicates%20the%20module%2C%20but%20the%20import%20now%20lives%20in%20an%20unexpected%20module%20rather%20than%20the%20entry.%0A%0ASetting%20%60injected%20%3D%20true%60%20here%E2%80%94mirroring%20the%20pattern%20at%20line%2064%E2%80%94prevents%20the%20plugin%20from%20falling%20through%20to%20a%20second%20injection%20site.%0A%0A%23%23%23%20Issue%202%20of%204%0Apackages%2Fpolyfills%2Fsrc%2Fplugin.ts%3A40-51%0A**Non-deterministic%20injection%20in%20multi-entry%20builds**%0A%0AWhen%20%60entry%60%20is%20omitted%2C%20%60transformInclude%60%20returns%20%60true%60%20for%20every%20JS%2FTS%20file%20in%20the%20project%2C%20and%20%60transform%60%20injects%20into%20whichever%20file%20is%20processed%20first%20%28excluding%20%60node_modules%60%29.%20In%20single-entry%20apps%20the%20first%20file%20is%20typically%20the%20entry%2C%20but%20this%20is%20an%20implementation%20detail%20of%20the%20bundler.%20In%20multi-entry%20configurations%20%28e.g.%2C%20%60entry%3A%20%7B%20app%3A%20'.%2Fsrc%2Fapp.ts'%2C%20admin%3A%20'.%2Fsrc%2Fadmin.ts'%20%7D%60%20in%20webpack%2Fesbuild%2C%20or%20multiple%20SSR%2Fclient%20builds%20in%20Vite%29%2C%20only%20one%20of%20the%20entry%20chunks%20receives%20the%20polyfills%20because%20%60injected%60%20is%20set%20to%20%60true%60%20after%20the%20first%20hit.%20Users%20targeting%20multi-entry%20setups%20would%20silently%20get%20polyfills%20only%20in%20one%20chunk.%0A%0A%23%23%23%20Issue%203%20of%204%0Apackages%2Fpolyfills%2Fsrc%2FresolveLocales.ts%3A88-91%0A**JSON%20parse%20error%20breaks%20loop%20instead%20of%20falling%20through%20to%20the%20next%20default%20path**%0A%0AThe%20%60catch%60%20block%20calls%20%60break%60%2C%20which%20exits%20the%20whole%20loop%20when%20any%20config%20file%20fails%20to%20parse%20%28e.g.%2C%20malformed%20JSON%29.%20If%20%60gt.config.json%60%20at%20the%20project%20root%20contains%20invalid%20JSON%2C%20the%20loop%20breaks%20before%20attempting%20%60.locadex%2Fgt.config.json%60.%20The%20%60continue%60%20on%20line%2071%20%28file%20not%20found%29%20is%20correct%3B%20the%20parse-error%20path%20should%20behave%20the%20same%E2%80%94log%20the%20error%20and%20move%20on%20to%20the%20next%20candidate%20rather%20than%20stopping%20entirely.%0A%0A%23%23%23%20Issue%204%20of%204%0Apackages%2Fpolyfills%2Fsrc%2Fpolyfills.ts%3A1-11%0A**%60POLYFILLS%60%20constant%20is%20exported%20but%20never%20consumed**%0A%0A%60POLYFILLS%60%20is%20declared%20and%20exported%20here%20but%20imported%20nowhere.%20The%20same%20list%20is%20manually%20duplicated%20as%20bare%20%60import%60%20statements%20in%20%60src%2Findex.ts%60.%20If%20a%20new%20polyfill%20is%20added%20to%20this%20constant%20%28or%20if%20one%20needs%20to%20be%20changed%29%2C%20%60src%2Findex.ts%60%20would%20not%20be%20updated%20automatically%2C%20causing%20the%20two%20lists%20to%20drift%20silently.%0A%0A&repo=generaltranslation%2Fgt&pr=1465&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22feat%2Fgt-polyfills%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fgt-polyfills%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Apackages%2Fpolyfills%2Fsrc%2Fplugin.ts%3A59-62%0A**Double-injection%20when%20%60gt-polyfills%60%20already%20exists%20in%20a%20file**%0A%0AWhen%20a%20file%20already%20contains%20%60'gt-polyfills'%60%2C%20the%20guard%20returns%20early%20*without*%20setting%20%60injected%20%3D%20true%60.%20This%20means%20the%20plugin%20keeps%20scanning%20and%20will%20inject%20into%20the%20very%20next%20non-%60node_modules%60%20JS%2FTS%20file%20it%20encounters.%20A%20user%20who%20manually%20adds%20%60import%20'gt-polyfills'%60%20to%20their%20entry%20AND%20uses%20this%20plugin%20will%20end%20up%20with%20the%20injection%20appearing%20in%20an%20unrelated%20second%20file%20%28e.g.%2C%20%60App.tsx%60%29.%20The%20bundler%20deduplicates%20the%20module%2C%20but%20the%20import%20now%20lives%20in%20an%20unexpected%20module%20rather%20than%20the%20entry.%0A%0ASetting%20%60injected%20%3D%20true%60%20here%E2%80%94mirroring%20the%20pattern%20at%20line%2064%E2%80%94prevents%20the%20plugin%20from%20falling%20through%20to%20a%20second%20injection%20site.%0A%0A%23%23%23%20Issue%202%20of%204%0Apackages%2Fpolyfills%2Fsrc%2Fplugin.ts%3A40-51%0A**Non-deterministic%20injection%20in%20multi-entry%20builds**%0A%0AWhen%20%60entry%60%20is%20omitted%2C%20%60transformInclude%60%20returns%20%60true%60%20for%20every%20JS%2FTS%20file%20in%20the%20project%2C%20and%20%60transform%60%20injects%20into%20whichever%20file%20is%20processed%20first%20%28excluding%20%60node_modules%60%29.%20In%20single-entry%20apps%20the%20first%20file%20is%20typically%20the%20entry%2C%20but%20this%20is%20an%20implementation%20detail%20of%20the%20bundler.%20In%20multi-entry%20configurations%20%28e.g.%2C%20%60entry%3A%20%7B%20app%3A%20'.%2Fsrc%2Fapp.ts'%2C%20admin%3A%20'.%2Fsrc%2Fadmin.ts'%20%7D%60%20in%20webpack%2Fesbuild%2C%20or%20multiple%20SSR%2Fclient%20builds%20in%20Vite%29%2C%20only%20one%20of%20the%20entry%20chunks%20receives%20the%20polyfills%20because%20%60injected%60%20is%20set%20to%20%60true%60%20after%20the%20first%20hit.%20Users%20targeting%20multi-entry%20setups%20would%20silently%20get%20polyfills%20only%20in%20one%20chunk.%0A%0A%23%23%23%20Issue%203%20of%204%0Apackages%2Fpolyfills%2Fsrc%2FresolveLocales.ts%3A88-91%0A**JSON%20parse%20error%20breaks%20loop%20instead%20of%20falling%20through%20to%20the%20next%20default%20path**%0A%0AThe%20%60catch%60%20block%20calls%20%60break%60%2C%20which%20exits%20the%20whole%20loop%20when%20any%20config%20file%20fails%20to%20parse%20%28e.g.%2C%20malformed%20JSON%29.%20If%20%60gt.config.json%60%20at%20the%20project%20root%20contains%20invalid%20JSON%2C%20the%20loop%20breaks%20before%20attempting%20%60.locadex%2Fgt.config.json%60.%20The%20%60continue%60%20on%20line%2071%20%28file%20not%20found%29%20is%20correct%3B%20the%20parse-error%20path%20should%20behave%20the%20same%E2%80%94log%20the%20error%20and%20move%20on%20to%20the%20next%20candidate%20rather%20than%20stopping%20entirely.%0A%0A%23%23%23%20Issue%204%20of%204%0Apackages%2Fpolyfills%2Fsrc%2Fpolyfills.ts%3A1-11%0A**%60POLYFILLS%60%20constant%20is%20exported%20but%20never%20consumed**%0A%0A%60POLYFILLS%60%20is%20declared%20and%20exported%20here%20but%20imported%20nowhere.%20The%20same%20list%20is%20manually%20duplicated%20as%20bare%20%60import%60%20statements%20in%20%60src%2Findex.ts%60.%20If%20a%20new%20polyfill%20is%20added%20to%20this%20constant%20%28or%20if%20one%20needs%20to%20be%20changed%29%2C%20%60src%2Findex.ts%60%20would%20not%20be%20updated%20automatically%2C%20causing%20the%20two%20lists%20to%20drift%20silently.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
packages/polyfills/src/plugin.ts:59-62
**Double-injection when `gt-polyfills` already exists in a file**

When a file already contains `'gt-polyfills'`, the guard returns early *without* setting `injected = true`. This means the plugin keeps scanning and will inject into the very next non-`node_modules` JS/TS file it encounters. A user who manually adds `import 'gt-polyfills'` to their entry AND uses this plugin will end up with the injection appearing in an unrelated second file (e.g., `App.tsx`). The bundler deduplicates the module, but the import now lives in an unexpected module rather than the entry.

Setting `injected = true` here—mirroring the pattern at line 64—prevents the plugin from falling through to a second injection site.

### Issue 2 of 4
packages/polyfills/src/plugin.ts:40-51
**Non-deterministic injection in multi-entry builds**

When `entry` is omitted, `transformInclude` returns `true` for every JS/TS file in the project, and `transform` injects into whichever file is processed first (excluding `node_modules`). In single-entry apps the first file is typically the entry, but this is an implementation detail of the bundler. In multi-entry configurations (e.g., `entry: { app: './src/app.ts', admin: './src/admin.ts' }` in webpack/esbuild, or multiple SSR/client builds in Vite), only one of the entry chunks receives the polyfills because `injected` is set to `true` after the first hit. Users targeting multi-entry setups would silently get polyfills only in one chunk.

### Issue 3 of 4
packages/polyfills/src/resolveLocales.ts:88-91
**JSON parse error breaks loop instead of falling through to the next default path**

The `catch` block calls `break`, which exits the whole loop when any config file fails to parse (e.g., malformed JSON). If `gt.config.json` at the project root contains invalid JSON, the loop breaks before attempting `.locadex/gt.config.json`. The `continue` on line 71 (file not found) is correct; the parse-error path should behave the same—log the error and move on to the next candidate rather than stopping entirely.

### Issue 4 of 4
packages/polyfills/src/polyfills.ts:1-11
**`POLYFILLS` constant is exported but never consumed**

`POLYFILLS` is declared and exported here but imported nowhere. The same list is manually duplicated as bare `import` statements in `src/index.ts`. If a new polyfill is added to this constant (or if one needs to be changed), `src/index.ts` would not be updated automatically, causing the two lists to drift silently.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add gt-polyfills package with unpl..."](https://github.com/generaltranslation/gt/commit/d4baf5e8edbf7137561dadcfdf0b058afa0ff491) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33103338)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->