### PR TITLE
fix(next): navigate to unprefixed default locale

### DIFF
--- a/.changeset/default-locale-navigation.md
+++ b/.changeset/default-locale-navigation.md
@@ -1,0 +1,5 @@
+---
+'gt-next': patch
+---
+
+Use a browser navigation when switching back to an unprefixed default locale.

--- a/packages/next/src/utils/__tests__/client-boundary.test.tsx
+++ b/packages/next/src/utils/__tests__/client-boundary.test.tsx
@@ -3,13 +3,19 @@ import React, { act } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockGetI18nConfig, mockInitializeGTClient, mockRefresh } = vi.hoisted(
-  () => ({
-    mockGetI18nConfig: vi.fn(),
-    mockInitializeGTClient: vi.fn(),
-    mockRefresh: vi.fn(),
-  })
-);
+const {
+  mockGetI18nConfig,
+  mockInitializeGTClient,
+  mockPathname,
+  mockRefresh,
+  mockReloadPage,
+} = vi.hoisted(() => ({
+  mockGetI18nConfig: vi.fn(),
+  mockInitializeGTClient: vi.fn(),
+  mockPathname: vi.fn(),
+  mockRefresh: vi.fn(),
+  mockReloadPage: vi.fn(),
+}));
 
 vi.mock('gt-i18n/internal', async (importOriginal) => ({
   ...(await importOriginal<typeof import('gt-i18n/internal')>()),
@@ -23,7 +29,7 @@ vi.mock('gt-react', () => ({
 }));
 
 vi.mock('next/navigation', () => ({
-  usePathname: () => '/uk',
+  usePathname: mockPathname,
   useRouter: () => ({ refresh: mockRefresh }),
 }));
 
@@ -35,6 +41,8 @@ describe('Client_GTProvider', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    vi.stubGlobal('location', { reload: mockReloadPage });
+    mockPathname.mockReturnValue('/uk');
     process.env._GENERALTRANSLATION_PATH_REGEX = '^/(?!uk(?:/|$)).*';
     document.cookie = 'generaltranslation.locale-routing-enabled=true;path=/';
     mockGetI18nConfig.mockReturnValue({
@@ -52,6 +60,7 @@ describe('Client_GTProvider', () => {
     delete process.env._GENERALTRANSLATION_PATH_REGEX;
     document.cookie =
       'generaltranslation.locale-routing-enabled=;max-age=0;path=/';
+    vi.unstubAllGlobals();
     globalThis.IS_REACT_ACT_ENVIRONMENT = false;
   });
 
@@ -69,6 +78,35 @@ describe('Client_GTProvider', () => {
     });
 
     expect(mockGetI18nConfig).toHaveBeenCalled();
+    expect(mockRefresh).not.toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+  });
+
+  it('reloads the page when switching to the default locale', async () => {
+    process.env._GENERALTRANSLATION_PATH_REGEX = '.*';
+    mockPathname.mockReturnValue('/pt-BR');
+    mockGetI18nConfig.mockReturnValue({
+      determineLocale: vi.fn(([locale]: string[]) => locale),
+      getDefaultLocale: () => 'en',
+      getLocales: () => ['en', 'pt-BR'],
+      isGTServicesEnabled: () => false,
+      resolveAliasLocale: (locale: string) => locale,
+      standardizeLocale: (locale: string) => locale,
+    });
+    const { Client_GTProvider } = await import('../client-boundary');
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <Client_GTProvider dictionaries={{}} locale='en' translations={{}}>
+          content
+        </Client_GTProvider>
+      );
+    });
+
+    expect(mockReloadPage).toHaveBeenCalledOnce();
     expect(mockRefresh).not.toHaveBeenCalled();
 
     await act(async () => root.unmount());

--- a/packages/next/src/utils/__tests__/client-boundary.test.tsx
+++ b/packages/next/src/utils/__tests__/client-boundary.test.tsx
@@ -5,12 +5,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   mockGetI18nConfig,
+  mockGTProvider,
   mockInitializeGTClient,
   mockPathname,
   mockRefresh,
   mockReloadPage,
 } = vi.hoisted(() => ({
   mockGetI18nConfig: vi.fn(),
+  mockGTProvider: vi.fn(
+    ({ children }: { children?: React.ReactNode }) => children
+  ),
   mockInitializeGTClient: vi.fn(),
   mockPathname: vi.fn(),
   mockRefresh: vi.fn(),
@@ -23,7 +27,7 @@ vi.mock('gt-i18n/internal', async (importOriginal) => ({
 }));
 
 vi.mock('gt-react', () => ({
-  GTProvider: ({ children }: { children?: React.ReactNode }) => children,
+  GTProvider: mockGTProvider,
   LocaleSelector: () => null,
   RegionSelector: () => null,
 }));
@@ -41,7 +45,7 @@ describe('Client_GTProvider', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
-    vi.stubGlobal('location', { reload: mockReloadPage });
+    vi.stubGlobal('location', { pathname: '/uk', reload: mockReloadPage });
     mockPathname.mockReturnValue('/uk');
     process.env._GENERALTRANSLATION_PATH_REGEX = '^/(?!uk(?:/|$)).*';
     document.cookie = 'generaltranslation.locale-routing-enabled=true;path=/';
@@ -86,6 +90,10 @@ describe('Client_GTProvider', () => {
   it('reloads the page when switching to the default locale', async () => {
     process.env._GENERALTRANSLATION_PATH_REGEX = '.*';
     mockPathname.mockReturnValue('/pt-BR');
+    vi.stubGlobal('location', {
+      pathname: '/pt-BR',
+      reload: mockReloadPage,
+    });
     mockGetI18nConfig.mockReturnValue({
       determineLocale: vi.fn(([locale]: string[]) => locale),
       getDefaultLocale: () => 'en',
@@ -100,14 +108,41 @@ describe('Client_GTProvider', () => {
 
     await act(async () => {
       root.render(
-        <Client_GTProvider dictionaries={{}} locale='en' translations={{}}>
+        <Client_GTProvider dictionaries={{}} locale='pt-BR' translations={{}}>
           content
         </Client_GTProvider>
       );
     });
 
+    const reload = mockGTProvider.mock.calls.at(-1)?.[0]._reload;
+    reload({ enableI18n: true, locale: 'en', region: undefined });
+
     expect(mockReloadPage).toHaveBeenCalledOnce();
     expect(mockRefresh).not.toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+  });
+
+  it('refreshes server components without locale routing', async () => {
+    document.cookie =
+      'generaltranslation.locale-routing-enabled=;max-age=0;path=/';
+    const { Client_GTProvider } = await import('../client-boundary');
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <Client_GTProvider dictionaries={{}} locale='fr' translations={{}}>
+          content
+        </Client_GTProvider>
+      );
+    });
+
+    const reload = mockGTProvider.mock.calls.at(-1)?.[0]._reload;
+    reload({ enableI18n: true, locale: 'en', region: undefined });
+
+    expect(mockRefresh).toHaveBeenCalledOnce();
+    expect(mockReloadPage).not.toHaveBeenCalled();
 
     await act(async () => root.unmount());
   });

--- a/packages/next/src/utils/__tests__/client-boundary.test.tsx
+++ b/packages/next/src/utils/__tests__/client-boundary.test.tsx
@@ -8,8 +8,8 @@ const {
   mockGTProvider,
   mockInitializeGTClient,
   mockPathname,
-  mockRefresh,
-  mockReloadPage,
+  mockRefreshServerComponents,
+  mockReloadBrowserPage,
 } = vi.hoisted(() => ({
   mockGetI18nConfig: vi.fn(),
   mockGTProvider: vi.fn(
@@ -17,8 +17,8 @@ const {
   ),
   mockInitializeGTClient: vi.fn(),
   mockPathname: vi.fn(),
-  mockRefresh: vi.fn(),
-  mockReloadPage: vi.fn(),
+  mockRefreshServerComponents: vi.fn(),
+  mockReloadBrowserPage: vi.fn(),
 }));
 
 vi.mock('gt-i18n/internal', async (importOriginal) => ({
@@ -34,7 +34,7 @@ vi.mock('gt-react', () => ({
 
 vi.mock('next/navigation', () => ({
   usePathname: mockPathname,
-  useRouter: () => ({ refresh: mockRefresh }),
+  useRouter: () => ({ refresh: mockRefreshServerComponents }),
 }));
 
 vi.mock('../../setup/initGT.client', () => ({
@@ -45,7 +45,10 @@ describe('Client_GTProvider', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
-    vi.stubGlobal('location', { pathname: '/uk', reload: mockReloadPage });
+    vi.stubGlobal('location', {
+      pathname: '/uk',
+      reload: mockReloadBrowserPage,
+    });
     mockPathname.mockReturnValue('/uk');
     process.env._GENERALTRANSLATION_PATH_REGEX = '^/(?!uk(?:/|$)).*';
     document.cookie = 'generaltranslation.locale-routing-enabled=true;path=/';
@@ -82,17 +85,17 @@ describe('Client_GTProvider', () => {
     });
 
     expect(mockGetI18nConfig).toHaveBeenCalled();
-    expect(mockRefresh).not.toHaveBeenCalled();
+    expect(mockRefreshServerComponents).not.toHaveBeenCalled();
 
     await act(async () => root.unmount());
   });
 
-  it('reloads the page when switching to the default locale', async () => {
+  it('reloads the browser page when switching to the default locale', async () => {
     process.env._GENERALTRANSLATION_PATH_REGEX = '.*';
     mockPathname.mockReturnValue('/pt-BR');
     vi.stubGlobal('location', {
       pathname: '/pt-BR',
-      reload: mockReloadPage,
+      reload: mockReloadBrowserPage,
     });
     mockGetI18nConfig.mockReturnValue({
       determineLocale: vi.fn(([locale]: string[]) => locale),
@@ -114,11 +117,48 @@ describe('Client_GTProvider', () => {
       );
     });
 
-    const reload = mockGTProvider.mock.calls.at(-1)?.[0]._reload;
-    reload({ enableI18n: true, locale: 'en', region: undefined });
+    const syncServerContent = mockGTProvider.mock.calls.at(-1)?.[0]._reload;
+    syncServerContent({ enableI18n: true, locale: 'en', region: undefined });
 
-    expect(mockReloadPage).toHaveBeenCalledOnce();
-    expect(mockRefresh).not.toHaveBeenCalled();
+    expect(mockReloadBrowserPage).toHaveBeenCalledOnce();
+    expect(mockRefreshServerComponents).not.toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+  });
+
+  it('refreshes server components on excluded paths', async () => {
+    process.env._GENERALTRANSLATION_PATH_REGEX =
+      '^/(?!fr/favicon\\.ico(?:/|$)).*';
+    mockPathname.mockReturnValue('/fr/favicon.ico');
+    vi.stubGlobal('location', {
+      pathname: '/fr/favicon.ico',
+      reload: mockReloadBrowserPage,
+    });
+    mockGetI18nConfig.mockReturnValue({
+      determineLocale: vi.fn(),
+      getDefaultLocale: () => 'en',
+      getLocales: () => ['en', 'fr'],
+      isGTServicesEnabled: () => false,
+      resolveAliasLocale: (locale: string) => locale,
+      standardizeLocale: (locale: string) => locale,
+    });
+    const { Client_GTProvider } = await import('../client-boundary');
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <Client_GTProvider dictionaries={{}} locale='fr' translations={{}}>
+          content
+        </Client_GTProvider>
+      );
+    });
+
+    const syncServerContent = mockGTProvider.mock.calls.at(-1)?.[0]._reload;
+    syncServerContent({ enableI18n: true, locale: 'en', region: undefined });
+
+    expect(mockRefreshServerComponents).toHaveBeenCalledOnce();
+    expect(mockReloadBrowserPage).not.toHaveBeenCalled();
 
     await act(async () => root.unmount());
   });
@@ -138,11 +178,11 @@ describe('Client_GTProvider', () => {
       );
     });
 
-    const reload = mockGTProvider.mock.calls.at(-1)?.[0]._reload;
-    reload({ enableI18n: true, locale: 'en', region: undefined });
+    const syncServerContent = mockGTProvider.mock.calls.at(-1)?.[0]._reload;
+    syncServerContent({ enableI18n: true, locale: 'en', region: undefined });
 
-    expect(mockRefresh).toHaveBeenCalledOnce();
-    expect(mockReloadPage).not.toHaveBeenCalled();
+    expect(mockRefreshServerComponents).toHaveBeenCalledOnce();
+    expect(mockReloadBrowserPage).not.toHaveBeenCalled();
 
     await act(async () => root.unmount());
   });

--- a/packages/next/src/utils/client-boundary.tsx
+++ b/packages/next/src/utils/client-boundary.tsx
@@ -44,21 +44,26 @@ export function Client_GTProvider(props: SharedGTProviderProps) {
     // Reload server components
     router.refresh();
   }, [router]);
+  const reloadPage = useCallback(() => {
+    globalThis.location.reload();
+  }, []);
   // TODO: when routing is enabled, validate the path matches the locale
-  usePathCheck({ reloadServer: reload, locale: props.locale });
+  usePathCheck({ reloadPage, reloadServer: reload, locale: props.locale });
   return <GTProvider {...props} _reload={reload} />;
 }
 
 /**
- * Reloads the server components if
+ * Reloads content if the URL locale does not match the selected locale.
  * TODO: optimize this hook
  */
 function usePathCheck({
+  reloadPage,
   reloadServer,
   locale,
   referrerLocaleCookieName = defaultReferrerLocaleCookieName,
   localeRoutingEnabledCookieName = defaultLocaleRoutingEnabledCookieName,
 }: {
+  reloadPage: () => void;
   reloadServer: () => void;
   locale: string;
   referrerLocaleCookieName?: string;
@@ -98,8 +103,13 @@ function usePathCheck({
         // clear cookie (avoids infinite loop when there is no middleware)
         document.cookie = `${localeRoutingEnabledCookieName}=;path=/`;
 
-        // reload page
-        reloadServer();
+        if (locale === i18nConfig.resolveAliasLocale(defaultLocale)) {
+          // A browser navigation follows the middleware redirect that removes
+          // the default locale prefix. Next.js router.refresh() does not.
+          reloadPage();
+        } else {
+          reloadServer();
+        }
       }
     }
   }, [
@@ -107,6 +117,7 @@ function usePathCheck({
     locale,
     referrerLocaleCookieName,
     localeRoutingEnabledCookieName,
+    reloadPage,
     reloadServer,
   ]);
 }

--- a/packages/next/src/utils/client-boundary.tsx
+++ b/packages/next/src/utils/client-boundary.tsx
@@ -40,59 +40,67 @@ if (typeof window !== 'undefined') {
  */
 export function Client_GTProvider(props: SharedGTProviderProps) {
   const router = useRouter();
-  const refresh = useCallback(() => {
+  const refreshServerComponents = useCallback(() => {
     router.refresh();
   }, [router]);
-  const reloadPage = useCallback(() => {
+  const reloadBrowserPage = useCallback(() => {
     globalThis.location.reload();
   }, []);
-  const reload = useCallback<NonNullable<SharedGTProviderProps['_reload']>>(
+  const syncServerContent = useCallback<
+    NonNullable<SharedGTProviderProps['_reload']>
+  >(
     ({ locale }) => {
       const i18nConfig = getI18nConfig();
-      const middlewareEnabled =
+      const localeRoutingEnabled =
         getCookieValue(
           document.cookie,
           defaultLocaleRoutingEnabledCookieName
         ) === 'true';
       const defaultLocale = i18nConfig.getDefaultLocale();
-      const pathLocale = extractLocale(
-        globalThis.location.pathname,
-        i18nConfig
-      );
+      const currentPathname = globalThis.location.pathname;
+      const localeRoutingApplies =
+        localeRoutingEnabled &&
+        pathnameMatchesRegex(currentPathname, pathRegex);
+      const currentPathLocale = localeRoutingApplies
+        ? extractLocale(currentPathname, i18nConfig)
+        : null;
 
       if (
-        middlewareEnabled &&
+        localeRoutingApplies &&
         locale === defaultLocale &&
-        pathLocale &&
-        pathLocale !== defaultLocale
+        currentPathLocale &&
+        currentPathLocale !== defaultLocale
       ) {
-        reloadPage();
+        reloadBrowserPage();
         return;
       }
 
-      // Reload server components
-      refresh();
+      refreshServerComponents();
     },
-    [refresh, reloadPage]
+    [refreshServerComponents, reloadBrowserPage]
   );
-  // TODO: when routing is enabled, validate the path matches the locale
-  usePathCheck({ reloadPage, reloadServer: refresh, locale: props.locale });
-  return <GTProvider {...props} _reload={reload} />;
+  usePathCheck({
+    reloadBrowserPage,
+    refreshServerComponents,
+    locale: props.locale,
+  });
+  return <GTProvider {...props} _reload={syncServerContent} />;
 }
 
 /**
- * Reloads content if the URL locale does not match the selected locale.
+ * Synchronizes server content if the URL locale does not match the selected
+ * locale.
  * TODO: optimize this hook
  */
 function usePathCheck({
-  reloadPage,
-  reloadServer,
+  reloadBrowserPage,
+  refreshServerComponents,
   locale,
   referrerLocaleCookieName = defaultReferrerLocaleCookieName,
   localeRoutingEnabledCookieName = defaultLocaleRoutingEnabledCookieName,
 }: {
-  reloadPage: () => void;
-  reloadServer: () => void;
+  reloadBrowserPage: () => void;
+  refreshServerComponents: () => void;
   locale: string;
   referrerLocaleCookieName?: string;
   localeRoutingEnabledCookieName?: string;
@@ -104,17 +112,17 @@ function usePathCheck({
     const i18nConfig = getI18nConfig();
     document.cookie = `${referrerLocaleCookieName}=${i18nConfig.resolveAliasLocale(locale)};path=/`;
 
-    // Reload the server components if the pathname changes
+    // Synchronize server content if the pathname changes
     const locales = i18nConfig.getLocales();
     const defaultLocale = i18nConfig.getDefaultLocale();
-    const middlewareEnabled =
+    const localeRoutingEnabled =
       getCookieValue(document.cookie, localeRoutingEnabledCookieName) ===
       'true';
-    if (middlewareEnabled && pathnameMatchesRegex(pathname, pathRegex)) {
+    if (localeRoutingEnabled && pathnameMatchesRegex(pathname, pathRegex)) {
       // Extract locale from pathname
       const extractedLocale =
         extractLocale(pathname, i18nConfig) || defaultLocale;
-      let pathLocale = i18nConfig.determineLocale(
+      let currentPathLocale = i18nConfig.determineLocale(
         [
           i18nConfig.isGTServicesEnabled()
             ? i18nConfig.standardizeLocale(extractedLocale)
@@ -123,20 +131,24 @@ function usePathCheck({
         ],
         locales
       );
-      if (pathLocale) {
-        pathLocale = i18nConfig.resolveAliasLocale(pathLocale);
+      if (currentPathLocale) {
+        currentPathLocale = i18nConfig.resolveAliasLocale(currentPathLocale);
       }
 
-      if (pathLocale && locales.includes(pathLocale) && pathLocale !== locale) {
+      if (
+        currentPathLocale &&
+        locales.includes(currentPathLocale) &&
+        currentPathLocale !== locale
+      ) {
         // clear cookie (avoids infinite loop when there is no middleware)
         document.cookie = `${localeRoutingEnabledCookieName}=;path=/`;
 
         if (locale === defaultLocale) {
           // A browser navigation follows the middleware redirect that removes
           // the default locale prefix. Next.js router.refresh() does not.
-          reloadPage();
+          reloadBrowserPage();
         } else {
-          reloadServer();
+          refreshServerComponents();
         }
       }
     }
@@ -145,8 +157,8 @@ function usePathCheck({
     locale,
     referrerLocaleCookieName,
     localeRoutingEnabledCookieName,
-    reloadPage,
-    reloadServer,
+    reloadBrowserPage,
+    refreshServerComponents,
   ]);
 }
 

--- a/packages/next/src/utils/client-boundary.tsx
+++ b/packages/next/src/utils/client-boundary.tsx
@@ -40,15 +40,46 @@ if (typeof window !== 'undefined') {
  */
 export function Client_GTProvider(props: SharedGTProviderProps) {
   const router = useRouter();
-  const reload = useCallback(() => {
-    // Reload server components
+  const refresh = useCallback(() => {
     router.refresh();
   }, [router]);
   const reloadPage = useCallback(() => {
     globalThis.location.reload();
   }, []);
+  const reload = useCallback<NonNullable<SharedGTProviderProps['_reload']>>(
+    ({ locale }) => {
+      const i18nConfig = getI18nConfig();
+      const middlewareEnabled =
+        getCookieValue(
+          document.cookie,
+          defaultLocaleRoutingEnabledCookieName
+        ) === 'true';
+      const nextLocale = i18nConfig.resolveAliasLocale(locale);
+      const defaultLocale = i18nConfig.resolveAliasLocale(
+        i18nConfig.getDefaultLocale()
+      );
+      const pathLocale = extractLocale(
+        globalThis.location.pathname,
+        i18nConfig
+      );
+
+      if (
+        middlewareEnabled &&
+        nextLocale === defaultLocale &&
+        pathLocale &&
+        pathLocale !== defaultLocale
+      ) {
+        reloadPage();
+        return;
+      }
+
+      // Reload server components
+      refresh();
+    },
+    [refresh, reloadPage]
+  );
   // TODO: when routing is enabled, validate the path matches the locale
-  usePathCheck({ reloadPage, reloadServer: reload, locale: props.locale });
+  usePathCheck({ reloadPage, reloadServer: refresh, locale: props.locale });
   return <GTProvider {...props} _reload={reload} />;
 }
 

--- a/packages/next/src/utils/client-boundary.tsx
+++ b/packages/next/src/utils/client-boundary.tsx
@@ -54,10 +54,7 @@ export function Client_GTProvider(props: SharedGTProviderProps) {
           document.cookie,
           defaultLocaleRoutingEnabledCookieName
         ) === 'true';
-      const nextLocale = i18nConfig.resolveAliasLocale(locale);
-      const defaultLocale = i18nConfig.resolveAliasLocale(
-        i18nConfig.getDefaultLocale()
-      );
+      const defaultLocale = i18nConfig.getDefaultLocale();
       const pathLocale = extractLocale(
         globalThis.location.pathname,
         i18nConfig
@@ -65,7 +62,7 @@ export function Client_GTProvider(props: SharedGTProviderProps) {
 
       if (
         middlewareEnabled &&
-        nextLocale === defaultLocale &&
+        locale === defaultLocale &&
         pathLocale &&
         pathLocale !== defaultLocale
       ) {
@@ -134,7 +131,7 @@ function usePathCheck({
         // clear cookie (avoids infinite loop when there is no middleware)
         document.cookie = `${localeRoutingEnabledCookieName}=;path=/`;
 
-        if (locale === i18nConfig.resolveAliasLocale(defaultLocale)) {
+        if (locale === defaultLocale) {
           // A browser navigation follows the middleware redirect that removes
           // the default locale prefix. Next.js router.refresh() does not.
           reloadPage();


### PR DESCRIPTION
- next 16.3 introduced some issues with redirect. basically, the router.refresh() no longer fulfills 307 redirects from server which we depend on when naving from localized route back to unprefixed default locale (eg `/fr` -> `/`)
- fix is to determine when this case applies and do a `window.location.reload()`

## Summary

- Use a browser navigation immediately when locale routing switches from a prefixed locale back to the default locale, allowing the browser to follow the middleware redirect that removes the prefix.
- Keep `router.refresh()` for other locale changes, including apps without locale routing, and retain the path-mismatch recovery check.
- Cover both the routed default-locale change and the non-routing refresh behavior with regression tests.

## Testing

- `pnpm --filter gt-next test:js` — passed (26 files, 284 tests)
- `pnpm --filter gt-next build:no-swc-plugin` — passed
- Focused `oxlint` and `oxfmt --check` — passed
- Next.js 16.3.0 linked routing and non-routing apps: TypeScript and production builds — passed
- Published `gt-next@11.1.9` Playwright control — reproduced the failure: `/fr` and French server content remained while the client locale and selector showed English
- Linked fixed Playwright app — passed 10 repeated `en → fr → en` attempts plus `en → fr → zh → en`, always ending at `/` with matching server, client, and selector state
- Linked non-routing Playwright app — passed `en → fr → zh → en`; the URL remained `/` and no locale-routing cookie was created

## Notes

- Changeset: added a patch release for `gt-next`.
- The reproduction apps, linking adjustments, and test-only `NextRequest`/`NextResponse` injection are not included in this PR.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Locale synchronization now performs a browser navigation only for paths covered by locale routing, while excluded and non-routed paths refresh server-rendered content without discarding client-side page state. Focused coverage confirms excluded `/fr/favicon.ico` refreshes server components and routed `/pt-BR` still navigates when switching to the default locale.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge: no blocking failure remains.

No blocking failure remains.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the focused client-boundary test suite for locale routing.
- The focused jsdom tests passed all four cases, including that the excluded /fr/favicon.ico path refreshed server components without a browser reload.
- The test results showed that the /pt-BR route reloaded when switching to the default en locale, confirming correct routing behavior.
- T-Rex analyzed the implementation and confirmed localeRoutingApplies is computed from the locale-routing cookie and the configured pathname regex, with a full reload only for the routed default-locale transition.
- It was verified that non-default locale transitions call router.refresh() rather than a full page reload.

<a href="https://app.greptile.com/trex/runs/19707529/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;main&#39; into e/next/fix-defa..."](https://github.com/generaltranslation/gt/commit/8c0a40b06a537b3aebcba21cc33d3e0ba1431853) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54877592)</sub>

<!-- /greptile_comment -->