### PR TITLE
test(vue): lock React runtime parity

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -41,7 +41,10 @@
   },
   "homepage": "https://generaltranslation.com/",
   "devDependencies": {
+    "@generaltranslation/react-core": "workspace:*",
     "@types/node": "catalog:",
+    "@types/react": "19.1.15",
+    "react": "19.1.1",
     "tsdown": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:",

--- a/packages/vue/src/__tests__/reactCatalogInterop.test.ts
+++ b/packages/vue/src/__tests__/reactCatalogInterop.test.ts
@@ -1,0 +1,245 @@
+import { readFileSync } from 'node:fs';
+import { hashSource } from 'generaltranslation/id';
+import type { JsxChildren } from 'generaltranslation/types';
+import { createSSRApp, h, type VNode, type VNodeChild } from 'vue';
+import { renderToString } from 'vue/server-renderer';
+import { describe, expect, it } from 'vitest';
+import { serializeVueChildren } from '../rendering/translateVueChildren';
+import { Branch, Num, Plural, T, Var, createGT } from '../index';
+
+type CatalogInteropCase = {
+  alternateExpectedHtml?: string;
+  expectedHtml: string;
+  source: (alternate?: boolean) => VNodeChild[];
+  target: JsxChildren;
+};
+
+const cases = {
+  'nested-element': {
+    source: () => [
+      'Hello ',
+      h('strong', null, ['wonderful ', h('em', null, 'world')]),
+      '.',
+    ],
+    target: [
+      'Deux fois: ',
+      {
+        t: 'x',
+        i: 1,
+        c: [
+          { t: 'x', i: 2, c: 'monde' },
+          ' puis ',
+          { t: 'x', i: 2, c: 'encore' },
+        ],
+      },
+      ' / ',
+      { t: 'x', i: 1, c: 'fin' },
+      '.',
+    ],
+    expectedHtml:
+      '<main>Deux fois: <strong><em>monde</em> puis <em>encore</em></strong> / <strong>fin</strong>.</main>',
+  },
+  'typed-variables': {
+    source: () => [
+      'Hello ',
+      h(Var, null, { default: () => 'Ada' }),
+      ', you have ',
+      h(Num, { value: 3 }),
+      ' messages.',
+    ],
+    target: [
+      { k: '_gt_n_2', v: 'n' },
+      ' messages pour ',
+      { k: '_gt_value_1', v: 'v' },
+      '; encore ',
+      { k: '_gt_n_2', v: 'n' },
+      ' pour ',
+      { k: '_gt_value_1', v: 'v' },
+      '.',
+    ],
+    expectedHtml: '<main>3 messages pour Ada; encore 3 pour Ada.</main>',
+  },
+  'independent-branch-numbering': {
+    source: (alternate = false) => [
+      h(
+        Branch,
+        { branch: alternate ? 'casual' : 'formal' },
+        {
+          casual: () => [
+            h('em', null, 'Hi'),
+            ' ',
+            h(Var, null, { default: () => 'Ada' }),
+          ],
+          default: () => 'Fallback',
+          formal: () => [
+            h('strong', null, 'Hello'),
+            ' ',
+            h(Var, null, { default: () => 'Ada' }),
+          ],
+        }
+      ),
+      h('span', null, 'After'),
+    ],
+    target: [
+      { t: 'x', i: 2, c: 'Avant' },
+      ' | ',
+      {
+        t: 'x',
+        i: 1,
+        d: {
+          t: 'b',
+          b: {
+            casual: [
+              { k: '_gt_value_3', v: 'v' },
+              ' dit ',
+              { t: 'x', i: 2, c: 'Salut' },
+            ],
+            formal: [
+              { k: '_gt_value_3', v: 'v' },
+              ' dit ',
+              { t: 'x', i: 2, c: 'Bonjour' },
+              ' et ',
+              { t: 'x', i: 2, c: 'salut' },
+            ],
+          },
+        },
+        c: 'Secours',
+      },
+      ' | ',
+      { t: 'x', i: 2, c: 'Après' },
+    ],
+    expectedHtml:
+      '<main><span>Avant</span> | Ada dit <strong>Bonjour</strong> et <strong>salut</strong> | <span>Après</span></main>',
+    alternateExpectedHtml:
+      '<main><span>Avant</span> | Ada dit <em>Salut</em> | <span>Après</span></main>',
+  },
+  'independent-plural-numbering': {
+    source: (alternate = false) => [
+      h(
+        Plural,
+        { n: alternate ? 1 : 2 },
+        {
+          default: () => 'Fallback',
+          one: () => ['One ', h(Num, { value: 1 })],
+          other: () => ['Many ', h(Num, { value: 2 })],
+        }
+      ),
+      h('span', null, 'After'),
+    ],
+    target: [
+      { t: 'x', i: 2, c: 'Début' },
+      ' | ',
+      {
+        t: 'x',
+        i: 1,
+        d: {
+          t: 'p',
+          b: {
+            one: ['Un: ', { k: '_gt_n_2', v: 'n' }],
+            other: [
+              { k: '_gt_n_2', v: 'n' },
+              ' éléments + ',
+              { k: '_gt_n_2', v: 'n' },
+            ],
+          },
+        },
+        c: 'Secours',
+      },
+      ' | ',
+      { t: 'x', i: 2, c: 'Fin' },
+    ],
+    expectedHtml:
+      '<main><span>Début</span> | 2 éléments + 2 | <span>Fin</span></main>',
+    alternateExpectedHtml:
+      '<main><span>Début</span> | Un: 1 | <span>Fin</span></main>',
+  },
+} satisfies Record<string, CatalogInteropCase>;
+
+type FixtureId = keyof typeof cases;
+
+type WireFormatFixture = {
+  description: string;
+  hash: string;
+  id: FixtureId;
+  source: JsxChildren;
+};
+
+const fixtures = JSON.parse(
+  readFileSync(
+    new URL(
+      '../../../../test-fixtures/rich-content-wire-format.json',
+      import.meta.url
+    ),
+    'utf8'
+  )
+) as WireFormatFixture[];
+
+describe('React-canonical rich catalog interoperability', () => {
+  it.each(fixtures)('$id: $description', async (fixture) => {
+    const testCase = cases[fixture.id];
+    const expectedRenders = [
+      testCase.expectedHtml,
+      ...(testCase.alternateExpectedHtml
+        ? [testCase.alternateExpectedHtml]
+        : []),
+    ];
+
+    for (const [index, expectedHtml] of expectedRenders.entries()) {
+      const alternate = index > 0;
+      const sourceChildren = testCase.source(alternate);
+      const serialized = serializeVueChildren(sourceChildren as VNode[]);
+
+      // Component labels can be minified independently in React and Vue. IDs,
+      // variable records, and d.t branch metadata remain part of the contract.
+      expect(removeElementLabels(serialized)).toStrictEqual(
+        removeElementLabels(fixture.source)
+      );
+      expect(hashSource({ dataFormat: 'JSX', source: serialized })).toBe(
+        fixture.hash
+      );
+
+      const gt = createGT({
+        locale: 'fr',
+        loadTranslations: async () => ({ [fixture.hash]: testCase.target }),
+      });
+      await gt.loadTranslations('fr');
+      const app = createSSRApp({
+        render: () =>
+          h('main', null, [
+            h(T, null, { default: () => testCase.source(alternate) }),
+          ]),
+      });
+      app.use(gt);
+
+      const html = stripFragmentMarkers(await renderToString(app));
+      expect(html).toBe(expectedHtml);
+    }
+  });
+});
+
+function removeElementLabels(children: JsxChildren): JsxChildren {
+  if (typeof children === 'string') return children;
+  if (Array.isArray(children)) return children.map(removeElementLabels);
+  if ('k' in children) return children;
+
+  const { t: _elementLabel, ...element } = children;
+  return {
+    ...element,
+    ...(element.c !== undefined && { c: removeElementLabels(element.c) }),
+    ...(element.d?.b !== undefined && {
+      d: {
+        ...element.d,
+        b: Object.fromEntries(
+          Object.entries(element.d.b).map(([key, branch]) => [
+            key,
+            removeElementLabels(branch),
+          ])
+        ),
+      },
+    }),
+  };
+}
+
+function stripFragmentMarkers(html: string): string {
+  return html.replaceAll('<!--[-->', '').replaceAll('<!--]-->', '');
+}

--- a/packages/vue/src/__tests__/seedRuntimeParity.test.ts
+++ b/packages/vue/src/__tests__/seedRuntimeParity.test.ts
@@ -169,31 +169,33 @@ describe('React and Vue seed runtime parity', () => {
     }
   });
 
-  describe('repairable runtime mismatches', () => {
-    for (const fixture of expectedFailureSeeds) {
-      it(`${fixture.id} is limited to its declared semantic repairs`, () => {
-        const vueSource = getVueSource(fixture);
-        const repairedVueSource = applySemanticWireRepairs(
-          toSemanticWireSource(vueSource),
-          fixture.repairs
-        );
+  if (expectedFailureSeeds.length) {
+    describe('repairable runtime mismatches', () => {
+      for (const fixture of expectedFailureSeeds) {
+        it(`${fixture.id} is limited to its declared semantic repairs`, () => {
+          const vueSource = getVueSource(fixture);
+          const repairedVueSource = applySemanticWireRepairs(
+            toSemanticWireSource(vueSource),
+            fixture.repairs
+          );
 
-        expect(sourceHash(vueSource, fixture)).toBe(fixture.brokenVueHash);
-        expect(repairedVueSource).toStrictEqual(
-          toSemanticWireSource(getExpectedSource(fixture))
-        );
-      });
+          expect(sourceHash(vueSource, fixture)).toBe(fixture.brokenVueHash);
+          expect(repairedVueSource).toStrictEqual(
+            toSemanticWireSource(getExpectedSource(fixture))
+          );
+        });
 
-      it(`${fixture.id} compiles and serializes in both runtimes`, () => {
-        expect(getReactSource(fixture)).toBeDefined();
-        expect(getVueSource(fixture)).toBeDefined();
-      });
+        it(`${fixture.id} compiles and serializes in both runtimes`, () => {
+          expect(getReactSource(fixture)).toBeDefined();
+          expect(getVueSource(fixture)).toBeDefined();
+        });
 
-      it.fails(`${fixture.id}: ${fixture.reason}`, () => {
-        assertVueRuntimeParity(fixture);
-      });
-    }
-  });
+        it.fails(`${fixture.id}: ${fixture.reason}`, () => {
+          assertVueRuntimeParity(fixture);
+        });
+      }
+    });
+  }
 
   describe('explicitly excluded seeds', () => {
     for (const fixture of excludedSeeds) {

--- a/packages/vue/src/__tests__/seedRuntimeParity.test.ts
+++ b/packages/vue/src/__tests__/seedRuntimeParity.test.ts
@@ -1,0 +1,727 @@
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { hashSource } from 'generaltranslation/id';
+import type { JsxChildren } from 'generaltranslation/types';
+import {
+  DiagnosticCategory,
+  JsxEmit,
+  ModuleKind,
+  ScriptTarget,
+  formatDiagnostics,
+  transpileModule,
+} from 'typescript';
+import * as Vue from 'vue';
+import { compileScript, parse } from 'vue/compiler-sfc';
+import { describe, expect, it } from 'vitest';
+import * as ReactCoreSource from '../../../react-core/src/components';
+import { prepareT } from '../../../react-core/src/utils/translation/prepareT.shared';
+import * as GTVue from '../index';
+import { serializeVueChildren } from '../rendering/translateVueChildren';
+
+type ParityMode = 'semantic-wire-exact' | 'expected-failure' | 'excluded';
+
+type SemanticWireRepair = {
+  after: unknown;
+  before: unknown;
+  path: (number | string)[];
+};
+
+type ParitySeedBase = {
+  context?: string;
+  hash: string;
+  id: string;
+  mode: ParityMode;
+  reason: string;
+};
+
+type ExpectedFailureSeed = ParitySeedBase & {
+  brokenVueHash: string;
+  mode: 'expected-failure';
+  repairs: SemanticWireRepair[];
+};
+
+type ParitySeed =
+  | ExpectedFailureSeed
+  | (ParitySeedBase & {
+      mode: Exclude<ParityMode, 'expected-failure'>;
+    });
+
+type CompiledSeed = {
+  filename: string;
+  javascript: string;
+};
+
+type ReactBoundaryElement = {
+  props: {
+    children?: unknown;
+    context?: unknown;
+  };
+  type: unknown;
+};
+
+type ReactRuntime = {
+  isValidElement: (value: unknown) => boolean;
+};
+
+type VueSetupComponent = {
+  setup?: (
+    props: Record<string, unknown>,
+    context: {
+      attrs: Record<string, unknown>;
+      emit: () => void;
+      expose: () => void;
+      slots: Record<string, never>;
+    }
+  ) => unknown;
+};
+
+const repositoryRoot = path.resolve(__dirname, '../../../..');
+const requireFromReactCore = createRequire(
+  path.join(repositoryRoot, 'packages/react-core/package.json')
+);
+const React = requireFromReactCore('react') as ReactRuntime;
+const ReactJsxRuntime = requireFromReactCore('react/jsx-runtime') as Record<
+  string,
+  unknown
+>;
+const seedRoot = path.join(repositoryRoot, 'tests/seeds');
+const manifestPath = path.join(
+  repositoryRoot,
+  'test-fixtures/react-vue-runtime-parity.json'
+);
+const manifest = readManifest(manifestPath);
+const runnableSeeds = manifest.filter(({ mode }) => mode !== 'excluded');
+const semanticWireExactSeeds = manifest.filter(
+  ({ mode }) => mode === 'semantic-wire-exact'
+);
+const expectedFailureSeeds = manifest.filter(
+  (fixture): fixture is ExpectedFailureSeed =>
+    fixture.mode === 'expected-failure'
+);
+const excludedSeeds = manifest.filter(({ mode }) => mode === 'excluded');
+const expectedSourceCache = new Map<string, JsxChildren>();
+const reactSourceCache = new Map<string, JsxChildren>();
+const vueSourceCache = new Map<string, JsxChildren>();
+
+/** Boundary identity substituted only while evaluating a compiled seed. */
+function ReactTBoundary(): null {
+  return null;
+}
+
+/** Named stand-in for a seed child that prepareT inspects but never renders. */
+function LocaleSelector(): null {
+  return null;
+}
+
+/** Boundary identity substituted only while evaluating a compiled seed. */
+const VueTBoundary = Vue.defineComponent({
+  name: 'SeedTBoundary',
+  render: () => null,
+});
+
+const reactSeedImports = Object.freeze({
+  ...ReactCoreSource,
+  LocaleSelector,
+  T: ReactTBoundary,
+});
+const vueSeedImports = Object.freeze({
+  ...GTVue,
+  T: VueTBoundary,
+});
+
+describe('React and Vue seed runtime parity', () => {
+  it('accounts for every paired seed exactly once in sorted order', () => {
+    const ids = manifest.map(({ id }) => id);
+
+    expect(ids).toEqual([...ids].sort());
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toEqual(collectPairedSeedIds(seedRoot));
+    for (const fixture of manifest) {
+      expect(fixture.reason).toBe(fixture.reason.trim());
+      expect(fixture.reason.length).toBeGreaterThan(0);
+    }
+  });
+
+  describe('checked-in expected catalog hashes', () => {
+    for (const fixture of manifest) {
+      it(`${fixture.id}: ${fixture.hash}`, () => {
+        expect(sourceHash(getExpectedSource(fixture), fixture)).toBe(
+          fixture.hash
+        );
+      });
+    }
+  });
+
+  describe('React runtime oracle', () => {
+    for (const fixture of runnableSeeds) {
+      it(`${fixture.id}: ${fixture.reason}`, () => {
+        assertReactRuntimeOracle(fixture);
+      });
+    }
+  });
+
+  describe('semantic-wire-exact runtime sources', () => {
+    for (const fixture of semanticWireExactSeeds) {
+      it(`${fixture.id}: ${fixture.reason}`, () => {
+        assertVueRuntimeParity(fixture);
+      });
+    }
+  });
+
+  describe('repairable runtime mismatches', () => {
+    for (const fixture of expectedFailureSeeds) {
+      it(`${fixture.id} is limited to its declared semantic repairs`, () => {
+        const vueSource = getVueSource(fixture);
+        const repairedVueSource = applySemanticWireRepairs(
+          toSemanticWireSource(vueSource),
+          fixture.repairs
+        );
+
+        expect(sourceHash(vueSource, fixture)).toBe(fixture.brokenVueHash);
+        expect(repairedVueSource).toStrictEqual(
+          toSemanticWireSource(getExpectedSource(fixture))
+        );
+      });
+
+      it(`${fixture.id} compiles and serializes in both runtimes`, () => {
+        expect(getReactSource(fixture)).toBeDefined();
+        expect(getVueSource(fixture)).toBeDefined();
+      });
+
+      it.fails(`${fixture.id}: ${fixture.reason}`, () => {
+        assertVueRuntimeParity(fixture);
+      });
+    }
+  });
+
+  describe('explicitly excluded seeds', () => {
+    for (const fixture of excludedSeeds) {
+      it(`${fixture.id}: ${fixture.reason}`, () => {
+        const directory = seedDirectory(fixture);
+        const reactCompilation = compileReactSeed(fixture);
+        const vueCompilation = compileVueSeed(fixture);
+
+        expect(fixture.mode).toBe('excluded');
+        expect(fixture.reason).toBe(fixture.reason.trim());
+        expect(fixture.reason.length).toBeGreaterThan(0);
+        expect(fs.existsSync(path.join(directory, 'page.tsx'))).toBe(true);
+        expect(fs.existsSync(path.join(directory, 'page.vue'))).toBe(true);
+        expect(reactCompilation.javascript.length).toBeGreaterThan(0);
+        expect(vueCompilation.javascript.length).toBeGreaterThan(0);
+      });
+    }
+  });
+});
+
+/** Pins React runtime semantics and hash to the checked-in catalog oracle. */
+function assertReactRuntimeOracle(fixture: ParitySeed): void {
+  const expected = getExpectedSource(fixture);
+  const source = getReactSource(fixture);
+
+  expect(toSemanticWireSource(source)).toStrictEqual(
+    toSemanticWireSource(expected)
+  );
+  expect(sourceHash(expected, fixture)).toBe(fixture.hash);
+  expect(sourceHash(source, fixture)).toBe(fixture.hash);
+}
+
+/** Compares every Vue semantic wire field before checking the literal hash. */
+function assertVueRuntimeParity(fixture: ParitySeed): void {
+  const expected = getExpectedSource(fixture);
+  const vueSource = getVueSource(fixture);
+
+  expect(toSemanticWireSource(vueSource)).toStrictEqual(
+    toSemanticWireSource(expected)
+  );
+  expect(sourceHash(vueSource, fixture)).toBe(fixture.hash);
+}
+
+/**
+ * Canonicalizes a runtime source to its persisted rich-content wire form.
+ *
+ * React derives these labels from function names, which production minifiers
+ * are free to rewrite. GT hashing already excludes them, and both renderers
+ * reconcile translated elements by `i`. The branch/plural discriminator at
+ * `d.t`, element IDs, variables, content props, branches, and children remain
+ * part of this comparison. Undefined object properties are also omitted
+ * because JSON catalogs cannot represent them; array positions and holes are
+ * deliberately left untouched.
+ */
+function toSemanticWireSource(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(toSemanticWireSource);
+  if (!isRecord(value)) return value;
+
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(
+        ([key, child]) =>
+          child !== undefined &&
+          (key !== 't' || !('i' in value) || 'k' in value)
+      )
+      .map(([key, child]) => [key, toSemanticWireSource(child)])
+  );
+}
+
+/** Applies declared, narrowly checked repairs to one known broken Vue source. */
+function applySemanticWireRepairs(
+  source: unknown,
+  repairs: SemanticWireRepair[]
+): unknown {
+  const repaired = structuredClone(source);
+
+  for (const repair of repairs) {
+    const lastSegment = repair.path.at(-1);
+    invariant(
+      lastSegment !== undefined,
+      'A semantic repair path cannot be empty'
+    );
+    let parent = repaired;
+    for (const segment of repair.path.slice(0, -1)) {
+      parent = readWirePath(parent, segment);
+    }
+    const before = readWirePath(parent, lastSegment);
+    expect(before).toStrictEqual(repair.before);
+    writeWirePath(parent, lastSegment, structuredClone(repair.after));
+  }
+
+  return repaired;
+}
+
+function readWirePath(parent: unknown, segment: number | string): unknown {
+  if (Array.isArray(parent)) {
+    invariant(
+      typeof segment === 'number',
+      'Array wire paths must use numeric segments'
+    );
+    return parent[segment];
+  }
+  invariant(isRecord(parent), 'A wire repair path must traverse objects');
+  invariant(
+    typeof segment === 'string',
+    'Object wire paths must use string segments'
+  );
+  invariant(
+    Object.prototype.hasOwnProperty.call(parent, segment),
+    `Wire repair path is missing ${segment}`
+  );
+  return parent[segment];
+}
+
+function writeWirePath(
+  parent: unknown,
+  segment: number | string,
+  value: unknown
+): void {
+  if (Array.isArray(parent)) {
+    invariant(
+      typeof segment === 'number',
+      'Array wire paths must use numeric segments'
+    );
+    parent[segment] = value;
+    return;
+  }
+  invariant(isRecord(parent), 'A wire repair path must terminate in an object');
+  invariant(
+    typeof segment === 'string',
+    'Object wire paths must use string segments'
+  );
+  parent[segment] = value;
+}
+
+function getExpectedSource(fixture: ParitySeed): JsxChildren {
+  const cached = expectedSourceCache.get(fixture.id);
+  if (cached !== undefined) return cached;
+
+  const source = readJson(
+    path.join(seedDirectory(fixture), 'expected.json')
+  ) as JsxChildren;
+  expectedSourceCache.set(fixture.id, source);
+  return source;
+}
+
+function getReactSource(fixture: ParitySeed): JsxChildren {
+  const cached = reactSourceCache.get(fixture.id);
+  if (cached !== undefined) return cached;
+
+  const { filename, javascript } = compileReactSeed(fixture);
+  const module = evaluateCommonJs(javascript, filename, (specifier) => {
+    if (specifier === 'gt-next') return reactSeedImports;
+    if (specifier === 'react') return React;
+    if (specifier === 'react/jsx-runtime') return ReactJsxRuntime;
+    throw new Error(`${fixture.id} has unexpected React import: ${specifier}`);
+  });
+  const Page = module.default;
+  invariant(
+    typeof Page === 'function',
+    `${fixture.id} must default-export a React page function`
+  );
+  const boundary = findReactBoundary((Page as () => unknown)(), fixture.id);
+  invariant(
+    boundary.props.context === fixture.context,
+    `${fixture.id} React context must match its parity manifest`
+  );
+  const prepared = prepareT({
+    locale: 'en',
+    params: fixture.context === undefined ? {} : { context: fixture.context },
+    sourceChildren: boundary.props.children as Parameters<
+      typeof prepareT
+    >[0]['sourceChildren'],
+  });
+  invariant(
+    prepared.targetOptions.$context === fixture.context,
+    `${fixture.id} React prepareT context must match its parity manifest`
+  );
+  const source = prepared.sourceJsxChildren;
+
+  reactSourceCache.set(fixture.id, source);
+  return source;
+}
+
+function getVueSource(fixture: ParitySeed): JsxChildren {
+  const cached = vueSourceCache.get(fixture.id);
+  if (cached !== undefined) return cached;
+
+  const { filename, javascript } = compileVueSeed(fixture);
+  const component = evaluateVueSfc(javascript, filename, (specifier) => {
+    if (specifier === 'vue') return Vue;
+    if (specifier === 'gt-vue') return vueSeedImports;
+    throw new Error(`${fixture.id} has unexpected Vue import: ${specifier}`);
+  });
+  const rendered = renderCompiledVueComponent(component, fixture.id);
+  const children = findVueBoundaryChildren(rendered, fixture);
+  const runtimeSource = serializeVueChildren(children);
+
+  vueSourceCache.set(fixture.id, runtimeSource);
+  return runtimeSource;
+}
+
+/** Compiles a React seed without resolving or executing its imports. */
+function compileReactSeed(fixture: ParitySeed): CompiledSeed {
+  const filename = path.join(seedDirectory(fixture), 'page.tsx');
+  return {
+    filename,
+    javascript: transpile(
+      fs.readFileSync(filename, 'utf8'),
+      filename,
+      JsxEmit.ReactJSX
+    ),
+  };
+}
+
+/** Compiles a Vue SFC and its generated TypeScript without executing it. */
+function compileVueSeed(fixture: ParitySeed): CompiledSeed {
+  const filename = path.join(seedDirectory(fixture), 'page.vue');
+  const source = fs.readFileSync(filename, 'utf8');
+  const parsed = parse(source, { filename });
+  invariant(
+    parsed.errors.length === 0,
+    `${fixture.id} Vue parse errors: ${parsed.errors.map(String).join('\n')}`
+  );
+  const compiled = compileScript(parsed.descriptor, {
+    genDefaultAs: '__sfc__',
+    id: `runtime-parity-${fixture.id.replaceAll('/', '-')}`,
+    inlineTemplate: true,
+  });
+  return { filename, javascript: transpile(compiled.content, filename) };
+}
+
+function findReactBoundary(
+  root: unknown,
+  fixtureId: string
+): ReactBoundaryElement {
+  const boundaries: ReactBoundaryElement[] = [];
+
+  function visit(node: unknown): void {
+    if (Array.isArray(node)) {
+      node.forEach(visit);
+      return;
+    }
+    if (!React.isValidElement(node)) return;
+    const element = node as ReactBoundaryElement;
+    if (element.type === ReactTBoundary) {
+      boundaries.push(element);
+      return;
+    }
+    visit(element.props.children);
+  }
+
+  visit(root);
+  invariant(
+    boundaries.length === 1,
+    `${fixtureId} must render exactly one outer React T; found ${boundaries.length}`
+  );
+  return boundaries[0];
+}
+
+function renderCompiledVueComponent(
+  component: Vue.Component,
+  fixtureId: string
+): unknown {
+  const setup = (component as VueSetupComponent).setup;
+  invariant(
+    typeof setup === 'function',
+    `${fixtureId} compiled Vue component must expose setup()`
+  );
+  const render = setup(
+    {},
+    {
+      attrs: {},
+      emit: () => undefined,
+      expose: () => undefined,
+      slots: {},
+    }
+  );
+  invariant(
+    typeof render === 'function',
+    `${fixtureId} compiled Vue setup() must return a render function`
+  );
+  return (
+    render as (context: Record<string, unknown>, cache: unknown[]) => unknown
+  )({}, []);
+}
+
+function findVueBoundaryChildren(
+  root: unknown,
+  fixture: ParitySeed
+): Vue.VNode[] {
+  const fixtureId = fixture.id;
+  const boundaries: Vue.VNode[] = [];
+
+  function visit(node: unknown): void {
+    if (Array.isArray(node)) {
+      node.forEach(visit);
+      return;
+    }
+    if (!Vue.isVNode(node)) return;
+    if (node.type === VueTBoundary) {
+      boundaries.push(node);
+      return;
+    }
+    if (Array.isArray(node.children)) visit(node.children);
+  }
+
+  visit(root);
+  invariant(
+    boundaries.length === 1,
+    `${fixtureId} must render exactly one outer Vue T; found ${boundaries.length}`
+  );
+  const boundary = boundaries[0];
+  invariant(
+    boundary.props?.context === fixture.context,
+    `${fixtureId} Vue context must match its parity manifest`
+  );
+  const slots = boundary.children;
+  invariant(
+    isRecord(slots) && typeof slots.default === 'function',
+    `${fixtureId} compiled Vue T must provide a default slot`
+  );
+  const children = (slots.default as () => unknown)();
+  invariant(
+    Array.isArray(children),
+    `${fixtureId} compiled Vue T default slot must return an array`
+  );
+  return children as Vue.VNode[];
+}
+
+function transpile(source: string, filename: string, jsx?: JsxEmit): string {
+  const result = transpileModule(source, {
+    compilerOptions: {
+      esModuleInterop: true,
+      ...(jsx === undefined ? {} : { jsx }),
+      module: ModuleKind.CommonJS,
+      target: ScriptTarget.ES2022,
+    },
+    fileName: filename,
+    reportDiagnostics: true,
+  });
+  const errors =
+    result.diagnostics?.filter(
+      ({ category }) => category === DiagnosticCategory.Error
+    ) ?? [];
+  invariant(errors.length === 0, formatDiagnostics(errors, formatHost));
+  return result.outputText;
+}
+
+function evaluateCommonJs(
+  javascript: string,
+  filename: string,
+  requireModule: (specifier: string) => unknown
+): Record<string, unknown> {
+  const commonJsModule = { exports: {} as Record<string, unknown> };
+  const evaluate = new Function(
+    'require',
+    'exports',
+    'module',
+    `${javascript}\n//# sourceURL=${filename}`
+  ) as (
+    require: (specifier: string) => unknown,
+    exports: Record<string, unknown>,
+    module: { exports: Record<string, unknown> }
+  ) => void;
+
+  evaluate(requireModule, commonJsModule.exports, commonJsModule);
+  return commonJsModule.exports;
+}
+
+function evaluateVueSfc(
+  javascript: string,
+  filename: string,
+  requireModule: (specifier: string) => unknown
+): Vue.Component {
+  const evaluate = new Function(
+    'require',
+    'exports',
+    `${javascript}\nreturn __sfc__;\n//# sourceURL=${filename}`
+  ) as (
+    require: (specifier: string) => unknown,
+    exports: Record<string, unknown>
+  ) => Vue.Component;
+
+  return evaluate(requireModule, {});
+}
+
+function sourceHash(source: JsxChildren, fixture: ParitySeed): string {
+  return hashSource({
+    context: fixture.context,
+    dataFormat: 'JSX',
+    source,
+  });
+}
+
+function seedDirectory({ id }: ParitySeed): string {
+  return path.join(seedRoot, id);
+}
+
+function readManifest(filename: string): ParitySeed[] {
+  const value = readJson(filename);
+  invariant(Array.isArray(value), 'Runtime parity manifest must be an array');
+
+  return value.map((entry, index) => {
+    invariant(isRecord(entry), `Manifest entry ${index} must be an object`);
+    invariant(
+      entry.mode === 'semantic-wire-exact' ||
+        entry.mode === 'expected-failure' ||
+        entry.mode === 'excluded',
+      `Manifest entry ${index} has an invalid parity mode`
+    );
+    const expectedKeys = [
+      ...(entry.mode === 'expected-failure'
+        ? ['brokenVueHash', 'repairs']
+        : []),
+      ...('context' in entry ? ['context'] : []),
+      'hash',
+      'id',
+      'mode',
+      'reason',
+    ].sort();
+    invariant(
+      JSON.stringify(Object.keys(entry).sort()) ===
+        JSON.stringify(expectedKeys),
+      `Manifest entry ${index} has fields that do not match its parity mode`
+    );
+    if ('context' in entry) {
+      invariant(
+        typeof entry.context === 'string' && entry.context.length > 0,
+        `Manifest entry ${index} must have a static nonempty context`
+      );
+    }
+    invariant(
+      typeof entry.hash === 'string' && /^[0-9a-f]{16}$/.test(entry.hash),
+      `Manifest entry ${index} must have a 16-character lowercase hexadecimal hash`
+    );
+    invariant(
+      typeof entry.id === 'string' &&
+        entry.id.length > 0 &&
+        !path.isAbsolute(entry.id) &&
+        !entry.id.split('/').includes('..') &&
+        !entry.id.includes('\\'),
+      `Manifest entry ${index} has an invalid seed id`
+    );
+    invariant(
+      typeof entry.reason === 'string' &&
+        entry.reason.length > 0 &&
+        entry.reason === entry.reason.trim(),
+      `Manifest entry ${index} must have a precise nonempty reason`
+    );
+    if (entry.mode === 'expected-failure') {
+      invariant(
+        typeof entry.brokenVueHash === 'string' &&
+          /^[0-9a-f]{16}$/.test(entry.brokenVueHash),
+        `Manifest entry ${index} must pin its broken Vue hash`
+      );
+      invariant(
+        Array.isArray(entry.repairs) && entry.repairs.length > 0,
+        `Manifest entry ${index} must declare its semantic repairs`
+      );
+      const repairPaths = entry.repairs.map((repair, repairIndex) => {
+        invariant(
+          isRecord(repair) &&
+            JSON.stringify(Object.keys(repair).sort()) ===
+              JSON.stringify(['after', 'before', 'path']),
+          `Manifest entry ${index} repair ${repairIndex} has invalid fields`
+        );
+        invariant(
+          Array.isArray(repair.path) &&
+            repair.path.length > 0 &&
+            repair.path.every(
+              (segment) =>
+                (typeof segment === 'number' &&
+                  Number.isSafeInteger(segment) &&
+                  segment >= 0) ||
+                (typeof segment === 'string' &&
+                  segment.length > 0 &&
+                  segment !== '__proto__' &&
+                  segment !== 'constructor' &&
+                  segment !== 'prototype')
+            ),
+          `Manifest entry ${index} repair ${repairIndex} has an invalid path`
+        );
+        return JSON.stringify(repair.path);
+      });
+      invariant(
+        new Set(repairPaths).size === repairPaths.length,
+        `Manifest entry ${index} must not repair the same path twice`
+      );
+    }
+    return entry as ParitySeed;
+  });
+}
+
+function readJson(filename: string): unknown {
+  return JSON.parse(fs.readFileSync(filename, 'utf8')) as unknown;
+}
+
+function collectPairedSeedIds(directory: string): string[] {
+  const ids: string[] = [];
+
+  function visit(current: string): void {
+    const entries = fs.readdirSync(current, { withFileTypes: true });
+    const files = new Set(
+      entries.filter((entry) => entry.isFile()).map(({ name }) => name)
+    );
+    if (files.has('page.tsx') && files.has('page.vue')) {
+      ids.push(path.relative(directory, current).replaceAll(path.sep, '/'));
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) visit(path.join(current, entry.name));
+    }
+  }
+
+  visit(directory);
+  return ids.sort();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function invariant(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+const formatHost = {
+  getCanonicalFileName: (filename: string) => filename,
+  getCurrentDirectory: () => repositoryRoot,
+  getNewLine: () => '\n',
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1643,9 +1643,18 @@ importers:
         specifier: workspace:*
         version: link:../i18n
     devDependencies:
+      '@generaltranslation/react-core':
+        specifier: workspace:*
+        version: link:../react-core
       '@types/node':
         specifier: 'catalog:'
         version: 22.13.10
+      '@types/react':
+        specifier: 19.1.15
+        version: 19.1.15
+      react:
+        specifier: 19.1.1
+        version: 19.1.1
       tsdown:
         specifier: 'catalog:'
         version: 0.21.10(synckit@0.11.11)(typescript@5.9.3)

--- a/test-fixtures/react-vue-runtime-parity.json
+++ b/test-fixtures/react-vue-runtime-parity.json
@@ -1,0 +1,525 @@
+[
+  {
+    "id": "branching-components/branch/complex/big",
+    "hash": "38ec69190078142b",
+    "mode": "excluded",
+    "reason": "The fixtures are not equivalent: React uses singular/plural branches while Vue uses one/other, and the case also mixes fragments with boolean and null branches that Vue normalizes away."
+  },
+  {
+    "id": "branching-components/branch/complex/composite",
+    "hash": "190eeac7f8c818ed",
+    "mode": "semantic-wire-exact",
+    "reason": "At runtime prepareT and gt-vue serialize the same Branch transformation, branches, variables, IDs, and hash."
+  },
+  {
+    "id": "branching-components/branch/complex/nestedbranches",
+    "hash": "f4ffc9cbcc62ebe4",
+    "mode": "semantic-wire-exact",
+    "reason": "Both runtimes serialize the same nested Branch transformations, branch content, IDs, and hash."
+  },
+  {
+    "id": "branching-components/branch/simple/basic",
+    "hash": "a785b696e567580b",
+    "mode": "semantic-wire-exact",
+    "reason": "Both runtimes serialize identical Branch transformation data, branch content, IDs, and hash."
+  },
+  {
+    "id": "branching-components/branch/simple/default",
+    "hash": "09560c569c4865b7",
+    "mode": "semantic-wire-exact",
+    "reason": "Both runtimes serialize the same default content, Branch transformation data, IDs, and hash."
+  },
+  {
+    "id": "branching-components/branch/simple/empty",
+    "hash": "b5c4b7b8cbea300b",
+    "mode": "excluded",
+    "reason": "The compiled Vue branch slot retains the explicit empty Fragment VNode, but gt-vue's current serializer deliberately treats Fragment as transparent; explicit Fragment identity is outside the initial portable grammar."
+  },
+  {
+    "id": "branching-components/branch/simple/jsx-branch",
+    "hash": "4984101a84f79442",
+    "mode": "semantic-wire-exact",
+    "reason": "Both runtimes serialize identical element-valued branch structure, Branch transformation data, IDs, and hash."
+  },
+  {
+    "id": "branching-components/branch/simple/stringliterals",
+    "hash": "257b552d655ac08e",
+    "mode": "semantic-wire-exact",
+    "reason": "Both runtimes serialize the same literal branches, defaults, Branch transformation data, IDs, and hash."
+  },
+  {
+    "id": "branching-components/plural/complex/composite",
+    "hash": "3e41ae7ee96a8a45",
+    "mode": "semantic-wire-exact",
+    "reason": "At runtime prepareT and gt-vue serialize identical rich plural forms, Plural transformation data, IDs, and hash."
+  },
+  {
+    "id": "branching-components/plural/complex/nestedbranches",
+    "hash": "6bb5921309dccd8e",
+    "mode": "semantic-wire-exact",
+    "reason": "Both runtimes serialize the same nested Plural transformations, form content, IDs, and hash."
+  },
+  {
+    "id": "branching-components/plural/simple/basic",
+    "hash": "e55955253ba86252",
+    "mode": "semantic-wire-exact",
+    "reason": "Both runtimes serialize identical Plural transformation data, form content, IDs, and hash."
+  },
+  {
+    "id": "branching-components/plural/simple/default",
+    "hash": "dd1dea877e2e4cd8",
+    "mode": "semantic-wire-exact",
+    "reason": "Both runtimes serialize the same default content, Plural transformation data, forms, IDs, and hash."
+  },
+  {
+    "id": "branching-components/plural/simple/empty",
+    "hash": "a595c029effd5e36",
+    "mode": "excluded",
+    "reason": "The compiled Vue plural-form slot retains the explicit empty Fragment VNode, but gt-vue's current serializer deliberately treats Fragment as transparent; explicit Fragment identity is outside the initial portable grammar."
+  },
+  {
+    "id": "branching-components/plural/simple/jsx-branch",
+    "hash": "d9cd02a509fe5c49",
+    "mode": "semantic-wire-exact",
+    "reason": "Both runtimes serialize identical element-valued form structure, Plural transformation data, IDs, and hash."
+  },
+  {
+    "id": "branching-components/plural/simple/stringliterals",
+    "hash": "0231d21d66b43987",
+    "mode": "semantic-wire-exact",
+    "reason": "Both runtimes serialize the same literal forms, defaults, Plural transformation data, IDs, and hash."
+  },
+  {
+    "id": "complex-cases/all-empty-branch-attr",
+    "hash": "b5afa467eff619c8",
+    "mode": "excluded",
+    "reason": "The compiled Branch VNode retains null, false, and the explicit empty Fragment as distinct inputs, but gt-vue's current serializer normalizes the primitive branches and deliberately treats Fragment as transparent; this Fragment-sensitive case is outside the initial portable grammar."
+  },
+  {
+    "id": "complex-cases/all-plual-forms",
+    "hash": "38512687adbc60fa",
+    "mode": "semantic-wire-exact",
+    "reason": "Both runtimes serialize the same complete set of plural-form keys, values, Plural transformation data, IDs, and hash."
+  },
+  {
+    "id": "complex-cases/attribute-props",
+    "hash": "c6d7761ce8dd2a59",
+    "mode": "semantic-wire-exact",
+    "reason": "Both runtimes serialize the same Branch transformation data, branch structure, translatable HTML attributes, IDs, and hash."
+  },
+  {
+    "id": "complex-cases/boundary-numeric-values",
+    "hash": "f78e188604fcfff4",
+    "mode": "semantic-wire-exact",
+    "reason": "Both runtimes serialize every boundary numeric form with the same Plural transformation data, IDs, and hash."
+  },
+  {
+    "id": "complex-cases/complex-fragment-nesting",
+    "hash": "6c901a520d542fa8",
+    "mode": "excluded",
+    "reason": "The compiled Vue slots retain the explicit nested Fragment VNodes, but gt-vue's current serializer deliberately treats them as transparent and Vue normalizes the surrounding template whitespace differently; Fragment identity and ambiguous formatting whitespace are outside the initial portable grammar."
+  },
+  {
+    "id": "complex-cases/component-nesting-edge-cases",
+    "hash": "7e4bbf7961dcca27",
+    "mode": "excluded",
+    "reason": "A Fragment inside a nested branch slot is flattened and surrounding template whitespace is normalized, so the React child structure and numbering cannot be reconstructed."
+  },
+  {
+    "id": "complex-cases/deeply-nested-branch-components",
+    "hash": "a3bad22afc92233b",
+    "mode": "excluded",
+    "reason": "The evening branch relies on a Fragment wrapper that Vue flattens; its loss shifts variable and nested-branch IDs and combines differently normalized text."
+  },
+  {
+    "id": "complex-cases/different-number-formats",
+    "hash": "4d68f22fc6e97b8f",
+    "mode": "expected-failure",
+    "reason": "The only runtime mismatch is direct Branch props true, false, and null being normalized to empty children; their typed values remain available on the compiled VNode, so gt-vue can preserve them in source serialization.",
+    "brokenVueHash": "4c9ba22391e5f1dc",
+    "repairs": [
+      {
+        "path": [1, "d", "b", "active"],
+        "before": [],
+        "after": true
+      },
+      {
+        "path": [1, "d", "b", "inactive"],
+        "before": [],
+        "after": false
+      },
+      {
+        "path": [1, "d", "b", "unknown"],
+        "before": [],
+        "after": null
+      }
+    ]
+  },
+  {
+    "id": "complex-cases/duplicate-branches",
+    "hash": "bc1400bbcd8c5a7a",
+    "mode": "excluded",
+    "reason": "Each rich branch is wrapped in a React Fragment that Vue flattens, changing both element numbering and compiler-normalized whitespace."
+  },
+  {
+    "id": "complex-cases/empty-fragments",
+    "hash": "5e3dfbb4983ff412",
+    "mode": "excluded",
+    "reason": "React serializes the empty Fragment as a tagged child, but Vue compiles the corresponding form to an empty slot with no recoverable node."
+  },
+  {
+    "id": "complex-cases/empty-minimal-content",
+    "hash": "cb715c6c561d06e6",
+    "mode": "excluded",
+    "reason": "The Vue fixture supplies the singleChar branch as the distinct single-char key; the runtime cannot infer the React branch name from that compiled prop."
+  },
+  {
+    "id": "complex-cases/five-level-nesting",
+    "hash": "9095e84edac4763a",
+    "mode": "excluded",
+    "reason": "React assigns the deepest Var the explicit name deep_var, but the Vue fixture omits that name and only exposes an auto-generated variable identity."
+  },
+  {
+    "id": "complex-cases/fragments-and-elements",
+    "hash": "8c456a04a0aa6795",
+    "mode": "excluded",
+    "reason": "The compiled Vue children retain both explicit Fragment VNodes, but gt-vue's current serializer deliberately treats them as transparent, changing semantic element identity and numbering; explicit Fragment identity is outside the initial portable grammar."
+  },
+  {
+    "id": "complex-cases/fragments-with-only-whitespace",
+    "hash": "fe4d6d291f5f1384",
+    "mode": "excluded",
+    "reason": "Vue exposes the whitespace form as text and the empty form as no nodes, while React preserves a distinct Fragment element for each form."
+  },
+  {
+    "id": "complex-cases/leading-trailing-spaces-with-diff-sibs-pos",
+    "hash": "87521cdd2d9e92b7",
+    "mode": "semantic-wire-exact",
+    "reason": "The compiled Vue text boundaries, element IDs, semantic wire source, and hash match the React fixture."
+  },
+  {
+    "id": "complex-cases/long-attributes",
+    "hash": "540627838e017e07",
+    "mode": "semantic-wire-exact",
+    "reason": "Both runtimes serialize the same long attribute values, Plural transformation data, IDs, and hash."
+  },
+  {
+    "id": "complex-cases/long-content-string",
+    "hash": "d5fbcdfef5e87db1",
+    "mode": "excluded",
+    "reason": "The mixed branch uses a Fragment that Vue flattens, and multiline template formatting is normalized into different text boundaries and element IDs."
+  },
+  {
+    "id": "complex-cases/many-edge-cases",
+    "hash": "9975ce1096bddd02",
+    "mode": "excluded",
+    "reason": "The Vue fixture intentionally omits and changes portions of the React stress corpus, while also mixing fragments, named variables, booleans, and nulls, so the inputs are not equivalent."
+  },
+  {
+    "id": "complex-cases/mixed-component-types",
+    "hash": "62b7f2d2a37f1bf9",
+    "mode": "excluded",
+    "reason": "Fragment children inside both plural forms are flattened by Vue and formatted template text is normalized, removing nodes and changing subsequent IDs."
+  },
+  {
+    "id": "complex-cases/mixed-element-types-in-branches",
+    "hash": "0278d0825cf63b05",
+    "mode": "excluded",
+    "reason": "Fragments nested under footer and main elements are flattened by Vue, which removes React wire nodes and shifts every following descendant ID."
+  },
+  {
+    "id": "complex-cases/more-extreme-edge-cases",
+    "hash": "03192064013401f9",
+    "mode": "excluded",
+    "reason": "This stress corpus combines retained explicit Fragment VNodes with empty expressions, primitive interpolations, and Vue cases that differ from the React fixture; those Fragment-sensitive, primitive, and non-equivalent inputs are outside the initial portable grammar."
+  },
+  {
+    "id": "complex-cases/multiple-variable-types-in-branch",
+    "hash": "3147331853462b48",
+    "mode": "excluded",
+    "reason": "The singular Fragment is flattened and the React Var name reference is omitted from Vue, so neither the original IDs nor the named variable key can be recovered."
+  },
+  {
+    "id": "complex-cases/multiple-vars-same-keys",
+    "hash": "acf6252b72f8a938",
+    "mode": "excluded",
+    "reason": "Vue template whitespace normalization moves spaces around each variable relative to React JSX, and the compiled text nodes do not retain the original source placement."
+  },
+  {
+    "id": "complex-cases/nested-fragments",
+    "hash": "f7a2329cfdc886aa",
+    "mode": "excluded",
+    "reason": "Vue flattens both levels of nested Fragments into text, while React retains tagged fragment elements in the wire structure."
+  },
+  {
+    "id": "complex-cases/parallel-branches-with-fragments",
+    "hash": "098f517dbae38267",
+    "mode": "excluded",
+    "reason": "The compiled singular slot retains its explicit Fragment VNode, but gt-vue's current serializer deliberately treats it as transparent, shifting variable IDs relative to the element-wrapped plural form; explicit Fragment identity is outside the initial portable grammar."
+  },
+  {
+    "id": "complex-cases/previous-issues",
+    "hash": "9f8429513a1e9f3a",
+    "mode": "excluded",
+    "reason": "The compiled Vue slots retain the explicit Fragment VNodes, but gt-vue's current serializer deliberately treats them as transparent and Vue normalizes the root template whitespace differently; Fragment identity and ambiguous formatting whitespace are outside the initial portable grammar."
+  },
+  {
+    "id": "complex-cases/self-closing-and-void",
+    "hash": "a4c913018a80e6e9",
+    "mode": "excluded",
+    "reason": "Every branch is Fragment-wrapped in React; Vue flattens those wrappers and normalizes surrounding text, shifting the void elements and variable IDs."
+  },
+  {
+    "id": "complex-cases/special-control-characters",
+    "hash": "063494e573a854aa",
+    "mode": "excluded",
+    "reason": "The fixtures are not equivalent: React preserves backslash escape text in a JSX attribute while Vue evaluates a bound expression to actual control characters."
+  },
+  {
+    "id": "complex-cases/special-js-values-in-branches",
+    "hash": "fcce7d4952f02096",
+    "mode": "excluded",
+    "reason": "The Vue fixture compiles bigNumber and negativeScientific as kebab-case branch keys, which are distinct from React's camelCase keys and cannot be inferred at runtime."
+  },
+  {
+    "id": "complex-cases/unicode-special-characters",
+    "hash": "86e21ba52010f7ef",
+    "mode": "semantic-wire-exact",
+    "reason": "Both runtimes serialize all Unicode branch values with the same Branch transformation data, IDs, and hash."
+  },
+  {
+    "id": "complex-cases/whitespace",
+    "hash": "711b912bc06378a1",
+    "mode": "excluded",
+    "reason": "This stress fixture combines non-equivalent content with compiler-normalized whitespace, Fragments, booleans, and nulls, so Vue's compiled VNodes cannot reproduce React's source."
+  },
+  {
+    "id": "complex-cases/whitespace-preservation-complex-structure",
+    "hash": "df2fcc8f82538d01",
+    "mode": "excluded",
+    "reason": "Vue flattens each branch Fragment and normalizes its indentation into different leading and trailing text, losing React's fragment nodes and exact spaces."
+  },
+  {
+    "id": "t-component/simple/context/static",
+    "context": "runtime parity",
+    "hash": "d3507605a23269dc",
+    "mode": "semantic-wire-exact",
+    "reason": "Both runtimes preserve the same static context and mix it into the same literal catalog hash."
+  },
+  {
+    "id": "t-component/simple/expressions/null/fragment-null",
+    "hash": "a013c005483cdd19",
+    "mode": "excluded",
+    "reason": "Vue flattens the Fragment and renders null interpolation as empty text, while React preserves a tagged Fragment containing null semantics."
+  },
+  {
+    "id": "t-component/simple/expressions/null/plain-null",
+    "hash": "471b9124c31817e9",
+    "mode": "excluded",
+    "reason": "Vue exposes null interpolation as an empty text value, which is indistinguishable from authored empty text and cannot recover React's null child."
+  },
+  {
+    "id": "t-component/simple/expressions/static-boolean/array",
+    "hash": "9ff224ca1118e4df",
+    "mode": "excluded",
+    "reason": "Vue stringifies and coalesces the boolean interpolations after flattening the Fragment, whereas React preserves a fragment node with boolean children."
+  },
+  {
+    "id": "t-component/simple/expressions/static-boolean/false",
+    "hash": "d98d8886a31c98f3",
+    "mode": "excluded",
+    "reason": "Vue interpolation supplies the text false rather than a typed boolean, and the runtime cannot distinguish it from an authored string."
+  },
+  {
+    "id": "t-component/simple/expressions/static-boolean/fragment-false",
+    "hash": "a013c005483cdd19",
+    "mode": "excluded",
+    "reason": "Vue both flattens the Fragment and stringifies false, losing the tagged wrapper and typed boolean that React preserves."
+  },
+  {
+    "id": "t-component/simple/expressions/static-boolean/fragment-true",
+    "hash": "200db4fbcabc7d06",
+    "mode": "excluded",
+    "reason": "Vue both flattens the Fragment and stringifies true, losing the tagged wrapper and typed boolean that React preserves."
+  },
+  {
+    "id": "t-component/simple/expressions/static-boolean/true",
+    "hash": "73b6b211a4122ba8",
+    "mode": "excluded",
+    "reason": "Vue interpolation supplies the text true rather than a typed boolean, and the runtime cannot distinguish it from an authored string."
+  },
+  {
+    "id": "t-component/simple/expressions/static-number",
+    "hash": "4d7c200090ca2696",
+    "mode": "semantic-wire-exact",
+    "reason": "Both frameworks serialize the static number to the same text source and hash."
+  },
+  {
+    "id": "t-component/simple/expressions/static-special-identifiers",
+    "hash": "4f82a98ad0b111d9",
+    "mode": "excluded",
+    "reason": "The Vue extractor rejects these dynamic special identifiers, and Vue coalesces their runtime interpolation output after null and undefined disappear, so the React array cannot be recovered."
+  },
+  {
+    "id": "t-component/simple/expressions/static-string",
+    "hash": "9373218d961a8520",
+    "mode": "semantic-wire-exact",
+    "reason": "Both frameworks serialize the static string expression to the same source and hash."
+  },
+  {
+    "id": "t-component/simple/expressions/static-template",
+    "hash": "c8681c983afc3a29",
+    "mode": "semantic-wire-exact",
+    "reason": "Both frameworks serialize the static template literal to the same source and hash."
+  },
+  {
+    "id": "t-component/simple/misc/customcomponents",
+    "hash": "0a4baa9bf7d3c242",
+    "mode": "excluded",
+    "reason": "Vue intentionally treats arbitrary custom-component slots as opaque, so T cannot inspect the Link and Button slot text that React serializes."
+  },
+  {
+    "id": "t-component/simple/misc/localeselector",
+    "hash": "354f3fe65565abba",
+    "mode": "semantic-wire-exact",
+    "reason": "The childless opaque custom component has the same ID, semantic wire record, and hash after ordinary element labels are normalized."
+  },
+  {
+    "id": "t-component/simple/plain-text/plain-text",
+    "hash": "0894d32c42fe7e31",
+    "mode": "semantic-wire-exact",
+    "reason": "The plain text source and hash already match exactly."
+  },
+  {
+    "id": "t-component/simple/plain-text/plain-text-deeply-nested",
+    "hash": "8a7e316169324f40",
+    "mode": "semantic-wire-exact",
+    "reason": "The complete nested element structure, IDs, text, and hash already match exactly."
+  },
+  {
+    "id": "t-component/simple/plain-text/plain-text-nested",
+    "hash": "7bf637c4fa920fb5",
+    "mode": "semantic-wire-exact",
+    "reason": "The nested element structure, IDs, text, and hash match after ordinary element labels are normalized."
+  },
+  {
+    "id": "t-component/simple/plain-text/plain-text-nested-fragment",
+    "hash": "7bf637c4fa920fb5",
+    "mode": "excluded",
+    "reason": "The compiled Vue child retains its explicit Fragment VNode, but gt-vue's current serializer deliberately treats Fragment as transparent; explicit Fragment identity is outside the initial portable grammar."
+  },
+  {
+    "id": "t-component/simple/plain-text/plain-text-siblings",
+    "hash": "743972847e294775",
+    "mode": "semantic-wire-exact",
+    "reason": "The sibling text boundaries, nested element, IDs, and hash already match exactly."
+  },
+  {
+    "id": "t-component/simple/special-react-components",
+    "hash": "4c76e787e705659e",
+    "mode": "excluded",
+    "reason": "The compiled Vue children retain the explicit empty Fragment VNode, but gt-vue's current serializer deliberately treats it as transparent; this Fragment-sensitive case also uses framework-specific Suspense semantics outside the initial portable grammar."
+  },
+  {
+    "id": "variable-components/currency/simple/basic",
+    "hash": "ca1ff7d6802b1d46",
+    "mode": "semantic-wire-exact",
+    "reason": "Both runtimes produce the same generated currency variable key, type, ID, source, and hash."
+  },
+  {
+    "id": "variable-components/currency/simple/siblings",
+    "hash": "2084cabfb2ecd9cd",
+    "mode": "semantic-wire-exact",
+    "reason": "The sibling text and generated currency variable wire data already match exactly."
+  },
+  {
+    "id": "variable-components/currency/simple/variable",
+    "hash": "7bde2306205fa50a",
+    "mode": "semantic-wire-exact",
+    "reason": "All generated currency variables have identical order, IDs, keys, types, source, and hash."
+  },
+  {
+    "id": "variable-components/datetime/simple/basic",
+    "hash": "1b218e0af4bb7cf8",
+    "mode": "semantic-wire-exact",
+    "reason": "Both runtimes produce the same generated date variable wire data and hash."
+  },
+  {
+    "id": "variable-components/datetime/simple/siblings",
+    "hash": "ec6838ca65e06e9c",
+    "mode": "semantic-wire-exact",
+    "reason": "The sibling text and generated date variable wire data already match exactly."
+  },
+  {
+    "id": "variable-components/datetime/simple/variable",
+    "hash": "b31170adc0017f5d",
+    "mode": "semantic-wire-exact",
+    "reason": "All generated date variables have identical order, IDs, keys, types, source, and hash."
+  },
+  {
+    "id": "variable-components/num/simple/basic",
+    "hash": "2280bcd71389dedf",
+    "mode": "semantic-wire-exact",
+    "reason": "Both runtimes produce the same generated number variable wire data and hash."
+  },
+  {
+    "id": "variable-components/num/simple/siblings",
+    "hash": "e8390dd22a8dec20",
+    "mode": "semantic-wire-exact",
+    "reason": "The sibling text and generated number variable wire data already match exactly."
+  },
+  {
+    "id": "variable-components/num/simple/variable",
+    "hash": "d95f311f07b58f05",
+    "mode": "semantic-wire-exact",
+    "reason": "All generated number variables have identical order, IDs, keys, types, source, and hash."
+  },
+  {
+    "id": "variable-components/static/branches",
+    "hash": "a013c005483cdd19",
+    "mode": "excluded",
+    "reason": "React's source is a Derive expansion map, while gt-vue does not support Derive and the Vue fixture substitutes a manually authored Branch structure."
+  },
+  {
+    "id": "variable-components/static/simple",
+    "hash": "a013c005483cdd19",
+    "mode": "excluded",
+    "reason": "React's Derive runtime enumerates a static content map, while the Vue fixture manually rewrites it as Branch components; these are different wire semantics."
+  },
+  {
+    "id": "variable-components/static/ternaries",
+    "hash": "a013c005483cdd19",
+    "mode": "excluded",
+    "reason": "React uses unsupported Derive output with a static content map, while the Vue fixture replaces it with a Branch and therefore is not equivalent at runtime."
+  },
+  {
+    "id": "variable-components/var/simple/basic",
+    "hash": "933fa7740fe8c681",
+    "mode": "semantic-wire-exact",
+    "reason": "Both runtimes produce the same generated Var key, type, ID, source, and hash."
+  },
+  {
+    "id": "variable-components/var/simple/empty",
+    "hash": "933fa7740fe8c681",
+    "mode": "semantic-wire-exact",
+    "reason": "The empty Var remains an identical generated variable record and hash in both fixtures."
+  },
+  {
+    "id": "variable-components/var/simple/name",
+    "hash": "5313ec64034eb6b2",
+    "mode": "excluded",
+    "reason": "React's three explicit Var names are omitted from the Vue fixture, so gt-vue only receives auto-generated variable keys and cannot recover test1, test2, or test3."
+  },
+  {
+    "id": "variable-components/var/simple/siblings",
+    "hash": "5aa66fd8e225d406",
+    "mode": "semantic-wire-exact",
+    "reason": "The sibling text and generated Var record already match exactly."
+  },
+  {
+    "id": "variable-components/var/simple/variable",
+    "hash": "aec76c6e76ba1b89",
+    "mode": "semantic-wire-exact",
+    "reason": "All generated Var records have identical order, IDs, keys, types, source, and hash."
+  }
+]

--- a/tests/seeds/branching-components/branch/complex/big/page.vue
+++ b/tests/seeds/branching-components/branch/complex/big/page.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import { Fragment } from 'vue';
+import { Branch, Currency, DateTime, Plural, T, Var } from 'gt-vue';
+
+const variable = 'test';
+const createdAt = new Date(0);
+const multilineFile = `
+            Multiline
+            File
+          `;
+</script>
+
+<template><T><Plural :n="1" one="File" other="Files" /><Branch branch="file" file="file.svg" directory="public" /><Plural :n="1" one="File" :other="42" /><Plural :n="1" :one="true" :other="false" /><Plural :n="1" :one="null" other="Files" /><Plural :n="1" :one="`File`" :other="`Files`" /><Plural :n="1" one="File" :other="42" /><Plural :n="1"><template #one><Fragment>Single file</Fragment></template><template #other><Fragment>Multiple files</Fragment></template></Plural><Plural :n="1"><template #one><span>Single file</span></template><template #other><span>Multiple files</span></template></Plural><Plural :n="1"><template #one><Var>{{ variable }}</Var></template><template #other><Fragment>Multiple <Var>{{ variable }}</Var>s</Fragment></template></Plural><div><Fragment>Yo</Fragment><Var>test</Var></div><Plural :n="1"><template #one><Var>{{ variable }}</Var></template><template #other><div><Fragment>Multiple <Var>{{ variable }}</Var>s</Fragment></div></template></Plural><Plural :n="1" other="Multiple top-level items"><template #one><Branch branch="type"><template #file><Plural :n="1" other="Multiple nested files"><template #one><Fragment>Single nested file</Fragment></template></Plural></template><template #directory><Fragment>Public directory</Fragment></template></Branch></template></Plural><Plural :n="1" one="" other="Files" /><Plural :n="1" one="File" other="" /><Plural :n="1" one="   File   " other="   Files   " /><Plural :n="1" :one="multilineFile" other="Files" /><Plural :n="1" one="File with emoji 📁" other="Files with emoji 📁📂" /><Branch branch="file" file="special-chars!@#$%^&amp;*().svg" directory="unicode-path-ñáéíóú" /><div>hello</div><Branch branch="level1" option2="Level 1 option 2"><template #option1><Branch branch="level2" option2="Level 2 option 2"><template #option1><Plural :n="1"><template #one><Branch branch="level3"><template #option1><Fragment>Deep option 1</Fragment></template><template #option2><Var>{{ variable }}</Var></template></Branch></template><template #other><Branch branch="level3"><template #option1><Currency :value="100" currency="USD" /></template><template #option2><DateTime :value="createdAt" /></template></Branch></template></Plural></template></Branch></template></Branch></T></template>

--- a/tests/seeds/branching-components/branch/complex/composite/page.vue
+++ b/tests/seeds/branching-components/branch/complex/composite/page.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+import { Branch, T, Var } from 'gt-vue';
+
+const name = 'John';
+</script>
+
+<template><T><Branch :branch="name"><template #John><p>Good morning <Var>{{ name }}</Var></p></template><template #Rose><p>Good evening <Var>{{ name }}</Var></p></template></Branch></T></template>

--- a/tests/seeds/branching-components/branch/complex/nestedbranches/page.vue
+++ b/tests/seeds/branching-components/branch/complex/nestedbranches/page.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts">
+import { Branch, T } from 'gt-vue';
+</script>
+
+<template><T><Branch branch="morning" evening="Good evening"><template #morning><Branch branch="time" morning="Good morning" evening="Good evening" /></template></Branch></T></template>

--- a/tests/seeds/branching-components/branch/simple/basic/page.vue
+++ b/tests/seeds/branching-components/branch/simple/basic/page.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts">
+import { Branch, T } from 'gt-vue';
+</script>
+
+<template><T><Branch branch="morning" morning="Good morning" evening="Good evening" /></T></template>

--- a/tests/seeds/branching-components/branch/simple/default/page.vue
+++ b/tests/seeds/branching-components/branch/simple/default/page.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts">
+import { Branch, T } from 'gt-vue';
+</script>
+
+<template><T><Branch branch="morning" morning="Good morning" evening="Good evening">default</Branch></T></template>

--- a/tests/seeds/branching-components/branch/simple/empty/page.vue
+++ b/tests/seeds/branching-components/branch/simple/empty/page.vue
@@ -1,0 +1,6 @@
+<script setup lang="ts">
+import { Fragment } from 'vue';
+import { Branch, T } from 'gt-vue';
+</script>
+
+<template><T><Branch branch="morning" evening=""><template #morning><Fragment /></template></Branch></T></template>

--- a/tests/seeds/branching-components/branch/simple/jsx-branch/page.vue
+++ b/tests/seeds/branching-components/branch/simple/jsx-branch/page.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts">
+import { Branch, T } from 'gt-vue';
+</script>
+
+<template><T><Branch branch="morning"><template #morning><div>Good morning</div></template><template #evening><div>Good evening</div></template></Branch></T></template>

--- a/tests/seeds/branching-components/branch/simple/stringliterals/page.vue
+++ b/tests/seeds/branching-components/branch/simple/stringliterals/page.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts">
+import { Branch, T } from 'gt-vue';
+</script>
+
+<template><T><Branch branch="morning" morning="Good morning" evening="Good evening" /><Branch branch="morning" :morning="'Good morning'" evening="Good evening" /><Branch branch="morning" :morning="`Good morning`" evening="Good evening" /><Branch branch="morning" :morning="`Good morning`" evening="Good evening">{{ 'default' }}</Branch><Branch branch="morning" :morning="`Good morning`" evening="Good evening">{{ `default` }}</Branch></T></template>

--- a/tests/seeds/branching-components/plural/complex/composite/page.vue
+++ b/tests/seeds/branching-components/plural/complex/composite/page.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+import { Num, Plural, T } from 'gt-vue';
+
+const count = 1;
+</script>
+
+<template><T><Plural :n="count"><template #one><p>There is <Num :value="count" /> item</p></template><template #other><p>There are <Num :value="count" /> items</p></template></Plural></T></template>

--- a/tests/seeds/branching-components/plural/complex/nestedbranches/page.vue
+++ b/tests/seeds/branching-components/plural/complex/nestedbranches/page.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts">
+import { Plural, T } from 'gt-vue';
+</script>
+
+<template><T><Plural :n="1" other="Good evening"><template #one><Plural :n="1" one="Good morning" other="Good evening" /></template></Plural></T></template>

--- a/tests/seeds/branching-components/plural/simple/basic/page.vue
+++ b/tests/seeds/branching-components/plural/simple/basic/page.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts">
+import { Plural, T } from 'gt-vue';
+</script>
+
+<template><T><Plural :n="1" one="Good morning" other="Good evening" /></T></template>

--- a/tests/seeds/branching-components/plural/simple/default/page.vue
+++ b/tests/seeds/branching-components/plural/simple/default/page.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts">
+import { Plural, T } from 'gt-vue';
+</script>
+
+<template><T><Plural :n="1" one="Good morning" other="Good evening">default</Plural></T></template>

--- a/tests/seeds/branching-components/plural/simple/empty/page.vue
+++ b/tests/seeds/branching-components/plural/simple/empty/page.vue
@@ -1,0 +1,6 @@
+<script setup lang="ts">
+import { Fragment } from 'vue';
+import { Plural, T } from 'gt-vue';
+</script>
+
+<template><T><Plural :n="1" other=""><template #one><Fragment /></template></Plural></T></template>

--- a/tests/seeds/branching-components/plural/simple/jsx-branch/page.vue
+++ b/tests/seeds/branching-components/plural/simple/jsx-branch/page.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts">
+import { Plural, T } from 'gt-vue';
+</script>
+
+<template><T><Plural :n="1"><template #one><div>Good morning</div></template><template #other><div>Good evening</div></template></Plural></T></template>

--- a/tests/seeds/branching-components/plural/simple/stringliterals/page.vue
+++ b/tests/seeds/branching-components/plural/simple/stringliterals/page.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts">
+import { Plural, T } from 'gt-vue';
+</script>
+
+<template><T><Plural :n="1" one="Good morning" other="Good evening" /><Plural :n="1" :one="'Good morning'" other="Good evening" /><Plural :n="1" :one="`Good morning`" other="Good evening" /><Plural :n="1" :one="`Good morning`" other="Good evening">{{ 'default' }}</Plural><Plural :n="1" :one="`Good morning`" other="Good evening">{{ `default` }}</Plural></T></template>

--- a/tests/seeds/complex-cases/all-empty-branch-attr/page.vue
+++ b/tests/seeds/complex-cases/all-empty-branch-attr/page.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import { Branch, T } from 'gt-vue';
+import { Fragment } from 'vue';
+</script>
+
+<template>
+  <T>
+    <Branch branch="type" option1="" :option2="null" :option4="false">
+      <template #option3><Fragment /></template>
+    </Branch>
+  </T>
+</template>

--- a/tests/seeds/complex-cases/all-plual-forms/page.vue
+++ b/tests/seeds/complex-cases/all-plual-forms/page.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import { Plural, T } from 'gt-vue';
+
+const count = 5;
+</script>
+
+<template>
+  <T>
+    <Plural
+      :n="count"
+      zero="zero items"
+      one="one item"
+      two="two items"
+      few="few items"
+      many="many items"
+      other="other items"
+      singular="singular form"
+      plural="plural form"
+    />
+  </T>
+</template>

--- a/tests/seeds/complex-cases/attribute-props/page.vue
+++ b/tests/seeds/complex-cases/attribute-props/page.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import { Branch, T } from 'gt-vue';
+</script>
+
+<template>
+  <T>
+    <Branch branch="element">
+      <template #input><input placeholder="Branch placeholder" title="Branch title" /></template>
+      <template #image>
+        <img src="test.jpg" alt="Branch image" title="Branch image title" />
+      </template>
+      <template #link>
+        <a href="#" aria-label="Branch link" aria-describedby="desc">Link</a>
+      </template>
+    </Branch>
+  </T>
+</template>

--- a/tests/seeds/complex-cases/boundary-numeric-values/page.vue
+++ b/tests/seeds/complex-cases/boundary-numeric-values/page.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import { Plural, T } from 'gt-vue';
+
+const count = 5;
+</script>
+
+<template>
+  <T>
+    <Plural
+      :n="count"
+      :zero="0.0"
+      :one="1e-323"
+      :two="5e-324"
+      :few="1.7976931348623157e308"
+      :many="-1.7976931348623157e308"
+      :other="2.2250738585072014e-308"
+    />
+  </T>
+</template>

--- a/tests/seeds/complex-cases/complex-fragment-nesting/page.vue
+++ b/tests/seeds/complex-cases/complex-fragment-nesting/page.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { Currency, Num, Plural, T, Var } from 'gt-vue';
+import { Fragment } from 'vue';
+
+const amount = 100.5;
+const count = 5;
+</script>
+
+<template>
+  <T>
+    <Plural :n="count">
+      <template #singular>
+        <Fragment>
+          Outer fragment
+          <Fragment>
+            Nested fragment with
+            <Var>variable</Var>
+            <Fragment>
+              Deep nested with
+              <Num :value="count" />
+              <Fragment>More nesting</Fragment>
+            </Fragment>
+          </Fragment>
+          Back to outer
+        </Fragment>
+      </template>
+      <template #plural>
+        <div>
+          <Fragment>Fragment in div</Fragment>
+          <span>
+            <Fragment>
+              Fragment in span with {{ ' ' }}
+              <Currency :value="amount" currency="USD" />
+            </Fragment>
+          </span>
+        </div>
+      </template>
+    </Plural>
+  </T>
+</template>

--- a/tests/seeds/complex-cases/component-nesting-edge-cases/page.vue
+++ b/tests/seeds/complex-cases/component-nesting-edge-cases/page.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { Branch, Currency, Plural, T, Var } from 'gt-vue';
+import { Fragment } from 'vue';
+
+const amount = 100.5;
+const count = 5;
+</script>
+
+<template>
+  <T>
+    <Branch branch="structure" flat="Simple flat content">
+      <template #nested>
+        <div>
+          <Plural :n="count">
+            <template #singular>
+              <span>
+                Nested plural:
+                <Var>single</Var>
+              </span>
+            </template>
+            <template #plural>
+              <Branch branch="inner" option1="Double nested!">
+                <template #option2>
+                  <Fragment>
+                    With
+                    <Currency :value="amount" currency="USD" />
+                  </Fragment>
+                </template>
+              </Branch>
+            </template>
+          </Plural>
+        </div>
+      </template>
+    </Branch>
+  </T>
+</template>

--- a/tests/seeds/complex-cases/deeply-nested-branch-components/page.vue
+++ b/tests/seeds/complex-cases/deeply-nested-branch-components/page.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { Branch, T, Var } from 'gt-vue';
+import { Fragment } from 'vue';
+
+const location = 'home';
+</script>
+
+<template>
+  <T>
+    <Branch :branch="location" work="At the office">
+      <template #home>
+        <Branch branch="time" morning="Good morning at home">
+          <template #evening>
+            <Fragment>
+              Good evening at
+              <Var>home</Var>
+              with {{ ' ' }}
+              <Branch branch="weather" sunny="sunny skies" rainy="rainy weather" />
+            </Fragment>
+          </template>
+        </Branch>
+      </template>
+    </Branch>
+  </T>
+</template>

--- a/tests/seeds/complex-cases/different-number-formats/page.vue
+++ b/tests/seeds/complex-cases/different-number-formats/page.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import { Branch, Plural, T } from 'gt-vue';
+</script>
+
+<template>
+  <T>
+    <Plural :n="1" :zero="0" :one="1" :two="-1" :few="3.14159" :many="1e6" :other="0xff" />
+    <Branch branch="status" :active="true" :inactive="false" :unknown="null" pending="" />
+    <Plural
+      :n="1"
+      singular="Single 'quotes' inside"
+      plural='Double "quotes" inside'
+      other="Template with 'both' &quot;types&quot;"
+    />
+  </T>
+</template>

--- a/tests/seeds/complex-cases/duplicate-branches/page.vue
+++ b/tests/seeds/complex-cases/duplicate-branches/page.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { Branch, Num, T, Var } from 'gt-vue';
+import { Fragment } from 'vue';
+
+const count = 5;
+</script>
+
+<template>
+  <T>
+    <Branch branch="copy">
+      <template #version1>
+        <Fragment>
+          Identical content with
+          <Var>same variable</Var>
+          and {{ ' ' }}
+          <Num :value="count" />
+        </Fragment>
+      </template>
+      <template #version2>
+        <Fragment>
+          Identical content with
+          <Var>same variable</Var>
+          and {{ ' ' }}
+          <Num :value="count" />
+        </Fragment>
+      </template>
+      <template #different>
+        <Fragment>
+          Different content with
+          <Var>other variable</Var>
+          and {{ ' ' }}
+          <Num :value="count + 1" />
+        </Fragment>
+      </template>
+    </Branch>
+  </T>
+</template>

--- a/tests/seeds/complex-cases/empty-fragments/page.vue
+++ b/tests/seeds/complex-cases/empty-fragments/page.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import { Plural, T } from 'gt-vue';
+</script>
+
+<template>
+  <T>
+    <Plural :n="1" plural="files"><template #singular></template></Plural>
+  </T>
+</template>

--- a/tests/seeds/complex-cases/empty-minimal-content/page.vue
+++ b/tests/seeds/complex-cases/empty-minimal-content/page.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { Branch, T } from 'gt-vue';
+</script>
+
+<template>
+  <T>
+    <Branch branch="content" empty="" space=" " :newline="'\n'" :tab="'\t'" single-char="x">
+      <template #minimal><span></span></template>
+    </Branch>
+  </T>
+</template>

--- a/tests/seeds/complex-cases/five-level-nesting/page.vue
+++ b/tests/seeds/complex-cases/five-level-nesting/page.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { Branch, Plural, T, Var } from 'gt-vue';
+</script>
+
+<template>
+  <T>
+    <Branch branch="level1" option2="level1 option2">
+      <template #option1>
+        <Plural :n="1" plural="level1 plurals">
+          <template #singular>
+            <Branch branch="level2" option2="level2 option2">
+              <template #option1>
+                <Plural :n="1" plural="level2 plurals">
+                  <template #singular>
+                    <Branch branch="level3" option2="level3 option2">
+                      <template #option1>
+                        <Plural :n="1" plural="deep files">
+                          <template #singular><Var>deeply nested variable</Var></template>
+                        </Plural>
+                      </template>
+                    </Branch>
+                  </template>
+                </Plural>
+              </template>
+            </Branch>
+          </template>
+        </Plural>
+      </template>
+    </Branch>
+  </T>
+</template>

--- a/tests/seeds/complex-cases/fragments-and-elements/page.vue
+++ b/tests/seeds/complex-cases/fragments-and-elements/page.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import { T } from 'gt-vue';
+import { Fragment } from 'vue';
+</script>
+
+<template>
+  <T>
+    <Fragment>text before</Fragment>
+    <div>element</div>
+    <Fragment>text after</Fragment>
+  </T>
+</template>

--- a/tests/seeds/complex-cases/fragments-with-only-whitespace/page.vue
+++ b/tests/seeds/complex-cases/fragments-with-only-whitespace/page.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import { Plural, T } from 'gt-vue';
+</script>
+
+<template>
+  <T>
+    <Plural :n="1">
+      <template #singular>{{ ' ' }}</template>
+      <template #plural></template>
+    </Plural>
+  </T>
+</template>

--- a/tests/seeds/complex-cases/leading-trailing-spaces-with-diff-sibs-pos/page.vue
+++ b/tests/seeds/complex-cases/leading-trailing-spaces-with-diff-sibs-pos/page.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import { T } from 'gt-vue';
+</script>
+
+<template>
+  <T>
+    <div>before</div>
+    space after div space before div
+    <div>after</div>
+    <div>first</div>
+    middle space
+    <div>last</div>
+  </T>
+</template>

--- a/tests/seeds/complex-cases/long-attributes/page.vue
+++ b/tests/seeds/complex-cases/long-attributes/page.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import { Plural, T } from 'gt-vue';
+</script>
+
+<template>
+  <T>
+    <Plural
+      :n="1"
+      singular="This is an extremely long string value that tests how the plugin handles very long attribute content that might span multiple lines and contain various characters including unicode ñáéíóú and emoji 📁📂🎉"
+      plural="This is an extremely long template literal that tests how the plugin handles very long template content with potential whitespace normalization issues and various characters"
+    />
+  </T>
+</template>

--- a/tests/seeds/complex-cases/long-content-string/page.vue
+++ b/tests/seeds/complex-cases/long-content-string/page.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { Branch, Currency, Num, T, Var } from 'gt-vue';
+import { Fragment } from 'vue';
+</script>
+
+<template>
+  <T>
+    <Branch
+      branch="size"
+      short="Brief"
+      long="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+    >
+      <template #mixed>
+        <Fragment>
+          Very long text with
+          <Var>embedded variables</Var>
+          that continues for a very long time and includes multiple
+          <Num :value="9999999" />
+          {{ ' ' }}numeric values and{{ ' ' }}
+          <Currency :value="1234567.89" currency="USD" />
+          monetary amounts spread throughout the content to test how the algorithm handles very
+          large content blocks with mixed variable types.
+        </Fragment>
+      </template>
+    </Branch>
+  </T>
+</template>

--- a/tests/seeds/complex-cases/many-edge-cases/page.vue
+++ b/tests/seeds/complex-cases/many-edge-cases/page.vue
@@ -1,0 +1,212 @@
+<script setup lang="ts">
+import { Branch, Currency, DateTime, Num, Plural, T, Var } from 'gt-vue';
+import { Fragment } from 'vue';
+
+const count = 42;
+const price = 9.99;
+const timestamp = new Date(0);
+</script>
+
+<template>
+  <T>
+    <Plural :n="1">
+      <template #singular>{{ ' ' }}</template>
+      <template #plural>{{ '\t' }}</template>
+    </Plural>
+    <span>start</span>
+    <span>middle</span>
+    <span>end</span>
+    <Plural :n="1" plural="files">
+      <template #singular>
+        <Fragment>
+          <Fragment><Fragment>deep fragment nesting</Fragment></Fragment>
+        </Fragment>
+      </template>
+    </Plural>
+    <Branch branch="mixed" option2="simple">
+      <template #option1>
+        <Fragment>
+          text
+          <span>element</span>
+          {{ 42 }}{{ true }}{{ null }}more text
+        </Fragment>
+      </template>
+    </Branch>
+    <Plural
+      :n="1"
+      :zero="0.0"
+      :one="-0"
+      :two="999999999999"
+      :few="-999999999999"
+      :many="0.000000001"
+      :other="-0.000000001"
+    />
+    <Branch
+      branch="floats"
+      :tiny="0.1"
+      :precise="3.141592653589793"
+      :scientific="1.23e-10"
+      :big-scientific="1.23e10"
+    />
+    <Branch branch="hex" :small="0x1" :medium="0xabc" :large="0xdeadbeef" :mixed="0x123abc" />
+    <Plural
+      :n="1"
+      singular="Quotes: &quot; and '"
+      plural="Backslashes: \ and \n and \t"
+      other="Unicode: \u0041 and \x41"
+    />
+    <Branch
+      branch="raw"
+      json='{"key": "value", "array": [1,2,3]}'
+      regex="/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$/"
+      path="C:\Program Files\App\file.exe"
+    />
+    <Plural :n="1" :zero="false" :one="true" :two="null" few="" :many="0" other="false" />
+    <Branch
+      branch="booleans"
+      :truthy="true"
+      :falsy="false"
+      :nullish="null"
+      empty=""
+      :zero="0"
+      string-true="true"
+      string-false="false"
+    />
+    <Plural
+      :n="1"
+      singular="Template with ${escaped} and `backticks`"
+      plural="Multi line template literal"
+      other="Mixed &quot;quotes&quot; and 'apostrophes' in template"
+    />
+    <Plural
+      :n="count"
+      zero=""
+      one="1"
+      two="2"
+      few="few"
+      many="many"
+      other="other"
+      singular="sing"
+      plural="plur"
+    />
+    <Branch
+      branch="many_options"
+      a="option a"
+      b="option b"
+      c="option c"
+      d="option d"
+      e="option e"
+      :h="42"
+      :i="true"
+      :j="null"
+    >
+      <template #f><Fragment>fragment f</Fragment></template>
+      <template #g><span>element g</span></template>
+    </Branch>
+    <Var>underscore content</Var>
+    <Var>camel case content</Var>
+    <Num :value="42" />
+    <Num :value="-42" />
+    <Num :value="3.14159" />
+    <Currency :value="price" currency="USD" />
+    <Currency :value="1234.56" currency="EUR" />
+    <Currency :value="1000" currency="JPY" />
+    <DateTime :value="timestamp" />
+    <DateTime :value="0" />
+    <Branch branch="l1" option2="l1 end">
+      <template #option1>
+        <Plural :n="1" plural="l1 plural">
+          <template #singular>
+            <Branch branch="l2" option2="l2 end">
+              <template #option1>
+                <Plural :n="1" plural="l2 plural">
+                  <template #singular>
+                    <Branch branch="l3" option2="l3 end">
+                      <template #option1><Var>maximum depth</Var></template>
+                    </Branch>
+                  </template>
+                </Plural>
+              </template>
+            </Branch>
+          </template>
+        </Plural>
+      </template>
+    </Branch>
+    <div class="wrapper">
+      <Branch branch="outer" option2="simple option">
+        <template #option1>
+          <Fragment>
+            <span>Before plural</span>
+            <Plural :n="count">
+              <template #singular>
+                <div>
+                  Single item:
+                  <Num :value="count" />
+                  costing {{ ' ' }}
+                  <Currency :value="price" currency="USD" />
+                  at
+                  <DateTime :value="timestamp" />
+                  in {{ ' ' }}
+                  <Branch branch="location" work="office">
+                    <template #home>
+                      <Fragment>
+                        home folder with
+                        <Var>variable</Var>
+                      </Fragment>
+                    </template>
+                  </Branch>
+                </div>
+              </template>
+              <template #plural>
+                <div>
+                  Multiple items:
+                  <Num :value="count" />
+                  costing {{ ' ' }}
+                  <Currency :value="price * count" currency="USD" />
+                  <Fragment>with fragments</Fragment>
+                  and
+                  <span>elements</span>
+                </div>
+              </template>
+            </Plural>
+            <span>After plural</span>
+          </Fragment>
+        </template>
+      </Branch>
+    </div>
+    <Branch
+      branch="unicode"
+      latin="àáâãäåæçèéêëìíîï"
+      cyrillic="абвгдежзийклмнопрстуфхцчшщъыьэюя"
+      greek="αβγδεζηθικλμνξοπρστυφχψω"
+      arabic="ابتثجحخدذرزسشصضطظعغفقكلمنهوي"
+      hebrew="אבגדהוזחטיכלמנסעפצקרשת"
+      chinese="你好世界中文测试"
+      japanese="こんにちは世界ひらがなカタカナ漢字"
+      korean="안녕하세요세계한글테스트"
+      emoji="🌍🌎🌏🚀⚡️🎉💯✨🔥💎🌟⭐️🎯"
+    />
+    <Plural
+      :n="1"
+      singular="English left-to-right"
+      plural="العربية من اليمين إلى اليسار"
+      other="עברית מימין לשמאל"
+    />
+    <Branch branch="consistency">
+      <template #path_a>
+        <div>
+          <Var>var1</Var>
+          <Num :value="42" />
+          <Currency :value="9.99" currency="USD" />
+        </div>
+      </template>
+      <template #path_b>
+        <Fragment>
+          <Var>var1</Var>
+          <Num :value="42" />
+          <Currency :value="9.99" currency="USD" />
+        </Fragment>
+      </template>
+    </Branch>
+  </T>
+</template>

--- a/tests/seeds/complex-cases/mixed-component-types/page.vue
+++ b/tests/seeds/complex-cases/mixed-component-types/page.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { Branch, Currency, DateTime, Num, Plural, T } from 'gt-vue';
+import { Fragment } from 'vue';
+
+const amount = 100.5;
+const count = 5;
+const date = new Date(0);
+</script>
+
+<template>
+  <T>
+    <div class="container">
+      <Plural :n="count">
+        <template #singular>
+          <div>
+            You have
+            <Num :value="count" />
+            item costing {{ ' ' }}
+            <Currency :value="amount" currency="USD" />
+            on
+            <DateTime :value="date" />
+            in the
+            <Branch branch="location" home="home folder">
+              <template #work><Fragment>work directory</Fragment></template>
+            </Branch>
+          </div>
+        </template>
+        <template #plural>
+          <div>
+            You have
+            <Num :value="count" />
+            items costing {{ ' ' }}
+            <Currency :value="amount * count" currency="USD" />
+            <Fragment>fragments mixed</Fragment>
+            with elements
+          </div>
+        </template>
+      </Plural>
+    </div>
+  </T>
+</template>

--- a/tests/seeds/complex-cases/mixed-element-types-in-branches/page.vue
+++ b/tests/seeds/complex-cases/mixed-element-types-in-branches/page.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { Currency, DateTime, Num, Plural, T, Var } from 'gt-vue';
+import { Fragment } from 'vue';
+
+const amount = 100.5;
+const count = 5;
+const date = new Date(0);
+</script>
+
+<template>
+  <T>
+    <Plural :n="count">
+      <template #singular>
+        <article>
+          <h1>Single Item</h1>
+          <p>
+            Description with
+            <Var>details</Var>
+          </p>
+          <footer>
+            <Fragment>
+              Footer with
+              <Currency :value="amount" currency="USD" />
+              <span>
+                and
+                <DateTime :value="date" />
+              </span>
+            </Fragment>
+          </footer>
+        </article>
+      </template>
+      <template #plural>
+        <section>
+          <header>
+            <h2>
+              <Num :value="count" />
+              Items
+            </h2>
+          </header>
+          <main>
+            <Fragment>
+              <p>
+                Multiple items totaling {{ ' ' }}
+                <Currency :value="amount * count" currency="USD" />
+              </p>
+              <ul>
+                <li>
+                  Item with
+                  <Var>variable</Var>
+                </li>
+              </ul>
+            </Fragment>
+          </main>
+        </section>
+      </template>
+    </Plural>
+  </T>
+</template>

--- a/tests/seeds/complex-cases/more-extreme-edge-cases/page.vue
+++ b/tests/seeds/complex-cases/more-extreme-edge-cases/page.vue
@@ -1,0 +1,307 @@
+<script setup lang="ts">
+import { Branch, Currency, DateTime, Num, Plural, T, Var } from 'gt-vue';
+import { Fragment } from 'vue';
+
+const amount = 123.45;
+const count = 7;
+const date = new Date(0);
+</script>
+
+<template>
+  <T>
+    <Branch branch="test" option4="normal">
+      <template #option1><Fragment>Start middle end</Fragment></template>
+      <template #option2>
+        <Fragment>
+          Before
+          <Fragment />
+          After
+        </Fragment>
+      </template>
+      <template #option3>
+        <Fragment><span>element</span></Fragment>
+      </template>
+    </Branch>
+    <Plural :n="count">
+      <template #singular>
+        <Fragment>
+          Text
+          <Fragment />
+          More text
+        </Fragment>
+      </template>
+      <template #plural>
+        <Fragment>
+          <Fragment>Fragment</Fragment>
+          content
+        </Fragment>
+      </template>
+      <template #other>
+        <Fragment><Fragment /></Fragment>
+      </template>
+    </Plural>
+    <Branch branch="bool">
+      <template #true_val>
+        <Fragment>{{ true }}</Fragment>
+      </template>
+      <template #false_val>
+        <Fragment>{{ false }}</Fragment>
+      </template>
+      <template #mixed_true>
+        <Fragment>Before {{ true }} after</Fragment>
+      </template>
+      <template #mixed_false>
+        <Fragment>Before {{ false }} after</Fragment>
+      </template>
+      <template #multiple>
+        <Fragment>{{ true }}{{ false }}{{ true }}</Fragment>
+      </template>
+    </Branch>
+    <Plural :n="1" other="normal">
+      <template #zero>
+        <Fragment>{{ null }}</Fragment>
+      </template>
+      <template #one><Fragment /></template>
+      <template #two>
+        <Fragment>{{ false }}</Fragment>
+      </template>
+      <template #few>
+        <Fragment>{{ true }}{{ null }}</Fragment>
+      </template>
+      <template #many>
+        <Fragment>Mixed {{ false }} and {{ null }}</Fragment>
+      </template>
+    </Plural>
+    <Branch
+      branch="precision"
+      :tiny="1e-324"
+      :almost-zero="4.9e-324"
+      :epsilon="2.220446049250313e-16"
+      :almost-one="0.9999999999999999"
+      :not-quite-two="1.9999999999999998"
+      :close-to-pi="3.141592653589793"
+    />
+    <Plural
+      :n="count"
+      :zero="1.0"
+      :one="1.0"
+      :two="1.0"
+      :few="5.0e10"
+      :many="5.0e10"
+      :other="5.0e-10"
+    />
+    <Branch branch="space">
+      <template #zero_width><Fragment>word1​word2</Fragment></template>
+      <template #thin_space><Fragment>word1 word2</Fragment></template>
+      <template #hair_space><Fragment>word1 word2</Fragment></template>
+      <template #figure_space><Fragment>word1 word2</Fragment></template>
+      <template #normal><Fragment>word1 word2</Fragment></template>
+    </Branch>
+    <Branch branch="nested">
+      <template #option1>
+        <Fragment>
+          <Fragment>
+            <Fragment>
+              <Fragment>
+                <Fragment>Text</Fragment>
+                <Fragment />
+                <Fragment>More</Fragment>
+              </Fragment>
+            </Fragment>
+            <span>Element</span>
+          </Fragment>
+          <Fragment>Final</Fragment>
+        </Fragment>
+      </template>
+      <template #option2>
+        <Fragment>
+          <Fragment>
+            <Fragment>
+              <Fragment><Fragment>Flat</Fragment></Fragment>
+               
+            </Fragment>
+          </Fragment>
+        </Fragment>
+      </template>
+    </Branch>
+    <Plural :n="count">
+      <template #singular>
+        <Fragment>
+          <Fragment />
+          Content
+          <Fragment />
+          More
+          <Fragment />
+          End
+        </Fragment>
+      </template>
+      <template #plural>
+        <Fragment>
+          Start
+          <Fragment />
+          Middle
+          <Fragment />
+          End
+        </Fragment>
+      </template>
+      <template #other>
+        <Fragment>
+          <Fragment />
+          Text
+          <Fragment><Fragment /></Fragment>
+        </Fragment>
+      </template>
+    </Plural>
+    <Plural :n="1">
+      <template #singular>
+        <Fragment>
+          <Var>v1</Var>
+          <Num :value="1" />
+          <Currency :value="1" currency="USD" />
+          <DateTime :value="date" />
+          <Var>v2</Var>
+          <Num :value="2" />
+          <Currency :value="2" currency="EUR" />
+          <DateTime :value="date" />
+        </Fragment>
+      </template>
+      <template #plural>
+        <Fragment>
+          <DateTime :value="date" />
+          <Currency :value="2" currency="EUR" />
+          <Num :value="2" />
+          <Var>v2</Var>
+          <DateTime :value="date" />
+          <Currency :value="1" currency="USD" />
+          <Num :value="1" />
+          <Var>v1</Var>
+        </Fragment>
+      </template>
+    </Plural>
+    <Plural :n="1" singular="é" plural="é" other="ñ vs ñ" />
+    <Branch
+      branch="emoji"
+      basic="👍"
+      skin-tone="👍🏽"
+      zwj-sequence="👨‍👩‍👧‍👦"
+      flag="🇺🇸"
+      text-vs-emoji="©️ vs ©"
+    />
+    <Plural :n="1" singular="\x41" plural="\u0041" other="\101" />
+    <Branch
+      branch="many"
+      a1="1"
+      a2="2"
+      a3="3"
+      a4="4"
+      a5="5"
+      a6="6"
+      a7="7"
+      a8="8"
+      a9="9"
+      a10="10"
+      b1="1"
+      b2="2"
+      b3="3"
+      b4="4"
+      b5="5"
+      b6="6"
+      b7="7"
+      b8="8"
+      b9="9"
+      b10="10"
+      c1="1"
+      c2="2"
+      c3="3"
+      c4="4"
+      c5="5"
+      c6="6"
+      c7="7"
+      c8="8"
+      c9="9"
+      c10="10"
+    />
+    <Branch branch="outer">
+      <template #path1>
+        <Branch branch="inner">
+          <template #option1>
+            <Fragment>
+              <Var>shared1</Var>
+              <Num :value="2" />
+              <Branch branch="deepest">
+                <template #a><Var>deep1</Var></template>
+                <template #b><Var>deep2</Var></template>
+              </Branch>
+            </Fragment>
+          </template>
+          <template #option2>
+            <Fragment>
+              <Var>shared1</Var>
+              <Num :value="2" />
+            </Fragment>
+          </template>
+        </Branch>
+      </template>
+      <template #path2>
+        <Branch branch="inner">
+          <template #option1>
+            <Fragment>
+              <Var>shared1</Var>
+              <Num :value="2" />
+            </Fragment>
+          </template>
+        </Branch>
+      </template>
+    </Branch>
+    <Branch
+      branch="json"
+      object='{"key": "value"}'
+      array="[1, 2, 3]"
+      nested='{"a": {"b": [1, {"c": true}]}}'
+    />
+    <Branch branch="complex" option2="Simple option for comparison">
+      <template #option1>
+        <Fragment>
+          Start
+          <Plural :n="count">
+            <template #zero>
+              <Fragment>
+                Zero with
+                <Var>var1</Var>
+              </Fragment>
+            </template>
+            <template #one>
+              <Fragment>
+                One with
+                <Num :value="count" />
+              </Fragment>
+            </template>
+            <template #two>
+              <Fragment>
+                Two with
+                <Currency :value="amount" currency="USD" />
+              </Fragment>
+            </template>
+            <template #few>
+              <Fragment>
+                Few with
+                <DateTime :value="date" />
+              </Fragment>
+            </template>
+            <template #many>
+              <Branch branch="nested">
+                <template #c>
+                  <Fragment>{{ 0xff }} and {{ 0o755 }} and {{ 0b1111 }}</Fragment>
+                </template>
+              </Branch>
+            </template>
+            <template #other>
+              <Fragment>Other {{ +0 }} vs {{ -0 }} {{ +1 }} vs {{ -1 }}</Fragment>
+            </template>
+          </Plural>
+          End
+        </Fragment>
+      </template>
+    </Branch>
+  </T>
+</template>

--- a/tests/seeds/complex-cases/multiple-variable-types-in-branch/page.vue
+++ b/tests/seeds/complex-cases/multiple-variable-types-in-branch/page.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { Currency, DateTime, Num, Plural, T, Var } from 'gt-vue';
+import { Fragment } from 'vue';
+
+const amount = 100.5;
+const count = 5;
+const date = new Date(0);
+</script>
+
+<template>
+  <T>
+    <Plural :n="count">
+      <template #singular>
+        <Fragment>
+          Transaction:
+          <Currency :value="amount" currency="USD" />
+          on {{ ' ' }}
+          <DateTime :value="date" />
+          for
+          <Num :value="0.15" />
+          tax with {{ ' ' }}
+          <Var>REF-123</Var>
+        </Fragment>
+      </template>
+      <template #plural>
+        <div>
+          <Currency :value="amount * count" currency="EUR" />
+          total from {{ ' ' }}
+          <Num :value="count" />
+          transactions on
+          <DateTime :value="date" />
+        </div>
+      </template>
+    </Plural>
+  </T>
+</template>

--- a/tests/seeds/complex-cases/multiple-vars-same-keys/page.vue
+++ b/tests/seeds/complex-cases/multiple-vars-same-keys/page.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { Branch, Currency, Num, T, Var } from 'gt-vue';
+
+const amount = 100.5;
+const count = 5;
+const variable = 'test';
+</script>
+
+<template>
+  <T>
+    <Branch branch="type">
+      <template #option1>
+        <div>
+          First:
+          <Var>{{ variable }}</Var>
+          Second:
+          <Num :value="count" />
+          Third:
+          <Currency :value="amount" currency="USD" />
+        </div>
+      </template>
+      <template #option2>
+        <div>
+          First:
+          <Var>{{ variable }}</Var>
+          Second:
+          <Num :value="count" />
+          Third:
+          <Currency :value="amount" currency="USD" />
+        </div>
+      </template>
+    </Branch>
+  </T>
+</template>

--- a/tests/seeds/complex-cases/nested-fragments/page.vue
+++ b/tests/seeds/complex-cases/nested-fragments/page.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import { Plural, T } from 'gt-vue';
+import { Fragment } from 'vue';
+</script>
+
+<template>
+  <T>
+    <Plural :n="1" plural="files">
+      <template #singular>
+        <Fragment>
+          <Fragment>nested</Fragment>
+          fragment
+        </Fragment>
+      </template>
+    </Plural>
+  </T>
+</template>

--- a/tests/seeds/complex-cases/parallel-branches-with-fragments/page.vue
+++ b/tests/seeds/complex-cases/parallel-branches-with-fragments/page.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { Num, Plural, T, Var } from 'gt-vue';
+import { Fragment } from 'vue';
+</script>
+
+<template>
+  <T>
+    <Plural :n="1">
+      <template #singular>
+        <Fragment>
+          <Var>var1</Var>
+          and
+          <Num :value="1" />
+        </Fragment>
+      </template>
+      <template #plural>
+        <div>
+          <Var>var1</Var>
+          and
+          <Num :value="1" />
+        </div>
+      </template>
+    </Plural>
+  </T>
+</template>

--- a/tests/seeds/complex-cases/previous-issues/page.vue
+++ b/tests/seeds/complex-cases/previous-issues/page.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { Branch, Plural, T, Var } from 'gt-vue';
+import { Fragment } from 'vue';
+
+const count = 5;
+const variable = 'test';
+</script>
+
+<template>
+  <T>
+    Normal text
+    <div>nested content</div>
+    more text
+    <Plural
+      :n="count"
+      zero="No files"
+      one="One file"
+      two="Two files"
+      few="Few files"
+      many="Many files"
+      other="Other files"
+    >
+      <template #singular><Fragment>Single file</Fragment></template>
+    </Plural>
+    <Branch branch="context" option1="" option2="   padded   ">
+      <template #option3>
+        <Var>{{ variable }}</Var>
+      </template>
+      <template #option4><Fragment>fragment content</Fragment></template>
+      <template #option5><div>element content</div></template>
+    </Branch>
+  </T>
+</template>

--- a/tests/seeds/complex-cases/self-closing-and-void/page.vue
+++ b/tests/seeds/complex-cases/self-closing-and-void/page.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { Branch, Num, T, Var } from 'gt-vue';
+import { Fragment } from 'vue';
+
+const count = 5;
+</script>
+
+<template>
+  <T>
+    <Branch branch="type">
+      <template #line>
+        <Fragment>
+          <hr />
+          Line break
+          <br />
+          New line
+        </Fragment>
+      </template>
+      <template #image>
+        <Fragment>
+          <img src="test.jpg" alt="Test" />
+          Image with
+          <Var>caption</Var>
+        </Fragment>
+      </template>
+      <template #input>
+        <Fragment>
+          <input type="text" placeholder="Input" />
+          Field with
+          <Num :value="count" />
+        </Fragment>
+      </template>
+    </Branch>
+  </T>
+</template>

--- a/tests/seeds/complex-cases/special-control-characters/page.vue
+++ b/tests/seeds/complex-cases/special-control-characters/page.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { Branch, Plural, T } from 'gt-vue';
+</script>
+
+<template>
+  <T>
+    <Plural
+      :n="1"
+      :singular="'Line1\nLine2\tTabbed'"
+      plural="Special: !@#$%^&amp;*()_+-=[]{}|;:,.&lt;&gt;?"
+      other="Template with ${variable} and `backticks`"
+    />
+    <Branch
+      branch="language"
+      english="Hello World"
+      spanish="Hola Mundo ñáéíóú"
+      chinese="你好世界"
+      emoji="🌍🌎🌏 Hello 👋"
+      arabic="مرحبا بالعالم"
+      russian="Привет мир"
+    />
+    <Plural :n="1" singular="simple template" plural="another simple template" />
+    <Branch
+      branch="format"
+      single="single line"
+      :multi="'\n            line 1\n            line 2\n            line 3\n          '"
+    />
+  </T>
+</template>

--- a/tests/seeds/complex-cases/special-js-values-in-branches/page.vue
+++ b/tests/seeds/complex-cases/special-js-values-in-branches/page.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import { Branch, T } from 'gt-vue';
+</script>
+
+<template>
+  <T>
+    <Branch
+      branch="type"
+      :number="42"
+      :big-number="9007199254740991"
+      :scientific="1e-20"
+      :negative-scientific="-1e20"
+      :hex="0xdeadbeef"
+      :octal="0o755"
+      :binary="0b11111111"
+    />
+  </T>
+</template>

--- a/tests/seeds/complex-cases/unicode-special-characters/page.vue
+++ b/tests/seeds/complex-cases/unicode-special-characters/page.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import { Branch, T } from 'gt-vue';
+</script>
+
+<template>
+  <T>
+    <Branch
+      branch="language"
+      english="Hello 👋 World"
+      chinese="你好世界"
+      arabic="مرحبا بالعالم"
+      emoji="🚀 🌟 ✨ 💫 ⭐"
+      symbols="© ® ™ € £ ¥ § ¶ † ‡"
+      math="∞ ≠ ≤ ≥ ± ∓ × ÷ √"
+    />
+  </T>
+</template>

--- a/tests/seeds/complex-cases/whitespace-preservation-complex-structure/page.vue
+++ b/tests/seeds/complex-cases/whitespace-preservation-complex-structure/page.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { Branch, T, Var } from 'gt-vue';
+import { Fragment } from 'vue';
+</script>
+
+<template>
+  <T>
+    <Branch branch="format">
+      <template #compact>
+        <Fragment>
+          No spaces
+          <Var>here</Var>
+          at all
+        </Fragment>
+      </template>
+      <template #spaced>
+        <Fragment>
+          {{ ' ' }}Lots of spaces
+          <Var>here</Var>
+          everywhere{{ ' ' }}
+        </Fragment>
+      </template>
+      <template #mixed>
+        <Fragment>
+          Text
+          <span>embedded spaces</span>
+          more text
+          <Var>padded var</Var>
+          final text
+        </Fragment>
+      </template>
+    </Branch>
+  </T>
+</template>

--- a/tests/seeds/complex-cases/whitespace/page.vue
+++ b/tests/seeds/complex-cases/whitespace/page.vue
@@ -1,0 +1,195 @@
+<script setup lang="ts">
+import { Branch, Currency, Num, Plural, T, Var } from 'gt-vue';
+import { Fragment } from 'vue';
+
+const amount = 100;
+const count = 1;
+</script>
+
+<template>
+  <T>
+    Normal text
+    <div>and some nesting</div>
+    <div>content before</div>
+    trailing text Text with multiple spaces
+    <Fragment>
+      {{ '        ' }}Text
+      <div>yo yo</div>
+      with
+      <span />
+      multiple spaces
+    </Fragment>
+    Hello World with spaces
+    <Plural :n="1" singular="" plural="Files" />
+    <Plural :n="1" singular="   File   " plural="   Files   " />
+    <Branch branch="1" option1="" option2="   Padded   ">
+      <template #option3><span>JSX content</span></template>
+    </Branch>
+    Start
+    <strong>Bold</strong>
+    <em>Italic</em>
+    End
+    <div>Before</div>
+    {{ '   ' }}
+    <div>After</div>
+    User:
+    <Var>userName</Var>
+    has
+    <Num :value="count" />
+    items Click
+    <a href="#">here</a>
+    to continue. Line 1 Line 2 with tabs Line 3 with spaces You have
+    <Plural :n="5" singular="  1 item  " plural="  2 items  " />
+    Total:
+    <Currency :value="amount" currency="USD" />
+    available Status:
+    <Plural :n="1" :singular="true" :plural="false" />
+    -
+    <Plural :n="0" :singular="null" plural="Active" />
+    <div>Content</div>
+    {{ '   ' }}
+    <div>More content</div>
+    Boundary whitespace test Hello
+    <Var>name</Var>
+    , you have
+    <Num :value="5" />
+    new messages.
+    <Plural :n="count" singular="1 file" plural="2 files" />
+    <div>
+      Welcome
+      <strong>user</strong>
+      ,
+      <br />
+      You have
+      <span>messages</span>
+      waiting.
+    </div>
+    Text with multiple spaces Text with multiple spaces
+    <Branch
+      branch="mixed"
+      short="Brief"
+      long="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+    >
+      <template #mixed>
+        <Fragment>
+          Very long text with
+          <Var>embedded variables</Var>
+          that continues for a very long time and includes multiple
+          <Num :value="9999999" />
+          {{ ' ' }}numeric values and{{ ' ' }}
+          <Currency :value="1234567.89" currency="USD" />
+          monetary amounts spread throughout the content.
+        </Fragment>
+      </template>
+    </Branch>
+    Hello World with spaces{{ true }}{{ true }}
+    <div />
+    <div />
+    {{ true }}
+    <Plural :n="1" :singular="true">
+      <template #dual>
+        <Fragment>{{ false }}{{ true }}</Fragment>
+      </template>
+    </Plural>
+    <Plural :n="1" :singular="true">
+      <template #dual>
+        <Fragment>{{ true }}</Fragment>
+      </template>
+    </Plural>
+     yo   yo  yo yo
+    <div>{{ true }}</div>
+    <div>
+      <div />
+      <div />
+    </div>
+    Hello
+    <div>there</div>
+    <div>there</div>
+    <Plural :n="count">
+      <template #singular>
+        <Fragment>
+          Text
+          <Fragment />
+          More text
+        </Fragment>
+      </template>
+      <template #plural>
+        <Fragment>
+          <Fragment>Fragment</Fragment>
+          content
+        </Fragment>
+      </template>
+      <template #other>
+        <Fragment><Fragment /></Fragment>
+      </template>
+    </Plural>
+    <Fragment>{{ true }}</Fragment>
+    <Fragment>{{ false }}</Fragment>
+    <Fragment>{{ true }}{{ true }}</Fragment>
+    <span>{{ true }}</span>
+    <span>{{ false }}</span>
+    <span>{{ true }}{{ true }}</span>
+    <Branch branch="false" :a="false" :b="true" :c="null">
+      <template #e>
+        <Fragment>{{ false }}</Fragment>
+      </template>
+      <template #f>
+        <Fragment>{{ true }}</Fragment>
+      </template>
+      <template #g>
+        <Fragment>{{ null }}</Fragment>
+      </template>
+      <template #i>
+        <Fragment>{{ false }}{{ true }}</Fragment>
+      </template>
+    </Branch>
+    <Branch branch="bool">
+      <template #true_val>
+        <Fragment>{{ true }}</Fragment>
+      </template>
+      <template #false_val>
+        <Fragment>{{ false }}</Fragment>
+      </template>
+      <template #mixed_true>
+        <Fragment>Before {{ true }} after</Fragment>
+      </template>
+      <template #mixed_false>
+        <Fragment>Before {{ false }} after</Fragment>
+      </template>
+      <template #multiple>
+        <Fragment>
+          {{ true }}{{ false }}{{ true }}
+          <div />
+        </Fragment>
+      </template>
+    </Branch>
+     yo   yo 
+    <Branch branch="nested">
+      <template #option1>
+        <Fragment>
+          <Fragment>
+            <Fragment>
+              <Fragment>
+                <Fragment>Text</Fragment>
+                <Fragment />
+                <Fragment>More</Fragment>
+              </Fragment>
+            </Fragment>
+            <span>Element</span>
+          </Fragment>
+          <Fragment>Final</Fragment>
+        </Fragment>
+      </template>
+      <template #option2>
+        <Fragment>
+          <Fragment>
+            <Fragment>
+              <Fragment><Fragment>Flat</Fragment></Fragment>
+               
+            </Fragment>
+          </Fragment>
+        </Fragment>
+      </template>
+    </Branch>
+  </T>
+</template>

--- a/tests/seeds/t-component/simple/context/static/expected.json
+++ b/tests/seeds/t-component/simple/context/static/expected.json
@@ -1,0 +1,1 @@
+"Context parity"

--- a/tests/seeds/t-component/simple/context/static/page.tsx
+++ b/tests/seeds/t-component/simple/context/static/page.tsx
@@ -1,0 +1,5 @@
+import { T } from 'gt-next';
+
+export default function Home() {
+  return <T context="runtime parity">Context parity</T>;
+}

--- a/tests/seeds/t-component/simple/context/static/page.vue
+++ b/tests/seeds/t-component/simple/context/static/page.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+import { T } from 'gt-vue';
+</script>
+
+<template>
+  <T context="runtime parity">Context parity</T>
+</template>

--- a/tests/seeds/t-component/simple/context/static/state.json
+++ b/tests/seeds/t-component/simple/context/static/state.json
@@ -1,0 +1,75 @@
+{
+  "children": {
+    "type": "StringLiteral",
+    "start": 164,
+    "end": 176,
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 18,
+        "index": 164
+      },
+      "end": {
+        "line": 5,
+        "column": 30,
+        "index": 176
+      }
+    },
+    "extra": {
+      "rawValue": "Context parity",
+      "raw": "\"Context parity\""
+    },
+    "value": "Context parity"
+  },
+  "state": {
+    "stringCollector": {
+      "contentAggregators": {},
+      "jsxAggregators": {},
+      "hashAggregators": {},
+      "globalCallCounter": 0
+    },
+    "scopeTracker": {
+      "nextScopeId": 3,
+      "currentScope": 2,
+      "scopeStack": [
+        0,
+        1
+      ],
+      "scopeInfo": {
+        "1": {
+          "id": 1,
+          "parentId": 0,
+          "depth": 0
+        },
+        "2": {
+          "id": 2,
+          "parentId": 1,
+          "depth": 2
+        }
+      },
+      "scopedVariables": {
+        "_jsx": [
+          {
+            "scopeId": 0,
+            "canonicalName": "jsx",
+            "aliasName": "_jsx",
+            "isTranslationFunction": false,
+            "type": "react",
+            "identifier": 0
+          }
+        ],
+        "T": [
+          {
+            "scopeId": 0,
+            "canonicalName": "T",
+            "aliasName": "T",
+            "isTranslationFunction": true,
+            "type": "generaltranslation",
+            "identifier": 0
+          }
+        ]
+      },
+      "namespaceImports": []
+    }
+  }
+}

--- a/tests/seeds/t-component/simple/expressions/null/fragment-null/page.vue
+++ b/tests/seeds/t-component/simple/expressions/null/fragment-null/page.vue
@@ -1,0 +1,6 @@
+<script setup lang="ts">
+import { T } from 'gt-vue';
+import { Fragment } from 'vue';
+</script>
+
+<template><T><Fragment>{{ null }}</Fragment></T></template>

--- a/tests/seeds/t-component/simple/expressions/null/plain-null/page.vue
+++ b/tests/seeds/t-component/simple/expressions/null/plain-null/page.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts">
+import { T } from 'gt-vue';
+</script>
+
+<template><T>{{ null }}</T></template>

--- a/tests/seeds/t-component/simple/expressions/static-boolean/array/page.vue
+++ b/tests/seeds/t-component/simple/expressions/static-boolean/array/page.vue
@@ -1,0 +1,6 @@
+<script setup lang="ts">
+import { T } from 'gt-vue';
+import { Fragment } from 'vue';
+</script>
+
+<template><T><Fragment>{{ false }}{{ true }}</Fragment></T></template>

--- a/tests/seeds/t-component/simple/expressions/static-boolean/false/page.vue
+++ b/tests/seeds/t-component/simple/expressions/static-boolean/false/page.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts">
+import { T } from 'gt-vue';
+</script>
+
+<template><T>{{ false }}</T></template>

--- a/tests/seeds/t-component/simple/expressions/static-boolean/fragment-false/page.vue
+++ b/tests/seeds/t-component/simple/expressions/static-boolean/fragment-false/page.vue
@@ -1,0 +1,6 @@
+<script setup lang="ts">
+import { T } from 'gt-vue';
+import { Fragment } from 'vue';
+</script>
+
+<template><T><Fragment>{{ false }}</Fragment></T></template>

--- a/tests/seeds/t-component/simple/expressions/static-boolean/fragment-true/page.vue
+++ b/tests/seeds/t-component/simple/expressions/static-boolean/fragment-true/page.vue
@@ -1,0 +1,6 @@
+<script setup lang="ts">
+import { T } from 'gt-vue';
+import { Fragment } from 'vue';
+</script>
+
+<template><T><Fragment>{{ true }}</Fragment></T></template>

--- a/tests/seeds/t-component/simple/expressions/static-boolean/true/page.vue
+++ b/tests/seeds/t-component/simple/expressions/static-boolean/true/page.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts">
+import { T } from 'gt-vue';
+</script>
+
+<template><T>{{ true }}</T></template>

--- a/tests/seeds/t-component/simple/expressions/static-number/page.vue
+++ b/tests/seeds/t-component/simple/expressions/static-number/page.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts">
+import { T } from 'gt-vue';
+</script>
+
+<template><T>{{ 123 }}</T></template>

--- a/tests/seeds/t-component/simple/expressions/static-special-identifiers/page.vue
+++ b/tests/seeds/t-component/simple/expressions/static-special-identifiers/page.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts">
+import { T } from 'gt-vue';
+</script>
+
+<template><T>{{ null }}{{ undefined }}{{ NaN }}{{ Infinity }}</T></template>

--- a/tests/seeds/t-component/simple/expressions/static-string/page.vue
+++ b/tests/seeds/t-component/simple/expressions/static-string/page.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts">
+import { T } from 'gt-vue';
+</script>
+
+<template><T>{{ 'Here is some text' }}</T></template>

--- a/tests/seeds/t-component/simple/expressions/static-template/page.vue
+++ b/tests/seeds/t-component/simple/expressions/static-template/page.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts">
+import { T } from 'gt-vue';
+</script>
+
+<template><T>{{ `Here is a template` }}</T></template>

--- a/tests/seeds/t-component/simple/misc/customcomponents/page.vue
+++ b/tests/seeds/t-component/simple/misc/customcomponents/page.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import { defineComponent, h } from 'vue';
+import { T } from 'gt-vue';
+
+const Link = defineComponent({
+  name: 'Link',
+  props: {
+    href: {
+      required: true,
+      type: String,
+    },
+  },
+  setup(props, { slots }) {
+    return () => h('a', { href: props.href }, slots.default?.());
+  },
+});
+
+const Button = defineComponent({
+  name: 'Button',
+  setup(_props, { slots }) {
+    return () => h('button', null, slots.default?.());
+  },
+});
+</script>
+
+<template><T>Let's see some custom components<Link href="https://www.google.com">Google</Link><Button>Click me</Button></T></template>

--- a/tests/seeds/t-component/simple/misc/localeselector/page.vue
+++ b/tests/seeds/t-component/simple/misc/localeselector/page.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import { defineComponent, h } from 'vue';
+import { T } from 'gt-vue';
+
+const LocaleSelector = defineComponent({
+  name: 'LocaleSelector',
+  setup() {
+    return () => h('select');
+  },
+});
+</script>
+
+<template><T>Let's select some locales<LocaleSelector /></T></template>

--- a/tests/seeds/t-component/simple/plain-text/plain-text-deeply-nested/page.vue
+++ b/tests/seeds/t-component/simple/plain-text/plain-text-deeply-nested/page.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts">
+import { T } from 'gt-vue';
+</script>
+
+<template><T><div><div><div><div>Here is some deeply nested text</div></div></div></div></T></template>

--- a/tests/seeds/t-component/simple/plain-text/plain-text-nested-fragment/page.vue
+++ b/tests/seeds/t-component/simple/plain-text/plain-text-nested-fragment/page.vue
@@ -1,0 +1,6 @@
+<script setup lang="ts">
+import { T } from 'gt-vue';
+import { Fragment } from 'vue';
+</script>
+
+<template><T><Fragment>Plain text</Fragment></T></template>

--- a/tests/seeds/t-component/simple/plain-text/plain-text-nested/page.vue
+++ b/tests/seeds/t-component/simple/plain-text/plain-text-nested/page.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts">
+import { T } from 'gt-vue';
+</script>
+
+<template><T><div>Plain text</div></T></template>

--- a/tests/seeds/t-component/simple/plain-text/plain-text-siblings/page.vue
+++ b/tests/seeds/t-component/simple/plain-text/plain-text-siblings/page.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts">
+import { T } from 'gt-vue';
+</script>
+
+<template><T>Here is some text<div>Here is some nested text</div>Here is some more text here</T></template>

--- a/tests/seeds/t-component/simple/plain-text/plain-text/page.vue
+++ b/tests/seeds/t-component/simple/plain-text/plain-text/page.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts">
+import { T } from 'gt-vue';
+</script>
+
+<template><T>Plain text</T></template>

--- a/tests/seeds/t-component/simple/special-react-components/page.vue
+++ b/tests/seeds/t-component/simple/special-react-components/page.vue
@@ -1,0 +1,6 @@
+<script setup lang="ts">
+import { T } from 'gt-vue';
+import { Fragment } from 'vue';
+</script>
+
+<template><T><Fragment /><Suspense>Suspense</Suspense></T></template>

--- a/tests/seeds/variable-components/currency/simple/basic/page.vue
+++ b/tests/seeds/variable-components/currency/simple/basic/page.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+import { Currency, T } from 'gt-vue';
+</script>
+
+<template>
+  <T><Currency :value="100" currency="USD" /></T>
+</template>

--- a/tests/seeds/variable-components/currency/simple/siblings/page.vue
+++ b/tests/seeds/variable-components/currency/simple/siblings/page.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+import { Currency, T } from 'gt-vue';
+</script>
+
+<template>
+  <T>First sibling<Currency :value="100" currency="USD" /></T>
+</template>

--- a/tests/seeds/variable-components/currency/simple/variable/page.vue
+++ b/tests/seeds/variable-components/currency/simple/variable/page.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import { Currency, T } from 'gt-vue';
+
+const test = 100;
+</script>
+
+<template>
+  <T
+    ><Currency :value="test" currency="USD" /><Currency
+      :value="(() => test)()"
+      currency="USD"
+    /><Currency :value="test + 1" currency="USD" /><Currency
+      :value="0"
+      currency="USD"
+  /></T>
+</template>

--- a/tests/seeds/variable-components/datetime/simple/basic/page.vue
+++ b/tests/seeds/variable-components/datetime/simple/basic/page.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import { DateTime, T } from 'gt-vue';
+
+const timestamp = new Date(0);
+</script>
+
+<template>
+  <T><DateTime :value="timestamp" /></T>
+</template>

--- a/tests/seeds/variable-components/datetime/simple/siblings/page.vue
+++ b/tests/seeds/variable-components/datetime/simple/siblings/page.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import { DateTime, T } from 'gt-vue';
+
+const timestamp = new Date(0);
+</script>
+
+<template>
+  <T>First sibling<DateTime :value="timestamp" /></T>
+</template>

--- a/tests/seeds/variable-components/datetime/simple/variable/page.vue
+++ b/tests/seeds/variable-components/datetime/simple/variable/page.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import { DateTime, T } from 'gt-vue';
+
+const test = new Date(0);
+</script>
+
+<template>
+  <T
+    ><DateTime :value="test" /><DateTime :value="(() => test)()" /><DateTime
+      :value="new Date(test.getTime() + 1)"
+    /><DateTime :value="new Date(0)"
+  /></T>
+</template>

--- a/tests/seeds/variable-components/num/simple/basic/page.vue
+++ b/tests/seeds/variable-components/num/simple/basic/page.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+import { Num, T } from 'gt-vue';
+</script>
+
+<template>
+  <T><Num :value="100" /></T>
+</template>

--- a/tests/seeds/variable-components/num/simple/siblings/page.vue
+++ b/tests/seeds/variable-components/num/simple/siblings/page.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+import { Num, T } from 'gt-vue';
+</script>
+
+<template>
+  <T>First sibling<Num :value="100" /></T>
+</template>

--- a/tests/seeds/variable-components/num/simple/variable/page.vue
+++ b/tests/seeds/variable-components/num/simple/variable/page.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import { Num, T } from 'gt-vue';
+
+const test = 100;
+</script>
+
+<template>
+  <T
+    ><Num :value="test" /><Num :value="(() => test)()" /><Num
+      :value="test + 1"
+    /><Num :value="0"
+  /></T>
+</template>

--- a/tests/seeds/variable-components/static/branches/page.vue
+++ b/tests/seeds/variable-components/static/branches/page.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import { Fragment } from 'vue';
+import { Branch, T } from 'gt-vue';
+
+const derived = 'fn2';
+const selection = 'yes';
+</script>
+
+<template><T>Hello there<Branch :branch="derived"><template #fn2><Fragment>Hello my good friend<span>fn1 hi fn2</span><Branch :branch="selection" other="yo"><template #yes><Fragment>yes</Fragment></template><template #no><Fragment>no</Fragment></template></Branch></Fragment></template><template #nope><Fragment>Hello my good friend<span>fn1 hi nope</span><Branch :branch="selection" other="yo"><template #yes><Fragment>yes</Fragment></template><template #no><Fragment>no</Fragment></template></Branch></Fragment></template><template #no><Fragment>Hello my good friend<span>no</span><Branch :branch="selection" other="yo"><template #yes><Fragment>yes</Fragment></template><template #no><Fragment>no</Fragment></template></Branch></Fragment></template></Branch></T></template>

--- a/tests/seeds/variable-components/static/simple/page.vue
+++ b/tests/seeds/variable-components/static/simple/page.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { Branch, T, Var } from 'gt-vue';
+
+const subjectChoice = ref('archie');
+const subject = ref('Brian');
+const predicateChoice = ref('is');
+const predicate = ref('wants to be');
+const objectChoice = ref('person');
+const personStyle = ref('person');
+</script>
+
+<template><T><Branch :branch="subjectChoice"><template #archie>Archie</template><template #ernest>Ernest</template><template #fernanda>Fernanda</template><template #lily>Lily</template><template #brian>The beautiful <Var>{{ subject }}</Var></template></Branch> <Branch :branch="predicateChoice"><template #is>is</template><template #wouldHaveBeen>would have been</template><template #was>was</template><template #other><Var>{{ predicate }}</Var></template></Branch> <Branch :branch="objectChoice"><template #painter>a painter</template><template #famousPerson>a famous person</template><template #sculptor>a sculptor</template><template #person>a <Branch :branch="personStyle" person="person" coolPerson="cool person" /></template><template #coolPerson>a <Branch :branch="personStyle" person="person" coolPerson="cool person" /></template></Branch></T></template>

--- a/tests/seeds/variable-components/static/ternaries/page.vue
+++ b/tests/seeds/variable-components/static/ternaries/page.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import { Branch, T } from 'gt-vue';
+
+const state = false;
+</script>
+
+<template>
+  <T
+    ><Branch :branch="state"
+      ><template #true>The boy</template><template #false>The girl</template></Branch
+    > is beautiful</T
+  >
+</template>

--- a/tests/seeds/variable-components/var/simple/basic/page.vue
+++ b/tests/seeds/variable-components/var/simple/basic/page.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+import { T, Var } from 'gt-vue';
+</script>
+
+<template>
+  <T><Var>test</Var></T>
+</template>

--- a/tests/seeds/variable-components/var/simple/empty/page.vue
+++ b/tests/seeds/variable-components/var/simple/empty/page.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+import { T, Var } from 'gt-vue';
+</script>
+
+<template>
+  <T><Var></Var></T>
+</template>

--- a/tests/seeds/variable-components/var/simple/name/page.vue
+++ b/tests/seeds/variable-components/var/simple/name/page.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+import { T, Var } from 'gt-vue';
+</script>
+
+<template>
+  <T><Var>test</Var><Var>test</Var><Var>test</Var></T>
+</template>

--- a/tests/seeds/variable-components/var/simple/siblings/page.vue
+++ b/tests/seeds/variable-components/var/simple/siblings/page.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+import { T, Var } from 'gt-vue';
+</script>
+
+<template>
+  <T>First sibling<Var>100</Var></T>
+</template>

--- a/tests/seeds/variable-components/var/simple/variable/page.vue
+++ b/tests/seeds/variable-components/var/simple/variable/page.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import { T, Var } from 'gt-vue';
+
+const test = 'test';
+</script>
+
+<template>
+  <T
+    ><Var>{{ test }}</Var><Var>{{ (() => test)() }}</Var
+    ><Var><div>test</div></Var><Var></Var
+  ></T>
+</template>


### PR DESCRIPTION
## Summary

- compile 84 colocated React TSX and Vue SFC seeds through their real framework compilers
- pin React `prepareT()` as the runtime oracle with literal catalog hashes, strict semantic wire comparisons, and static-context coverage
- document 40 portable matches, one narrowly specified expected Vue failure, and 43 explicit exclusions without changing production code
- verify that React-keyed rich catalogs render through Vue with reordered and repeated elements, variables, branches, and plurals

## Testing

- `pnpm --filter gt-vue test` — 350 tests passed on Vue 3.5.40
- `pnpm --filter gt-vue typecheck` — passed
- `pnpm --filter gt-vue build` — passed
- `pnpm --filter @generaltranslation/react-core test` — 50 tests passed
- `pnpm lint` — passed (pre-existing warnings only)
- `pnpm format` — passed
- fresh filtered install plus focused parity suite — 216 tests passed
- isolated Vue 3.3.13 matrix: full gt-vue suite (350 tests) and typecheck passed

## Notes

- No changeset is included because this PR changes tests, fixtures, and test-only dependencies only.
- The single expected failure pins the current Vue hash and exactly three direct `Branch` values; the stacked runtime PR will promote it without changing the locked assertions.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds test-only React/Vue runtime-parity coverage without changing production behavior.

- Compiles paired React TSX and Vue SFC seeds and compares their semantic wire output and catalog hashes.
- Adds React-catalog interoperability rendering tests for Vue.
- Records portable, excluded, and expected-failure seeds in a checked-in parity manifest.
- Adds the test-only React dependencies required by the Vue parity suite.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/vue/src/__tests__/seedRuntimeParity.test.ts | Adds the compiler-backed parity harness, manifest validation, runtime source comparison, and expected-failure repair checks. |
| packages/vue/src/__tests__/reactCatalogInterop.test.ts | Verifies that React-canonical rich-content catalogs serialize and render correctly through Vue. |
| test-fixtures/react-vue-runtime-parity.json | Classifies every paired seed with pinned hashes and explicit parity, exclusion, or expected-failure rationale. |
| packages/vue/package.json | Adds test-only React and react-core dependencies needed to execute the parity oracle. |
| pnpm-lock.yaml | Locks the newly added Vue-package development dependencies. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(vue): add compiler state for contex..."](https://github.com/generaltranslation/gt/commit/46291edfafc5cf45bb5b52d7e33dbd9c1c1dfbcb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51922726)</sub>

<!-- /greptile_comment -->