### PR TITLE
perf(format): index locale resolution scope

### DIFF
--- a/.changeset/calm-locales-index.md
+++ b/.changeset/calm-locales-index.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/format': patch
+---
+
+Prepare and reuse an indexed configured-locale scope when determining the best supported locale.

--- a/packages/format/src/LocaleConfig.ts
+++ b/packages/format/src/LocaleConfig.ts
@@ -27,6 +27,7 @@ import { _isSupersetLocale } from './locales/isSupersetLocale';
 import type { CustomMapping, FormatVariables } from './types';
 import { _resolveAliasLocale } from './locales/resolveAliasLocale';
 import { _resolveCanonicalLocale } from './locales/resolveCanonicalLocale';
+import { getCustomLocaleCode } from './locales/customLocaleMapping';
 import type { CutoffFormatOptions } from './formatting/custom-formats/CutoffFormat/types';
 import type { StringFormat } from './types-dir/jsx/content';
 
@@ -48,6 +49,7 @@ type WithLocales<T = object> = T & LocalesOption;
  */
 type LocaleResolutionScope = {
   approvedLocalePairs: { locale: string; canonicalLocale: string }[];
+  canonicalMappingCodes: (string | undefined)[];
   approved: ApprovedLocales;
 };
 
@@ -63,14 +65,42 @@ export class LocaleConfig {
   readonly defaultLocale: string;
   readonly locales: string[];
   readonly customMapping?: CustomMapping;
-  // Derived from this.locales and this.customMapping, which are set once in
-  // the constructor. Built lazily so construction stays cheap for instances
-  // that never resolve locales.
+  // Built lazily so construction stays cheap for instances that never resolve
+  // locales. The snapshot is refreshed if callers mutate the public locale or
+  // custom-mapping collections retained by this instance.
   private resolutionScope?: LocaleResolutionScope;
 
   private getResolutionScope(): LocaleResolutionScope {
-    this.resolutionScope ??= this.buildResolutionScope(this.locales);
-    return this.resolutionScope;
+    if (
+      this.resolutionScope &&
+      this.isResolutionScopeCurrent(this.resolutionScope)
+    ) {
+      return this.resolutionScope;
+    }
+    const resolutionScope = this.buildResolutionScope(this.locales);
+    Object.defineProperty(this, 'resolutionScope', {
+      configurable: true,
+      value: resolutionScope,
+      writable: true,
+    });
+    return resolutionScope;
+  }
+
+  private isResolutionScopeCurrent(scope: LocaleResolutionScope): boolean {
+    if (scope.approvedLocalePairs.length !== this.locales.length) return false;
+    for (let index = 0; index < this.locales.length; index++) {
+      const locale = this.locales[index];
+      const pair = scope.approvedLocalePairs[index];
+      if (
+        pair.locale !== locale ||
+        pair.canonicalLocale !== this.resolveCanonicalLocale(locale) ||
+        scope.canonicalMappingCodes[index] !==
+          getCustomLocaleCode(this.customMapping, pair.canonicalLocale)
+      ) {
+        return false;
+      }
+    }
+    return true;
   }
 
   private buildResolutionScope(
@@ -82,6 +112,9 @@ export class LocaleConfig {
     }));
     return {
       approvedLocalePairs,
+      canonicalMappingCodes: approvedLocalePairs.map(({ canonicalLocale }) =>
+        getCustomLocaleCode(this.customMapping, canonicalLocale)
+      ),
       approved: _prepareApprovedLocales(
         approvedLocalePairs.map(({ canonicalLocale }) => canonicalLocale),
         this.customMapping

--- a/packages/format/src/LocaleConfig.ts
+++ b/packages/format/src/LocaleConfig.ts
@@ -9,8 +9,12 @@ import {
   _selectRelativeTimeUnit,
 } from './formatting/format';
 import { intlCache } from './cache/IntlCache';
+import {
+  _prepareApprovedLocales,
+  type ApprovedLocales,
+} from './locales/approvedLocales';
 import { _requiresTranslation } from './locales/requiresTranslation';
-import { _determineLocale } from './locales/determineLocale';
+import { _determineLocaleWithIndex } from './locales/determineLocale';
 import { _isSameLanguage } from './locales/isSameLanguage';
 import { _getLocaleProperties } from './locales/getLocaleProperties';
 import { _getLocaleEmoji } from './locales/getLocaleEmoji';
@@ -39,6 +43,15 @@ type LocalesOption = {
 type WithLocales<T = object> = T & LocalesOption;
 
 /**
+ * Approved-locales work that determineLocale would otherwise redo on every
+ * call: canonical codes plus the validated and indexed scope built from them.
+ */
+type LocaleResolutionScope = {
+  approvedLocalePairs: { locale: string; canonicalLocale: string }[];
+  approved: ApprovedLocales;
+};
+
+/**
  * LocaleConfig contains the locale and formatting primitives exposed through
  * the core entrypoint.
  *
@@ -50,6 +63,31 @@ export class LocaleConfig {
   readonly defaultLocale: string;
   readonly locales: string[];
   readonly customMapping?: CustomMapping;
+  // Derived from this.locales and this.customMapping, which are set once in
+  // the constructor. Built lazily so construction stays cheap for instances
+  // that never resolve locales.
+  private resolutionScope?: LocaleResolutionScope;
+
+  private getResolutionScope(): LocaleResolutionScope {
+    this.resolutionScope ??= this.buildResolutionScope(this.locales);
+    return this.resolutionScope;
+  }
+
+  private buildResolutionScope(
+    approvedLocales: string[]
+  ): LocaleResolutionScope {
+    const approvedLocalePairs = approvedLocales.map((locale) => ({
+      locale,
+      canonicalLocale: this.resolveCanonicalLocale(locale),
+    }));
+    return {
+      approvedLocalePairs,
+      approved: _prepareApprovedLocales(
+        approvedLocalePairs.map(({ canonicalLocale }) => canonicalLocale),
+        this.customMapping
+      ),
+    };
+  }
 
   constructor({
     defaultLocale = libraryDefaultLocale,
@@ -247,15 +285,15 @@ export class LocaleConfig {
     locales: string | string[],
     approvedLocales: string[] = this.locales
   ) {
-    const approvedLocalePairs = approvedLocales.map((locale) => ({
-      locale,
-      canonicalLocale: this.resolveCanonicalLocale(locale),
-    }));
-    const resolvedLocale = _determineLocale(
+    const { approvedLocalePairs, approved } =
+      approvedLocales === this.locales
+        ? this.getResolutionScope()
+        : this.buildResolutionScope(approvedLocales);
+    const resolvedLocale = _determineLocaleWithIndex(
       Array.isArray(locales)
         ? locales.map((locale) => this.resolveCanonicalLocale(locale))
         : this.resolveCanonicalLocale(locales),
-      approvedLocalePairs.map(({ canonicalLocale }) => canonicalLocale),
+      approved,
       this.customMapping
     );
     if (!resolvedLocale) return undefined;

--- a/packages/format/src/__tests__/LocaleConfig.test.ts
+++ b/packages/format/src/__tests__/LocaleConfig.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { LocaleConfig } from '../LocaleConfig';
+import type { CustomMapping } from '../types';
+
+describe('LocaleConfig', () => {
+  it('refreshes its prepared locale scope after the configured locales mutate', () => {
+    const locales = ['en-US', 'fr-FR'];
+    const config = new LocaleConfig({ locales });
+
+    expect(config.determineLocale('fr-FR')).toBe('fr-FR');
+    locales.splice(1, 1, 'de-DE');
+
+    expect(config.determineLocale('fr-FR')).toBeUndefined();
+    expect(config.determineLocale('de-DE')).toBe('de-DE');
+  });
+
+  it('refreshes its prepared locale scope after a canonical mapping mutates', () => {
+    const brandMapping = { code: 'fr-FR' };
+    const customMapping: CustomMapping = {
+      brand: brandMapping,
+    };
+    const config = new LocaleConfig({ locales: ['brand'], customMapping });
+
+    expect(config.determineLocale('fr-FR')).toBe('brand');
+    brandMapping.code = 'de-DE';
+
+    expect(config.determineLocale('fr-FR')).toBeUndefined();
+    expect(config.determineLocale('de-DE')).toBe('brand');
+  });
+
+  it('does not expose the prepared locale scope as enumerable state', () => {
+    const config = new LocaleConfig({ locales: ['en-US'] });
+    const serializedBeforeResolution = JSON.stringify(config);
+
+    config.determineLocale('en-US');
+
+    expect(JSON.stringify(config)).toBe(serializedBeforeResolution);
+    expect(Object.keys(config)).not.toContain('resolutionScope');
+  });
+});

--- a/packages/format/src/locales/__tests__/findMatchingCode.test.ts
+++ b/packages/format/src/locales/__tests__/findMatchingCode.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import { findMatchingCode } from '../determineLocale';
+
+describe('findMatchingCode', () => {
+  describe('exact matches', () => {
+    it('returns an exact locale match', () => {
+      expect(findMatchingCode('en-US', new Set(['en-US']))).toBe('en-US');
+    });
+
+    it('returns an exact bare-language match', () => {
+      expect(findMatchingCode('pt', new Set(['pt', 'pt-BR']))).toBe('pt');
+    });
+
+    it('prefers an exact match over every derived match', () => {
+      const candidates = new Set(['zh-Hans', 'zh-HK', 'zh-Hans-HK']);
+
+      expect(findMatchingCode('zh-Hans-HK', candidates)).toBe('zh-Hans-HK');
+    });
+
+    it('preserves an exact variant match', () => {
+      expect(findMatchingCode('sl-rozaj', new Set(['sl-rozaj']))).toBe(
+        'sl-rozaj'
+      );
+    });
+  });
+
+  describe('derived matches', () => {
+    it('matches a language-region candidate', () => {
+      expect(findMatchingCode('zh-Hans-HK', new Set(['zh-HK']))).toBe('zh-HK');
+    });
+
+    it('matches a language-script candidate', () => {
+      expect(findMatchingCode('zh-Hant-TW', new Set(['zh-Hant']))).toBe(
+        'zh-Hant'
+      );
+    });
+
+    it('infers a missing region from a script-only locale', () => {
+      expect(findMatchingCode('zh-Hant', new Set(['zh-TW']))).toBe('zh-TW');
+    });
+
+    it('infers a missing script from a region-only locale', () => {
+      expect(findMatchingCode('zh-TW', new Set(['zh-Hant']))).toBe('zh-Hant');
+    });
+
+    it('supports numeric region subtags', () => {
+      expect(findMatchingCode('es-Latn-419', new Set(['es-419']))).toBe(
+        'es-419'
+      );
+    });
+
+    it('uses a likely region when the input is a bare language', () => {
+      expect(findMatchingCode('pt', new Set(['pt-BR']))).toBe('pt-BR');
+    });
+
+    it('uses a likely script when the input is a bare language', () => {
+      expect(findMatchingCode('sr', new Set(['sr-Cyrl']))).toBe('sr-Cyrl');
+    });
+
+    it('falls back to the minimized locale', () => {
+      expect(findMatchingCode('en-Latn-US', new Set(['en']))).toBe('en');
+    });
+
+    it('preserves Unicode extensions in the minimized locale', () => {
+      expect(
+        findMatchingCode(
+          'en-Latn-US-u-ca-buddhist',
+          new Set(['en-u-ca-buddhist'])
+        )
+      ).toBe('en-u-ca-buddhist');
+    });
+
+    it('derives matches from a locale containing a variant', () => {
+      expect(findMatchingCode('sl-Latn-SI-rozaj', new Set(['sl-SI']))).toBe(
+        'sl-SI'
+      );
+    });
+  });
+
+  describe('precedence', () => {
+    it('prefers a region match over a script match', () => {
+      const candidates = new Set(['zh-Hans', 'zh-HK']);
+
+      expect(findMatchingCode('zh-Hans-HK', candidates)).toBe('zh-HK');
+    });
+
+    it('prefers a script match over a minimized match', () => {
+      const candidates = new Set(['en-u-ca-buddhist', 'en-Latn']);
+
+      expect(findMatchingCode('en-Latn-US-u-ca-buddhist', candidates)).toBe(
+        'en-Latn'
+      );
+    });
+
+    it('prefers a likely region over a likely script', () => {
+      const candidates = new Set(['sr-Cyrl', 'sr-RS']);
+
+      expect(findMatchingCode('sr', candidates)).toBe('sr-RS');
+    });
+
+    it('does not depend on candidate insertion order', () => {
+      const regionFirst = new Set(['zh-HK', 'zh-Hans']);
+      const scriptFirst = new Set(['zh-Hans', 'zh-HK']);
+
+      expect(findMatchingCode('zh-Hans-HK', regionFirst)).toBe('zh-HK');
+      expect(findMatchingCode('zh-Hans-HK', scriptFirst)).toBe('zh-HK');
+    });
+  });
+
+  describe('no match', () => {
+    it('returns undefined for an empty candidate set', () => {
+      expect(findMatchingCode('en-US', new Set())).toBeUndefined();
+    });
+
+    it('does not select an arbitrary dialect of the same language', () => {
+      expect(findMatchingCode('en-AU', new Set(['en-GB']))).toBeUndefined();
+    });
+
+    it('does not use prefix or partial matches', () => {
+      expect(
+        findMatchingCode('en-US', new Set(['en-U', 'en-US-extra']))
+      ).toBeUndefined();
+    });
+
+    it('does not match an unrelated language', () => {
+      expect(findMatchingCode('en-US', new Set(['fr-FR']))).toBeUndefined();
+    });
+  });
+});

--- a/packages/format/src/locales/approvedLocales.ts
+++ b/packages/format/src/locales/approvedLocales.ts
@@ -1,0 +1,39 @@
+import { CustomMapping } from './customLocaleMapping';
+import { _getLocaleLanguage } from './isSameLanguage';
+import { _isValidLocale, _standardizeLocale } from './isValidLocale';
+
+/**
+ * An approved-locales list prepared once so determineLocale does not
+ * revalidate, restandardize, and reindex the whole list on every call.
+ * @internal
+ */
+export type ApprovedLocales = {
+  /** Standardized valid approved codes, bucketed by language subtag. */
+  byLanguage: Map<string, Set<string>>;
+};
+
+/**
+ * Validates, standardizes, and indexes an approved-locales list in a single
+ * pass.
+ * @internal
+ */
+export function _prepareApprovedLocales(
+  approvedLocales: string[],
+  customMapping?: CustomMapping
+): ApprovedLocales {
+  const byLanguage = new Map<string, Set<string>>();
+  for (const approvedLocale of approvedLocales) {
+    if (!_isValidLocale(approvedLocale, customMapping)) {
+      continue;
+    }
+    const language = _getLocaleLanguage(approvedLocale);
+    if (language === undefined) continue;
+    let bucket = byLanguage.get(language);
+    if (bucket === undefined) {
+      bucket = new Set();
+      byLanguage.set(language, bucket);
+    }
+    bucket.add(_standardizeLocale(approvedLocale));
+  }
+  return { byLanguage };
+}

--- a/packages/format/src/locales/determineLocale.ts
+++ b/packages/format/src/locales/determineLocale.ts
@@ -1,32 +1,98 @@
-import { _isValidLocale, _standardizeLocale } from './isValidLocale';
-import { _isSameLanguage } from './isSameLanguage';
 import {
-  _getLocaleProperties,
-  type LocaleProperties,
-} from './getLocaleProperties';
+  _prepareApprovedLocales,
+  type ApprovedLocales,
+} from './approvedLocales';
+import { intlCache } from '../cache/IntlCache';
 import { CustomMapping } from './customLocaleMapping';
+import { _getLocaleLanguage } from './isSameLanguage';
+import { _isValidLocale, _standardizeLocale } from './isValidLocale';
 
-function standardizeValidLocales(
-  locales: string[],
-  customMapping?: CustomMapping
-) {
-  return locales
-    .filter((locale) => _isValidLocale(locale, customMapping))
-    .map(_standardizeLocale);
+type LocaleMatchCodes = {
+  languageCode: string;
+  regionCode: string;
+  scriptCode: string;
+  minimizedCode: string;
+};
+
+/**
+ * Derives the subtag codes used for matching. Mirrors how
+ * _getLocaleProperties derives languageCode, regionCode, scriptCode, and
+ * minimizedCode without a custom mapping, but skips the display-name and
+ * emoji lookups that matching never reads.
+ */
+function getLocaleMatchCodes(locale: string): LocaleMatchCodes {
+  try {
+    const localeObject = intlCache.get('Locale', locale);
+    const languageCode = localeObject.language;
+    let regionCode = localeObject.region || '';
+    let scriptCode = localeObject.script || '';
+    if (!regionCode || !scriptCode) {
+      const maximizedLocale = localeObject.maximize();
+      regionCode ||= maximizedLocale.region || '';
+      scriptCode ||= maximizedLocale.script || '';
+    }
+    return {
+      languageCode,
+      regionCode,
+      scriptCode,
+      minimizedCode: localeObject.minimize().toString(),
+    };
+  } catch {
+    const code = _isValidLocale(locale) ? _standardizeLocale(locale) : locale;
+    const codeParts = code.split('-');
+    return {
+      languageCode: codeParts[0] || code,
+      regionCode: codeParts.length > 2 ? codeParts[2] : codeParts[1] || '',
+      scriptCode: codeParts[3] || '',
+      minimizedCode: code,
+    };
+  }
 }
 
-function getMatchingCode(
+function findMatchingCode(
   locale: string,
-  { languageCode, minimizedCode, regionCode, scriptCode }: LocaleProperties,
   candidates: Set<string>
-) {
-  const localeCodes = [
-    locale, // If the full locale is supported under this language category
-    `${languageCode}-${regionCode}`, // Attempt to match parts
-    `${languageCode}-${scriptCode}`,
-    minimizedCode, // If a minimized variant of this locale is supported
-  ];
-  return localeCodes.find((localeCode) => candidates.has(localeCode));
+): string | undefined {
+  // Preference order: the full locale, then partial and minimized variants.
+  // The exact match needs no derived codes, so check it first.
+  if (candidates.has(locale)) return locale;
+  const { languageCode, regionCode, scriptCode, minimizedCode } =
+    getLocaleMatchCodes(locale);
+  const languageRegionCode = `${languageCode}-${regionCode}`;
+  if (candidates.has(languageRegionCode)) return languageRegionCode;
+  const languageScriptCode = `${languageCode}-${scriptCode}`;
+  if (candidates.has(languageScriptCode)) return languageScriptCode;
+  if (candidates.has(minimizedCode)) return minimizedCode;
+  return undefined;
+}
+
+/**
+ * Same contract as _determineLocale, with the approved-locales work hoisted
+ * into a prepared index.
+ * @internal
+ */
+export function _determineLocaleWithIndex(
+  locales: string | string[],
+  approvedIndex: ApprovedLocales,
+  customMapping?: CustomMapping
+): string | undefined {
+  const candidateLocales = Array.isArray(locales) ? locales : [locales];
+  for (const candidateLocale of candidateLocales) {
+    if (!_isValidLocale(candidateLocale, customMapping)) continue;
+    const locale = _standardizeLocale(candidateLocale);
+    const language = _getLocaleLanguage(locale);
+    if (language === undefined) continue;
+    // Only approved locales of the same language can match.
+    const candidates = approvedIndex.byLanguage.get(language);
+    if (candidates === undefined) continue;
+    const matchingCode =
+      findMatchingCode(locale, candidates) ||
+      // Fall back to matching through the bare language code, whose derived
+      // codes carry the language's most likely region and script.
+      findMatchingCode(language, candidates);
+    if (matchingCode) return matchingCode;
+  }
+  return undefined;
 }
 
 /**
@@ -39,26 +105,9 @@ export function _determineLocale(
   approvedLocales: string[],
   customMapping?: CustomMapping
 ): string | undefined {
-  locales = standardizeValidLocales(
-    Array.isArray(locales) ? locales : [locales],
+  return _determineLocaleWithIndex(
+    locales,
+    _prepareApprovedLocales(approvedLocales, customMapping),
     customMapping
   );
-  approvedLocales = standardizeValidLocales(approvedLocales, customMapping);
-  for (const locale of locales) {
-    const candidates = new Set(
-      approvedLocales.filter((approvedLocale) =>
-        _isSameLanguage(locale, approvedLocale)
-      )
-    );
-    const properties = _getLocaleProperties(locale);
-    const matchingCode =
-      getMatchingCode(locale, properties, candidates) ||
-      getMatchingCode(
-        properties.languageCode,
-        _getLocaleProperties(properties.languageCode),
-        candidates
-      );
-    if (matchingCode) return matchingCode;
-  }
-  return undefined;
 }

--- a/packages/format/src/locales/determineLocale.ts
+++ b/packages/format/src/locales/determineLocale.ts
@@ -49,7 +49,12 @@ function getLocaleMatchCodes(locale: string): LocaleMatchCodes {
   }
 }
 
-function findMatchingCode(
+/**
+ * Matches a valid, standardized locale against standardized candidate codes.
+ * Callers are responsible for validation and canonicalization before matching.
+ * @internal
+ */
+export function findMatchingCode(
   locale: string,
   candidates: Set<string>
 ): string | undefined {

--- a/packages/format/src/locales/isSameLanguage.ts
+++ b/packages/format/src/locales/isSameLanguage.ts
@@ -1,6 +1,19 @@
 import { intlCache } from '../cache/IntlCache';
 
 /**
+ * Returns the language subtag of a locale, or undefined when the locale
+ * cannot be parsed.
+ * @internal
+ */
+export function _getLocaleLanguage(locale: string): string | undefined {
+  try {
+    return intlCache.get('Locale', locale).language;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * @internal
  */
 export function _isSameLanguage(...locales: (string | string[])[]): boolean {


### PR DESCRIPTION
## Summary

- Prepare the configured locale list once per `LocaleConfig` instance and reuse a language-bucketed index in `determineLocale()`.
- Match with the minimal `Intl.Locale` fields instead of constructing full locale metadata, display names, and emoji that locale resolution never reads.
- Preserve the standalone `_determineLocale()` signature and caller-provided approved-locale overrides while addressing the `determineLocale` portion of #2067.

## Testing

- `pnpm --filter @generaltranslation/icu build` — passed
- `pnpm --filter @generaltranslation/format test` — passed (298 tests)
- `pnpm --filter @generaltranslation/format typecheck` — passed
- `pnpm --filter @generaltranslation/format build` — passed
- `pnpm exec oxlint packages/format/src/LocaleConfig.ts packages/format/src/locales/approvedLocales.ts packages/format/src/locales/determineLocale.ts packages/format/src/locales/isSameLanguage.ts` — passed
- `pnpm exec oxfmt --check packages/format/src/LocaleConfig.ts packages/format/src/locales/approvedLocales.ts packages/format/src/locales/determineLocale.ts packages/format/src/locales/isSameLanguage.ts .changeset/calm-locales-index.md` — passed
- 55-locale microbenchmark, 10,000 warmed calls: `determineLocale(['ar-EG', 'ar'])` improved from about 165.5µs to 6.0µs per call on Node 24 / Apple Silicon

## Notes

- Changeset: patch release for `@generaltranslation/format`.
- First PR in a two-PR stack split from draft #2073. The follow-up will reuse this prepared scope in `requiresTranslation()` and target this branch.
- This PR intentionally leaves `requiresTranslation()` unchanged so its behavior and performance can be reviewed separately.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change keeps locale resolution aligned with the current approved locale list and custom locale mapping. Direct runtime checks confirmed that, after in-place updates, removed locales no longer resolve and newly configured locales resolve correctly.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

The previously reported stale locale-scope behavior was exercised directly and did not occur: resolution refreshed after both locale-list and custom-mapping mutations.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the authored Node runtime harness against the built @generaltranslation/format package and verified that resolution uses the refreshed configuration after mutating a caller-owned locale array and a custom mapping.
- Observed the before-and-after resolution behavior: before mutation fr-FR resolved to fr-FR and the custom mapping to brand, and after mutation fr-FR resolved to undefined while de-DE resolved to de-DE and then brand, confirming the refreshed configuration is used.
- The runtime harness includes assertions for both the locale-array mutation and the canonical-code mutation, and the before-and-after captures exited with code 0, indicating all runtime assertions passed; because focused Vitest/build commands could not run due to an unavailable temporary store, direct execution of the built package completed successfully.

<a href="https://app.greptile.com/trex/runs/19336282/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(format): refresh mutated locale reso..."](https://github.com/generaltranslation/gt/commit/159a8a87d34cf10a4f7258feb4f6721e46f49157) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54213158)</sub>

<!-- /greptile_comment -->