### PR TITLE
fix(react-core): keep the dev server alive when a runtime translation request is rejected

### DIFF
--- a/.changeset/tidy-moons-behave.md
+++ b/.changeset/tidy-moons-behave.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/react-core': patch
+---
+
+Log runtime translation failures from the i18n store instead of letting them escape as unhandled promise rejections that crash the dev server during SSR

--- a/packages/react-core/src/i18n-store/I18nStore.ts
+++ b/packages/react-core/src/i18n-store/I18nStore.ts
@@ -27,6 +27,20 @@ export type DictionaryStoreListener = (event: DictionaryLookup) => void;
 
 const MAX_LOGGED_RUNTIME_TRANSLATION_ERRORS = 100;
 
+function getRuntimeTranslationErrorDedupeKey(error: unknown): string {
+  if (error instanceof Error) {
+    return `${error.name}|${error.message}`;
+  }
+  if (error !== null && typeof error === 'object') {
+    try {
+      return `object|${JSON.stringify(error)}`;
+    } catch {
+      return `object|${String(error)}`;
+    }
+  }
+  return `${typeof error}|${String(error)}`;
+}
+
 /**
  * I18nStore gives us the ability to perform client-side updates to translations.
  * Primarily useful for dev hot reload.
@@ -104,7 +118,7 @@ export class I18nStore {
    */
   private logRuntimeTranslationError(error: unknown): void {
     const details = formatDiagnosticErrorDetails(error);
-    const dedupeKey = details ?? '';
+    const dedupeKey = getRuntimeTranslationErrorDedupeKey(error);
     if (this.loggedRuntimeTranslationErrors.has(dedupeKey)) return;
     this.loggedRuntimeTranslationErrors.add(dedupeKey);
     if (

--- a/packages/react-core/src/i18n-store/I18nStore.ts
+++ b/packages/react-core/src/i18n-store/I18nStore.ts
@@ -72,10 +72,7 @@ export class I18nStore {
         lookup.message,
         lookup.options
       )
-      .then((translation) => {
-        if (translation == null) {
-          // TODO: warn about runtime translation failure
-        }
+      .then(() => {
         this.emitTranslateEvent(lookup);
       })
       .catch((error) => this.logRuntimeTranslationError(error));
@@ -84,10 +81,7 @@ export class I18nStore {
   translateDictionaryEntry = (lookup: DictionaryLookup): void => {
     getReactI18nCache()
       .lookupDictionaryWithFallback(lookup.locale, lookup.id)
-      .then((dictionaryEntry) => {
-        if (dictionaryEntry == null) {
-          // TODO: warn about runtime dictionary translation failure
-        }
+      .then(() => {
         this.emitDictionaryEvent(lookup);
       })
       .catch((error) => this.logRuntimeTranslationError(error));
@@ -96,10 +90,7 @@ export class I18nStore {
   translateDictionaryObject = (lookup: DictionaryLookup): void => {
     getReactI18nCache()
       .lookupDictionaryObjWithFallback(lookup.locale, lookup.id)
-      .then((dictionaryObject) => {
-        if (dictionaryObject == null) {
-          // TODO: warn about runtime dictionary translation failure
-        }
+      .then(() => {
         this.emitDictionaryEvent(lookup);
       })
       .catch((error) => this.logRuntimeTranslationError(error));

--- a/packages/react-core/src/i18n-store/I18nStore.ts
+++ b/packages/react-core/src/i18n-store/I18nStore.ts
@@ -25,6 +25,8 @@ import {
 
 export type DictionaryStoreListener = (event: DictionaryLookup) => void;
 
+const MAX_LOGGED_RUNTIME_TRANSLATION_ERRORS = 100;
+
 /**
  * I18nStore gives us the ability to perform client-side updates to translations.
  * Primarily useful for dev hot reload.
@@ -114,6 +116,15 @@ export class I18nStore {
     const dedupeKey = details ?? '';
     if (this.loggedRuntimeTranslationErrors.has(dedupeKey)) return;
     this.loggedRuntimeTranslationErrors.add(dedupeKey);
+    if (
+      this.loggedRuntimeTranslationErrors.size >
+      MAX_LOGGED_RUNTIME_TRANSLATION_ERRORS
+    ) {
+      const oldest = this.loggedRuntimeTranslationErrors.values().next().value;
+      if (oldest !== undefined) {
+        this.loggedRuntimeTranslationErrors.delete(oldest);
+      }
+    }
     console.error(
       createDiagnosticMessage({
         source: '@generaltranslation/react-core',

--- a/packages/react-core/src/i18n-store/I18nStore.ts
+++ b/packages/react-core/src/i18n-store/I18nStore.ts
@@ -1,3 +1,7 @@
+import {
+  createDiagnosticMessage,
+  formatDiagnosticErrorDetails,
+} from 'generaltranslation/internal';
 import { getTranslateListenerKey } from 'gt-i18n/internal';
 import type {
   DictionaryEntrySnapshot,
@@ -36,6 +40,7 @@ export class I18nStore {
   private translateListeners = new Set<TranslateEventListener>();
   private dictionaryEntryListeners = new Set<DictionaryStoreListener>();
   private dictionaryObjectListeners = new Set<DictionaryStoreListener>();
+  private loggedRuntimeTranslationErrors = new Set<string>();
 
   /**
    * I18nCache must be already initialized
@@ -70,7 +75,8 @@ export class I18nStore {
           // TODO: warn about runtime translation failure
         }
         this.emitTranslateEvent(lookup);
-      });
+      })
+      .catch((error) => this.logRuntimeTranslationError(error));
   };
 
   translateDictionaryEntry = (lookup: DictionaryLookup): void => {
@@ -81,7 +87,8 @@ export class I18nStore {
           // TODO: warn about runtime dictionary translation failure
         }
         this.emitDictionaryEvent(lookup);
-      });
+      })
+      .catch((error) => this.logRuntimeTranslationError(error));
   };
 
   translateDictionaryObject = (lookup: DictionaryLookup): void => {
@@ -92,8 +99,31 @@ export class I18nStore {
           // TODO: warn about runtime dictionary translation failure
         }
         this.emitDictionaryEvent(lookup);
-      });
+      })
+      .catch((error) => this.logRuntimeTranslationError(error));
   };
+
+  /**
+   * Runtime translation runs fire-and-forget, so a rejected request (for
+   * example a 401 from an invalid dev API key) is logged here instead of
+   * escaping as an unhandled rejection that kills the dev server during SSR.
+   * Identical failures log once.
+   */
+  private logRuntimeTranslationError(error: unknown): void {
+    const details = formatDiagnosticErrorDetails(error);
+    const dedupeKey = details ?? '';
+    if (this.loggedRuntimeTranslationErrors.has(dedupeKey)) return;
+    this.loggedRuntimeTranslationErrors.add(dedupeKey);
+    console.error(
+      createDiagnosticMessage({
+        source: '@generaltranslation/react-core',
+        severity: 'Error',
+        whatHappened: 'A runtime translation request failed.',
+        wayOut: 'Rendering falls back to untranslated content.',
+        details,
+      })
+    );
+  }
 
   // ========== UseSyncExternalStore ========== //
 

--- a/packages/react-core/src/i18n-store/__tests__/I18nStore.test.ts
+++ b/packages/react-core/src/i18n-store/__tests__/I18nStore.test.ts
@@ -111,6 +111,26 @@ describe('I18nStore runtime translation failure handling', () => {
     expect(consoleError).toHaveBeenCalledTimes(102);
   });
 
+  it('logs distinct non-Error rejection reasons separately', async () => {
+    const store = new I18nStore();
+
+    lookupTranslationWithFallback.mockRejectedValueOnce({ code: 'A' });
+    await store.translate({ ...lookup, message: 'm1' });
+    lookupTranslationWithFallback.mockRejectedValueOnce({ code: 'B' });
+    await store.translate({ ...lookup, message: 'm2' });
+    expect(consoleError).toHaveBeenCalledTimes(2);
+
+    lookupTranslationWithFallback.mockRejectedValueOnce(null);
+    await store.translate({ ...lookup, message: 'm3' });
+    lookupTranslationWithFallback.mockRejectedValueOnce(undefined);
+    await store.translate({ ...lookup, message: 'm4' });
+    expect(consoleError).toHaveBeenCalledTimes(4);
+
+    lookupTranslationWithFallback.mockRejectedValueOnce({ code: 'A' });
+    await store.translate({ ...lookup, message: 'm5' });
+    expect(consoleError).toHaveBeenCalledTimes(4);
+  });
+
   it('translateDictionaryObject() logs instead of leaving an unhandled rejection', async () => {
     lookupDictionaryObjWithFallback.mockRejectedValue(rejectedKeyError);
     const store = new I18nStore();

--- a/packages/react-core/src/i18n-store/__tests__/I18nStore.test.ts
+++ b/packages/react-core/src/i18n-store/__tests__/I18nStore.test.ts
@@ -95,6 +95,22 @@ describe('I18nStore runtime translation failure handling', () => {
     await vi.waitFor(() => expect(consoleError).toHaveBeenCalledTimes(1));
   });
 
+  it('re-logs a failure after it is evicted from the bounded dedupe set', async () => {
+    const store = new I18nStore();
+    for (let i = 0; i <= 100; i++) {
+      lookupTranslationWithFallback.mockRejectedValueOnce(
+        new Error(`failure ${i}`)
+      );
+      await store.translate({ ...lookup, message: `message ${i}` });
+    }
+    expect(consoleError).toHaveBeenCalledTimes(101);
+
+    lookupTranslationWithFallback.mockRejectedValueOnce(new Error('failure 0'));
+    await store.translate(lookup);
+
+    expect(consoleError).toHaveBeenCalledTimes(102);
+  });
+
   it('translateDictionaryObject() logs instead of leaving an unhandled rejection', async () => {
     lookupDictionaryObjWithFallback.mockRejectedValue(rejectedKeyError);
     const store = new I18nStore();

--- a/packages/react-core/src/i18n-store/__tests__/I18nStore.test.ts
+++ b/packages/react-core/src/i18n-store/__tests__/I18nStore.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { initializeI18nConfig } from 'gt-i18n/internal';
+import { setReactI18nCache } from '../../i18n-cache/singleton-operations';
+import { I18nStore } from '../I18nStore';
+import type { ReactI18nCache } from '../../i18n-cache/ReactI18nCache';
+import type { TranslateLookup } from '../storeTypes';
+
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: unknown;
+};
+
+function resetGTGlobals() {
+  Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
+}
+
+const lookupTranslationWithFallback = vi.fn();
+const lookupDictionaryWithFallback = vi.fn();
+const lookupDictionaryObjWithFallback = vi.fn();
+
+function setup() {
+  initializeI18nConfig({
+    defaultLocale: 'en',
+    locales: ['en', 'fr'],
+  });
+  setReactI18nCache({
+    lookupTranslationWithFallback,
+    lookupDictionaryWithFallback,
+    lookupDictionaryObjWithFallback,
+  } as unknown as ReactI18nCache);
+}
+
+// In development the cache rejects when the runtime API rejects the request
+// (for example a 401 from an invalid dev API key). SSR fires these store
+// methods without awaiting them, so a rejection here used to become an
+// unhandled rejection that killed the dev server.
+const rejectedKeyError = new Error(
+  'Remote translation request failed: 401 Invalid API key'
+);
+
+const lookup: TranslateLookup = {
+  locale: 'fr',
+  message: 'Hello',
+  options: { $format: 'ICU' },
+};
+
+describe('I18nStore runtime translation failure handling', () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    resetGTGlobals();
+    vi.clearAllMocks();
+    setup();
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('translate() resolves and logs when the runtime request is rejected', async () => {
+    lookupTranslationWithFallback.mockRejectedValue(rejectedKeyError);
+    const store = new I18nStore();
+
+    await expect(store.translate(lookup)).resolves.toBeUndefined();
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('401 Invalid API key')
+    );
+  });
+
+  it('translate() does not emit a translate event for a failed request', async () => {
+    lookupTranslationWithFallback.mockRejectedValue(rejectedKeyError);
+    const store = new I18nStore();
+    const listener = vi.fn();
+    store.subscribeToTranslationEvents(listener);
+
+    await store.translate(lookup);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('translate() logs an identical failure once across lookups', async () => {
+    lookupTranslationWithFallback.mockRejectedValue(rejectedKeyError);
+    const store = new I18nStore();
+
+    await store.translate(lookup);
+    await store.translate({ ...lookup, message: 'Goodbye' });
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+  });
+
+  it('translateDictionaryEntry() logs instead of leaving an unhandled rejection', async () => {
+    lookupDictionaryWithFallback.mockRejectedValue(rejectedKeyError);
+    const store = new I18nStore();
+
+    store.translateDictionaryEntry({ locale: 'fr', id: 'greeting' });
+
+    await vi.waitFor(() => expect(consoleError).toHaveBeenCalledTimes(1));
+  });
+
+  it('translateDictionaryObject() logs instead of leaving an unhandled rejection', async () => {
+    lookupDictionaryObjWithFallback.mockRejectedValue(rejectedKeyError);
+    const store = new I18nStore();
+
+    store.translateDictionaryObject({ locale: 'fr', id: 'nav' });
+
+    await vi.waitFor(() => expect(consoleError).toHaveBeenCalledTimes(1));
+  });
+});


### PR DESCRIPTION
Fixes #1938.

## Summary

- Adds rejection handlers to the i18n store's three fire-and-forget translate paths, so a failed runtime translation request (for example a 401 from an invalid dev API key) no longer kills the Node process during SSR in development.
- Logs one console error per distinct failure, keyed on the error's identity and bounded at 100 entries with first-in-first-out eviction; rendering falls back to untranslated content and production behavior is unchanged.
- Removes the stale runtime-failure TODO comments these handlers replace, and adds a 7-test suite plus a patch changeset for @generaltranslation/react-core.

## Validation

- `npx tsc --noEmit` in packages/react-core: clean
- `npx vitest run`: react-core 75 passed (15 files), gt-react 30 passed (7 files) on b48ab689f; the new tests fail without the fix
- Not run locally: repo-wide build and gt-next (needs cargo); CI covers both

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Runtime translation and dictionary lookup failures are now handled without interrupting fallback rendering, and diagnostic retention is bounded.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

No blocking failure remains.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Collected the exact reproduction source used for the i18n runtime dedupe proof.
- Executed the focused verification checks and saved the full execution log, which exited with code 0.
- Compared the before and after cyclic-diagnostic logs and confirmed one cyclic failure in the before log and two distinct cyclic failures in the after log.
- Documented that artifacts were saved in the repository's artifacts directory since no separate upload tool was available.

<a href="https://app.greptile.com/trex/runs/19929993/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(react-core): key the error dedupe on..."](https://github.com/generaltranslation/gt/commit/b48ab689f70fc335651c32b1f618e1155d31d0f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55311845)</sub>

<!-- /greptile_comment -->
