### PR TITLE
fix(next): stop injecting stable rootParams flag

### DIFF
--- a/.changeset/calm-ravens-smile.md
+++ b/.changeset/calm-ravens-smile.md
@@ -1,0 +1,5 @@
+---
+'gt-next': patch
+---
+
+Stop adding the deprecated `experimental.rootParams` option on Next.js 16.3 and newer.

--- a/packages/next/src/__tests__/config.test.ts
+++ b/packages/next/src/__tests__/config.test.ts
@@ -2052,9 +2052,11 @@ describe('withGTConfig', () => {
   describe('18. Function-form next config', () => {
     it('calls a sync config function and layers GT on the result', async () => {
       const withGTConfig = await getWithGTConfig();
-      const built = withGTConfig((_phase: string): NextConfig => ({
-        reactStrictMode: true,
-      }));
+      const built = withGTConfig(
+        (_phase: string): NextConfig => ({
+          reactStrictMode: true,
+        })
+      );
 
       expect(typeof built).toBe('function');
       const resolved = (

--- a/packages/next/src/__tests__/config.test.ts
+++ b/packages/next/src/__tests__/config.test.ts
@@ -305,6 +305,14 @@ describe('withGTConfig', () => {
 
       expect(result.experimental!.rootParams).toBe(true);
     });
+
+    it('omits experimental.rootParams when root params are stable', async () => {
+      const withGTConfig = await getWithGTConfig();
+      mockVersionInfo.rootParamStability = 'stable';
+      const result = withGTConfig();
+
+      expect(result.experimental).not.toHaveProperty('rootParams');
+    });
   });
 
   // ==============================
@@ -2044,11 +2052,9 @@ describe('withGTConfig', () => {
   describe('18. Function-form next config', () => {
     it('calls a sync config function and layers GT on the result', async () => {
       const withGTConfig = await getWithGTConfig();
-      const built = withGTConfig(
-        (_phase: string): NextConfig => ({
-          reactStrictMode: true,
-        })
-      );
+      const built = withGTConfig((_phase: string): NextConfig => ({
+        reactStrictMode: true,
+      }));
 
       expect(typeof built).toBe('function');
       const resolved = (

--- a/packages/next/src/plugin/__tests__/getStableNextVersionInfo.test.ts
+++ b/packages/next/src/plugin/__tests__/getStableNextVersionInfo.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { getRootParamStability } from '../getStableNextVersionInfo';
+
+describe('getRootParamStability', () => {
+  it.each([
+    ['14.2.0', 'unsupported'],
+    ['15.2.0', 'unstable'],
+    ['15.4.9', 'unstable'],
+    ['15.5.0', 'experimental'],
+    ['16.2.9', 'experimental'],
+    ['16.3.0', 'stable'],
+    ['17.0.0', 'stable'],
+  ] as const)('classifies Next.js %s as %s', (nextVersion, expected) => {
+    expect(getRootParamStability(nextVersion)).toBe(expected);
+  });
+});

--- a/packages/next/src/plugin/constants.ts
+++ b/packages/next/src/plugin/constants.ts
@@ -7,6 +7,7 @@ export const ROOT_PARAM_STABILITY = {
   unsupported: '0.0.0',
   unstable: '15.2.0',
   experimental: '15.5.0',
+  stable: '16.3.0',
 };
 
 export const STABLE_TURBO_CONFIG_VERSION = '15.3.0';

--- a/packages/next/src/plugin/getStableNextVersionInfo.ts
+++ b/packages/next/src/plugin/getStableNextVersionInfo.ts
@@ -82,22 +82,30 @@ export const turboConfigStable = comparePackageVersion(
 
 export type RootParam = 'unsupported' | 'unstable' | 'experimental' | 'stable';
 
-export const rootParamStability: RootParam = (() => {
-  const nextVersion = getNextVersion();
+/**
+ * Classify the stability of root params for a Next.js version.
+ *
+ * @param nextVersion - The Next.js version to classify.
+ * @returns The root params stability tier for the supplied version.
+ */
+export function getRootParamStability(nextVersion: string): RootParam {
+  // Check stable before experimental because each threshold is a lower bound.
+  if (comparePackageVersion(nextVersion, ROOT_PARAM_STABILITY.stable)) {
+    return 'stable';
+  }
 
-  // Check if experimental
   if (comparePackageVersion(nextVersion, ROOT_PARAM_STABILITY.experimental)) {
     return 'experimental';
   }
 
-  // Check if unstable
   if (comparePackageVersion(nextVersion, ROOT_PARAM_STABILITY.unstable)) {
     return 'unstable';
   }
 
-  // return unsupported
   return 'unsupported';
-})();
+}
+
+export const rootParamStability = getRootParamStability(getNextVersion());
 
 export const swcPluginCompatible = comparePackageVersion(
   getNextVersion(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- classify `next/root-params` as stable starting with Next.js 16.3
- keep `experimental.rootParams` enabled for Next.js 15.5 through 16.2
- cover version boundaries and stable config output with unit tests
- add a patch changeset for `gt-next`

## Testing
- `pnpm --filter gt-next exec vitest run src/plugin/__tests__/getStableNextVersionInfo.test.ts src/__tests__/config.test.ts` (125 passed)
- `pnpm --filter gt-next test` (282 JavaScript and 297 Rust tests passed)
- `pnpm --filter gt-next build`
- `pnpm --filter gt-next typecheck`
- targeted `oxlint` and `oxfmt --check`
- packed the local `gt-next` package and completed an isolated Next.js 16.3.1 production build without the deprecated `experimental.rootParams` warning
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://generaltranslation.slack.com/archives/C0BJA1M93QC/p1786832475917289?thread_ts=1786832475.917289&cid=C0BJA1M93QC)

<div><a href="https://cursor.com/agents/bc-29ff55e9-a8da-50d3-9f10-1f810a581f3b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29ff55e9-a8da-50d3-9f10-1f810a581f3b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds a Next.js 16.3.0 threshold for treating root params as stable and updates the associated configuration tests and release metadata. The prerelease boundary was exercised and `16.3.0-canary.1` was classified as stable, causing the generated configuration to omit `experimental.rootParams`; this must be corrected before merging.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Not safe to merge until prerelease-aware version comparison preserves the root-params flag for Next.js 16.3.0 prereleases.

The affected canary and stable-release boundary was executed directly, and the observed generated configuration confirmed the compatibility failure.

**Files Needing Attention:** packages/next/src/plugin/getStableNextVersionInfo.ts needs prerelease-aware comparison; packages/next/src/plugin/__tests__/getStableNextVersionInfo.test.ts should cover the canary and stable boundaries.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Created a runtime boundary-check source for the candidate and semver-corrected comparison to validate version boundary handling.
- Observed the candidate runtime output classifying Next 16.3.0 canary as stable.
- Validated the semver-aware boundary logic and noted the corrected boundary output showing experimental stability with rootParams enabled, and identified the root-cause in the comparison function.
- Produced proof for an additional posted P1 finding.

<a href="https://app.greptile.com/trex/runs/19070056/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Next 16.3.0 prereleases are treated as stable**

   - **Bug**
     - At `packages/next/src/plugin/getStableNextVersionInfo.ts:93-95`, `getRootParamStability('16.3.0-canary.1')` returns `stable`. The config condition in `packages/next/src/config.ts:791-792` only adds `experimental.rootParams` for `experimental`, so the generated config omits it.
   - **Cause**
     - `comparePackageVersion` splits only on dots and coerces `0-canary` to numeric `0`, losing SemVer prerelease information; equal numeric components then return true.
   - **Fix**
     - Use a SemVer-compliant comparator (or explicitly recognize prereleases) so `16.3.0-canary.1 < 16.3.0`; add the canary/stable boundary assertions to `getStableNextVersionInfo.test.ts`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20generaltranslation%2Fgt%20PR%20%232104%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=generaltranslation%2Fgt&pr=2104&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fnext%2Fsrc%2Fplugin%2FgetStableNextVersionInfo.ts%3A93-95%0A**Prerelease%20versions%20bypass%20the%20root-params%20flag**%0A%0A%60comparePackageVersion%60%20drops%20the%20prerelease%20suffix%20while%20coercing%20version%20components%20to%20numbers%2C%20so%20%6016.3.0-canary.1%60%20is%20considered%20to%20meet%20the%20%6016.3.0%60%20stable%20threshold.%20The%20generated%20config%20consequently%20omits%20%60experimental.rootParams%60%2C%20although%20that%20prerelease%20still%20requires%20the%20flag.%20Use%20SemVer%20prerelease%20ordering%20%28and%20cover%20%6016.3.0-canary.1%60%20alongside%20stable%20%6016.3.0%60%29%20so%20only%20the%20stable%20release%20disables%20the%20experimental%20setting.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2104&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22cursor%2Ffix-next-root-params-1f3b%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2Ffix-next-root-params-1f3b%22.%0A%0A%23%23%23%20Issue%201%0Apackages%2Fnext%2Fsrc%2Fplugin%2FgetStableNextVersionInfo.ts%3A93-95%0A**Prerelease%20versions%20bypass%20the%20root-params%20flag**%0A%0A%60comparePackageVersion%60%20drops%20the%20prerelease%20suffix%20while%20coercing%20version%20components%20to%20numbers%2C%20so%20%6016.3.0-canary.1%60%20is%20considered%20to%20meet%20the%20%6016.3.0%60%20stable%20threshold.%20The%20generated%20config%20consequently%20omits%20%60experimental.rootParams%60%2C%20although%20that%20prerelease%20still%20requires%20the%20flag.%20Use%20SemVer%20prerelease%20ordering%20%28and%20cover%20%6016.3.0-canary.1%60%20alongside%20stable%20%6016.3.0%60%29%20so%20only%20the%20stable%20release%20disables%20the%20experimental%20setting.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2104&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/next/src/plugin/getStableNextVersionInfo.ts:93-95
**Prerelease versions bypass the root-params flag**

`comparePackageVersion` drops the prerelease suffix while coercing version components to numbers, so `16.3.0-canary.1` is considered to meet the `16.3.0` stable threshold. The generated config consequently omits `experimental.rootParams`, although that prerelease still requires the flag. Use SemVer prerelease ordering (and cover `16.3.0-canary.1` alongside stable `16.3.0`) so only the stable release disables the experimental setting.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["style(next): preserve config test format..."](https://github.com/generaltranslation/gt/commit/97dc80a73bff5539c03f4557a5cb17ec326eae19) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53695398)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->