### PR TITLE
fix(cli): fail fast without a TTY and add --yes to init and configure

### DIFF
--- a/.changeset/lazy-donuts-refuse.md
+++ b/.changeset/lazy-donuts-refuse.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+gt init and gt configure now exit with an error when stdin is not an interactive terminal instead of silently exiting 0, and both accept a --yes flag that skips all prompts and applies the recommended defaults for CI and scripted runs. When no package manager can be detected and stdin is not an interactive terminal, the CLI defaults to npm instead of prompting.

--- a/.changeset/lazy-donuts-refuse.md
+++ b/.changeset/lazy-donuts-refuse.md
@@ -2,4 +2,4 @@
 'gt': patch
 ---
 
-gt init and gt configure now exit with an error when stdin is not an interactive terminal instead of silently exiting 0, and both accept a --yes flag that skips all prompts and applies the recommended defaults for CI and scripted runs. When no package manager can be detected and stdin is not an interactive terminal, the CLI defaults to npm instead of prompting.
+gt init and gt configure now exit with an error when stdin is not an interactive terminal instead of silently exiting 0, and both accept a --yes flag that skips all prompts and applies the recommended defaults for CI and scripted runs. The --yes flow rejects an empty locales list, gt init now reads and writes the file passed with --config instead of always using gt.config.json, and when no package manager can be detected without an interactive terminal the CLI defaults to npm instead of prompting.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -29,6 +29,15 @@ Set up your project:
 npx gt init
 ```
 
+In CI or other non-interactive environments, `gt init` and `gt configure` exit
+with an error unless you pass `--yes`, which accepts the recommended defaults.
+`--yes` reads `locales` from an existing `gt.config.json` and uses the
+`GT_API_KEY` and `GT_PROJECT_ID` environment variables for credentials.
+
+```bash
+npx gt init --yes
+```
+
 Generate translations:
 
 ```bash

--- a/packages/cli/src/cli/__tests__/nonInteractiveSetup.test.ts
+++ b/packages/cli/src/cli/__tests__/nonInteractiveSetup.test.ts
@@ -1,0 +1,207 @@
+import { Command } from 'commander';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { logErrorAndExit } from '../../console/logging.js';
+import { retrieveCredentials } from '../../utils/credentials.js';
+import { installPackage } from '../../utils/installPackage.js';
+import { BaseCLI } from '../base.js';
+
+vi.mock('../../console/logging.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../console/logging.js')>();
+  const rejectPrompt = vi.fn(() => {
+    throw new Error('unexpected prompt');
+  });
+  return {
+    ...actual,
+    logErrorAndExit: vi.fn((message: string) => {
+      throw new Error(message);
+    }),
+    promptText: rejectPrompt,
+    promptLocale: rejectPrompt,
+    promptLocaleList: rejectPrompt,
+    promptGlobPatterns: rejectPrompt,
+    promptSelect: rejectPrompt,
+    promptMultiSelect: rejectPrompt,
+    promptConfirm: rejectPrompt,
+  };
+});
+
+vi.mock('../../utils/credentials.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../utils/credentials.js')>();
+  return {
+    ...actual,
+    retrieveCredentials: vi.fn(() => {
+      throw new Error('unexpected browser login');
+    }),
+  };
+});
+
+vi.mock('../../utils/installPackage.js', () => ({
+  installPackage: vi.fn(() => Promise.resolve()),
+}));
+
+function runCommand(args: string[]) {
+  const program = new Command();
+  program.exitOverride();
+  new BaseCLI(program, 'base');
+  return program.parseAsync(args, { from: 'user' });
+}
+
+function readConfig(dir: string) {
+  return JSON.parse(readFileSync(path.join(dir, 'gt.config.json'), 'utf8'));
+}
+
+describe('non-interactive init and configure', () => {
+  let projectDir: string;
+  let originalCwd: string;
+  const originalIsTTY = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete (
+      global as typeof global & {
+        _gt_wizard_cached_package_manager?: unknown;
+      }
+    )._gt_wizard_cached_package_manager;
+    vi.stubEnv('GT_PROJECT_ID', '');
+    vi.stubEnv('GT_API_KEY', '');
+    vi.stubEnv('GT_DEV_API_KEY', '');
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: undefined,
+      configurable: true,
+    });
+    originalCwd = process.cwd();
+    projectDir = mkdtempSync(path.join(tmpdir(), 'gt-noninteractive-'));
+    process.chdir(projectDir);
+    writeFileSync(
+      path.join(projectDir, 'package.json'),
+      JSON.stringify({ name: 'example-app', devDependencies: { gt: '1.0.0' } })
+    );
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    if (originalIsTTY) {
+      Object.defineProperty(process.stdin, 'isTTY', originalIsTTY);
+    }
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it.each(['init', 'configure'])(
+    'exits nonzero from %s when stdin is not a TTY',
+    async (command) => {
+      await expect(runCommand([command])).rejects.toThrow('--yes');
+
+      expect(logErrorAndExit).toHaveBeenCalledWith(
+        expect.stringContaining('--yes')
+      );
+      expect(existsSync(path.join(projectDir, 'gt.config.json'))).toBe(false);
+    }
+  );
+
+  it('completes init --yes without prompts when locales are configured', async () => {
+    writeFileSync(
+      path.join(projectDir, 'package.json'),
+      JSON.stringify({
+        name: 'example-app',
+        dependencies: { 'gt-next': '1.0.0' },
+        devDependencies: { gt: '1.0.0' },
+      })
+    );
+    writeFileSync(
+      path.join(projectDir, 'gt.config.json'),
+      JSON.stringify({ defaultLocale: 'en', locales: ['es', 'fr'] })
+    );
+
+    await runCommand(['init', '--yes']);
+
+    const config = readConfig(projectDir);
+    expect(config.defaultLocale).toBe('en');
+    expect(config.locales).toEqual(['es', 'fr']);
+    expect(config.files.gt.output).toContain('[locale].json');
+    expect(existsSync(path.join(projectDir, 'loadTranslations.js'))).toBe(true);
+    expect(retrieveCredentials).not.toHaveBeenCalled();
+  });
+
+  it('completes configure --yes when locales and files are configured', async () => {
+    const seededFiles = {
+      json: { include: ['./content/[locale]/*.json'] },
+    };
+    writeFileSync(
+      path.join(projectDir, 'gt.config.json'),
+      JSON.stringify({
+        defaultLocale: 'en',
+        locales: ['es'],
+        files: seededFiles,
+      })
+    );
+
+    await runCommand(['configure', '--yes']);
+
+    const config = readConfig(projectDir);
+    expect(config.defaultLocale).toBe('en');
+    expect(config.locales).toEqual(['es']);
+    expect(config.files).toEqual(seededFiles);
+    expect(retrieveCredentials).not.toHaveBeenCalled();
+  });
+
+  it('fails init --yes when no locales are configured', async () => {
+    await expect(runCommand(['init', '--yes'])).rejects.toThrow('locales');
+
+    expect(logErrorAndExit).toHaveBeenCalledWith(
+      expect.stringContaining('gt.config.json')
+    );
+    expect(existsSync(path.join(projectDir, 'gt.config.json'))).toBe(false);
+  });
+
+  it('defaults to npm for the gt install when no package manager is detectable', async () => {
+    writeFileSync(
+      path.join(projectDir, 'package.json'),
+      JSON.stringify({ name: 'example-app' })
+    );
+    const seededFiles = {
+      json: { include: ['./content/[locale]/*.json'] },
+    };
+    writeFileSync(
+      path.join(projectDir, 'gt.config.json'),
+      JSON.stringify({
+        defaultLocale: 'en',
+        locales: ['es'],
+        files: seededFiles,
+      })
+    );
+
+    await runCommand(['configure', '--yes']);
+
+    expect(installPackage).toHaveBeenCalledWith(
+      'gt',
+      expect.objectContaining({ id: 'npm' }),
+      true
+    );
+    expect(readConfig(projectDir).files).toEqual(seededFiles);
+  });
+
+  it('fails init --yes when a project without a GT library has no files entry', async () => {
+    const seededConfig = { defaultLocale: 'en', locales: ['es'] };
+    writeFileSync(
+      path.join(projectDir, 'gt.config.json'),
+      JSON.stringify(seededConfig)
+    );
+
+    await expect(runCommand(['init', '--yes'])).rejects.toThrow('files');
+
+    expect(readConfig(projectDir)).toEqual(seededConfig);
+  });
+});

--- a/packages/cli/src/cli/__tests__/nonInteractiveSetup.test.ts
+++ b/packages/cli/src/cli/__tests__/nonInteractiveSetup.test.ts
@@ -166,6 +166,44 @@ describe('non-interactive init and configure', () => {
     expect(existsSync(path.join(projectDir, 'gt.config.json'))).toBe(false);
   });
 
+  it.each(['init', 'configure'])(
+    'rejects an empty locales list from %s --yes',
+    async (command) => {
+      const seededConfig = { defaultLocale: 'en', locales: [] };
+      writeFileSync(
+        path.join(projectDir, 'gt.config.json'),
+        JSON.stringify(seededConfig)
+      );
+
+      await expect(runCommand([command, '--yes'])).rejects.toThrow('locales');
+
+      expect(readConfig(projectDir)).toEqual(seededConfig);
+    }
+  );
+
+  it('reads locales from the config file passed with --config', async () => {
+    const seededFiles = {
+      json: { include: ['./content/[locale]/*.json'] },
+    };
+    writeFileSync(
+      path.join(projectDir, 'custom.json'),
+      JSON.stringify({
+        defaultLocale: 'en',
+        locales: ['es'],
+        files: seededFiles,
+      })
+    );
+
+    await runCommand(['init', '--yes', '--config', 'custom.json']);
+
+    const config = JSON.parse(
+      readFileSync(path.join(projectDir, 'custom.json'), 'utf8')
+    );
+    expect(config.locales).toEqual(['es']);
+    expect(config.files).toEqual(seededFiles);
+    expect(existsSync(path.join(projectDir, 'gt.config.json'))).toBe(false);
+  });
+
   it('defaults to npm for the gt install when no package manager is detectable', async () => {
     writeFileSync(
       path.join(projectDir, 'package.json'),

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -101,6 +101,20 @@ const electronSetupError = createDiagnosticMessage({
     'The automatic setup wizard is not ready for Electron applications',
   docsUrl: 'https://generaltranslation.com/docs/react',
 });
+const nonInteractiveSetupError = createDiagnosticMessage({
+  source: 'gt',
+  severity: 'Error',
+  whatHappened: 'The setup wizard cannot prompt for input',
+  why: 'stdin is not an interactive terminal',
+  fix: 'Rerun with --yes to accept the recommended defaults, or write gt.config.json by hand and set the GT_API_KEY and GT_PROJECT_ID environment variables',
+  docsUrl: 'https://generaltranslation.com/docs/cli/reference/config',
+});
+
+function exitIfNonInteractiveSetup(assumeYes: boolean | undefined): void {
+  if (!assumeYes && process.stdin.isTTY !== true) {
+    logErrorAndExit(nonInteractiveSetupError);
+  }
+}
 
 async function exitIfUnsupportedSetupTarget(): Promise<void> {
   const packageJson = await searchForPackageJson();
@@ -602,14 +616,20 @@ export class BaseCLI {
         'Filepath to config file, by default gt.config.json',
         findFilepath(['gt.config.json'])
       )
+      .option(
+        '--yes',
+        'Skip all prompts and accept the recommended defaults; requires locales in gt.config.json'
+      )
       .action(async (options: SetupOptions) => {
         await exitIfUnsupportedSetupTarget();
+        exitIfNonInteractiveSetup(options.yes);
         const settings = await generateSettings(options);
         displayHeader('Running setup wizard...');
 
         const framework = await detectFramework();
 
         const useAgent = await (async () => {
+          if (options.yes) return false;
           let useAgentMessage;
           if (framework.name === 'mintlify') {
             useAgentMessage = `Mintlify project detected. Would you like to connect to GitHub so that the Locadex AI Agent can translate your project automatically?`;
@@ -656,10 +676,12 @@ export class BaseCLI {
                 : `Files saved locally in ${defaultTranslationsDir}`;
 
           // Ask if user wants to use defaults
-          const useDefaults = await promptConfirm({
-            message: `Would you like to use the recommended General Translation defaults? ${chalk.dim(`(${defaultsDescription})`)}`,
-            defaultValue: true,
-          });
+          const useDefaults =
+            options.yes ||
+            (await promptConfirm({
+              message: `Would you like to use the recommended General Translation defaults? ${chalk.dim(`(${defaultsDescription})`)}`,
+              defaultValue: true,
+            }));
 
           let ranReactSetup = false;
 
@@ -695,7 +717,8 @@ export class BaseCLI {
           await this.handleInitCommand(
             ranReactSetup,
             useDefaults,
-            framework.name === 'vite'
+            framework.name === 'vite',
+            Boolean(options.yes)
           );
 
           logger.endCommand(
@@ -711,8 +734,13 @@ export class BaseCLI {
       .description(
         'Configure your project for General Translation. This will create a gt.config.json file in your codebase.'
       )
-      .action(async () => {
+      .option(
+        '--yes',
+        'Skip all prompts and accept the recommended defaults; requires locales in gt.config.json'
+      )
+      .action(async (options: { yes?: boolean }) => {
         await exitIfUnsupportedSetupTarget();
+        exitIfNonInteractiveSetup(options.yes);
         displayHeader('Configuring project...');
 
         logger.info(
@@ -721,7 +749,12 @@ export class BaseCLI {
 
         // Configure gt.config.json
         const framework = await detectFramework();
-        await this.handleInitCommand(false, false, framework.name === 'vite');
+        await this.handleInitCommand(
+          false,
+          Boolean(options.yes),
+          framework.name === 'vite',
+          Boolean(options.yes)
+        );
 
         logger.endCommand(
           'Done! Make sure you have an API key and project ID to use General Translation. Get them on the dashboard: https://generaltranslation.com/dashboard'
@@ -744,14 +777,18 @@ export class BaseCLI {
   protected async handleInitCommand(
     ranReactSetup: boolean,
     useDefaults: boolean = false,
-    isVite: boolean = false
+    isVite: boolean = false,
+    assumeYes: boolean = false
   ): Promise<void> {
     const configFilepath =
       !isVite && fs.existsSync('src/gt.config.json')
         ? 'src/gt.config.json'
         : 'gt.config.json';
     const existingConfig = loadConfig(configFilepath);
-    const { defaultLocale, locales } = await getDesiredLocales(existingConfig);
+    const { defaultLocale, locales } = await getDesiredLocales(
+      existingConfig,
+      assumeYes
+    );
 
     const packageJson = await searchForPackageJson();
 
@@ -815,8 +852,13 @@ See https://generaltranslation.com/en/docs/next/guides/local-tx`
       : `Do you have any additional files in this project to translate? For example, Markdown files for docs. ${chalk.dim(
           '(To continue without selecting press Enter)'
         )}`;
+    if (assumeYes && !isUsingGT && !existingConfig.files) {
+      logErrorAndExit(
+        'No translatable files are configured. Add a files entry to gt.config.json, or rerun without --yes to select file formats.'
+      );
+    }
     const fileExtensions =
-      useDefaults && isUsingGT
+      assumeYes || (useDefaults && isUsingGT)
         ? [] // Skip for GT projects when using defaults
         : await promptMultiSelect({
             message,
@@ -895,6 +937,12 @@ See https://generaltranslation.com/en/docs/next/guides/local-tx`
 
     // Set credentials
     if ((!isVite || !isUsingGT || usingCDN) && !areCredentialsSet()) {
+      if (assumeYes) {
+        logger.info(
+          'Skipping API key generation. Set the GT_API_KEY and GT_PROJECT_ID environment variables to authenticate.'
+        );
+        return;
+      }
       const loginQuestion = useDefaults
         ? true
         : await promptConfirm({

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -620,9 +620,13 @@ export class BaseCLI {
         '--yes',
         'Skip all prompts and accept the recommended defaults; requires locales in gt.config.json'
       )
-      .action(async (options: SetupOptions) => {
+      .action(async (options: SetupOptions, command: Command) => {
         await exitIfUnsupportedSetupTarget();
         exitIfNonInteractiveSetup(options.yes);
+        const explicitConfigPath =
+          command.getOptionValueSource('config') === 'cli'
+            ? options.config
+            : undefined;
         const settings = await generateSettings(options);
         displayHeader('Running setup wizard...');
 
@@ -718,7 +722,8 @@ export class BaseCLI {
             ranReactSetup,
             useDefaults,
             framework.name === 'vite',
-            Boolean(options.yes)
+            Boolean(options.yes),
+            explicitConfigPath
           );
 
           logger.endCommand(
@@ -778,12 +783,14 @@ export class BaseCLI {
     ranReactSetup: boolean,
     useDefaults: boolean = false,
     isVite: boolean = false,
-    assumeYes: boolean = false
+    assumeYes: boolean = false,
+    configPath?: string
   ): Promise<void> {
     const configFilepath =
-      !isVite && fs.existsSync('src/gt.config.json')
+      configPath ??
+      (!isVite && fs.existsSync('src/gt.config.json')
         ? 'src/gt.config.json'
-        : 'gt.config.json';
+        : 'gt.config.json');
     const existingConfig = loadConfig(configFilepath);
     const { defaultLocale, locales } = await getDesiredLocales(
       existingConfig,

--- a/packages/cli/src/setup/userInput.ts
+++ b/packages/cli/src/setup/userInput.ts
@@ -1,10 +1,17 @@
 import { libraryDefaultLocale } from 'generaltranslation/internal';
-import { promptLocale, promptLocaleList } from '../console/logging.js';
+import {
+  logErrorAndExit,
+  promptLocale,
+  promptLocaleList,
+} from '../console/logging.js';
 
-export async function getDesiredLocales(existingConfig?: {
-  defaultLocale?: unknown;
-  locales?: unknown;
-}): Promise<{
+export async function getDesiredLocales(
+  existingConfig?: {
+    defaultLocale?: unknown;
+    locales?: unknown;
+  },
+  nonInteractive: boolean = false
+): Promise<{
   defaultLocale: string;
   locales: string[];
 }> {
@@ -22,10 +29,18 @@ export async function getDesiredLocales(existingConfig?: {
   // Ask for the default locale
   const defaultLocale =
     configuredDefaultLocale ??
-    (await promptLocale({
-      message: 'What is the default locale for your project?',
-      defaultValue: libraryDefaultLocale,
-    }));
+    (nonInteractive
+      ? libraryDefaultLocale
+      : await promptLocale({
+          message: 'What is the default locale for your project?',
+          defaultValue: libraryDefaultLocale,
+        }));
+
+  if (nonInteractive && !configuredLocales) {
+    logErrorAndExit(
+      'No locales are configured. Add defaultLocale and locales to gt.config.json, or rerun without --yes to be prompted.'
+    );
+  }
 
   // Ask for the locales
   const locales =

--- a/packages/cli/src/setup/userInput.ts
+++ b/packages/cli/src/setup/userInput.ts
@@ -36,7 +36,10 @@ export async function getDesiredLocales(
           defaultValue: libraryDefaultLocale,
         }));
 
-  if (nonInteractive && !configuredLocales) {
+  if (
+    nonInteractive &&
+    (!configuredLocales || configuredLocales.length === 0)
+  ) {
     logErrorAndExit(
       'No locales are configured. Add defaultLocale and locales to gt.config.json, or rerun without --yes to be prompted.'
     );

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -102,6 +102,7 @@ export type WrapOptions = {
 export type SetupOptions = {
   src?: string[];
   config: string;
+  yes?: boolean;
 };
 
 export type GenerateSourceOptions = {

--- a/packages/cli/src/utils/packageManager.ts
+++ b/packages/cli/src/utils/packageManager.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { getPackageJson, updatePackageJson } from './packageJson.js';
 import { promptSelect } from '../console/logging.js';
+import { logger } from '../console/logger.js';
 
 export interface PackageManager {
   id: string;
@@ -299,6 +300,14 @@ export async function getPackageManager(
 
   if (errorIfNotFound) {
     throw new NoPackageManagerError('No package manager found');
+  }
+
+  if (process.stdin.isTTY !== true) {
+    logger.info(
+      'No package manager detected and no interactive terminal to ask; defaulting to npm.'
+    );
+    globalWizard._gt_wizard_cached_package_manager = NPM;
+    return NPM;
   }
 
   const selectedPackageManager: PackageManager =


### PR DESCRIPTION
## Summary

- Fixes #1939: `gt init` and `gt configure` exit with an error when stdin is not an interactive terminal, instead of exiting 0 in CI having written nothing; the error points to `--yes` or a handwritten `gt.config.json` with the `GT_API_KEY` and `GT_PROJECT_ID` environment variables.
- Adds a `--yes` flag to both commands that skips every prompt: it applies the recommended defaults, requires a non-empty `locales` list in the config and errors otherwise, skips API key generation with a pointer to the environment variables, and defaults the package manager to npm when none is detectable and there is no terminal to ask.
- Makes `gt init` read and write the file passed with `--config` instead of always using `gt.config.json`; the default path selection is unchanged when the flag is not passed.
- Documents the non-interactive path in the CLI README and adds a patch changeset for `gt`.

## Validation

- `npx vitest run` in `packages/cli`: 112 files, 2170 tests passed on 21be356e4; the 10 new non-interactive tests fail against main's files.
- Built binary in a bare npm project: `gt init < /dev/null` exits 1 with the error; `gt configure --yes` exits 0 and installs gt via the npm fallback; `locales: []` with `--yes` exits 1; `gt init --yes --config custom.json` reads and updates only `custom.json`.
- `npx tsc --noEmit` in `packages/cli`, `npx oxlint packages/cli`, and `npx oxfmt --check` on touched paths: clean.
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change makes unattended CLI setup safer and supports custom configuration paths consistently. Built CLI checks confirmed that both `init --yes` and `configure --yes` reject an empty locale list without modifying the configuration, and that `init --yes --config custom.json` updates only the selected custom file. The focused unattended-setup test suite passed.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

The previously reported empty-locale and custom-config-path failures were exercised against the built CLI and did not reproduce.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran an authored black-box harness against the built CLI in disposable non-interactive projects.
- Validated that init and configure reject empty locales, exiting with code 1 and preserving the original configuration.
- Validated that init --yes --config custom.json updates only custom.json, exits with code 0, and does not create gt.config.json.
- Validated that a custom non-GT configuration with locales but no files exits with code 1 and does not modify the configuration.
- Focused unattended setup Vitest suite completed with 10 passing tests.

<a href="https://app.greptile.com/trex/runs/19920883/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(cli): reject empty locales in --yes ..."](https://github.com/generaltranslation/gt/commit/21be356e413a22d4802ad59a553c7877a1bacb62) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55372168)</sub>

<!-- /greptile_comment -->
