### PR TITLE
ci: pin GitHub Actions to immutable SHAs

### DIFF
--- a/.github/workflows/asset-upload.yml
+++ b/.github/workflows/asset-upload.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: ryand56/r2-upload-action@v1.4
+      - uses: ryand56/r2-upload-action@b801a390acbdeb034c5e684ff5e1361c06639e7c # v1.4
         with:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
           r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
@@ -68,20 +68,20 @@ jobs:
 
       # --- Setup ---
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         if: steps.should-run.outputs.run == 'true'
         name: Install pnpm
 
       - name: Setup Node.js
         if: steps.should-run.outputs.run == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: 'pnpm'
 
       - name: Setup Rust
         if: steps.should-run.outputs.run == 'true'
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           targets: wasm32-wasip1
 
@@ -155,7 +155,7 @@ jobs:
 
       - name: Store benchmark results
         if: steps.should-run.outputs.run == 'true'
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1
         with:
           name: 'Middleware Benchmarks'
           tool: 'customSmallerIsBetter'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,21 +16,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         name: Install pnpm
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: 'pnpm'
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           targets: wasm32-wasip1
 
@@ -47,21 +47,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         name: Install pnpm
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: 'pnpm'
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           targets: wasm32-wasip1
 
@@ -117,11 +117,11 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         name: Install pnpm
 
       - name: Check if gt-next changed
@@ -135,13 +135,13 @@ jobs:
           fi
       - name: Setup Node.js
         if: steps.gt_next_changed.outputs.changed == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ matrix.node }}
           cache: 'pnpm'
       - name: Setup Rust
         if: steps.gt_next_changed.outputs.changed == 'true'
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           targets: wasm32-wasip1
 
@@ -184,7 +184,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
@@ -198,26 +198,26 @@ jobs:
             echo "changed=false" >> $GITHUB_OUTPUT
           fi
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         if: steps.gt_cli_changed.outputs.changed == 'true'
         name: Install pnpm
 
       - name: Setup Node.js
         if: steps.gt_cli_changed.outputs.changed == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: 'pnpm'
 
       - name: Setup Bun
         if: steps.gt_cli_changed.outputs.changed == 'true'
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 
       - name: Setup Rust
         if: steps.gt_cli_changed.outputs.changed == 'true'
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           targets: wasm32-wasip1
 
@@ -256,19 +256,19 @@ jobs:
       TURBO_ENV_MODE: loose
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         name: Install pnpm
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: 'pnpm'
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           targets: wasm32-wasip1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,12 +25,12 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,15 +24,15 @@ jobs:
       name: 'release'
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 2
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         name: Install pnpm
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24.18.0
           cache: 'pnpm'
@@ -43,12 +43,12 @@ jobs:
         run: pnpm run check:release-versions
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           targets: wasm32-wasip1
 
@@ -63,7 +63,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1
         with:
           version: pnpm run version-packages
           publish: pnpm run release
@@ -74,7 +74,7 @@ jobs:
 
       - name: Trigger benchmark baseline update
         if: steps.changesets.outputs.published == 'true'
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
         with:
           event-type: release-published
           client-payload: '{"publishedPackages": ${{ steps.changesets.outputs.publishedPackages }}}'
@@ -112,7 +112,7 @@ jobs:
       - name: Notify Slack of release
         if: steps.changesets.outputs.published == 'true'
         continue-on-error: true
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           webhook: ${{ secrets.MOSS_PAGER_SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -160,7 +160,7 @@ jobs:
 
       - name: Upload gt binaries to R2
         if: steps.check-gt.outputs.should_release_bin == 'true'
-        uses: ryand56/r2-upload-action@v1.4
+        uses: ryand56/r2-upload-action@b801a390acbdeb034c5e684ff5e1361c06639e7c # v1.4
         with:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
           r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -171,7 +171,7 @@ jobs:
 
       - name: Upload gt binaries to R2 (latest)
         if: steps.check-gt.outputs.should_release_bin == 'true'
-        uses: ryand56/r2-upload-action@v1.4
+        uses: ryand56/r2-upload-action@b801a390acbdeb034c5e684ff5e1361c06639e7c # v1.4
         with:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
           r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -183,7 +183,7 @@ jobs:
       # PyPI: gtx-cli (Python launcher with bundled gt binaries)
       - name: Setup Python
         if: steps.check-gt.outputs.should_release_bin == 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.x'
 
@@ -253,7 +253,7 @@ jobs:
 
       - name: Upload gtx-cli binaries to R2
         if: steps.check-gtx-cli.outputs.should_release_bin == 'true'
-        uses: ryand56/r2-upload-action@v1.4
+        uses: ryand56/r2-upload-action@b801a390acbdeb034c5e684ff5e1361c06639e7c # v1.4
         with:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
           r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -264,7 +264,7 @@ jobs:
 
       - name: Upload gtx-cli binaries to R2 (latest)
         if: steps.check-gtx-cli.outputs.should_release_bin == 'true'
-        uses: ryand56/r2-upload-action@v1.4
+        uses: ryand56/r2-upload-action@b801a390acbdeb034c5e684ff5e1361c06639e7c # v1.4
         with:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
           r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -307,7 +307,7 @@ jobs:
       name: 'release'
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Verify Odysseus prerelease mode
         run: |
@@ -315,18 +315,18 @@ jobs:
           test "$(jq -r '.mode' .changeset/pre.json)" = "pre"
           test "$(jq -r '.tag' .changeset/pre.json)" = "odysseus"
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         name: Install pnpm
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           targets: wasm32-wasip1
 
@@ -341,7 +341,7 @@ jobs:
 
       - name: Create Odysseus Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1
         with:
           version: bash scripts/version-packages-odysseus.sh
           publish: pnpm run release

--- a/.github/workflows/test-apps-e2e-cron.yml
+++ b/.github/workflows/test-apps-e2e-cron.yml
@@ -29,19 +29,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         name: Install pnpm
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: 'pnpm'
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           targets: wasm32-wasip1
 
@@ -59,7 +59,7 @@ jobs:
 
       - name: Upload Playwright artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: gt-test-apps-playwright-${{ github.run_id }}
           path: .turbo/playwright/
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Send Slack notification
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook


### PR DESCRIPTION
## Summary

- Pin every GitHub Action invocation to a verified full commit SHA while retaining the current version in a comment.
- Remove mutable tag and branch references from CI, release, benchmark, asset, browser-test, and Claude workflows so upstream tag movement cannot silently change executed code.

## Testing

- `pnpm install --force` — passed
- `pnpm exec oxfmt --check .github/workflows` — passed
- `ruby -e 'require "yaml"; ... YAML.parse_file(f)'` across all workflow files — passed
- Full-SHA assertion across every remote `uses:` reference — passed
- `git diff --check` — passed

## Notes

- Changeset: not required; this only hardens repository workflows.
- Stack: base PR for `e/release/isolate-release-oidc`, which will isolate npm publishing authority in a follow-up PR.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This update pins third-party GitHub Actions in CI, release, benchmark, upload, Claude, and scheduled test workflows to immutable commit SHAs while retaining their version comments. The workflow references were checked against their previous mutable forms and against GitHub remote resolution: all 54 updated references are valid full SHAs, and all 13 unique commented versions or branches resolve to the pinned commits. No defects were found.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge: the update preserves each action's resolved revision while making workflow dependencies immutable.

The changed workflow references were syntax-checked, checked for 40-character immutable SHAs and version comments, and verified through remote resolution for every distinct action/version pair. No review findings remain.

**Files Needing Attention:** No files need follow-up attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the Python validator to compare the six changed workflows with the parent revision and verify each updated remote uses valid GitHub Actions syntax, a lowercase 40-character commit SHA, and a version comment.
- Confirmed all 13 unique action/version references resolve to exact pinned commits, including dtolnay/rust-toolchain@stable, benchmark-action/github-action-benchmark@v1, and changesets/action@v1.
- Verified the updated revision contains 54 immutable references while the parent had 54 mutable references.
- Validated that the three dependencies are branches, not tags, and their tips match the pinned SHAs; no workflow files were altered and validator artifacts were produced.

<a href="https://app.greptile.com/trex/runs/18940425/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: pin GitHub Actions to immutable SHAs"](https://github.com/generaltranslation/gt/commit/32ba91ee46107fcc4dc9a6850f83b4bc6aae7e12) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53430282)</sub>

<!-- /greptile_comment -->