### PR TITLE
chore(release): ignore locale test apps

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -43,6 +43,8 @@
     "gt-test-next-app-router-locale-routing",
     "gt-test-next-app-router-locale-routing-ssg",
     "gt-test-next-app-router-locale-routing-use-cache",
+    "gt-test-next-latest-locale-switch-no-routing",
+    "gt-test-next-latest-locale-switch-routing",
     "gt-test-next-pages-router",
     "gt-test-node-express",
     "gt-test-react-native",


### PR DESCRIPTION
## Summary

- Exclude the two private Next.js locale-switch test applications from Changesets versioning.
- Prevent `gt-next` releases from generating test-app version bumps and changelogs.

## Testing

- `pnpm exec oxfmt --check .changeset/config.json` — passed
- `pnpm changeset status --since origin/main` — passed
- `pnpm changeset version` release simulation — both ignored apps remained at `0.1.0`; the unmodified control bumped both to `0.1.1`
- `git diff --check origin/main...HEAD` — passed

## Notes

- Changeset intentionally omitted because this only updates release configuration.
