### PR TITLE
fix(cli): avoid the missing-project warning when a package.json exists

### DIFF
--- a/.changeset/setup-project-warning.md
+++ b/.changeset/setup-project-warning.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Stop warning that no package.json or Python project file was found when a package.json exists without a supported framework dependency.

--- a/packages/cli/src/cli/commands/__tests__/upload.test.ts
+++ b/packages/cli/src/cli/commands/__tests__/upload.test.ts
@@ -62,7 +62,7 @@ vi.mock('../../../fs/determineFramework/index.js', () => ({
   determineLibrary: vi.fn(() => ({
     library: 'base',
     additionalModules: [],
-    hasPackageJson: false,
+    hasProjectFile: false,
   })),
 }));
 

--- a/packages/cli/src/cli/commands/__tests__/upload.test.ts
+++ b/packages/cli/src/cli/commands/__tests__/upload.test.ts
@@ -59,7 +59,11 @@ vi.mock('node:fs', () => ({
   readFileSync: mockFs.readFileSync,
 }));
 vi.mock('../../../fs/determineFramework/index.js', () => ({
-  determineLibrary: vi.fn(() => ({ library: 'base', additionalModules: [] })),
+  determineLibrary: vi.fn(() => ({
+    library: 'base',
+    additionalModules: [],
+    hasPackageJson: false,
+  })),
 }));
 
 import { readFile, readBinaryFileBase64 } from '../../../fs/findFilepath.js';

--- a/packages/cli/src/config/__tests__/generateSettings.test.ts
+++ b/packages/cli/src/config/__tests__/generateSettings.test.ts
@@ -14,6 +14,7 @@ vi.mock('../../fs/determineFramework/index.js', () => ({
   determineLibrary: vi.fn(() => ({
     library: 'base',
     additionalModules: [],
+    hasPackageJson: false,
   })),
 }));
 
@@ -97,6 +98,7 @@ describe('generateSettings - composite patterns', () => {
     mockDetermineLibrary.mockReturnValue({
       library: 'base',
       additionalModules: [],
+      hasPackageJson: false,
     });
   });
 
@@ -172,6 +174,20 @@ describe('generateSettings - composite patterns', () => {
 
     expect(mockLogWarning).toHaveBeenCalledWith(
       expect.stringContaining('No package.json or Python project file found')
+    );
+  });
+
+  it('suppresses the warning when package.json exists without a supported library', async () => {
+    mockDetermineLibrary.mockReturnValue({
+      library: 'base',
+      additionalModules: [],
+      hasPackageJson: true,
+    });
+
+    await generateSettings({}, '/test/cwd');
+
+    expect(mockLogWarning).not.toHaveBeenCalledWith(
+      expect.stringContaining('No package.json')
     );
   });
 

--- a/packages/cli/src/config/__tests__/generateSettings.test.ts
+++ b/packages/cli/src/config/__tests__/generateSettings.test.ts
@@ -14,7 +14,7 @@ vi.mock('../../fs/determineFramework/index.js', () => ({
   determineLibrary: vi.fn(() => ({
     library: 'base',
     additionalModules: [],
-    hasPackageJson: false,
+    hasProjectFile: false,
   })),
 }));
 
@@ -98,7 +98,7 @@ describe('generateSettings - composite patterns', () => {
     mockDetermineLibrary.mockReturnValue({
       library: 'base',
       additionalModules: [],
-      hasPackageJson: false,
+      hasProjectFile: false,
     });
   });
 
@@ -181,7 +181,7 @@ describe('generateSettings - composite patterns', () => {
     mockDetermineLibrary.mockReturnValue({
       library: 'base',
       additionalModules: [],
-      hasPackageJson: true,
+      hasProjectFile: true,
     });
 
     await generateSettings({}, '/test/cwd');

--- a/packages/cli/src/config/generateSettings.ts
+++ b/packages/cli/src/config/generateSettings.ts
@@ -180,8 +180,10 @@ export async function generateSettings(
   // merge options
   const mergedOptions: Settings = { ...gtConfig, ...flags } as Settings;
 
+  const { library, hasPackageJson } = determineLibrary();
   if (
-    determineLibrary().library === 'base' &&
+    library === 'base' &&
+    !hasPackageJson &&
     !hasConfiguredTranslationFiles(mergedOptions.files)
   ) {
     logger.warn(

--- a/packages/cli/src/config/generateSettings.ts
+++ b/packages/cli/src/config/generateSettings.ts
@@ -180,10 +180,10 @@ export async function generateSettings(
   // merge options
   const mergedOptions: Settings = { ...gtConfig, ...flags } as Settings;
 
-  const { library, hasPackageJson } = determineLibrary();
+  const { library, hasProjectFile } = determineLibrary();
   if (
     library === 'base' &&
-    !hasPackageJson &&
+    !hasProjectFile &&
     !hasConfiguredTranslationFiles(mergedOptions.files)
   ) {
     logger.warn(

--- a/packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts
+++ b/packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts
@@ -45,6 +45,7 @@ describe('aggregateFiles - Empty File Handling', () => {
     mockDetermineLibrary.mockReturnValue({
       library: 'next-intl',
       additionalModules: [],
+      hasPackageJson: true,
     });
 
     // Mock parseJson to return empty string for empty/null content, valid content otherwise
@@ -80,6 +81,7 @@ describe('aggregateFiles - Empty File Handling', () => {
       mockDetermineLibrary.mockReturnValueOnce({
         library: 'base',
         additionalModules: [],
+        hasPackageJson: true,
       });
 
       const settings = {

--- a/packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts
+++ b/packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts
@@ -45,7 +45,7 @@ describe('aggregateFiles - Empty File Handling', () => {
     mockDetermineLibrary.mockReturnValue({
       library: 'next-intl',
       additionalModules: [],
-      hasPackageJson: true,
+      hasProjectFile: true,
     });
 
     // Mock parseJson to return empty string for empty/null content, valid content otherwise
@@ -81,7 +81,7 @@ describe('aggregateFiles - Empty File Handling', () => {
       mockDetermineLibrary.mockReturnValueOnce({
         library: 'base',
         additionalModules: [],
-        hasPackageJson: true,
+        hasProjectFile: true,
       });
 
       const settings = {

--- a/packages/cli/src/fs/determineFramework/__tests__/determineLibrary.test.ts
+++ b/packages/cli/src/fs/determineFramework/__tests__/determineLibrary.test.ts
@@ -71,7 +71,7 @@ describe('determineLibrary', () => {
 
       const result = determineLibrary();
       expect(result.library).toBe('base');
-      expect(result.hasPackageJson).toBe(true);
+      expect(result.hasProjectFile).toBe(true);
     });
 
     it("returns 'base' without warning when no JS or Python project file exists", () => {
@@ -80,11 +80,24 @@ describe('determineLibrary', () => {
       const result = determineLibrary();
 
       expect(result.library).toBe('base');
-      expect(result.hasPackageJson).toBe(false);
+      expect(result.hasProjectFile).toBe(false);
       expect(mockWarn).not.toHaveBeenCalled();
     });
 
-    it('reports hasPackageJson when package.json cannot be parsed', () => {
+    it('reports hasProjectFile for a Python project with no recognized library', () => {
+      mockExistsSync.mockImplementation((path) => {
+        if (String(path).endsWith('pyproject.toml')) return true;
+        return false;
+      });
+      mockReadFileSync.mockReturnValue('[project]\nname = "example"\n');
+
+      const result = determineLibrary();
+
+      expect(result.library).toBe('base');
+      expect(result.hasProjectFile).toBe(true);
+    });
+
+    it('reports hasProjectFile when package.json cannot be parsed', () => {
       mockExistsSync.mockImplementation((path) => {
         if (String(path).endsWith('package.json')) return true;
         return false;
@@ -94,7 +107,7 @@ describe('determineLibrary', () => {
       const result = determineLibrary();
 
       expect(result.library).toBe('base');
-      expect(result.hasPackageJson).toBe(true);
+      expect(result.hasProjectFile).toBe(true);
     });
 
     it('detects i18next-icu as additional module', () => {

--- a/packages/cli/src/fs/determineFramework/__tests__/determineLibrary.test.ts
+++ b/packages/cli/src/fs/determineFramework/__tests__/determineLibrary.test.ts
@@ -71,6 +71,7 @@ describe('determineLibrary', () => {
 
       const result = determineLibrary();
       expect(result.library).toBe('base');
+      expect(result.hasPackageJson).toBe(true);
     });
 
     it("returns 'base' without warning when no JS or Python project file exists", () => {
@@ -79,7 +80,21 @@ describe('determineLibrary', () => {
       const result = determineLibrary();
 
       expect(result.library).toBe('base');
+      expect(result.hasPackageJson).toBe(false);
       expect(mockWarn).not.toHaveBeenCalled();
+    });
+
+    it('reports hasPackageJson when package.json cannot be parsed', () => {
+      mockExistsSync.mockImplementation((path) => {
+        if (String(path).endsWith('package.json')) return true;
+        return false;
+      });
+      mockReadFileSync.mockReturnValue('not json');
+
+      const result = determineLibrary();
+
+      expect(result.library).toBe('base');
+      expect(result.hasPackageJson).toBe(true);
     });
 
     it('detects i18next-icu as additional module', () => {

--- a/packages/cli/src/fs/determineFramework/detectPythonLibrary.ts
+++ b/packages/cli/src/fs/determineFramework/detectPythonLibrary.ts
@@ -38,3 +38,9 @@ export function detectPythonLibrary(
 
   return null;
 }
+
+export function hasPythonProjectFile(cwd: string): boolean {
+  return ['pyproject.toml', 'requirements.txt', 'setup.py'].some((file) =>
+    fs.existsSync(path.join(cwd, file))
+  );
+}

--- a/packages/cli/src/fs/determineFramework/index.ts
+++ b/packages/cli/src/fs/determineFramework/index.ts
@@ -3,16 +3,19 @@ import fs from 'node:fs';
 import { SupportedLibraries } from '../../types/index.js';
 import { logger } from '../../console/logger.js';
 import { Libraries } from '../../types/libraries.js';
-import { detectPythonLibrary } from './detectPythonLibrary.js';
+import {
+  detectPythonLibrary,
+  hasPythonProjectFile,
+} from './detectPythonLibrary.js';
 
 export function determineLibrary(): {
   library: SupportedLibraries;
   additionalModules: SupportedLibraries[];
-  hasPackageJson: boolean;
+  hasProjectFile: boolean;
 } {
   let library: SupportedLibraries = 'base';
   const additionalModules: SupportedLibraries[] = [];
-  let hasPackageJson = false;
+  let hasProjectFile = false;
   try {
     // Get the current working directory (where the CLI is being run)
     const cwd = process.cwd();
@@ -20,7 +23,7 @@ export function determineLibrary(): {
 
     // Check if package.json exists
     if (fs.existsSync(packageJsonPath)) {
-      hasPackageJson = true;
+      hasProjectFile = true;
       // Read and parse package.json
       const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
       const dependencies = {
@@ -52,6 +55,7 @@ export function determineLibrary(): {
 
     // If no JS library found, check for Python project files
     if (library === 'base') {
+      hasProjectFile = hasProjectFile || hasPythonProjectFile(cwd);
       const pythonLibrary = detectPythonLibrary(cwd);
       if (pythonLibrary) {
         library = pythonLibrary;
@@ -59,9 +63,9 @@ export function determineLibrary(): {
     }
 
     // Fallback to base if neither is found
-    return { library, additionalModules, hasPackageJson };
+    return { library, additionalModules, hasProjectFile };
   } catch (error) {
     logger.error('Error determining framework: ' + String(error));
-    return { library: 'base', additionalModules: [], hasPackageJson };
+    return { library: 'base', additionalModules: [], hasProjectFile };
   }
 }

--- a/packages/cli/src/fs/determineFramework/index.ts
+++ b/packages/cli/src/fs/determineFramework/index.ts
@@ -8,9 +8,11 @@ import { detectPythonLibrary } from './detectPythonLibrary.js';
 export function determineLibrary(): {
   library: SupportedLibraries;
   additionalModules: SupportedLibraries[];
+  hasPackageJson: boolean;
 } {
   let library: SupportedLibraries = 'base';
   const additionalModules: SupportedLibraries[] = [];
+  let hasPackageJson = false;
   try {
     // Get the current working directory (where the CLI is being run)
     const cwd = process.cwd();
@@ -18,6 +20,7 @@ export function determineLibrary(): {
 
     // Check if package.json exists
     if (fs.existsSync(packageJsonPath)) {
+      hasPackageJson = true;
       // Read and parse package.json
       const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
       const dependencies = {
@@ -56,9 +59,9 @@ export function determineLibrary(): {
     }
 
     // Fallback to base if neither is found
-    return { library, additionalModules };
+    return { library, additionalModules, hasPackageJson };
   } catch (error) {
     logger.error('Error determining framework: ' + String(error));
-    return { library: 'base', additionalModules: [] };
+    return { library: 'base', additionalModules: [], hasPackageJson };
   }
 }


### PR DESCRIPTION
## Summary

- Fixes #2030: CLI commands no longer warn about a missing project file for a project whose `package.json`, `pyproject.toml`, `requirements.txt`, or `setup.py` contains no recognized i18n library; the warning now fires only when none of those files exist and no translation files are configured.
- Extends `determineLibrary()` to report a `hasProjectFile` flag covering both the JavaScript and Python project files, and keys the warning in `generateSettings()` on that flag.
- Adds a patch changeset for `gt`.

## Validation

- `npx vitest run` in `packages/cli`: 111 files, 2163 tests passed on 5ff3bc3f3; the 5 new warning-condition tests fail against main's files.
- `npx tsc --noEmit` in `packages/cli`, `npx oxlint`, and `npx oxfmt --check` on touched paths: clean.
- Not run: a live command invocation; the warning path is pinned by the `generateSettings` and `determineLibrary` unit tests.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Python project files are now recognized as valid project roots even when they do not declare a supported General Translation dependency. Focused filesystem checks confirmed that setup suppresses the missing-project warning for `pyproject.toml`, `requirements.txt`, and `setup.py`, while still emitting it when no JavaScript or Python project file and no translation-file configuration are present.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(cli): count Python project files tow..."](https://github.com/generaltranslation/gt/commit/5ff3bc3f37d4bab4f9a61035ac9829430b31d012) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55410988)</sub>

<!-- /greptile_comment -->
