### PR TITLE
fix(cli): [1/4] add portable path helpers

### DIFF
--- a/packages/cli/src/utils/__tests__/paths.test.ts
+++ b/packages/cli/src/utils/__tests__/paths.test.ts
@@ -1,0 +1,113 @@
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resolvePosixGlob, toPosixGlob, toPosixPath } from '../paths.js';
+
+describe('toPosixPath', () => {
+  const originalSeparator = Object.getOwnPropertyDescriptor(path, 'sep')!;
+
+  afterEach(() => {
+    Object.defineProperty(path, 'sep', originalSeparator);
+    vi.restoreAllMocks();
+  });
+
+  it('normalizes concrete Windows paths', () => {
+    Object.defineProperty(path, 'sep', {
+      ...originalSeparator,
+      value: path.win32.sep,
+    });
+
+    expect(toPosixPath('C:\\project\\src\\**\\*.json')).toBe(
+      'C:/project/src/**/*.json'
+    );
+  });
+
+  it('preserves literal backslashes in concrete POSIX paths', () => {
+    Object.defineProperty(path, 'sep', {
+      ...originalSeparator,
+      value: path.posix.sep,
+    });
+
+    expect(toPosixPath('src/literal\\name.json')).toBe(
+      'src/literal\\name.json'
+    );
+  });
+});
+
+describe('toPosixGlob', () => {
+  const originalSeparator = Object.getOwnPropertyDescriptor(path, 'sep')!;
+
+  afterEach(() => {
+    Object.defineProperty(path, 'sep', originalSeparator);
+    vi.restoreAllMocks();
+  });
+
+  it('normalizes Windows separators without consuming glob escapes', () => {
+    Object.defineProperty(path, 'sep', {
+      ...originalSeparator,
+      value: path.win32.sep,
+    });
+
+    expect(toPosixGlob('src\\**\\*.json')).toBe('src/**/*.json');
+    expect(toPosixGlob('app/\\(marketing\\)/*.mdx')).toBe(
+      'app/\\(marketing\\)/*.mdx'
+    );
+    expect(toPosixGlob('src/\\[slug\\]/*.json')).toBe('src/\\[slug\\]/*.json');
+  });
+
+  it('normalizes separators before ordinary extglob prefix characters', () => {
+    Object.defineProperty(path, 'sep', {
+      ...originalSeparator,
+      value: path.win32.sep,
+    });
+
+    expect(toPosixGlob('src\\!important\\+vendor\\@scope\\*.ts')).toBe(
+      'src/!important/+vendor/@scope/*.ts'
+    );
+    expect(toPosixGlob('src/\\@(draft|final)/*.ts')).toBe(
+      'src/\\@(draft|final)/*.ts'
+    );
+  });
+
+  it('preserves authored glob syntax on POSIX', () => {
+    Object.defineProperty(path, 'sep', {
+      ...originalSeparator,
+      value: path.posix.sep,
+    });
+
+    expect(toPosixGlob('app/\\(marketing\\)/*.mdx')).toBe(
+      'app/\\(marketing\\)/*.mdx'
+    );
+  });
+});
+
+describe('resolvePosixGlob', () => {
+  const originalSeparator = Object.getOwnPropertyDescriptor(path, 'sep')!;
+
+  afterEach(() => {
+    Object.defineProperty(path, 'sep', originalSeparator);
+    vi.restoreAllMocks();
+  });
+
+  it('resolves the cwd separately from an escaped Windows glob', () => {
+    Object.defineProperty(path, 'sep', {
+      ...originalSeparator,
+      value: path.win32.sep,
+    });
+
+    expect(resolvePosixGlob('/project', 'app/\\(marketing\\)/*.mdx')).toBe(
+      '/project/app/\\(marketing\\)/*.mdx'
+    );
+  });
+
+  it('escapes glob syntax in a concrete Windows cwd', () => {
+    Object.defineProperty(path, 'sep', {
+      ...originalSeparator,
+      value: path.win32.sep,
+    });
+    vi.spyOn(path, 'resolve').mockReturnValue('C:\\projects\\(team)');
+
+    expect(resolvePosixGlob('.', 'src/*.json')).toBe(
+      'C:/projects/\\(team\\)/src/*.json'
+    );
+  });
+});

--- a/packages/cli/src/utils/paths.ts
+++ b/packages/cli/src/utils/paths.ts
@@ -1,0 +1,42 @@
+import path from 'node:path';
+
+const POSIX_GLOB_SYMBOLS_RE =
+  /(\\?)([()*?[\]{|}]|^!|[!+@](?=\()|\\(?![!()*+?@[\]{|}]))/g;
+
+function escapePosixGlobPath(filePath: string): string {
+  return filePath.replace(POSIX_GLOB_SYMBOLS_RE, '\\$2');
+}
+
+/**
+ * Converts a concrete native filesystem path to slash-separated form.
+ * POSIX backslashes are valid filename characters, so they must be preserved.
+ */
+export function toPosixPath(filePath: string): string {
+  if (path.sep !== '\\') return filePath;
+  return filePath.replace(/\\/g, '/');
+}
+
+/**
+ * Converts separators in a user-authored glob while preserving backslashes
+ * that escape Windows glob metacharacters.
+ */
+export function toPosixGlob(pattern: string): string {
+  if (path.sep !== '\\') return pattern;
+  return pattern.replace(/\\(?![()[\]{}]|[!+@](?=\())/g, '/');
+}
+
+/**
+ * Resolves a user-authored glob without passing its escape characters through
+ * the platform path resolver. The cwd is resolved separately as a concrete
+ * path, then joined using the slash syntax expected by glob matchers.
+ */
+export function resolvePosixGlob(cwd: string, pattern: string): string {
+  if (path.isAbsolute(pattern)) return toPosixGlob(pattern);
+
+  const absoluteCwd = escapePosixGlobPath(toPosixPath(path.resolve(cwd)));
+  const normalizedPattern = toPosixGlob(pattern).replace(/^\.\/+/, '');
+  if (!normalizedPattern) return absoluteCwd;
+
+  const base = absoluteCwd.replace(/\/+$/, '');
+  return `${base}/${normalizedPattern}`;
+}


### PR DESCRIPTION
- add helpers

## Summary

- Add three focused helpers for portable path and glob handling.
- Preserve POSIX literal backslashes and escaped glob metacharacters while converting Windows-native separators.
- Escape concrete working-directory segments separately from user-authored glob syntax.

## Helper API

- `toPosixPath(filePath)`: converts a concrete native filesystem path to slash-separated form on Windows and is an identity function on POSIX.
- `toPosixGlob(pattern)`: converts Windows separators in a user-authored glob while preserving backslashes that escape glob metacharacters; it leaves POSIX patterns unchanged.
- `resolvePosixGlob(cwd, pattern)`: resolves and escapes the concrete `cwd` separately, then appends the authored glob without passing its escape syntax through `path.resolve()`.

## Testing

- `pnpm --filter gt exec vitest run src/utils/__tests__/paths.test.ts` — passed (7 tests)
- `pnpm --filter gt typecheck` — passed
- Top-of-stack `pnpm exec turbo run build --filter=gt...` — passed (8 packages)

## Notes

- Stack: 1 of 4; base is `main`; continued in #2159.
- Together, the stack supersedes #2057.
- Changeset intentionally omitted because this PR only adds unused internal helpers; the release note is included at the top of the stack.








<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds portable path and glob helpers for the CLI, including Windows separator normalization and safe joining of relative glob patterns to an escaped working directory. The previously reported Windows behavior was exercised directly: ordinary `!important`, `+vendor`, and `@scope` path segments normalize to slash-separated paths, while an authored extglob escape remains intact.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

The reported Windows glob normalization path was executed against the current helper and produced the intended ordinary-prefix and escaped-extglob results.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the Windows glob runtime validation script from the repository, and the process exited with code 0.
- The validation showed ordinary path separators are normalized, while the extglob escaping is preserved under Windows-style inputs.
- Artifacts were collected to document the run, including the focused runtime script and two comparison logs for legacy and current normalization results.
- The artifact sources import only the built library and Node assertions, with no production source modified during the validation.

<a href="https://app.greptile.com/trex/runs/20517210/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (5): Last reviewed commit: [6bc4ef8](https://github.com/generaltranslation/gt/commit/6bc4ef854fa6e0997c0185414139373dbc0a0362) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56346335)</sub>

<!-- /greptile_comment -->