### PR TITLE
ci: verify release pull request provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,13 +44,38 @@ jobs:
         run: pnpm install --no-frozen-lockfile
 
       - name: Create Release Pull Request
+        id: changesets-pr
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1
         with:
           version: pnpm run version-packages
           commit: '[ci] release'
           title: '[ci] release'
+          commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Clarify automatic publishing
+        if: steps.changesets-pr.outputs.pullRequestNumber != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.changesets-pr.outputs.pullRequestNumber }}
+        run: |
+          body=$(gh pr view "$PR_NUMBER" --json body --jq .body)
+          manual_text='publish to npm yourself or [setup this action to publish automatically](https://github.com/changesets/action#with-publishing)'
+          automatic_text='the packages will be published to npm automatically after this pull request is reviewed and merged'
+
+          if [[ "$body" == *"$automatic_text"* ]]; then
+            exit 0
+          fi
+          if [[ "$body" != *"$manual_text"* ]]; then
+            echo '::error::The Changesets release instructions did not match the pinned action output.'
+            exit 1
+          fi
+
+          updated_body=${body/"$manual_text"/"$automatic_text"}
+          gh api --method PATCH \
+            "/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
+            --raw-field body="$updated_body" > /dev/null
 
   # GitHub Actions bot: 41898282. Allowed mergers: eoinest (73407149),
   # brian-lou (69982825), and archie-mckenzie (90429137).
@@ -77,6 +102,38 @@ jobs:
     environment:
       name: 'release'
     steps:
+      - name: Verify release pull request provenance
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          commits=$(gh api --paginate --slurp \
+            "/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/commits?per_page=100")
+
+          if echo "$commits" | jq -e '
+            flatten |
+            length > 0 and
+            all(.[];
+              .author.id == 41898282 and
+              .committer.id == 41898282 and
+              .commit.verification.verified == true
+            )
+          ' > /dev/null; then
+            exit 0
+          fi
+
+          echo '::error::Every release PR commit must be GitHub-signed and attributed to github-actions[bot].'
+          echo "$commits" | jq -r '
+            flatten[] |
+            select(
+              .author.id != 41898282 or
+              .committer.id != 41898282 or
+              .commit.verification.verified != true
+            ) |
+            "::error::Untrusted release commit \(.sha)"
+          '
+          exit 1
+
       - name: Checkout Repo
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,32 +107,63 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          commits=$(gh api --paginate --slurp \
-            "/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/commits?per_page=100")
+          owner=${GITHUB_REPOSITORY%%/*}
+          repository=${GITHUB_REPOSITORY#*/}
+          mapfile -t commit_shas < <(gh api --paginate --slurp \
+            "/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/commits?per_page=100" \
+            --jq 'flatten | .[].sha')
 
-          if echo "$commits" | jq -e '
-            flatten |
-            length > 0 and
-            all(.[];
-              .author.id == 41898282 and
-              .committer.id == 41898282 and
-              .commit.verification.verified == true
-            )
-          ' > /dev/null; then
-            exit 0
+          if [ "${#commit_shas[@]}" -eq 0 ]; then
+            echo '::error::The release pull request has no commits.'
+            exit 1
           fi
 
-          echo '::error::Every release PR commit must be GitHub-signed and attributed to github-actions[bot].'
-          echo "$commits" | jq -r '
-            flatten[] |
-            select(
-              .author.id != 41898282 or
-              .committer.id != 41898282 or
-              .commit.verification.verified != true
-            ) |
-            "::error::Untrusted release commit \(.sha)"
-          '
-          exit 1
+          for sha in "${commit_shas[@]}"; do
+            commit=$(gh api graphql \
+              -f owner="$owner" \
+              -f name="$repository" \
+              -f oid="$sha" \
+              -f query='query($owner: String!, $name: String!, $oid: GitObjectID!) {
+                repository(owner: $owner, name: $name) {
+                  object(oid: $oid) {
+                    ... on Commit {
+                      author { user { databaseId } }
+                      signature {
+                        isValid
+                        signer { databaseId }
+                        wasSignedByGitHub
+                      }
+                    }
+                  }
+                }
+              }')
+
+            if echo "$commit" | jq -e '
+              .data.repository.object as $commit |
+              ($commit.author.user.databaseId // 0) as $author |
+              ($commit.signature // {}) as $signature |
+              (
+                $author == 41898282 and
+                $signature.isValid == true and
+                $signature.wasSignedByGitHub == true and
+                $signature.signer.databaseId == 19864447
+              ) or (
+                ([73407149, 69982825, 90429137] | index($author)) != null and
+                $signature.isValid == true and
+                (
+                  ($signature.wasSignedByGitHub == true and
+                    $signature.signer.databaseId == 19864447) or
+                  ($signature.wasSignedByGitHub == false and
+                    $signature.signer.databaseId == $author)
+                )
+              )
+            ' > /dev/null; then
+              continue
+            fi
+
+            echo "::error::Untrusted release commit ${sha}. Commits must be created by github-actions[bot] or verifiably signed by Ernest, Brian, or Archie."
+            exit 1
+          done
 
       - name: Checkout Repo
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4


### PR DESCRIPTION
## Summary

- make Changesets create GitHub-signed release commits attributed to `github-actions[bot]`
- reject publishing unless every release PR commit is either GitHub-signed bot output or verifiably signed by Ernest, Brian, or Archie
- keep the generated release PR instructions accurate without granting publishing access to the PR-generation job

## Testing

- `pnpm exec oxfmt --check .github/workflows/release.yml` — passed
- `actionlint .github/workflows/*.yml` — passed
- YAML parse and workflow provenance assertions — passed
- actual GitHub-signed bot commit fixture — accepted
- actual GitHub-signed allowed-admin commit fixture — accepted
- synthetic verified locally signed allowed-admin commit fixture — accepted
- admin commit with an unregistered signing key — rejected as expected
- GitHub-signed non-admin commit fixture — rejected as expected
- spoofed admin author and unsigned admin fixtures — rejected as expected
- release PR body replacement fixture — passed
- `git diff --check` — passed

## Notes

- Changeset: not required because this only changes CI configuration.
- Stack: based on #2099 (`e/release/isolate-release-oidc`); merge #2099 first.
- The `release` environment is already restricted to `main`. After #2099 merges, add Ernest, Brian, and Archie as environment reviewers before merging any Changesets release PR.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change hardens package-release provenance by creating release commits through the GitHub API, updating generated release pull requests to describe automatic publishing, and checking every merged release commit before publishing. Executed coverage confirmed that the provenance gate accepts the intended GitHub Actions and designated-administrator signatures while rejecting untrusted or incomplete signature data.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains; the release provenance control behaved as intended across the exercised trusted and untrusted commit cases.

No blocking failure remains.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the self-contained release provenance harness against both the parent and changed release workflow gates using mocked REST and GraphQL responses.
- The changed gate completed five assertions successfully, including accepting GitHub Actions signed commits and allowlisted administrator self-signed commits while rejecting untrusted authors, missing signatures, and malformed GraphQL responses.
- Compared the baseline and changed-gate logs to confirm behavior against the intended policy, noting baseline exit code 0 with old-policy results and changed-gate exit code 0 with five assertions passed.

<a href="https://app.greptile.com/trex/runs/20696809/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): allow verified admin release co..."](https://github.com/generaltranslation/gt/commit/c668e07e73d5cc36de6c43e0b3f16997ffb0c3ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53486942)</sub>

<!-- /greptile_comment -->