### PR TITLE
fix(react-core): return an empty snapshot when a translation load fails

### DIFF
--- a/.changeset/translations-snapshot-missing-file.md
+++ b/.changeset/translations-snapshot-missing-file.md
@@ -2,4 +2,4 @@
 '@generaltranslation/react-core': patch
 ---
 
-Return an empty snapshot and warn when `getTranslationsSnapshot()` cannot load translations for a locale, instead of letting the loader error propagate. Selecting a locale whose translation files do not exist yet crashed server route loaders (such as the TanStack Start root loader) with an HTTP 500 in development; content for that locale now renders untranslated.
+Return a snapshot with no entry for the locale, and warn, when `getTranslationsSnapshot()` cannot load translations for that locale, instead of letting the loader error propagate. Selecting a locale whose translation files do not exist yet crashed server route loaders (such as the TanStack Start root loader) with an HTTP 500 in development; content for that locale now renders untranslated. Because the failed locale is omitted rather than hydrated as an empty cache entry, a later lookup retries the loader once translations exist.

--- a/.changeset/translations-snapshot-missing-file.md
+++ b/.changeset/translations-snapshot-missing-file.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/react-core': patch
+---
+
+Return an empty snapshot and warn when `getTranslationsSnapshot()` cannot load translations for a locale, instead of letting the loader error propagate. Selecting a locale whose translation files do not exist yet crashed server route loaders (such as the TanStack Start root loader) with an HTTP 500 in development; content for that locale now renders untranslated.

--- a/packages/react-core/src/functions/helpers/__tests__/getTranslationsSnapshot.test.ts
+++ b/packages/react-core/src/functions/helpers/__tests__/getTranslationsSnapshot.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ReactI18nCache } from '../../../i18n-cache/ReactI18nCache';
+import { setReactI18nCache } from '../../../i18n-cache/singleton-operations';
+import { initializeI18nConfig } from '../../../setup/i18nConfig';
+import { getTranslationsSnapshot } from '../getTranslationsSnapshot';
+
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: unknown;
+};
+
+function resetGTGlobals() {
+  Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
+}
+
+function setup(loadTranslations: (locale: string) => Promise<unknown>) {
+  initializeI18nConfig(
+    {
+      defaultLocale: 'en',
+      locales: ['en', 'es'],
+    },
+    'SPA'
+  );
+  setReactI18nCache(new ReactI18nCache({ loadTranslations }));
+}
+
+describe('getTranslationsSnapshot', () => {
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    resetGTGlobals();
+    consoleWarnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    resetGTGlobals();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('returns the loaded translations keyed by locale', async () => {
+    setup(async () => ({ hash1: 'hola' }));
+
+    await expect(getTranslationsSnapshot('es')).resolves.toEqual({
+      es: { hash1: 'hola' },
+    });
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('development: returns an empty snapshot and warns when the loader fails', async () => {
+    // Reproduces gt#1937: a translation file that does not exist yet must not
+    // crash the caller (eg a TanStack Start route loader) with a 500
+    vi.stubEnv('NODE_ENV', 'development');
+    setup(() =>
+      Promise.reject(new Error("Cannot find module './_gt/es.json'"))
+    );
+
+    await expect(getTranslationsSnapshot('es')).resolves.toEqual({ es: {} });
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"es"')
+    );
+  });
+});

--- a/packages/react-core/src/functions/helpers/__tests__/getTranslationsSnapshot.test.ts
+++ b/packages/react-core/src/functions/helpers/__tests__/getTranslationsSnapshot.test.ts
@@ -48,7 +48,7 @@ describe('getTranslationsSnapshot', () => {
     expect(consoleWarnSpy).not.toHaveBeenCalled();
   });
 
-  it('development: returns an empty snapshot and warns when the loader fails', async () => {
+  it('development: omits the locale and warns when the loader fails', async () => {
     // Reproduces gt#1937: a translation file that does not exist yet must not
     // crash the caller (eg a TanStack Start route loader) with a 500
     vi.stubEnv('NODE_ENV', 'development');
@@ -56,9 +56,24 @@ describe('getTranslationsSnapshot', () => {
       Promise.reject(new Error("Cannot find module './_gt/es.json'"))
     );
 
-    await expect(getTranslationsSnapshot('es')).resolves.toEqual({ es: {} });
+    await expect(getTranslationsSnapshot('es')).resolves.toEqual({});
     expect(consoleWarnSpy).toHaveBeenCalledWith(
       expect.stringContaining('"es"')
     );
+  });
+
+  it('development: retries the loader and recovers after a failed load', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    const loadTranslations = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Cannot find module './_gt/es.json'"))
+      .mockResolvedValue({ hash1: 'hola' });
+    setup(loadTranslations);
+
+    await expect(getTranslationsSnapshot('es')).resolves.toEqual({});
+    await expect(getTranslationsSnapshot('es')).resolves.toEqual({
+      es: { hash1: 'hola' },
+    });
+    expect(loadTranslations).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/react-core/src/functions/helpers/getTranslationsSnapshot.ts
+++ b/packages/react-core/src/functions/helpers/getTranslationsSnapshot.ts
@@ -8,14 +8,14 @@ import { getReactI18nCache } from '../../i18n-cache/singleton-operations';
 
 /**
  * Serializable cached translations for provider hydration; a failed load
- * degrades to an empty snapshot. TODO: perhaps move to /i18n for type generics
+ * yields a snapshot with no entry for the locale, so hydration caches nothing
+ * and a later lookup retries. TODO: perhaps move to /i18n for type generics
  */
 export async function getTranslationsSnapshot(
   locale: Locale
 ): Promise<Record<Locale, Record<Hash, Translation>>> {
   const i18nCache = getReactI18nCache();
   try {
-    // Only pass translations for the given locale to minimize the snapshot
     return { [locale]: await i18nCache.loadTranslations(locale) };
   } catch (error) {
     console.warn(
@@ -28,6 +28,6 @@ export async function getTranslationsSnapshot(
         details: formatDiagnosticErrorDetails(error),
       })
     );
-    return { [locale]: {} };
+    return {};
   }
 }

--- a/packages/react-core/src/functions/helpers/getTranslationsSnapshot.ts
+++ b/packages/react-core/src/functions/helpers/getTranslationsSnapshot.ts
@@ -1,18 +1,33 @@
 import { Hash, Locale } from 'gt-i18n/internal/types';
 import { Translation } from 'gt-i18n/types';
+import {
+  createDiagnosticMessage,
+  formatDiagnosticErrorDetails,
+} from 'generaltranslation/internal';
 import { getReactI18nCache } from '../../i18n-cache/singleton-operations';
 
 /**
- * Returns a promise of serializable cached translations that
- * can be passed to a provider for hydration
- *
- * TODO: perhaps should be moved to /i18n if allowing for type generics
+ * Serializable cached translations for provider hydration; a failed load
+ * degrades to an empty snapshot. TODO: perhaps move to /i18n for type generics
  */
 export async function getTranslationsSnapshot(
   locale: Locale
 ): Promise<Record<Locale, Record<Hash, Translation>>> {
   const i18nCache = getReactI18nCache();
-  const translations = await i18nCache.loadTranslations(locale);
-  // Only pass translations for the given locale to minimize the size of the snapshot
-  return { [locale]: translations };
+  try {
+    // Only pass translations for the given locale to minimize the snapshot
+    return { [locale]: await i18nCache.loadTranslations(locale) };
+  } catch (error) {
+    console.warn(
+      createDiagnosticMessage({
+        source: '@generaltranslation/react-core',
+        severity: 'Warning',
+        whatHappened: `Could not load translations for locale "${locale}", so content for this locale renders untranslated`,
+        why: 'the translation loader failed, usually because translations for this locale have not been generated yet',
+        fix: 'Generate translations for this locale, or check your loadTranslations configuration.',
+        details: formatDiagnosticErrorDetails(error),
+      })
+    );
+    return { [locale]: {} };
+  }
 }


### PR DESCRIPTION
## Summary

- Fixes #1937: catches the translation loader error inside `getTranslationsSnapshot()`, so selecting a locale whose translation files do not exist yet renders that locale untranslated instead of crashing server route loaders (such as the TanStack Start root loader) with an HTTP 500.
- Omits the failed locale from the returned snapshot and logs a structured console warning, so hydration caches nothing for the failure and a later lookup retries the loader once translations exist.
- Adds a patch changeset for `@generaltranslation/react-core`.

## Validation

- `npx vitest run` in `packages/react-core`: 15 files, 71 tests passed on d0e19deb6; the failure-path and recovery tests fail against main's version of the file.
- `npx oxlint packages/react-core` (no findings in touched files) and `npx oxfmt --check` on touched paths: clean.
- `npx tsc --noEmit` in `packages/react-core`: clean. Not run: a live TanStack Start app reproduction.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Translation snapshot loading now handles unavailable locale data without storing an empty locale entry. The focused recovery test confirms that a failed load returns no locale snapshot and that a later successful request reloads and returns the translations.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

The exercised failure-and-recovery path returns an empty snapshot after failure and successfully reloads translations on the next request.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused fail-then-recover getTranslationsSnapshot test using pnpm with the @generaltranslation/react-core filter and Vitest, and the test run completed with 1 passed and 2 skipped, exit code 0.
- The test asserts that the first load returns {}, the second load returns { es: { hash1: 'hola' } }, and that loadTranslations was called twice.
- Artifacts were collected to support verification: the focused fail-then-recover test source and two test-output logs.

<a href="https://app.greptile.com/trex/runs/19907042/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(react-core): omit the locale from th..."](https://github.com/generaltranslation/gt/commit/d0e19deb6cb5007dd026155af405040aadc52010) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55345069)</sub>

<!-- /greptile_comment -->
