### PR TITLE
docs: update README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
   <h1>General Translation</h1>
 
 <a href="https://generaltranslation.com"><img alt="General Translation" src="https://img.shields.io/badge/MADE%20BY%20General%20Translation-000000.svg?style=for-the-badge&labelColor=ffffff&color=000000"></a>
-<a href="https://www.npmjs.com/package/gt-next"><img alt="NPM version" src="https://img.shields.io/npm/v/gt-next.svg?style=for-the-badge&labelColor=000000&color=CB3837"></a>
-<a href="https://github.com/generaltranslation/gt/blob/main/LICENSE.md"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-FAEBD7.svg?style=for-the-badge&labelColor=000000"></a>
+<a href="https://www.npmjs.com/package/gt"><img alt="NPM version" src="https://img.shields.io/npm/v/gt.svg?style=for-the-badge&labelColor=000000&color=CB3837"></a>
+<a href="https://github.com/generaltranslation/gt/blob/main/LICENSE.md"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-A31F34.svg?style=for-the-badge&labelColor=000000"></a>
 <a href="https://discord.gg/W99K6fchSu"><img alt="Join the community on Discord" src="https://img.shields.io/badge/Join%20the%20community-5865F2.svg?style=for-the-badge&logo=discord&labelColor=23272A&logoWidth=20"></a>
 
 </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- point the npm badge and destination at the `gt` package
- update the MIT license badge to classic MIT red (`#A31F34`)

## Validation
- confirmed the old `gt-next` and `FAEBD7` badge values are absent from the root README
- confirmed the new `gt` package targets and `A31F34` license badge color are present
- `git diff --check HEAD^ HEAD`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://generaltranslation.slack.com/archives/C0BJA1M93QC/p1786559912682519?thread_ts=1786559912.682519&cid=C0BJA1M93QC)

<div><a href="https://cursor.com/agents/bc-2cba2621-9298-5f3c-93ef-f84cbe0a88fc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2cba2621-9298-5f3c-93ef-f84cbe0a88fc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the root README badges to reference the `gt` npm package and use the classic MIT red license color.
- Changes both the npm badge image and destination from `gt-next` to `gt`.
- Changes the MIT badge color from `FAEBD7` to `A31F34`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The README-only changes consistently point the npm badge and link to the existing `gt` package and update the license badge color without affecting runtime behavior.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | The badge targets and license color are updated consistently with the stated documentation goal; no actionable issues were found. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: update README badges"](https://github.com/generaltranslation/gt/commit/6125d93d2a6a9eeaf2097f90ef0cae25a9af07ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52688334)</sub>

<!-- /greptile_comment -->