### PR TITLE
ci: isolate release publishing permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ on:
       - main
     types:
       - closed
-  workflow_dispatch:
 
 permissions:
   contents: read
@@ -18,7 +17,7 @@ env:
   CI: true
 jobs:
   release-pr:
-    if: github.event_name == 'push' && github.ref_name == 'main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     name: Create Release Pull Request
     runs-on: ubuntu-latest
     concurrency: ${{ github.workflow }}-release-pr-${{ github.ref }}
@@ -53,28 +52,28 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # GitHub Actions bot: 41898282. Manual recovery: eoinest (73407149),
+  # GitHub Actions bot: 41898282. Allowed mergers: eoinest (73407149),
   # brian-lou (69982825), and archie-mckenzie (90429137).
   release:
     if: >-
-      (github.event_name == 'pull_request' &&
-        github.event.action == 'closed' &&
-        github.event.pull_request.merged == true &&
-        github.event.pull_request.base.ref == 'main' &&
-        github.event.pull_request.head.ref == 'changeset-release/main' &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        github.event.pull_request.user.id == 41898282) ||
-      (github.event_name == 'workflow_dispatch' &&
-        github.ref_name == 'main' &&
-        (github.actor_id == '73407149' ||
-          github.actor_id == '69982825' ||
-          github.actor_id == '90429137'))
+      github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.head.ref == 'changeset-release/main' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.id == 41898282 &&
+      (github.event.pull_request.merged_by.id == 73407149 ||
+        github.event.pull_request.merged_by.id == 69982825 ||
+        github.event.pull_request.merged_by.id == 90429137)
     name: Publish Release
     runs-on: ubuntu-latest
     concurrency: ${{ github.workflow }}-publish-main
     permissions:
+      actions: read # Required to authenticate retry recovery
       id-token: write # Required for npm trusted publishing
       contents: write
+      pull-requests: read
     environment:
       name: 'release'
     steps:
@@ -102,9 +101,34 @@ jobs:
             exit 1
           fi
 
-      - name: Validate release versions
-        if: github.event_name == 'pull_request'
-        run: pnpm run check:release-versions
+      - name: Authorize package publishing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if pnpm run check:release-versions; then
+            exit 0
+          fi
+
+          if [ "$GITHUB_RUN_ATTEMPT" = '1' ]; then
+            echo '::error::Release version validation failed before package publishing began.'
+            exit 1
+          fi
+
+          attempt=1
+          while [ "$attempt" -lt "$GITHUB_RUN_ATTEMPT" ]; do
+            publish_conclusion=$(gh api \
+              -H 'Accept: application/vnd.github+json' \
+              "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${attempt}/jobs?per_page=100" \
+              --jq '[.jobs[].steps[]? | select(.name == "Publish packages to npm") | .conclusion] | map(select(. != null and . != "skipped")) | first // ""')
+            if [ -n "$publish_conclusion" ]; then
+              echo "A previous attempt reached package publishing (${publish_conclusion}); continuing exact-run recovery."
+              exit 0
+            fi
+            attempt=$((attempt + 1))
+          done
+
+          echo '::error::Release version validation failed, and no previous attempt reached package publishing.'
+          exit 1
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -204,9 +228,15 @@ jobs:
           if [ -n "$published_packages" ] && echo "$published_packages" | jq -e 'any(.[]; .name == "gt")' > /dev/null; then
             echo "should_release_bin=true" >> $GITHUB_OUTPUT
           elif npm view "gt@${version}" version > /dev/null 2>&1 && ! npm view "gt@${version}-bin.0" version > /dev/null 2>&1; then
-            # A previous run published gt but failed before the binary
-            # release landed; finish it on this run.
-            echo "should_release_bin=true" >> $GITHUB_OUTPUT
+            latest_version=$(npm view 'gt@latest' version)
+            if [ "$version" = "$latest_version" ]; then
+              # This exact run published gt but failed before the binary
+              # release landed; finish it without rolling latest backwards.
+              echo "should_release_bin=true" >> $GITHUB_OUTPUT
+            else
+              echo "::warning::Skipping gt@${version} binary recovery because gt@latest is ${latest_version}."
+              echo "should_release_bin=false" >> $GITHUB_OUTPUT
+            fi
           else
             echo "should_release_bin=false" >> $GITHUB_OUTPUT
           fi
@@ -297,9 +327,15 @@ jobs:
           if [ -n "$published_packages" ] && echo "$published_packages" | jq -e 'any(.[]; .name == "gtx-cli")' > /dev/null; then
             echo "should_release_bin=true" >> $GITHUB_OUTPUT
           elif npm view "gtx-cli@${version}" version > /dev/null 2>&1 && ! npm view "gtx-cli@${version}-bin.0" version > /dev/null 2>&1; then
-            # A previous run published gtx-cli but failed before the binary
-            # release landed; finish it on this run.
-            echo "should_release_bin=true" >> $GITHUB_OUTPUT
+            latest_version=$(npm view 'gtx-cli@latest' version)
+            if [ "$version" = "$latest_version" ]; then
+              # This exact run published gtx-cli but failed before the binary
+              # release landed; finish it without rolling latest backwards.
+              echo "should_release_bin=true" >> $GITHUB_OUTPUT
+            else
+              echo "::warning::Skipping gtx-cli@${version} binary recovery because gtx-cli@latest is ${latest_version}."
+              echo "should_release_bin=false" >> $GITHUB_OUTPUT
+            fi
           else
             echo "should_release_bin=false" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,22 +4,60 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
-  id-token: write # Required for OIDC
-  contents: write
-  pull-requests: write
-  packages: write
+  contents: read
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 env:
   CI: true
 jobs:
-  release:
-    if: github.ref_name == 'main'
-    name: Release
+  release-pr:
+    if: github.event_name == 'push' && github.ref_name == 'main' && !startsWith(github.event.head_commit.message, '[ci] release')
+    name: Create Release Pull Request
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 2
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        name: Install pnpm
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24.18.0
+          cache: 'pnpm'
+
+      - name: Install Dependencies
+        # not frozen since we are using workspaces & package versions will change
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Create Release Pull Request
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1
+        with:
+          version: pnpm run version-packages
+          commit: '[ci] release'
+          title: '[ci] release'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release:
+    if: github.ref_name == 'main' && (github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message, '[ci] release'))
+    name: Publish Release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for npm trusted publishing
+      contents: write
+      pull-requests: write
+      packages: write
     environment:
       name: 'release'
     steps:
@@ -39,7 +77,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Validate release versions
-        if: startsWith(github.event.head_commit.message, '[ci] release')
         run: pnpm run check:release-versions
 
       - name: Setup Bun
@@ -303,6 +340,11 @@ jobs:
     if: github.ref_name == 'odysseus'
     name: Odysseus Release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for npm trusted publishing
+      contents: write
+      pull-requests: write
+      packages: write
     environment:
       name: 'release'
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,20 +4,24 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
   workflow_dispatch:
 
 permissions:
   contents: read
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
-
 env:
   CI: true
 jobs:
   release-pr:
-    if: github.event_name == 'push' && github.ref_name == 'main' && !startsWith(github.event.head_commit.message, '[ci] release')
+    if: github.event_name == 'push' && github.ref_name == 'main'
     name: Create Release Pull Request
     runs-on: ubuntu-latest
+    concurrency: ${{ github.workflow }}-release-pr-${{ github.ref }}
     permissions:
       contents: write
       pull-requests: write
@@ -49,15 +53,28 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # GitHub Actions bot: 41898282. Manual recovery: eoinest (73407149),
+  # brian-lou (69982825), and archie-mckenzie (90429137).
   release:
-    if: github.ref_name == 'main' && (github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message, '[ci] release'))
+    if: >-
+      (github.event_name == 'pull_request' &&
+        github.event.action == 'closed' &&
+        github.event.pull_request.merged == true &&
+        github.event.pull_request.base.ref == 'main' &&
+        github.event.pull_request.head.ref == 'changeset-release/main' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.pull_request.user.id == 41898282) ||
+      (github.event_name == 'workflow_dispatch' &&
+        github.ref_name == 'main' &&
+        (github.actor_id == '73407149' ||
+          github.actor_id == '69982825' ||
+          github.actor_id == '90429137'))
     name: Publish Release
     runs-on: ubuntu-latest
+    concurrency: ${{ github.workflow }}-publish-main
     permissions:
       id-token: write # Required for npm trusted publishing
       contents: write
-      pull-requests: write
-      packages: write
     environment:
       name: 'release'
     steps:
@@ -65,6 +82,7 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 2
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         name: Install pnpm
@@ -76,7 +94,16 @@ jobs:
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Verify publish-only state
+        run: |
+          pending_changeset=$(find .changeset -maxdepth 1 -type f -name '*.md' ! -name 'README.md' -print -quit)
+          if [ -n "$pending_changeset" ]; then
+            echo "::error file=$pending_changeset::Publishing requires a merged Changesets release PR with no pending changesets."
+            exit 1
+          fi
+
       - name: Validate release versions
+        if: github.event_name == 'pull_request'
         run: pnpm run check:release-versions
 
       - name: Setup Bun
@@ -98,14 +125,11 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
-      - name: Create Release Pull Request or Publish to npm
+      - name: Publish packages to npm
         id: changesets
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1
         with:
-          version: pnpm run version-packages
           publish: pnpm run release
-          commit: '[ci] release'
-          title: '[ci] release'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -120,7 +144,10 @@ jobs:
         id: find-release-pr
         if: steps.changesets.outputs.published == 'true'
         run: |
-          pr_url=$(gh pr list --state merged --search "[ci] release" --limit 1 --json url --jq '.[0].url // ""')
+          pr_url='${{ github.event.pull_request.html_url }}'
+          if [ -z "$pr_url" ]; then
+            pr_url=$(gh pr list --state merged --base main --head changeset-release/main --limit 1 --json url --jq '.[0].url // ""')
+          fi
           echo "pr_url=$pr_url" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -337,9 +364,10 @@ jobs:
           pnpm --filter gtx-cli run build:clean
 
   odysseus-release:
-    if: github.ref_name == 'odysseus'
+    if: github.event_name == 'push' && github.ref_name == 'odysseus'
     name: Odysseus Release
     runs-on: ubuntu-latest
+    concurrency: ${{ github.workflow }}-publish-odysseus
     permissions:
       id-token: write # Required for npm trusted publishing
       contents: write


### PR DESCRIPTION
## Summary

- separate routine Changesets release-PR maintenance from package publishing
- publish only after a same-repository bot release PR is merged by Ernest, Brian, or Archie
- remove general-purpose manual publishing and recover only by rerunning the exact authenticated release event
- allow collision recovery only when an earlier attempt of that same run reached npm publishing

## Testing

- `pnpm install`
- `pnpm exec oxfmt --check .github/workflows/release.yml`
- `actionlint .github/workflows/*.yml`
- parsed the workflow as YAML and asserted trigger, permission, and merger invariants
- exercised validator success, first-attempt collision rejection, pre-publish retry rejection, and partial-publish retry recovery fixtures
- exercised current-version and stale-version binary recovery fixtures for `gt` and `gtx-cli`
- `git diff --check`

## Notes

- No changeset is needed because this only changes CI configuration.
- The GitHub `release` environment is now restricted to the `main` branch.
- After this PR merges, add Ernest, Brian, and Archie as environment reviewers before merging any Changesets release PR. Staging that approval rule avoids pausing today's combined release-PR job.
- #2101 adds GitHub-signed release-PR provenance and accurate generated instructions as a separate child PR.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The release workflow now allows a rerun to continue after an earlier attempt reached package publishing, so it can recover a missing CLI binary release. The previously reported recovery failure was disproved by exercising the rerun path: the workflow reached the binary check and selected the missing binary for release.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

The exercised recovery path continues after an earlier package-publishing attempt and correctly enables the missing binary release.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex completed the requested general contract validation verification, but local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(ci): fail closed during release reco..."](https://github.com/generaltranslation/gt/commit/f89bd88b7466f2d9c6a5921ca7ec8f503fc2d8e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53430966)</sub>

<!-- /greptile_comment -->