### PR TITLE
perf(react-core): reuse useGT translation conditions

### DIFF
--- a/.changeset/calm-hooks-share.md
+++ b/.changeset/calm-hooks-share.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/react-core': patch
+---
+
+Reuse resolved translation conditions across each `useGT` call.

--- a/packages/react-core/src/hooks/__tests__/translationConditions.test.ts
+++ b/packages/react-core/src/hooks/__tests__/translationConditions.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getI18nConfig } from 'gt-i18n/internal';
+import { useConditionStore } from '../condition-store';
+import { useTranslationConditions } from '../utils';
+
+vi.mock('gt-i18n/internal', () => ({
+  getI18nConfig: vi.fn(),
+}));
+
+vi.mock('../condition-store', () => ({
+  useConditionStore: vi.fn(),
+  useEnableI18n: vi.fn(),
+  useLocale: vi.fn(),
+}));
+
+describe('useTranslationConditions', () => {
+  const getLocale = vi.fn();
+  const getEnableI18n = vi.fn();
+  const requiresTranslation = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getLocale.mockReturnValue('fr');
+    getEnableI18n.mockReturnValue(true);
+    requiresTranslation.mockReturnValue(true);
+    vi.mocked(useConditionStore).mockReturnValue({
+      getLocale,
+      getEnableI18n,
+    });
+    vi.mocked(getI18nConfig).mockReturnValue({
+      requiresTranslation,
+    } as ReturnType<typeof getI18nConfig>);
+  });
+
+  it('reads each condition once and derives whether translation is required', () => {
+    expect(useTranslationConditions()).toEqual({
+      locale: 'fr',
+      shouldTranslate: true,
+    });
+    expect(getLocale).toHaveBeenCalledTimes(1);
+    expect(getEnableI18n).toHaveBeenCalledTimes(1);
+    expect(requiresTranslation).toHaveBeenCalledOnce();
+    expect(requiresTranslation).toHaveBeenCalledWith('fr');
+  });
+
+  it('skips the translation check when i18n is disabled', () => {
+    getEnableI18n.mockReturnValue(false);
+
+    expect(useTranslationConditions()).toEqual({
+      locale: 'fr',
+      shouldTranslate: false,
+    });
+    expect(requiresTranslation).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-core/src/hooks/__tests__/useGT.test.ts
+++ b/packages/react-core/src/hooks/__tests__/useGT.test.ts
@@ -1,17 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { useLocale } from '../condition-store';
 import { useTrackedTranslationResolver } from '../external-store/useTrackedTranslationResolver';
 import { useDefaultLocale } from '../i18n-config';
-import { useShouldTranslate } from '../utils';
+import { useTranslationConditions } from '../utils';
 import { useGT } from '../useGT';
 
 vi.mock('react', () => ({
   useCallback: <T extends (...args: unknown[]) => unknown>(callback: T) =>
     callback,
-}));
-
-vi.mock('../condition-store', () => ({
-  useLocale: vi.fn(),
 }));
 
 vi.mock('../external-store/useTrackedTranslationResolver', () => ({
@@ -23,14 +18,16 @@ vi.mock('../i18n-config', () => ({
 }));
 
 vi.mock('../utils', () => ({
-  useShouldTranslate: vi.fn(),
+  useTranslationConditions: vi.fn(),
 }));
 
 describe('useGT', () => {
   beforeEach(() => {
-    vi.mocked(useLocale).mockReturnValue('en');
     vi.mocked(useDefaultLocale).mockReturnValue('en');
-    vi.mocked(useShouldTranslate).mockReturnValue(false);
+    vi.mocked(useTranslationConditions).mockReturnValue({
+      locale: 'en',
+      shouldTranslate: false,
+    });
     vi.mocked(useTrackedTranslationResolver).mockReturnValue(vi.fn());
   });
 
@@ -38,5 +35,21 @@ describe('useGT', () => {
     const gt = useGT();
 
     expect(gt('hello, {name}', { name: 'brian' })).toBe('hello, brian');
+  });
+
+  it('reuses the resolved translation conditions in the tracked resolver', () => {
+    const messages = [{ message: 'hello' }];
+    vi.mocked(useTranslationConditions).mockReturnValue({
+      locale: 'fr',
+      shouldTranslate: true,
+    });
+
+    useGT(messages);
+
+    expect(useTrackedTranslationResolver).toHaveBeenCalledWith(
+      messages,
+      'fr',
+      true
+    );
   });
 });

--- a/packages/react-core/src/hooks/external-store/useTrackedTranslationResolver.ts
+++ b/packages/react-core/src/hooks/external-store/useTrackedTranslationResolver.ts
@@ -11,13 +11,11 @@ import type {
 } from '../../i18n-store/storeTypes';
 import type { TranslationMetadata } from 'gt-i18n/internal/types';
 import type { StringFormat } from '@generaltranslation/format';
-import { useLocale } from '../condition-store';
-import { useShouldTranslate } from '../utils';
 import {
   useI18nStore,
   useTranslationsSnapshot,
 } from '../../i18n-store/useI18nStore';
-import { useHandleMissingTranslation } from '../utils/missing-translation';
+import { useHandleMissingTranslationWithConditions } from '../utils/missing-translation';
 import { useSubscribeToTrackedLookups } from './useSubscribeToTrackedLookups';
 
 /**
@@ -45,14 +43,17 @@ export type Message = TranslationMetadata & {
  */
 
 export function useTrackedTranslationResolver(
-  messages: Message[] = []
+  messages: Message[] = [],
+  locale: string,
+  shouldTranslate: boolean
 ): TrackedTranslationResolver {
   const translationsSnapshot = useTranslationsSnapshot();
   const i18nStore = useI18nStore();
   const devHotReloadEnabled =
     process.env.NODE_ENV !== 'production' &&
     getI18nConfig().isDevHotReloadEnabled();
-  const onMissingTranslation = useHandleMissingTranslation();
+  const onMissingTranslation =
+    useHandleMissingTranslationWithConditions(shouldTranslate);
 
   /**
    * Track lookups per hook instance without updating React state during render.
@@ -63,7 +64,7 @@ export function useTrackedTranslationResolver(
   }
 
   // (optimization) Pre-subscribe to compiler-injected lookups
-  usePreloadCompilerLookups(messages, trackedKeysRef);
+  usePreloadCompilerLookups(messages, trackedKeysRef, locale, shouldTranslate);
 
   // (tx hot reload) Subscribe to translation updates
   useSubscribeToTrackedLookups(
@@ -112,14 +113,14 @@ export function useTrackedTranslationResolver(
  */
 function usePreloadCompilerLookups(
   messages: Message[],
-  trackedKeysRef: RefObject<Set<string> | null>
+  trackedKeysRef: RefObject<Set<string> | null>,
+  locale: string,
+  shouldTranslate: boolean
 ) {
   const i18nStore = useI18nStore();
-  const locale = useLocale();
   const devHotReloadEnabled =
     process.env.NODE_ENV !== 'production' &&
     getI18nConfig().isDevHotReloadEnabled();
-  const shouldTranslate = useShouldTranslate();
   const translationsSnapshot = useTranslationsSnapshot();
   const txHotReloadEnabled = useMemo(() => {
     return messages?.length > 0 && shouldTranslate && devHotReloadEnabled;

--- a/packages/react-core/src/hooks/useGT.ts
+++ b/packages/react-core/src/hooks/useGT.ts
@@ -1,7 +1,6 @@
 import { useCallback } from 'react';
 import { createLookupOptions, interpolateMessage } from 'gt-i18n/internal';
-import { useLocale } from './condition-store';
-import { useShouldTranslate } from './utils';
+import { useTranslationConditions } from './utils';
 import type { GTFunctionType, GTTranslationOptions } from 'gt-i18n/types';
 import type { StringFormat } from '@generaltranslation/format/types';
 import { useDefaultLocale } from './i18n-config';
@@ -13,10 +12,13 @@ import {
 // ===== Hook ===== //
 
 export function useGT(_messages?: Message[]): GTFunctionType {
-  const locale = useLocale();
+  const { locale, shouldTranslate } = useTranslationConditions();
   const defaultLocale = useDefaultLocale();
-  const shouldTranslate = useShouldTranslate();
-  const resolveTranslation = useTrackedTranslationResolver(_messages);
+  const resolveTranslation = useTrackedTranslationResolver(
+    _messages,
+    locale,
+    shouldTranslate
+  );
 
   /**
    * gt() string translation callback

--- a/packages/react-core/src/hooks/utils.ts
+++ b/packages/react-core/src/hooks/utils.ts
@@ -1,6 +1,6 @@
 import type { LocaleProperties } from '@generaltranslation/format/types';
 import { useMemo } from 'react';
-import { useEnableI18n, useLocale } from './condition-store';
+import { useConditionStore, useEnableI18n, useLocale } from './condition-store';
 import { getFormatLocales } from './utils/getFormatLocales';
 import { getI18nConfig } from 'gt-i18n/internal';
 
@@ -28,6 +28,22 @@ export function useShouldTranslate(): boolean {
   const enableI18n = useEnableI18n();
   const locale = useLocale();
   return enableI18n && getI18nConfig().requiresTranslation(locale);
+}
+
+/**
+ * Resolves the condition values shared by translation hooks once per render.
+ */
+export function useTranslationConditions(): {
+  locale: string;
+  shouldTranslate: boolean;
+} {
+  const conditionStore = useConditionStore();
+  const locale = conditionStore.getLocale();
+  const enableI18n = conditionStore.getEnableI18n();
+  return {
+    locale,
+    shouldTranslate: enableI18n && getI18nConfig().requiresTranslation(locale),
+  };
 }
 
 export function useLocaleProperties(locale: string): LocaleProperties {

--- a/packages/react-core/src/hooks/utils/missing-translation.ts
+++ b/packages/react-core/src/hooks/utils/missing-translation.ts
@@ -51,12 +51,6 @@ function useHandleMissingTranslationDev(): OnMissingTranslation {
   return useHandleMissingTranslationWithConditionsDev(useShouldTranslate());
 }
 
-function useHandleMissingTranslationWithConditionsProd(
-  _shouldTranslate: boolean
-): OnMissingTranslation {
-  return noopOnMissingTranslation;
-}
-
 function useHandleMissingTranslationWithConditionsDev(
   shouldTranslate: boolean
 ): OnMissingTranslation {
@@ -132,7 +126,7 @@ export const useHandleMissingTranslationWithConditions: (
   shouldTranslate: boolean
 ) => OnMissingTranslation =
   process.env.NODE_ENV === 'production'
-    ? useHandleMissingTranslationWithConditionsProd
+    ? useHandleMissingTranslationProd
     : useHandleMissingTranslationWithConditionsDev;
 
 export const useHandleMissingDictionaryEntry: () => OnMissingDictionaryEntry =

--- a/packages/react-core/src/hooks/utils/missing-translation.ts
+++ b/packages/react-core/src/hooks/utils/missing-translation.ts
@@ -48,8 +48,20 @@ function useHandleMissingTranslationProd(): OnMissingTranslation {
 }
 
 function useHandleMissingTranslationDev(): OnMissingTranslation {
+  return useHandleMissingTranslationWithConditionsDev(useShouldTranslate());
+}
+
+function useHandleMissingTranslationWithConditionsProd(
+  _shouldTranslate: boolean
+): OnMissingTranslation {
+  return noopOnMissingTranslation;
+}
+
+function useHandleMissingTranslationWithConditionsDev(
+  shouldTranslate: boolean
+): OnMissingTranslation {
   const customHandleMissing = useGTContext()?.onMissingTranslation;
-  const pureHandleMissing = useDevHotReloadQueue();
+  const pureHandleMissing = useDevHotReloadQueue(shouldTranslate);
 
   return useCallback(
     (lookup: TranslateLookup) => {
@@ -72,7 +84,7 @@ function useHandleMissingDictionaryEntryProd(): OnMissingDictionaryEntry {
 
 function useHandleMissingDictionaryEntryDev(): OnMissingDictionaryEntry {
   const customHandleMissing = useGTContext()?.onMissingDictionaryEntry;
-  const pureHandleMissing = useDevHotReloadQueue();
+  const pureHandleMissing = useDevHotReloadQueue(useShouldTranslate());
 
   return useCallback(
     (lookup: DictionaryLookup) => {
@@ -95,7 +107,7 @@ function useHandleMissingDictionaryObjectProd(): OnMissingDictionaryObj {
 
 function useHandleMissingDictionaryObjectDev(): OnMissingDictionaryObj {
   const customHandleMissing = useGTContext()?.onMissingDictionaryObj;
-  const pureHandleMissing = useDevHotReloadQueue();
+  const pureHandleMissing = useDevHotReloadQueue(useShouldTranslate());
   return useCallback(
     (lookup: DictionaryLookup) => {
       if (customHandleMissing) {
@@ -116,6 +128,13 @@ export const useHandleMissingTranslation: () => OnMissingTranslation =
     ? useHandleMissingTranslationProd
     : useHandleMissingTranslationDev;
 
+export const useHandleMissingTranslationWithConditions: (
+  shouldTranslate: boolean
+) => OnMissingTranslation =
+  process.env.NODE_ENV === 'production'
+    ? useHandleMissingTranslationWithConditionsProd
+    : useHandleMissingTranslationWithConditionsDev;
+
 export const useHandleMissingDictionaryEntry: () => OnMissingDictionaryEntry =
   process.env.NODE_ENV === 'production'
     ? useHandleMissingDictionaryEntryProd
@@ -129,13 +148,12 @@ export const useHandleMissingDictionaryObject: () => OnMissingDictionaryObj =
 /**
  * HMR translation needs to be deferred to post-commit phase
  */
-function useDevHotReloadQueue() {
+function useDevHotReloadQueue(shouldTranslate: boolean) {
   // Statically gated so bundlers can drop dev hot-reload work from
   // production builds.
   const devHotReloadEnabled =
     process.env.NODE_ENV !== 'production' &&
     getI18nConfig().isDevHotReloadEnabled();
-  const shouldTranslate = useShouldTranslate();
   const i18nStore = useI18nStore();
 
   // No memoization bc we want to flush after every render


### PR DESCRIPTION
- use prop drilling to avoid duplicate `useShouldTranslate()` invocations (`useMemo()` is not solution here)
- `useGT()` invocation time fell from 65.4µs to 19.3µs (for 31 locales)

## Summary

- Resolve the locale and translation decision once per `useGT` render, then reuse them in the tracked resolver, compiler preload, and development missing-translation paths.
- Remove redundant cookie, browser-locale, and `requiresTranslation()` work without adding module-level caching or changing the public API.

## Testing

- `pnpm install` — passed
- `pnpm --filter @generaltranslation/react-core test` — passed (14 files, 68 tests)
- `pnpm --filter @generaltranslation/react-core typecheck` — passed
- `pnpm exec turbo run build --filter=gt-next --filter=@generaltranslation/compiler` — passed (8 tasks)
- `pnpm exec oxlint <changed files>` and `pnpm exec oxfmt --check <changed files>` — passed
- Linked standalone Next.js app with 31 locales and 2,500 `useGT` call sites — production median improved from 163.5 ms on #2109 to 48.2 ms with this PR (70.5% reduction)
- Linked standalone Next.js app rendering 50,000 cells — production median improved from 3,750.6 ms on #2109 to 1,395.5 ms with this PR (62.8% reduction)

## Notes

- Changeset: patch for `@generaltranslation/react-core` (and its fixed-version package group).
- Stacked on #2109; merge #2109 first.
- Relates to #2067.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change resolves the active locale and translation requirement once per `useGT` render and consistently reuses those values for lookup resolution, compiler-preloaded messages, and development missing-translation handling. Focused runtime coverage confirmed enabled translations are requested for the resolved locale, while disabled i18n does not request missing translations.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge based on the exercised translation and development hot-reload paths.

No blocking failure remains.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the pr2112-runtime-harness test suite with Vitest and confirmed that all 3 tests passed, while observing compiler preload requesting the fr locale, a missing runtime lookup being translated when i18n is enabled, and no translation request when i18n is disabled.
- Re-ran the tests after temporarily placing the untracked harness beside the changed hook sources to align workspace package resolution, and confirmed that 3 tests in pr2112-runtime-harness and 4 tests across useGT and translationConditions all passed, showing that the resolved conditions are forwarded to the tracked resolver and that requiredness is skipped when i18n is disabled.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(react-core): reuse production m..."](https://github.com/generaltranslation/gt/commit/5a2e4784ad06fbd8d18d7e24fff5afdf1b8fd45b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54486539)</sub>

<!-- /greptile_comment -->