### PR TITLE
fix(react): resolve region from the prop before the persisted cookie

### DIFF
--- a/.changeset/region-prop-before-cookie.md
+++ b/.changeset/region-prop-before-cookie.md
@@ -1,0 +1,5 @@
+---
+'gt-react': patch
+---
+
+Resolve the browser condition store's region from the `region` prop before the persisted region cookie, matching how the locale and `enableI18n` conditions already resolve. A stale `generaltranslation.region` cookie no longer overrides the region the server rendered with.

--- a/packages/react/src/condition-store/__tests__/createBrowserConditionStore.test.ts
+++ b/packages/react/src/condition-store/__tests__/createBrowserConditionStore.test.ts
@@ -63,6 +63,45 @@ describe('createOrUpdateBrowserConditionStore', () => {
     });
   });
 
+  it('uses the region prop before the persisted cookie', () => {
+    mockCookieValues.set('generaltranslation.region', 'CA');
+
+    createOrUpdateBrowserConditionStore({
+      locale: 'fr',
+      region: 'US',
+    });
+
+    expect(mockSetCookieValue).toHaveBeenCalledWith({
+      cookieName: 'generaltranslation.region',
+      value: 'US',
+    });
+  });
+
+  it('uses the persisted region cookie when the prop is omitted', () => {
+    mockCookieValues.set('generaltranslation.region', 'CA');
+
+    createOrUpdateBrowserConditionStore({
+      locale: 'fr',
+    });
+
+    expect(mockSetCookieValue).toHaveBeenCalledWith({
+      cookieName: 'generaltranslation.region',
+      value: 'CA',
+    });
+  });
+
+  it('uses _getRegion when the prop and cookie are omitted', () => {
+    createOrUpdateBrowserConditionStore({
+      locale: 'fr',
+      _getRegion: () => 'GB',
+    });
+
+    expect(mockSetCookieValue).toHaveBeenCalledWith({
+      cookieName: 'generaltranslation.region',
+      value: 'GB',
+    });
+  });
+
   it('uses the persisted enableI18n cookie when the prop is omitted', () => {
     mockCookieValues.set('generaltranslation.enable-i18n', 'false');
 

--- a/packages/react/src/condition-store/createBrowserConditionStore.ts
+++ b/packages/react/src/condition-store/createBrowserConditionStore.ts
@@ -78,7 +78,7 @@ function determineRegion({
   const cookieRegion = getCookieValue({
     cookieName: getI18nConfig().getRegionCookieName(),
   });
-  return cookieRegion || getRegion?.() || region;
+  return region || cookieRegion || getRegion?.();
 }
 
 function determineEnableI18n({


### PR DESCRIPTION
## Summary

- Resolves the browser condition store's region from the `region` prop before the persisted `generaltranslation.region` cookie, so a stale cookie no longer overrides the region the server rendered with.
- Brings `determineRegion` in line with the precedence the file already documents ("Server-provided props are the first candidates for hydration consistency. Cookies fill in missing values") and that its `determineLocale` and `determineEnableI18n` siblings already follow.
- Adds three tests to `createBrowserConditionStore.test.ts` covering the prop winning over the cookie, the cookie applying when the prop is omitted, and the `_getRegion` fallback when neither is set.

## Validation

- `vitest run` in `packages/react`: 33 passed across 7 files. The new prop-over-cookie test fails on the parent commit and passes here; the other two new tests pass on both, pinning the fallbacks the change must not alter.
- `oxlint packages/react`: no new warnings (two pre-existing `no-explicit-any` warnings in `LocaleSelector.tsx` and `RegionSelector.tsx` are untouched by this diff).
- `oxfmt --check` on the changed paths: clean. `tsc --noEmit` in `packages/react`: clean.
- Not run: the full monorepo suite. `pnpm install` currently fails on `main` because `packages/rrweb` requires `gt-react@>=11.1.13`, which the failing release workflow never published, so CI here is expected to fail at install until that is fixed on `main`.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change makes the server-provided `region` value authoritative over persisted browser cookie state while retaining cookie and `_getRegion` fallbacks. The region-precedence behavior was exercised against both revisions: the prior implementation wrote stale cookie value `CA` when given `region: 'US'`, while this revision writes `US`; cookie-only and callback-only resolution continue to write `CA` and `GB` respectively. No defects were found, and the change is safe to merge.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The updated resolution order preserves all exercised fallback behavior while ensuring the explicit server-rendered region wins over stale browser state.

The actual implementation was executed for explicit-prop, cookie-only, and callback-only region flows in both the parent revision and this revision. The comparison reproduced the former stale-cookie behavior and confirmed the intended corrected behavior.

**Files Needing Attention:** No files need further attention. The focused implementation and its new precedence coverage were exercised.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the region precedence harness against HEAD^ and HEAD on the actual TypeScript implementation to exercise both cookie-based and \_getRegion-based fallback paths.
- In the parent revision, explicit US with a persisted CA cookie wrote CA, while in the current revision the same inputs write US, and in both revisions the cookie-only flow writes CA and the \_getRegion-only flow writes GB.
- The comparison across before and after the fix shows the corrected ordering preserves both fallback paths, as evidenced by the harness outputs comparing the two revisions.
- The Vitest-focused test could not start because workspace dependencies are not installed in this checkout, so the executable harness loaded each revision's source directly and invoked createOrUpdateBrowserConditionStore with realistic cookie/config/store boundaries.

<a href="https://app.greptile.com/trex/runs/20087548/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(react): resolve region from the prop..."](https://github.com/generaltranslation/gt/commit/88978c7f3d122bbea421ab58ca46840d20fcf02d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55694748)</sub>

<!-- /greptile_comment -->