### PR TITLE
fix(react-native): re-export getLocaleProperties for parity with gt-react

### DIFF
--- a/.changeset/loud-mirrors-parity.md
+++ b/.changeset/loud-mirrors-parity.md
@@ -1,0 +1,5 @@
+---
+'gt-react-native': patch
+---
+
+Re-export `getLocaleProperties` from the package entrypoint, matching `gt-react`.

--- a/packages/react-native/src/__tests__/index.test.ts
+++ b/packages/react-native/src/__tests__/index.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+import { initializeI18nConfig } from '@generaltranslation/react-core/pure';
+
+// The barrel file re-exports GTProvider, which imports real react-native
+// components. react-native's own entrypoint uses Flow syntax vitest/Vite
+// can't parse, so it must be mocked before importing '../index' at all —
+// same approach as NativeGtReactNative.test.ts.
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+  TurboModuleRegistry: { getEnforcing: vi.fn(), get: vi.fn() },
+  ActivityIndicator: 'ActivityIndicator',
+  StyleSheet: { create: (styles: unknown) => styles },
+  View: 'View',
+}));
+
+describe('gt-react-native package exports', () => {
+  it('exports getLocaleProperties, matching the gt-react entrypoint', async () => {
+    initializeI18nConfig(
+      {
+        defaultLocale: 'en-US',
+        locales: ['en-US', 'de-AT'],
+      },
+      'server-render'
+    );
+
+    const { getLocaleProperties } = await import('../index');
+    const properties = getLocaleProperties('de-AT');
+
+    expect(properties.code).toBe('de-AT');
+    expect(properties.languageCode).toBe('de');
+    expect(properties.regionCode).toBe('AT');
+  });
+});

--- a/packages/react-native/src/index.tsx
+++ b/packages/react-native/src/index.tsx
@@ -42,6 +42,7 @@ export {
   derive,
   getDefaultLocale,
   getFormatLocales,
+  getLocaleProperties,
   getLocales,
   resolveCanonicalLocale,
   getReactI18nCache,


### PR DESCRIPTION
- `getLocaleProperties` existed in `gt-react` but not `gt-react-native`, even
though the sibling pairs `getDefaultLocale`/`getFormatLocales`/`getLocales`
all made it into both. #1734 mirrored the others into `gt-react-native` in
June but missed this one.

## Summary

- Add `getLocaleProperties` to the existing `@generaltranslation/react-core/pure`
  re-export block in `packages/react-native/src/index.tsx`, alongside its
  existing siblings.
- Add a test importing from the package's actual entrypoint (`../index`)
  rather than reaching around it, so it proves the export is really
  reachable, not just present in source.

## Testing

- `pnpm --filter gt-react-native test` — 7 files, 23 tests passed (1 new)
- `pnpm --filter gt-react-native typecheck` — passed
- `pnpm --filter gt-react-native build` — passed
- `pnpm exec oxlint packages/react-native/src/index.tsx packages/react-native/src/__tests__/index.test.ts` — passed
- `pnpm exec oxfmt --check packages/react-native/src/index.tsx packages/react-native/src/__tests__/index.test.ts .changeset/loud-mirrors-parity.md` — passed
- `git diff --check` — passed
- Live-app verification beyond the mocked unit test: temporarily wired
  `getLocaleProperties` into `tests/apps/react-native` (Expo app linked to
  this package via `workspace:*`), then:
  - `npx expo export --platform ios` — real Metro bundle against the actual
    `react-native` package, 991 modules, no resolution errors
  - `npx tsc --noEmit` in that app — exit code 0, confirming the export is
    genuinely typed and not silently `undefined` (Metro's bundler alone
    wouldn't have caught a missing-but-destructured export, since that's
    valid JS)
  - Reverted before committing; it was verification only, not part of the
    change

## Material risks

None expected. This is additive-only — it adds a new named export; it does
not modify, remove, or change the behavior of anything already exported. No
existing consumer's behavior can regress from this change. Traced the new
export to confirm it resolves to the identical underlying implementation
`useLocaleProperties` already uses in this package (see #2147) — not a new
code path.

## Notes

- Closes #2147.
- No Linear ticket — routine bug-fix/parity PR, which doesn't require one by
  default per `conventions/engineering-best-practices.md`.
- Changeset: patch for `gt-react-native` (and its fixed-version group:
  `@generaltranslation/react-core`, `gt-next`, `gt-react`,
  `gt-tanstack-start`).
- Considered testing this by importing straight from
  `@generaltranslation/react-core/pure` instead of `../index`, and
  considered building a full built-artifact-loading test suite matching
  `gt-react`'s (`react-package.test.ts`). Rejected both: the first would
  only prove the underlying function works, which was already true; the
  second is disproportionate machinery for a one-line export addition.
  Settled on a source-level import of the actual entrypoint, which proves
  exactly the thing this PR claims.
- Self-reviewed the diff before requesting review. `dist/` build output
  confirmed not present in the diff (gitignored, checked via `git status`).


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `getLocaleProperties` to the `gt-react-native` public entrypoint, matching the existing `gt-react` API, with entrypoint-level coverage and a patch release note. The built package entrypoint was imported and exercised with `de-AT`; it exposed a callable helper returning the expected locale, language, and region fields. A strict TypeScript consumer import, the focused Vitest test, and the package typecheck also completed successfully. No defects were found, and the change is safe to merge.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge: the new public export works at runtime and resolves correctly for TypeScript consumers.

The reviewed entrypoint was exercised through the built package, returning the expected `de-AT` metadata. Focused automated coverage and package typechecking also passed, with no remaining findings.

**Files Needing Attention:** None.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a runtime import against the built gt-react-native public entrypoint and called getLocaleProperties('de-AT') with a React Native module mock; the exported value was a function and returned code: 'de-AT', languageCode: 'de', and regionCode: 'AT'.
- Compiled a strict NodeNext TypeScript consumer importing getLocaleProperties from gt-react-native; compilation completed successfully.
- Ran the focused entrypoint test and the package no-emit typecheck; both completed successfully.
- The runtime result showed the exported value was a function and the three locale fields matched the expected values.
- The TypeScript surface compiled for a strict NodeNext consumer importing gt-react-native with exit code 0.

<a href="https://app.greptile.com/trex/runs/20126431/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(react-native): re-export getLocalePr..."](https://github.com/generaltranslation/gt/commit/4348bbb136db6d45b524648f5b45697bf68e02d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55767903)</sub>

<!-- /greptile_comment -->