### PR TITLE
chore: set up gt-rrweb

### DIFF
--- a/.changeset/set-up-gt-rrweb.md
+++ b/.changeset/set-up-gt-rrweb.md
@@ -1,0 +1,5 @@
+---
+'gt-rrweb': patch
+---
+
+Set up the `gt-rrweb` package: scaffold for recording a product walkthrough once with rrweb and replaying it per-locale using General Translation's own published translations.

--- a/packages/rrweb/.gitignore
+++ b/packages/rrweb/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+package-lock.json
+archived
+.rollup.cache

--- a/packages/rrweb/.npmignore
+++ b/packages/rrweb/.npmignore
@@ -1,0 +1,3 @@
+src
+node_modules
+package-lock.json

--- a/packages/rrweb/CHANGELOG.md
+++ b/packages/rrweb/CHANGELOG.md
@@ -1,0 +1,1 @@
+# gt-rrweb

--- a/packages/rrweb/README.md
+++ b/packages/rrweb/README.md
@@ -1,0 +1,11 @@
+# gt-rrweb
+
+Record a product walkthrough once with [rrweb](https://www.rrweb.io/), then replay it
+per-locale using your app's own published translations — no LLM, no re-recording.
+
+> **Scaffold.** This package is a work-in-progress skeleton; the public API
+> (`GTRecorder`, `useRecorder`, and the per-locale harvest) is added in follow-up work.
+
+## License
+
+MIT © General Translation, Inc.

--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "gt-rrweb",
+  "version": "0.0.1",
+  "description": "Record a product walkthrough once with rrweb and replay it per-locale using General Translation's own published translations",
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.cts",
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "sideEffects": false,
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "build:clean": "sh ../../scripts/clean.sh && pnpm run build",
+    "build:release": "pnpm run build:clean",
+    "release": "pnpm run build:clean && pnpm publish",
+    "release:alpha": "pnpm run build:clean && pnpm publish --tag alpha",
+    "release:beta": "pnpm run build:clean && pnpm publish --tag beta",
+    "release:latest": "pnpm run build:clean && pnpm publish --tag latest",
+    "test": "vitest run --passWithNoTests",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/generaltranslation/gt.git",
+    "directory": "packages/rrweb"
+  },
+  "author": "General Translation, Inc.",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/generaltranslation/gt/issues"
+  },
+  "homepage": "https://generaltranslation.com/",
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@types/react": ">=18.0.0 <20.0.0",
+    "@types/react-dom": ">=18.0.0 <20.0.0",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "exports": {
+    ".": {
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      },
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      }
+    }
+  },
+  "keywords": [
+    "rrweb",
+    "replay",
+    "recorder",
+    "demo",
+    "react",
+    "translation",
+    "internationalization",
+    "localization",
+    "i18n"
+  ]
+}

--- a/packages/rrweb/src/__tests__/packageExports.test.ts
+++ b/packages/rrweb/src/__tests__/packageExports.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+
+// Smoke test for the package entry. The scaffold exports nothing yet; this just
+// asserts the module loads. Real export assertions land with the public API.
+describe('gt-rrweb', () => {
+  it('loads its entry point', async () => {
+    const mod = await import('../index');
+    expect(mod).toBeTypeOf('object');
+  });
+});

--- a/packages/rrweb/src/index.ts
+++ b/packages/rrweb/src/index.ts
@@ -1,0 +1,6 @@
+// gt-rrweb — record a product walkthrough once and replay it per-locale using
+// General Translation's own published translations.
+//
+// Package scaffold: the public API (GTRecorder, useRecorder, and the per-locale
+// harvest) is added in follow-up work.
+export {};

--- a/packages/rrweb/tsconfig.json
+++ b/packages/rrweb/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "target": "ES6",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "moduleResolution": "Bundler",
+    "sourceMap": true,
+    "declarationMap": true,
+    "jsx": "react-jsx",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "composite": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+}

--- a/packages/rrweb/tsdown.config.mts
+++ b/packages/rrweb/tsdown.config.mts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsdown';
+import { createTsdownConfig } from '../../tsdown.preset.mts';
+
+// Dual CJS+ESM (the repo norm). react/react-dom are peers — keep them external so
+// the host app supplies one copy.
+export default defineConfig(
+  createTsdownConfig(['src/index.ts'], {
+    neverBundle: [/^react$/, /^react\//, /^react-dom$/, /^react-dom\//],
+  })
+);

--- a/packages/rrweb/vitest.config.ts
+++ b/packages/rrweb/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1496,6 +1496,34 @@ importers:
         specifier: 'catalog:'
         version: 3.2.4(@edge-runtime/vm@4.0.4)(@types/debug@4.1.12)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.33.0)(terser@5.44.0)(tsx@4.23.12)(yaml@2.9.0)
 
+  packages/rrweb:
+    dependencies:
+      react:
+        specifier: '>=18.0.0'
+        version: 19.2.3
+      react-dom:
+        specifier: '>=18.0.0'
+        version: 19.2.3(react@19.2.3)
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.13.10
+      '@types/react':
+        specifier: '>=18.0.0 <20.0.0'
+        version: 19.2.7
+      '@types/react-dom':
+        specifier: '>=18.0.0 <20.0.0'
+        version: 19.1.9(@types/react@19.2.7)
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.21.10(synckit@0.11.11)(typescript@5.9.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.4(@edge-runtime/vm@4.0.4)(@types/debug@4.1.12)(@types/node@22.13.10)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.33.0)(terser@5.44.0)(tsx@4.23.12)(yaml@2.9.0)
+
   packages/sanity:
     dependencies:
       '@portabletext/block-tools':


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds the initial `gt-rrweb` package scaffold with dual CommonJS/ESM packaging, TypeScript build configuration, package metadata, and an entry-point smoke test. The published package layout loads successfully through both CommonJS and ESM consumer paths.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

The built package was loaded successfully from an isolated consumer through both declared module formats, and both corresponding declaration files were present.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Cleaned the package output, built gt-rrweb, and prepared an isolated consumer node\_modules directory to simulate a clean baseline.
- Loaded the built package via bare-specifier CommonJS require('gt-rrweb') and via dynamic ESM import('gt-rrweb'), and both loaded their respective entry points successfully.
- Verified that dist/index.cjs, dist/index.mjs, dist/index.d.cts, and dist/index.d.mts exist after the build, confirming the declared runtime and type entry points are available.
- Validated exact behavior: CJS require loads dist/index.cjs and ESM import loads dist/index.mjs, with corresponding declaration files present after the build.
- Resolved an environment issue by reinstalling with a frozen lockfile, after which the clean baseline and final end-to-end validation completed successfully.

<a href="https://app.greptile.com/trex/runs/19319093/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: set up gt-rrweb"](https://github.com/generaltranslation/gt/commit/5ecb1c49af47987d646ad5654a079e46e7f20d02) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54118465)</sub>

<!-- /greptile_comment -->