### PR TITLE
fix(cli): receive wizard credentials through loopback

### DIFF
--- a/.changeset/secure-cli-wizard-loopback.md
+++ b/.changeset/secure-cli-wizard-loopback.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Return CLI setup credentials through a one-time local browser callback.

--- a/packages/cli/src/utils/__tests__/cliAuthorizationCallback.test.ts
+++ b/packages/cli/src/utils/__tests__/cliAuthorizationCallback.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { createCliAuthorizationCallback } from '../cliAuthorizationCallback.js';
+
+describe('CLI authorization callback', () => {
+  it('accepts a code only when the browser returns the matching state', async () => {
+    const callback = await createCliAuthorizationCallback();
+    const code = callback.waitForCode('cli_expected');
+
+    const wrongState = await fetch(
+      `${callback.callbackUrl}?code=${'B'.repeat(43)}&state=cli_other`
+    );
+    const accepted = await fetch(
+      `${callback.callbackUrl}?code=${'A'.repeat(43)}&state=cli_expected`
+    );
+
+    expect(wrongState.status).toBe(400);
+    expect(accepted.status).toBe(200);
+    await expect(code).resolves.toBe('A'.repeat(43));
+  });
+
+  it('closes the listener when authorization expires', async () => {
+    const callback = await createCliAuthorizationCallback();
+
+    await expect(callback.waitForCode('cli_expected', 10)).rejects.toThrow(
+      'CLI authorization timed out'
+    );
+    await expect(fetch(callback.callbackUrl)).rejects.toThrow();
+  });
+});

--- a/packages/cli/src/utils/__tests__/credentials.test.ts
+++ b/packages/cli/src/utils/__tests__/credentials.test.ts
@@ -1,8 +1,45 @@
 import fs from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { setCredentials } from '../credentials.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { generateCredentialsSession, setCredentials } from '../credentials.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('generateCredentialsSession', () => {
+  it('registers the loopback callback and new flow version', async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json({
+        sessionId: 'cli_synthetic',
+        verifier: 'V'.repeat(43),
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      generateCredentialsSession(
+        'https://api.example',
+        'production',
+        'http://127.0.0.1:49152/cli/callback'
+      )
+    ).resolves.toEqual({
+      sessionId: 'cli_synthetic',
+      verifier: 'V'.repeat(43),
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.example/cli/wizard/session',
+      expect.objectContaining({
+        body: JSON.stringify({
+          callbackUrl: 'http://127.0.0.1:49152/cli/callback',
+          flowVersion: 2,
+          keyType: 'production',
+        }),
+      })
+    );
+  });
+});
 
 describe('setCredentials', () => {
   let appDirectory: string;

--- a/packages/cli/src/utils/__tests__/credentials.test.ts
+++ b/packages/cli/src/utils/__tests__/credentials.test.ts
@@ -2,7 +2,11 @@ import fs from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { generateCredentialsSession, setCredentials } from '../credentials.js';
+import {
+  exchangeCliWizardCredentials,
+  generateCredentialsSession,
+  setCredentials,
+} from '../credentials.js';
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -38,6 +42,71 @@ describe('generateCredentialsSession', () => {
         }),
       })
     );
+  });
+});
+
+describe('exchangeCliWizardCredentials', () => {
+  it('sends the verifier and authorization code to the session exchange', async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json({
+        apiKeys: [{ key: 'gtx-api-synthetic', type: 'production' }],
+        projectId: 'project_1',
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      exchangeCliWizardCredentials(
+        'https://api.example',
+        'cli_synthetic',
+        'V'.repeat(43),
+        'A'.repeat(43)
+      )
+    ).resolves.toEqual({
+      apiKeys: [{ key: 'gtx-api-synthetic', type: 'production' }],
+      projectId: 'project_1',
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.example/cli/wizard/cli_synthetic/exchange',
+      expect.objectContaining({
+        body: JSON.stringify({ authorizationCode: 'A'.repeat(43) }),
+        headers: expect.objectContaining({
+          'x-gt-cli-verifier': 'V'.repeat(43),
+        }),
+      })
+    );
+  });
+
+  it('rejects an unsuccessful exchange response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 404 }))
+    );
+
+    await expect(
+      exchangeCliWizardCredentials(
+        'https://api.example',
+        'cli_synthetic',
+        'V'.repeat(43),
+        'A'.repeat(43)
+      )
+    ).rejects.toThrow('Credential exchange returned HTTP 404');
+  });
+
+  it('rejects credentials with an invalid response shape', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => Response.json({ apiKeys: [] }))
+    );
+
+    await expect(
+      exchangeCliWizardCredentials(
+        'https://api.example',
+        'cli_synthetic',
+        'V'.repeat(43),
+        'A'.repeat(43)
+      )
+    ).rejects.toThrow('Credential exchange returned an invalid response');
   });
 });
 

--- a/packages/cli/src/utils/cliAuthorizationCallback.ts
+++ b/packages/cli/src/utils/cliAuthorizationCallback.ts
@@ -1,0 +1,74 @@
+import { createServer } from 'node:http';
+
+const callbackPath = '/cli/callback';
+const callbackTimeoutMs = 15 * 60 * 1000;
+const authorizationCodePattern = /^[A-Za-z0-9_-]{43}$/;
+
+export async function createCliAuthorizationCallback() {
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    server.close();
+    throw new Error('Could not resolve the CLI callback address');
+  }
+
+  return {
+    callbackUrl: `http://127.0.0.1:${address.port}${callbackPath}`,
+    waitForCode(state: string, timeoutMs = callbackTimeoutMs) {
+      return new Promise<string>((resolve, reject) => {
+        let settled = false;
+        const timeout = setTimeout(() => {
+          settled = true;
+          server.close();
+          reject(new Error('CLI authorization timed out'));
+        }, timeoutMs);
+
+        server.on('request', (request, response) => {
+          const url = new URL(request.url ?? '/', 'http://127.0.0.1');
+          const code = url.searchParams.get('code');
+          const returnedState = url.searchParams.get('state');
+          if (
+            request.method !== 'GET' ||
+            url.pathname !== callbackPath ||
+            !code ||
+            !authorizationCodePattern.test(code) ||
+            returnedState !== state ||
+            settled
+          ) {
+            response.writeHead(400, {
+              'cache-control': 'no-store',
+              'content-type': 'text/plain; charset=utf-8',
+            });
+            response.end('Invalid CLI authorization callback.');
+            return;
+          }
+
+          settled = true;
+          clearTimeout(timeout);
+          response.writeHead(200, {
+            'cache-control': 'no-store',
+            'content-security-policy': "default-src 'none'",
+            'content-type': 'text/html; charset=utf-8',
+            'x-content-type-options': 'nosniff',
+          });
+          response.end(
+            '<!doctype html><title>CLI authorized</title><p>CLI authorization complete. Return to your terminal.</p>'
+          );
+          server.close();
+          resolve(code);
+        });
+      });
+    },
+    close() {
+      server.close();
+    },
+  };
+}

--- a/packages/cli/src/utils/credentials.ts
+++ b/packages/cli/src/utils/credentials.ts
@@ -54,22 +54,12 @@ export async function retrieveCredentials(
     );
     spinner.start('Waiting for response from dashboard...');
 
-    const response = await apiRequest(
+    const credentials = await exchangeCliWizardCredentials(
       settings.baseUrl,
-      `/cli/wizard/${sessionId}/exchange`,
-      {
-        body: { authorizationCode: await authorizationCode },
-        headers: { 'x-gt-cli-verifier': verifier },
-      }
+      sessionId,
+      verifier,
+      await authorizationCode
     );
-    if (!response.ok) {
-      throw new Error(`Credential exchange returned HTTP ${response.status}`);
-    }
-
-    const credentials = await response.json();
-    if (!isCredentials(credentials)) {
-      throw new Error('Credential exchange returned an invalid response');
-    }
 
     spinner.stop('Received credentials');
     return credentials;
@@ -86,6 +76,31 @@ export async function retrieveCredentials(
       })
     );
   }
+}
+
+export async function exchangeCliWizardCredentials(
+  baseUrl: string,
+  sessionId: string,
+  verifier: string,
+  authorizationCode: string
+): Promise<Credentials> {
+  const response = await apiRequest(
+    baseUrl,
+    `/cli/wizard/${sessionId}/exchange`,
+    {
+      body: { authorizationCode },
+      headers: { 'x-gt-cli-verifier': verifier },
+    }
+  );
+  if (!response.ok) {
+    throw new Error(`Credential exchange returned HTTP ${response.status}`);
+  }
+
+  const credentials = await response.json();
+  if (!isCredentials(credentials)) {
+    throw new Error('Credential exchange returned an invalid response');
+  }
+  return credentials;
 }
 
 export async function generateCredentialsSession(

--- a/packages/cli/src/utils/credentials.ts
+++ b/packages/cli/src/utils/credentials.ts
@@ -4,7 +4,12 @@ import path from 'node:path';
 import fs from 'node:fs';
 import { Settings, SupportedFrameworks } from '../types/index.js';
 import chalk from 'chalk';
+import {
+  createDiagnosticMessage,
+  formatDiagnosticErrorDetails,
+} from 'generaltranslation/internal';
 import apiRequest from './fetch.js';
+import { createCliAuthorizationCallback } from './cliAuthorizationCallback.js';
 // Type for credentials returned from the dashboard
 type Credentials = {
   apiKeys: ApiKey[];
@@ -21,79 +26,120 @@ export async function retrieveCredentials(
   settings: Settings,
   keyType: 'development' | 'production' | 'all'
 ): Promise<Credentials> {
-  // Generate a session ID
-  const { sessionId } = await generateCredentialsSession(
-    settings.baseUrl,
-    keyType
-  );
-
-  const urlToOpen = `${settings.dashboardUrl}/cli/wizard/${sessionId}`;
-  await import('open').then((open) =>
-    open.default(urlToOpen, {
-      wait: false,
-    })
-  );
-
-  logger.message(
-    `${chalk.dim(
-      `If the browser window didn't open automatically, please open the following link:`
-    )}\n\n${chalk.cyan(urlToOpen)}`
-  );
-
   const spinner = logger.createSpinner('dots');
-  spinner.start('Waiting for response from dashboard...');
+  let callback: Awaited<
+    ReturnType<typeof createCliAuthorizationCallback>
+  > | null = null;
 
-  const credentials = await new Promise<Credentials>((resolve) => {
-    const interval = setInterval(async () => {
-      // Ping the dashboard to see if the credentials are set
-      try {
-        const res = await apiRequest(
-          settings.baseUrl,
-          `/cli/wizard/${sessionId}`,
-          {
-            method: 'GET',
-          }
-        );
-        if (res.status === 200) {
-          const data = await res.json();
-          resolve(data as Credentials);
-          clearInterval(interval);
-          clearTimeout(timeout);
-          apiRequest(settings.baseUrl, `/cli/wizard/${sessionId}`, {
-            method: 'DELETE',
-          });
-        }
-      } catch (err) {
-        console.error(err);
-      }
-    }, 2000);
-    // timeout after 1 hour
-    const timeout = setTimeout(
-      () => {
-        spinner.stop('Timed out');
-        clearInterval(interval);
-        logErrorAndExit('Timed out waiting for response from dashboard');
-      },
-      1000 * 60 * 60
+  try {
+    callback = await createCliAuthorizationCallback();
+    const { sessionId, verifier } = await generateCredentialsSession(
+      settings.baseUrl,
+      keyType,
+      callback.callbackUrl
     );
-  });
-  spinner.stop('Received credentials');
-  return credentials;
+    const authorizationCode = callback.waitForCode(sessionId);
+    const urlToOpen = `${settings.dashboardUrl}/cli/wizard/${sessionId}`;
+
+    await import('open').then((open) =>
+      open.default(urlToOpen, {
+        wait: false,
+      })
+    );
+
+    logger.message(
+      `${chalk.dim(
+        `If the browser window didn't open automatically, please open the following link:`
+      )}\n\n${chalk.cyan(urlToOpen)}`
+    );
+    spinner.start('Waiting for response from dashboard...');
+
+    const response = await apiRequest(
+      settings.baseUrl,
+      `/cli/wizard/${sessionId}/exchange`,
+      {
+        body: { authorizationCode: await authorizationCode },
+        headers: { 'x-gt-cli-verifier': verifier },
+      }
+    );
+    if (!response.ok) {
+      throw new Error(`Credential exchange returned HTTP ${response.status}`);
+    }
+
+    const credentials = await response.json();
+    if (!isCredentials(credentials)) {
+      throw new Error('Credential exchange returned an invalid response');
+    }
+
+    spinner.stop('Received credentials');
+    return credentials;
+  } catch (error) {
+    callback?.close();
+    spinner.stop('Authorization failed');
+    return logErrorAndExit(
+      createDiagnosticMessage({
+        source: 'gt',
+        severity: 'Error',
+        whatHappened: 'CLI authorization did not complete',
+        fix: 'Run the setup command again and approve the new browser request',
+        details: formatDiagnosticErrorDetails(error),
+      })
+    );
+  }
 }
 
 export async function generateCredentialsSession(
   url: string,
-  keyType: 'development' | 'production' | 'all'
+  keyType: 'development' | 'production' | 'all',
+  callbackUrl: string
 ): Promise<{
   sessionId: string;
+  verifier: string;
 }> {
   const res = await apiRequest(url, '/cli/wizard/session', {
-    body: { keyType },
+    body: { callbackUrl, flowVersion: 2, keyType },
   });
   if (!res.ok) {
-    logErrorAndExit('Failed to generate credentials session');
+    throw new Error(`Session creation returned HTTP ${res.status}`);
   }
-  return await res.json();
+  const session = await res.json();
+  if (!isCredentialSession(session)) {
+    throw new Error('Session creation returned an invalid response');
+  }
+  return session;
+}
+
+function isCredentialSession(
+  value: unknown
+): value is { sessionId: string; verifier: string } {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const { sessionId, verifier } = value as Record<string, unknown>;
+  return (
+    typeof sessionId === 'string' &&
+    sessionId.startsWith('cli_') &&
+    typeof verifier === 'string' &&
+    /^[A-Za-z0-9_-]{43}$/.test(verifier)
+  );
+}
+
+function isCredentials(value: unknown): value is Credentials {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const { apiKeys, projectId } = value as Record<string, unknown>;
+  return (
+    typeof projectId === 'string' &&
+    Array.isArray(apiKeys) &&
+    apiKeys.length > 0 &&
+    apiKeys.every(
+      (apiKey) =>
+        !!apiKey &&
+        typeof apiKey === 'object' &&
+        !Array.isArray(apiKey) &&
+        typeof (apiKey as Record<string, unknown>).key === 'string' &&
+        ['development', 'production'].includes(
+          (apiKey as Record<string, unknown>).type as string
+        )
+    )
+  );
 }
 
 // Checks if the credentials are set in the environment variables

--- a/packages/cli/src/utils/fetch.ts
+++ b/packages/cli/src/utils/fetch.ts
@@ -12,6 +12,7 @@ export default async function apiRequest(
   endpoint: string,
   options?: {
     body?: unknown;
+    headers?: Record<string, string>;
     method?: 'GET' | 'POST' | 'DELETE';
   }
 ): Promise<Response> {
@@ -22,6 +23,7 @@ export default async function apiRequest(
     headers: {
       'Content-Type': 'application/json',
       'gt-api-version': API_VERSION,
+      ...options?.headers,
     },
   };
 


### PR DESCRIPTION
## Summary

- Fixes the CLI wizard so credentials return through a temporary listener on `127.0.0.1` instead of browser-session polling.
- Sends the exact callback URL and verifier when it creates the wizard session.
- Validates the returned state and single-use authorization code before exchanging them for credentials.
- Closes the listener after one valid callback or a 15-minute timeout.
- Adds a patch changeset for `gt`.
- Has no Linear issue yet.

## Stack

- Requires [generaltranslation/gt-cloud#4461](https://github.com/generaltranslation/gt-cloud/pull/4461).

## Validation

- `pnpm vitest run src/utils/__tests__/cliAuthorizationCallback.test.ts src/utils/__tests__/credentials.test.ts` from `packages/cli` (7 passed)
- `pnpm run typecheck` from `packages/cli`
- `pnpm run build` from `packages/cli`
- `pnpm lint` from the repository root
- Not run: the full monorepo test suite

![Synthetic CLI callback walkthrough](https://github.com/generaltranslation/gt-cloud/raw/assets/security-evidence-20260824/security-evidence-20260824/pr-4461.png)

Synthetic fixture only. No production data or credentials.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The CLI authorization flow now receives browser approval through a localhost callback, verifies the returned session state, and exchanges the one-time authorization code for credentials. The credential exchange is covered for successful requests, HTTP failures, and invalid response data.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

A real local callback and mock exchange-server flow confirmed that an invalid state cannot trigger credential exchange, while a matching state produces one correctly formed exchange request and validated credentials.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran the CLI loopback credential-exchange harness before against the real local callback and mock API servers; a wrong-session callback returned HTTP 400 and produced zero credential-exchange requests.
- I ran the CLI loopback credential-exchange harness after; a matching-state callback with a valid code returned HTTP 200, produced exactly one POST to /cli/wizard/cli\_loopback\_session/exchange with the authorization code and verifier header, and returned validated credentials.
- I executed the focused CLI callback and credential test suites from packages/cli; all 7 tests passed.
- I validated the capture results across success and rejection paths: the success path posted the authorizationCode and the 43-character verifier header and yielded validated credentials, while the rejection path returned HTTP 400 with zero exchange requests.

<a href="https://app.greptile.com/trex/runs/20416083/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["test(cli): cover credential exchange"](https://github.com/generaltranslation/gt/commit/6a4fb94ee431fdbc936416be4e89759a6fd37228) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56331009)</sub>

<!-- /greptile_comment -->