### PR TITLE
perf(format): reuse locale translation scope

### DIFF
--- a/.changeset/quick-translation-scope.md
+++ b/.changeset/quick-translation-scope.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/format': patch
+---
+
+Reuse the prepared configured-locale scope when deciding whether a locale requires translation.

--- a/packages/format/src/LocaleConfig.ts
+++ b/packages/format/src/LocaleConfig.ts
@@ -13,7 +13,7 @@ import {
   _prepareApprovedLocales,
   type ApprovedLocales,
 } from './locales/approvedLocales';
-import { _requiresTranslation } from './locales/requiresTranslation';
+import { _requiresTranslationWithScope } from './locales/requiresTranslation';
 import { _determineLocaleWithIndex } from './locales/determineLocale';
 import { _isSameLanguage } from './locales/isSameLanguage';
 import { _getLocaleProperties } from './locales/getLocaleProperties';
@@ -44,8 +44,9 @@ type LocalesOption = {
 type WithLocales<T = object> = T & LocalesOption;
 
 /**
- * Approved-locales work that determineLocale would otherwise redo on every
- * call: canonical codes plus the validated and indexed scope built from them.
+ * Approved-locales work that requiresTranslation and determineLocale would
+ * otherwise redo on every call: canonical codes plus the validated and
+ * indexed scope built from them.
  */
 type LocaleResolutionScope = {
   approvedLocalePairs: { locale: string; canonicalLocale: string }[];
@@ -300,12 +301,23 @@ export class LocaleConfig {
       ? this.locales
       : undefined
   ) {
-    return _requiresTranslation(
+    // The default scope (this.locales) is prepared once per instance; a
+    // caller-provided list is prepared for that call only. No configured
+    // locales means no approved-locales restriction.
+    const approvedScope = approvedLocales
+      ? approvedLocales === this.locales
+        ? this.getResolutionScope().approved
+        : _prepareApprovedLocales(
+            approvedLocales.map((locale) =>
+              this.resolveCanonicalLocale(locale)
+            ),
+            this.customMapping
+          )
+      : undefined;
+    return _requiresTranslationWithScope(
       this.resolveCanonicalLocale(sourceLocale),
       this.resolveCanonicalLocale(targetLocale),
-      approvedLocales
-        ? approvedLocales.map((locale) => this.resolveCanonicalLocale(locale))
-        : undefined,
+      approvedScope,
       this.customMapping
     );
   }

--- a/packages/format/src/__tests__/LocaleConfig.test.ts
+++ b/packages/format/src/__tests__/LocaleConfig.test.ts
@@ -28,6 +28,17 @@ describe('LocaleConfig', () => {
     expect(config.determineLocale('de-DE')).toBe('brand');
   });
 
+  it('refreshes translation decisions after the configured locales mutate', () => {
+    const locales = ['es'];
+    const config = new LocaleConfig({ defaultLocale: 'en', locales });
+
+    expect(config.requiresTranslation('es')).toBe(true);
+    locales.splice(0, 1, 'fr');
+
+    expect(config.requiresTranslation('es')).toBe(false);
+    expect(config.requiresTranslation('fr')).toBe(true);
+  });
+
   it('does not expose the prepared locale scope as enumerable state', () => {
     const config = new LocaleConfig({ locales: ['en-US'] });
     const serializedBeforeResolution = JSON.stringify(config);

--- a/packages/format/src/locales/approvedLocales.ts
+++ b/packages/format/src/locales/approvedLocales.ts
@@ -3,11 +3,16 @@ import { _getLocaleLanguage } from './isSameLanguage';
 import { _isValidLocale, _standardizeLocale } from './isValidLocale';
 
 /**
- * An approved-locales list prepared once so determineLocale does not
- * revalidate, restandardize, and reindex the whole list on every call.
+ * An approved-locales list prepared once so requiresTranslation and
+ * determineLocale do not revalidate, restandardize, and reindex the whole
+ * list on every call.
  * @internal
  */
 export type ApprovedLocales = {
+  /** Whether every approved locale is valid. */
+  allValid: boolean;
+  /** Language subtags of the valid approved locales. */
+  languages: Set<string>;
   /** Standardized valid approved codes, bucketed by language subtag. */
   byLanguage: Map<string, Set<string>>;
 };
@@ -21,13 +26,17 @@ export function _prepareApprovedLocales(
   approvedLocales: string[],
   customMapping?: CustomMapping
 ): ApprovedLocales {
+  let allValid = true;
+  const languages = new Set<string>();
   const byLanguage = new Map<string, Set<string>>();
   for (const approvedLocale of approvedLocales) {
     if (!_isValidLocale(approvedLocale, customMapping)) {
+      allValid = false;
       continue;
     }
     const language = _getLocaleLanguage(approvedLocale);
     if (language === undefined) continue;
+    languages.add(language);
     let bucket = byLanguage.get(language);
     if (bucket === undefined) {
       bucket = new Set();
@@ -35,5 +44,5 @@ export function _prepareApprovedLocales(
     }
     bucket.add(_standardizeLocale(approvedLocale));
   }
-  return { byLanguage };
+  return { allValid, languages, byLanguage };
 }

--- a/packages/format/src/locales/requiresTranslation.ts
+++ b/packages/format/src/locales/requiresTranslation.ts
@@ -21,9 +21,9 @@ export function _requiresTranslationWithScope(
 ): boolean {
   // If codes are invalid
   if (
+    (approvedScope && !approvedScope.allValid) ||
     !_isValidLocale(sourceLocale, customMapping) ||
-    !_isValidLocale(targetLocale, customMapping) ||
-    (approvedScope && !approvedScope.allValid)
+    !_isValidLocale(targetLocale, customMapping)
   ) {
     return false;
   }

--- a/packages/format/src/locales/requiresTranslation.ts
+++ b/packages/format/src/locales/requiresTranslation.ts
@@ -1,7 +1,46 @@
+import {
+  _prepareApprovedLocales,
+  type ApprovedLocales,
+} from './approvedLocales';
 import { CustomMapping } from './customLocaleMapping';
 import { _isSameDialect } from './isSameDialect';
-import { _isSameLanguage } from './isSameLanguage';
+import { _getLocaleLanguage } from './isSameLanguage';
 import { _isValidLocale } from './isValidLocale';
+
+/**
+ * Same contract as _requiresTranslation, with the approved-locales work
+ * hoisted into a prepared scope. An undefined scope means no approved-locales
+ * restriction.
+ * @internal
+ */
+export function _requiresTranslationWithScope(
+  sourceLocale: string,
+  targetLocale: string,
+  approvedScope: ApprovedLocales | undefined,
+  customMapping?: CustomMapping
+): boolean {
+  // If codes are invalid
+  if (
+    !_isValidLocale(sourceLocale, customMapping) ||
+    !_isValidLocale(targetLocale, customMapping) ||
+    (approvedScope && !approvedScope.allValid)
+  ) {
+    return false;
+  }
+
+  // Check if the languages are identical, if so, a translation is not required
+  if (_isSameDialect(sourceLocale, targetLocale)) {
+    return false;
+  }
+
+  // Check that the target locale is within the approvedLocales scope, if not, a translation is not required
+  // Language-level rather than dialect-level membership so we can show different dialects as a fallback
+  if (!approvedScope) return true;
+  const targetLanguage = _getLocaleLanguage(targetLocale);
+  return (
+    targetLanguage !== undefined && approvedScope.languages.has(targetLanguage)
+  );
+}
 
 /**
  * Given a target locale and a source locale, determines whether a translation is required
@@ -15,27 +54,12 @@ export function _requiresTranslation(
   approvedLocales?: string[],
   customMapping?: CustomMapping
 ): boolean {
-  // If codes are invalid
-  const localesToValidate = [
+  return _requiresTranslationWithScope(
     sourceLocale,
     targetLocale,
-    ...(approvedLocales ?? []),
-  ];
-  if (
-    localesToValidate.some((locale) => !_isValidLocale(locale, customMapping))
-  ) {
-    return false;
-  }
-
-  // Check if the languages are identical, if so, a translation is not required
-  if (_isSameDialect(sourceLocale, targetLocale)) {
-    return false;
-  }
-
-  // Check that the target locale is within the approvedLocales scope, if not, a translation is not required
-  // isSameLanguage rather than checkTwoLocalesAreSameDialect so we can show different dialects as a fallback
-  if (!approvedLocales) return true;
-  return approvedLocales.some((approvedLocale) =>
-    _isSameLanguage(targetLocale, approvedLocale)
+    approvedLocales
+      ? _prepareApprovedLocales(approvedLocales, customMapping)
+      : undefined,
+    customMapping
   );
 }


### PR DESCRIPTION
- use a persistent `resolutionScope` to cache locale validation
- 55 locales: 96.5µs → 4.5µs per call

## Summary

- Extend the prepared configured-locale scope from #2108 with aggregate validity and language membership.
- Reuse that scope in `LocaleConfig.requiresTranslation()` instead of revalidating and rescanning the full configured locale list on every call.
- Preserve the standalone `_requiresTranslation()` signature and prepare caller-provided override lists per call, so no request-specific results are retained.

## Testing

- `pnpm --filter @generaltranslation/format test` — passed (298 tests)
- `pnpm --filter @generaltranslation/format typecheck` — passed
- `pnpm --filter @generaltranslation/format build` — passed
- `pnpm exec oxlint packages/format/src/LocaleConfig.ts packages/format/src/locales/approvedLocales.ts packages/format/src/locales/requiresTranslation.ts` — passed
- `pnpm exec oxfmt --check packages/format/src/LocaleConfig.ts packages/format/src/locales/approvedLocales.ts packages/format/src/locales/requiresTranslation.ts .changeset/quick-translation-scope.md` — passed
- 55-locale microbenchmark, 10,000 warmed calls: `requiresTranslation('ar')` improved from about 96.5µs to 4.5µs per call on Node 24 / Apple Silicon

## Notes

- Changeset: patch release for `@generaltranslation/format`.
- Second PR in the stack split from draft #2073.
- Stack base: #2108 (`e/format/index-locale-resolution`). This PR contains only the `requiresTranslation()` follow-up relative to that base.
- Together, the two PRs address #2067 without adding a module-level or unbounded result cache.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prepared locale scopes now reflect changes to the configured locale array. A focused regression test warmed a configuration with Spanish, replaced the same array entry with French, and confirmed that translation and locale-selection results switched to the updated locale.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

The previously reported stale locale-scope behavior was disproved by exercising the warmed cache and configured-array mutation path successfully.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran the focused Vitest command to validate the locale and translation logic before and after warming the prepared scope.
- Before mutation, determineLocale('es') returned 'es' and requiresTranslation('es') returned true, while requiresTranslation('fr') returned false; after replacing the same array element with 'fr', determineLocale('es') became undefined, determineLocale('fr') became 'fr', requiresTranslation('es') became false, and requiresTranslation('fr') became true; the test exited with code 0.
- I reviewed the TypeScript artifact that contains the test logic to confirm the exact checks performed for locale and translation behavior.

<a href="https://app.greptile.com/trex/runs/19464098/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (4): Last reviewed commit: ["perf(format): check prepared scope valid..."](https://github.com/generaltranslation/gt/commit/f15dae7d1cd3d8eece507230790b9b6e8910aa2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54213268)</sub>

<!-- /greptile_comment -->