### PR TITLE
fix(cli): [2/4] normalize Windows path consumers

### DIFF
--- a/packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts
+++ b/packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts
@@ -8,6 +8,8 @@ import sanitizeFileContent from '../../../utils/sanitizeFileContent.js';
 import { determineLibrary } from '../../../fs/determineFramework/index.js';
 import { isValidMdx } from '../../../utils/validateMdx.js';
 import type { Settings } from '../../../types/index.js';
+import path from 'node:path';
+import { hashVersionId } from '../../../utils/hash.js';
 
 const aggregateTestFiles = (settings: Partial<Settings>) =>
   aggregateFiles(settings as Settings);
@@ -35,6 +37,8 @@ const mockDetermineLibrary = vi.mocked(determineLibrary);
 const mockIsValidMdx = vi.mocked(isValidMdx);
 
 describe('aggregateFiles - Empty File Handling', () => {
+  const originalSeparator = Object.getOwnPropertyDescriptor(path, 'sep')!;
+
   beforeEach(() => {
     vi.clearAllMocks();
 
@@ -72,10 +76,35 @@ describe('aggregateFiles - Empty File Handling', () => {
   });
 
   afterEach(() => {
+    Object.defineProperty(path, 'sep', originalSeparator);
     vi.clearAllMocks();
   });
 
   describe('JSON files', () => {
+    it('matches Windows paths in the normalized review set', async () => {
+      Object.defineProperty(path, 'sep', {
+        ...originalSeparator,
+        value: path.win32.sep,
+      });
+      const filePath = 'C:\\project\\messages.json';
+      const settings = {
+        files: {
+          resolvedPaths: { json: [filePath] },
+          placeholderPaths: {},
+          requiresReviewPaths: new Set(['C:/project/messages.json']),
+        },
+        options: {},
+        defaultLocale: 'en',
+      };
+      mockReadFile.mockReturnValueOnce('{"key":"value"}');
+
+      const { files } = await aggregateTestFiles(settings);
+
+      expect(files[0].versionId).toBe(
+        hashVersionId('parsed-json-content', true)
+      );
+    });
+
     it('detects JSON data format without project warnings', async () => {
       mockDetermineLibrary.mockReturnValueOnce({
         library: 'base',

--- a/packages/cli/src/formats/files/__tests__/collectFonts.test.ts
+++ b/packages/cli/src/formats/files/__tests__/collectFonts.test.ts
@@ -7,12 +7,14 @@ import { collectFonts } from '../collectFonts.js';
 
 describe('collectFonts', () => {
   let projectRoot: string;
+  const originalSeparator = Object.getOwnPropertyDescriptor(path, 'sep')!;
 
   beforeEach(() => {
     projectRoot = mkdtempSync(path.join(tmpdir(), 'gt-collect-fonts-'));
   });
 
   afterEach(() => {
+    Object.defineProperty(path, 'sep', originalSeparator);
     rmSync(projectRoot, { recursive: true, force: true });
   });
 
@@ -62,6 +64,45 @@ describe('collectFonts', () => {
 
     expect(fonts.map((f) => f.fileName)).toEqual(['Keep.ttf']);
   });
+
+  it('normalizes Windows separators in font globs on Windows', async () => {
+    Object.defineProperty(path, 'sep', {
+      ...originalSeparator,
+      value: path.win32.sep,
+    });
+    mkdirSync(path.join(projectRoot, 'public', 'fonts'), { recursive: true });
+    writeFileSync(
+      path.join(projectRoot, 'public', 'fonts', 'Inter.ttf'),
+      Buffer.from([1])
+    );
+
+    const fonts = await collectFonts(
+      makeSettings({ fonts: { include: ['public\\fonts\\*.ttf'] } })
+    );
+
+    expect(fonts.map((font) => font.fileName)).toEqual(['Inter.ttf']);
+  });
+
+  it.runIf(path.sep === path.posix.sep)(
+    'preserves escaped font globs on POSIX',
+    async () => {
+      mkdirSync(path.join(projectRoot, 'fonts', '(brand)'), {
+        recursive: true,
+      });
+      writeFileSync(
+        path.join(projectRoot, 'fonts', '(brand)', 'Inter.ttf'),
+        Buffer.from([1])
+      );
+
+      const fonts = await collectFonts(
+        makeSettings({
+          fonts: { include: ['fonts/\\(brand\\)/*.ttf'] },
+        })
+      );
+
+      expect(fonts.map((font) => font.fileName)).toEqual(['Inter.ttf']);
+    }
+  );
 
   it('returns no fonts when the config is missing or empty', async () => {
     expect(await collectFonts(makeSettings())).toEqual([]);

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -31,6 +31,7 @@ import {
 } from '../parseKeyedMetadata.js';
 import { buildPublishMap } from '../../utils/resolvePublish.js';
 import { getTransformFormatProperty } from './transformFormat.js';
+import { toPosixPath } from '../../utils/paths.js';
 
 /**
  * Checks if a file path is a metadata companion file (e.g. foo.metadata.json)
@@ -178,7 +179,7 @@ export async function aggregateFiles(
           fileId: hashStringSync(relativePath),
           versionId: hashVersionId(
             parsedJson,
-            requiresReviewPaths.has(filePath)
+            requiresReviewPaths.has(toPosixPath(filePath))
           ),
           content: parsedJson,
           fileName: relativePath,
@@ -273,7 +274,7 @@ export async function aggregateFiles(
           fileId: hashStringSync(relativePath),
           versionId: hashVersionId(
             parsedYaml,
-            requiresReviewPaths.has(filePath)
+            requiresReviewPaths.has(toPosixPath(filePath))
           ),
           locale: settings.defaultLocale,
           ...(keyedMetadata && {
@@ -331,7 +332,7 @@ export async function aggregateFiles(
           fileId: hashStringSync(relativePath),
           versionId: hashVersionId(
             parsedJson,
-            requiresReviewPaths.has(filePath)
+            requiresReviewPaths.has(toPosixPath(filePath))
           ),
           content: parsedJson,
           fileName: relativePath,
@@ -430,7 +431,7 @@ export async function aggregateFiles(
             fileId: hashStringSync(relativePath),
             versionId: hashVersionId(
               processed,
-              requiresReviewPaths.has(filePath)
+              requiresReviewPaths.has(toPosixPath(filePath))
             ),
             locale: settings.defaultLocale,
           } satisfies FileToUpload;

--- a/packages/cli/src/formats/files/collectFonts.ts
+++ b/packages/cli/src/formats/files/collectFonts.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import fg from 'fast-glob';
 
 import type { Settings } from '../../types/index.js';
+import { toPosixGlob } from '../../utils/paths.js';
 
 // One font to upload to /v2/project/assets. Structurally matches the SDK's
 // AssetUpload; content is base64 (fonts are binary).
@@ -26,9 +27,9 @@ export async function collectFonts(settings: Settings): Promise<FontUpload[]> {
   const cwd = settings.configDirectory
     ? path.dirname(settings.configDirectory)
     : process.cwd();
-  const matches = await fg(fonts.include, {
+  const matches = await fg(fonts.include.map(toPosixGlob), {
     cwd,
-    ignore: fonts.exclude ?? [],
+    ignore: fonts.exclude?.map(toPosixGlob) ?? [],
     absolute: true,
     onlyFiles: true,
     unique: true,

--- a/packages/cli/src/formats/json/utils.ts
+++ b/packages/cli/src/formats/json/utils.ts
@@ -11,6 +11,7 @@ import { flattenJson } from './flattenJson.js';
 import chalk from 'chalk';
 import path from 'node:path';
 import micromatch from 'micromatch';
+import { toPosixGlob, toPosixPath } from '../../utils/paths.js';
 import type { JSONObject, JSONValue } from '../../types/data/json.js';
 import { getJSONPathMatches } from './jsonPath.js';
 const { isMatch } = micromatch;
@@ -226,9 +227,10 @@ export function validateJsonSchema(
     return null;
   }
 
+  const relativeFilePath = toPosixPath(path.relative(process.cwd(), filePath));
   const fileGlobs = Object.keys(options.jsonSchema);
   const matchingGlob = fileGlobs.find((fileGlob) =>
-    isMatch(path.relative(process.cwd(), filePath), fileGlob)
+    isMatch(relativeFilePath, toPosixGlob(fileGlob))
   );
   if (!matchingGlob || !options.jsonSchema[matchingGlob]) {
     return null;

--- a/packages/cli/src/formats/yaml/__tests__/utils.test.ts
+++ b/packages/cli/src/formats/yaml/__tests__/utils.test.ts
@@ -13,12 +13,15 @@ const mockExit = vi.mocked(exitSync).mockImplementation(() => {
 });
 
 describe('validateYamlSchema', () => {
+  const originalSeparator = Object.getOwnPropertyDescriptor(path, 'sep')!;
+
   beforeEach(() => {
     mockLogError.mockClear();
     mockExit.mockClear();
   });
 
   afterEach(() => {
+    Object.defineProperty(path, 'sep', originalSeparator);
     vi.clearAllMocks();
   });
 
@@ -355,6 +358,37 @@ describe('validateYamlSchema', () => {
       expect(validateYamlSchema(options, 'config/app.yaml')).toEqual(schema1);
       expect(validateYamlSchema(options, 'docs/readme.yaml')).toEqual(schema2);
       expect(validateYamlSchema(options, 'other/file.yaml')).toEqual(schema3);
+    });
+
+    it('matches Windows paths against slash-separated globs', () => {
+      Object.defineProperty(path, 'sep', {
+        ...originalSeparator,
+        value: path.win32.sep,
+      });
+
+      const schema = { include: ['$.title'] };
+
+      const result = validateYamlSchema(
+        { yamlSchema: { 'src/**/*.yaml': schema } },
+        'src\\content\\messages.yaml'
+      );
+
+      expect(result).toEqual(schema);
+    });
+
+    it('preserves escaped schema globs on POSIX', () => {
+      Object.defineProperty(path, 'sep', {
+        ...originalSeparator,
+        value: path.posix.sep,
+      });
+      const schema = { include: ['$.title'] };
+
+      const result = validateYamlSchema(
+        { yamlSchema: { 'app/\\(marketing\\)/*.yaml': schema } },
+        'app/(marketing)/messages.yaml'
+      );
+
+      expect(result).toEqual(schema);
     });
   });
 

--- a/packages/cli/src/formats/yaml/utils.ts
+++ b/packages/cli/src/formats/yaml/utils.ts
@@ -4,6 +4,7 @@ import { logger } from '../../console/logger.js';
 import micromatch from 'micromatch';
 const { isMatch } = micromatch;
 import path from 'path';
+import { toPosixGlob, toPosixPath } from '../../utils/paths.js';
 
 export function validateYamlSchema(
   options: AdditionalOptions,
@@ -13,9 +14,10 @@ export function validateYamlSchema(
     return null;
   }
   // Check if the file matches any of the yaml schema globs
+  const relativeFilePath = toPosixPath(path.relative(process.cwd(), filePath));
   const fileGlobs = Object.keys(options.yamlSchema);
   const matchingGlob = fileGlobs.find((fileGlob) =>
-    isMatch(path.relative(process.cwd(), filePath), fileGlob)
+    isMatch(relativeFilePath, toPosixGlob(fileGlob))
   );
   if (!matchingGlob || !options.yamlSchema[matchingGlob]) {
     return null;

--- a/packages/cli/src/fs/__tests__/clearLocaleDirs.test.ts
+++ b/packages/cli/src/fs/__tests__/clearLocaleDirs.test.ts
@@ -6,6 +6,7 @@ import os from 'os';
 
 describe('clearLocaleDirs', () => {
   let testDir: string;
+  const originalSeparator = Object.getOwnPropertyDescriptor(path, 'sep')!;
 
   beforeEach(async () => {
     // Create a temporary test directory
@@ -13,6 +14,7 @@ describe('clearLocaleDirs', () => {
   });
 
   afterEach(async () => {
+    Object.defineProperty(path, 'sep', originalSeparator);
     // Clean up test directory
     await fs.rm(testDir, { recursive: true, force: true });
   });
@@ -427,6 +429,69 @@ describe('clearLocaleDirs', () => {
         fs.access(path.join(esDir, 'keep-that.mdx'))
       ).resolves.toBeUndefined();
     });
+
+    it.runIf(path.sep === path.posix.sep)(
+      'should preserve escaped exclude patterns on POSIX',
+      async () => {
+        const esDir = path.join(testDir, 'docs', 'es');
+        const protectedDir = path.join(esDir, '(protected)');
+        await fs.mkdir(protectedDir, { recursive: true });
+
+        await fs.writeFile(path.join(esDir, 'delete.mdx'), 'content');
+        await fs.writeFile(path.join(protectedDir, 'keep.mdx'), 'preserved');
+
+        const filePaths = new Set([
+          path.join(esDir, 'delete.mdx'),
+          path.join(protectedDir, 'keep.mdx'),
+        ]);
+        const excludePatterns = [
+          path.join(testDir, 'docs', '[locale]', '\\(protected\\)', '**'),
+        ];
+
+        await clearLocaleDirs(filePaths, ['es'], excludePatterns);
+
+        await expect(
+          fs.access(path.join(esDir, 'delete.mdx'))
+        ).rejects.toThrow();
+        await expect(
+          fs.access(path.join(protectedDir, 'keep.mdx'))
+        ).resolves.toBeUndefined();
+      }
+    );
+
+    it.runIf(path.sep === path.posix.sep)(
+      'should preserve escaped exclude patterns when Windows is simulated',
+      async () => {
+        const esDir = path.join(testDir, 'docs', 'es');
+        const protectedDir = path.join(esDir, '(protected)');
+        await fs.mkdir(protectedDir, { recursive: true });
+
+        await fs.writeFile(path.join(esDir, 'delete.mdx'), 'content');
+        await fs.writeFile(path.join(protectedDir, 'keep.mdx'), 'preserved');
+
+        Object.defineProperty(path, 'sep', {
+          ...originalSeparator,
+          value: path.win32.sep,
+        });
+
+        await clearLocaleDirs(
+          new Set([
+            path.join(esDir, 'delete.mdx'),
+            path.join(protectedDir, 'keep.mdx'),
+          ]),
+          ['es'],
+          ['docs/[locale]/\\(protected\\)/**'],
+          testDir
+        );
+
+        await expect(
+          fs.access(path.join(esDir, 'delete.mdx'))
+        ).rejects.toThrow();
+        await expect(
+          fs.access(path.join(protectedDir, 'keep.mdx'))
+        ).resolves.toBeUndefined();
+      }
+    );
 
     it('should handle [locales] placeholder to exclude across all locales', async () => {
       const esDir = path.join(testDir, 'content', 'es');

--- a/packages/cli/src/fs/__tests__/findFilepath.test.ts
+++ b/packages/cli/src/fs/__tests__/findFilepath.test.ts
@@ -1,0 +1,34 @@
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRelativePath } from '../findFilepath.js';
+
+describe('getRelativePath', () => {
+  const originalSeparator = Object.getOwnPropertyDescriptor(path, 'sep')!;
+
+  afterEach(() => {
+    Object.defineProperty(path, 'sep', originalSeparator);
+    vi.restoreAllMocks();
+  });
+
+  it('uses Windows separators as path segment boundaries', () => {
+    Object.defineProperty(path, 'sep', {
+      ...originalSeparator,
+      value: path.win32.sep,
+    });
+    vi.spyOn(path, 'relative').mockReturnValue('src\\components\\AccountMenu');
+
+    expect(getRelativePath('ignored.tsx', 'ignored')).toBe(
+      'src.components.accountmenu'
+    );
+  });
+
+  it('preserves a literal POSIX backslash within a path segment', () => {
+    Object.defineProperty(path, 'sep', {
+      ...originalSeparator,
+      value: path.posix.sep,
+    });
+    vi.spyOn(path, 'relative').mockReturnValue('src/Account\\Menu');
+
+    expect(getRelativePath('ignored.tsx', 'ignored')).toBe('src.account_menu');
+  });
+});

--- a/packages/cli/src/fs/__tests__/matchFiles.test.ts
+++ b/packages/cli/src/fs/__tests__/matchFiles.test.ts
@@ -1,0 +1,79 @@
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fg from 'fast-glob';
+import { matchFiles } from '../matchFiles.js';
+
+vi.mock('fast-glob', () => ({
+  default: {
+    sync: vi.fn(() => []),
+  },
+}));
+
+describe('matchFiles', () => {
+  const originalSeparator = Object.getOwnPropertyDescriptor(path, 'sep')!;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(path, 'sep', originalSeparator);
+  });
+
+  it('passes slash-separated patterns to fast-glob on Windows', () => {
+    Object.defineProperty(path, 'sep', {
+      ...originalSeparator,
+      value: path.win32.sep,
+    });
+
+    matchFiles('C:\\project', ['src\\**\\*.ts', 'tests/**/*.ts']);
+
+    expect(fg.sync).toHaveBeenCalledWith(['src/**/*.ts', 'tests/**/*.ts'], {
+      cwd: 'C:\\project',
+      absolute: true,
+      onlyFiles: true,
+    });
+  });
+
+  it('preserves escaped glob characters on Windows', () => {
+    Object.defineProperty(path, 'sep', {
+      ...originalSeparator,
+      value: path.win32.sep,
+    });
+
+    matchFiles('C:\\project', [
+      'app/\\(marketing\\)/*.mdx',
+      'src/\\[slug\\]/*.json',
+    ]);
+
+    expect(fg.sync).toHaveBeenCalledWith(
+      ['app/\\(marketing\\)/*.mdx', 'src/\\[slug\\]/*.json'],
+      {
+        cwd: 'C:\\project',
+        absolute: true,
+        onlyFiles: true,
+      }
+    );
+  });
+
+  it('preserves escaped glob characters on POSIX', () => {
+    Object.defineProperty(path, 'sep', {
+      ...originalSeparator,
+      value: path.posix.sep,
+    });
+
+    matchFiles('/project', [
+      'app/\\(marketing\\)/*.mdx',
+      'src/\\[slug\\]/*.json',
+    ]);
+
+    expect(fg.sync).toHaveBeenCalledWith(
+      ['app/\\(marketing\\)/*.mdx', 'src/\\[slug\\]/*.json'],
+      {
+        cwd: '/project',
+        absolute: true,
+        onlyFiles: true,
+      }
+    );
+  });
+});

--- a/packages/cli/src/fs/__tests__/parseFilesConfig.test.ts
+++ b/packages/cli/src/fs/__tests__/parseFilesConfig.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
 import {
   resolveLocaleFiles,
   resolveFiles,
@@ -35,11 +36,14 @@ import fg from 'fast-glob';
 import { logger } from '../../console/logger.js';
 
 describe('parseFilesConfig', () => {
+  const originalSeparator = Object.getOwnPropertyDescriptor(path, 'sep')!;
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   afterEach(() => {
+    Object.defineProperty(path, 'sep', originalSeparator);
     vi.restoreAllMocks();
   });
 
@@ -567,6 +571,72 @@ describe('parseFilesConfig', () => {
       });
     });
 
+    it('normalizes Windows separators in glob patterns on Windows', () => {
+      Object.defineProperty(path, 'sep', {
+        ...originalSeparator,
+        value: path.win32.sep,
+      });
+
+      expandGlobPatterns(
+        '/project',
+        ['src\\[locale]\\*.json'],
+        ['src\\[locale]\\ignored\\**'],
+        'en',
+        defaultLocales
+      );
+
+      expect(fg.sync).toHaveBeenCalledWith('/project/src/en/*.json', {
+        absolute: true,
+        ignore: ['/project/src/en/ignored/**'],
+      });
+    });
+
+    it('preserves escaped glob characters on Windows', () => {
+      Object.defineProperty(path, 'sep', {
+        ...originalSeparator,
+        value: path.win32.sep,
+      });
+
+      expandGlobPatterns(
+        '/project',
+        ['app/\\(marketing\\)/[locale]/*.mdx'],
+        ['src/\\[slug\\]/[locale]/**'],
+        'en',
+        defaultLocales
+      );
+
+      expect(fg.sync).toHaveBeenCalledWith(
+        '/project/app/\\(marketing\\)/en/*.mdx',
+        {
+          absolute: true,
+          ignore: ['/project/src/\\[slug\\]/en/**'],
+        }
+      );
+    });
+
+    it('preserves escaped glob characters on POSIX', () => {
+      Object.defineProperty(path, 'sep', {
+        ...originalSeparator,
+        value: path.posix.sep,
+      });
+
+      expandGlobPatterns(
+        '/project',
+        ['app/\\(marketing\\)/[locale]/*.mdx'],
+        ['src/\\[slug\\]/[locale]/**'],
+        'en',
+        defaultLocales
+      );
+
+      expect(fg.sync).toHaveBeenCalledWith(
+        '/project/app/\\(marketing\\)/en/*.mdx',
+        {
+          absolute: true,
+          ignore: ['/project/src/\\[slug\\]/en/**'],
+        }
+      );
+    });
+
     it('should handle complex locale replacement in paths', () => {
       const includePatterns = ['nested/[locale]/deep/[locale]/files.json'];
       const excludePatterns = [];
@@ -1083,6 +1153,28 @@ describe('parseFilesConfig', () => {
       const result = resolveFiles(files, 'en', defaultLocales, '/project');
 
       expect(result.requiresReviewPaths).toEqual(new Set(resolved));
+    });
+
+    it('stores Windows review paths with forward slashes', () => {
+      Object.defineProperty(path, 'sep', {
+        ...originalSeparator,
+        value: path.win32.sep,
+      });
+      vi.mocked(fg.sync).mockReturnValue([
+        'C:\\project\\locales\\en\\messages.json',
+      ]);
+      const files = {
+        json: {
+          include: ['locales\\[locale]\\*.json'],
+          requiresReview: true,
+        },
+      };
+
+      const result = resolveFiles(files, 'en', defaultLocales, 'C:\\project');
+
+      expect(result.requiresReviewPaths).toEqual(
+        new Set(['C:/project/locales/en/messages.json'])
+      );
     });
 
     it('file-type false overrides a top-level true default', () => {

--- a/packages/cli/src/fs/clearLocaleDirs.ts
+++ b/packages/cli/src/fs/clearLocaleDirs.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { logger } from '../console/logger.js';
 import fg from 'fast-glob';
 import micromatch from 'micromatch';
+import { resolvePosixGlob, toPosixPath } from '../utils/paths.js';
 
 /**
  * Extracts locale directories from translated file paths.
@@ -17,14 +18,14 @@ function extractLocaleDirectories(
   const localeSet = new Set(locales);
 
   for (const filePath of filePaths) {
-    const parts = filePath.split(path.sep);
+    const parts = toPosixPath(filePath).split('/');
 
     // Find directory segments that match the provided locales
     for (let i = 0; i < parts.length - 1; i++) {
       const segment = parts[i];
       if (localeSet.has(segment)) {
         // Found a locale directory, capture up to and including this segment
-        const localeDir = parts.slice(0, i + 1).join(path.sep);
+        const localeDir = path.normalize(parts.slice(0, i + 1).join('/'));
         localeDirs.add(localeDir);
         break;
       }
@@ -35,7 +36,7 @@ function extractLocaleDirectories(
 }
 
 async function getAllFiles(dirPath: string): Promise<string[]> {
-  return await fg(path.join(dirPath, '**/*'), {
+  return await fg(resolvePosixGlob(dirPath, '**/*'), {
     absolute: true,
     onlyFiles: true,
   });
@@ -51,18 +52,21 @@ async function getFilesToDelete(
 
   const absoluteCwd = path.resolve(cwd);
   const expandedExcludePatterns = excludePatterns.map((p) => {
-    const resolvedPattern = path.isAbsolute(p) ? p : path.join(absoluteCwd, p);
-    return resolvedPattern
-      .replace(/\[locale\]/g, currentLocale)
-      .replace(/\[locales\]/g, currentLocale);
+    return resolvePosixGlob(
+      absoluteCwd,
+      p
+        .replace(/\[locale\]/g, currentLocale)
+        .replace(/\[locales\]/g, currentLocale)
+    );
   });
 
-  const filesToKeep = micromatch(allFiles, expandedExcludePatterns, {
+  const posixFiles = allFiles.map(toPosixPath);
+  const filesToKeep = micromatch(posixFiles, expandedExcludePatterns, {
     dot: true,
   });
 
   const filesToKeepSet = new Set(filesToKeep);
-  return allFiles.filter((file) => !filesToKeepSet.has(file));
+  return allFiles.filter((_, index) => !filesToKeepSet.has(posixFiles[index]));
 }
 
 /**
@@ -86,7 +90,7 @@ export async function clearLocaleDirs(
       await fs.stat(dir);
 
       // Extract locale from directory path
-      const dirParts = dir.split(path.sep);
+      const dirParts = toPosixPath(dir).split('/');
       const locale = locales.find((loc) => dirParts.includes(loc));
 
       if (!locale) {

--- a/packages/cli/src/fs/config/parseFilesConfig.ts
+++ b/packages/cli/src/fs/config/parseFilesConfig.ts
@@ -21,6 +21,11 @@ import {
   GT_PARSING_FLAGS_DEFAULT,
 } from '../../config/defaults.js';
 import { resolveTransformationFormat } from '../../formats/files/transformFormat.js';
+import {
+  resolvePosixGlob,
+  toPosixGlob,
+  toPosixPath,
+} from '../../utils/paths.js';
 
 /**
  * Resolves the files from the files object
@@ -247,14 +252,14 @@ export function expandGlobPatterns(
     const expandedPattern = pattern.replace(/\[locale\]/g, locale);
 
     // Resolve the absolute pattern path
-    const absolutePattern = path.resolve(cwd, expandedPattern);
+    const absolutePattern = resolvePosixGlob(cwd, expandedPattern);
 
     // Prepare exclude patterns with locale replaced
     const expandedExcludePatterns = Array.from(
       new Set(
         excludePatterns.flatMap((p) =>
           locales.map((targetLocale) =>
-            path.resolve(
+            resolvePosixGlob(
               cwd,
               p
                 .replace(/\[locale\]/g, locale)
@@ -276,7 +281,7 @@ export function expandGlobPatterns(
     // For each match, create a version with [locale] in the correct positions
     matches.forEach((match) => {
       const absolutePath = path.resolve(cwd, match);
-      const patternPath = path.resolve(cwd, pattern);
+      const patternPath = resolvePosixGlob(cwd, pattern);
       let originalAbsolutePath = absolutePath;
 
       if (localePositions.length > 0) {
@@ -304,7 +309,7 @@ function buildPlaceholderPathFromPattern(
     return absolutePath;
   }
 
-  const posixPattern = toPosixPath(patternPath);
+  const posixPattern = toPosixGlob(patternPath);
   const posixPath = toPosixPath(absolutePath);
 
   const baseRegex = micromatch.makeRe(posixPattern, {
@@ -343,10 +348,6 @@ function buildPlaceholderPathFromPattern(
   return path.normalize(placeholderPosixPath);
 }
 
-function toPosixPath(value: string): string {
-  return value.split(path.sep).join(path.posix.sep);
-}
-
 /**
  * Classifies resolved file paths into publish/unpublish sets by matching
  * them against the given glob patterns. Uses POSIX paths for micromatch
@@ -365,7 +366,7 @@ function classifyPublishPaths(
 
   const posixPaths = resolvedPaths.map(toPosixPath);
   const toAbsoluteGlob = (p: string) =>
-    toPosixPath(path.resolve(cwd, p.replace(/\[locale\]/g, locale)));
+    resolvePosixGlob(cwd, p.replace(/\[locale\]/g, locale));
 
   for (const pattern of publishPatterns) {
     const matched = new Set(micromatch(posixPaths, toAbsoluteGlob(pattern)));
@@ -436,7 +437,7 @@ function classifyRequiresReviewPaths(
   if (typeof config === 'boolean' || config === undefined) {
     if (config ?? requiresReviewDefault) {
       for (const resolvedPath of resolvedPaths) {
-        requiresReviewPaths.add(resolvedPath);
+        requiresReviewPaths.add(toPosixPath(resolvedPath));
       }
     }
     return;
@@ -444,7 +445,7 @@ function classifyRequiresReviewPaths(
 
   const posixPaths = resolvedPaths.map(toPosixPath);
   const toAbsoluteGlob = (p: string) =>
-    toPosixPath(path.resolve(cwd, p.replace(/\[locale\]/g, locale)));
+    resolvePosixGlob(cwd, p.replace(/\[locale\]/g, locale));
   const matchAny = (patterns: string[]) => {
     const matched = new Set<string>();
     for (const pattern of patterns) {
@@ -463,7 +464,7 @@ function classifyRequiresReviewPaths(
       ? false
       : included.has(posixPaths[i]) || requiresReviewDefault;
     if (requiresReview) {
-      requiresReviewPaths.add(resolvedPaths[i]);
+      requiresReviewPaths.add(posixPaths[i]);
     }
   }
 }

--- a/packages/cli/src/fs/createLoadTranslationsFile.ts
+++ b/packages/cli/src/fs/createLoadTranslationsFile.ts
@@ -3,9 +3,10 @@ import path from 'node:path';
 import { logger } from '../console/logger.js';
 import chalk from 'chalk';
 import { DEFAULT_TRANSLATIONS_DIR } from '../utils/constants.js';
+import { toPosixPath } from '../utils/paths.js';
 
 function toRelativeImportPath(relativePath: string) {
-  const normalizedPath = relativePath.split(path.sep).join(path.posix.sep);
+  const normalizedPath = toPosixPath(relativePath);
 
   if (!normalizedPath) {
     return './';

--- a/packages/cli/src/fs/findFilepath.ts
+++ b/packages/cli/src/fs/findFilepath.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { logger } from '../console/logger.js';
 import { exitSync } from '../console/logging.js';
+import { toPosixPath } from '../utils/paths.js';
 
 /**
  * Resolve the file path from the given file path or default paths.
@@ -41,12 +42,12 @@ export function findFilepaths(
 
 export function getRelativePath(file: string, srcDirectory: string): string {
   // Create relative path from src directory and remove extension
-  return path
-    .relative(
+  return toPosixPath(
+    path.relative(
       srcDirectory,
       file.replace(/\.[^/.]+$/, '') // Remove file extension
     )
-    .replace(/\\/g, '.') // Replace Windows backslashes with dots
+  )
     .split(/[./]/) // Split on dots or forward slashes
     .filter(Boolean) // Remove empty segments that might cause extra dots
     .map((segment) => segment.replace(/[^a-zA-Z0-9]/g, '_').toLowerCase()) // Convert each segment to snake case

--- a/packages/cli/src/fs/matchFiles.ts
+++ b/packages/cli/src/fs/matchFiles.ts
@@ -1,7 +1,8 @@
 import fg from 'fast-glob';
+import { toPosixGlob } from '../utils/paths.js';
 
 export function matchFiles(cwd: string, patterns: string[]): string[] {
-  return fg.sync(patterns, {
+  return fg.sync(patterns.map(toPosixGlob), {
     cwd,
     absolute: true,
     onlyFiles: true,

--- a/packages/cli/src/react/parse/__tests__/wrapContent.test.ts
+++ b/packages/cli/src/react/parse/__tests__/wrapContent.test.ts
@@ -1,0 +1,75 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { matchFiles } from '../../../fs/matchFiles.js';
+import { Libraries } from '../../../types/libraries.js';
+import { wrapContentReact } from '../wrapContent.js';
+
+vi.mock('../../../fs/matchFiles.js', () => ({
+  matchFiles: vi.fn(),
+}));
+
+describe('wrapContentReact', () => {
+  const originalSeparator = Object.getOwnPropertyDescriptor(path, 'sep')!;
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    Object.defineProperty(path, 'sep', originalSeparator);
+    vi.restoreAllMocks();
+    for (const tempDir of tempDirs) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+    tempDirs.length = 0;
+  });
+
+  it('writes a slash-separated config import on Windows', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gt-wrap-'));
+    tempDirs.push(tempDir);
+    const filePath = path.join(tempDir, 'pages', '_app.tsx');
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(
+      filePath,
+      [
+        'export default function App({ Component, pageProps }) {',
+        '  return <Component {...pageProps} />;',
+        '}',
+      ].join('\n')
+    );
+    vi.mocked(matchFiles).mockReturnValue([filePath]);
+
+    Object.defineProperty(path, 'sep', {
+      ...originalSeparator,
+      value: path.win32.sep,
+    });
+    const nativeRelative = path.relative.bind(path);
+    vi.spyOn(path, 'relative').mockImplementation((from, to) =>
+      from === path.dirname(filePath) &&
+      to === path.resolve(process.cwd(), 'gt.config.json')
+        ? '..\\gt.config.json'
+        : nativeRelative(from, to)
+    );
+
+    const errors: string[] = [];
+    const result = await wrapContentReact(
+      {
+        src: ['pages/_app.tsx'],
+        config: 'gt.config.json',
+        skipTs: false,
+        disableIds: false,
+        disableFormatting: false,
+        addGTProvider: true,
+      },
+      Libraries.GT_REACT,
+      'next-pages',
+      errors,
+      []
+    );
+
+    expect(errors).toEqual([]);
+    expect(result.filesUpdated).toEqual([filePath]);
+    expect(fs.readFileSync(filePath, 'utf8')).toContain(
+      'from "../gt.config.json"'
+    );
+  });
+});

--- a/packages/cli/src/react/parse/wrapContent.ts
+++ b/packages/cli/src/react/parse/wrapContent.ts
@@ -21,6 +21,7 @@ import {
 import { DEFAULT_SRC_PATTERNS } from '../../config/generateSettings.js';
 import { matchFiles } from '../../fs/matchFiles.js';
 import { Libraries } from '../../types/libraries.js';
+import { toPosixPath } from '../../utils/paths.js';
 
 const IMPORT_MAP = {
   T: { name: 'T', source: Libraries.GT_REACT },
@@ -51,9 +52,11 @@ export async function wrapContentReact(
 
   for (const file of files) {
     const baseFileName = path.basename(file);
-    const configPath = path.relative(
-      path.dirname(file),
-      path.resolve(process.cwd(), options.config)
+    const configPath = toPosixPath(
+      path.relative(
+        path.dirname(file),
+        path.resolve(process.cwd(), options.config)
+      )
     );
 
     // Ensure the path starts with ./ or ../

--- a/packages/cli/src/translation/__tests__/reviewSetupWarning.test.ts
+++ b/packages/cli/src/translation/__tests__/reviewSetupWarning.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { afterEach, describe, it, expect, vi, beforeEach } from 'vitest';
 import path from 'node:path';
 import type { FileToUpload } from 'generaltranslation/types';
 import type { Settings } from '../../types/index.js';
 import { warnManualReviewSetup } from '../reviewSetupWarning.js';
 import { logger } from '../../console/logger.js';
+import { toPosixPath } from '../../utils/paths.js';
 
 vi.mock('../../console/logger.js', () => ({
   logger: {
@@ -25,7 +26,7 @@ const makeSettings = (reviewPaths: string[] = []): Settings =>
     dashboardUrl: 'https://dash.generaltranslation.com',
     files: {
       requiresReviewPaths: new Set(
-        reviewPaths.map((p) => path.resolve(process.cwd(), p))
+        reviewPaths.map((p) => toPosixPath(path.resolve(process.cwd(), p)))
       ),
     },
   }) as unknown as Settings;
@@ -54,10 +55,16 @@ const gtjsonFile = (
   }) as unknown as FileToUpload;
 
 describe('warnManualReviewSetup', () => {
+  const originalSeparator = Object.getOwnPropertyDescriptor(path, 'sep')!;
+
   beforeEach(() => {
     vi.clearAllMocks();
     // Default: setting unavailable (older API / no credentials)
     vi.mocked(gt.getProjectInfo).mockRejectedValue(new Error('unavailable'));
+  });
+
+  afterEach(() => {
+    Object.defineProperty(path, 'sep', originalSeparator);
   });
 
   it('does not warn when nothing requires review', async () => {
@@ -76,6 +83,23 @@ describe('warnManualReviewSetup', () => {
     expect(vi.mocked(logger.warn).mock.calls[0][0]).toContain(
       'https://dash.generaltranslation.com/project/proj-123/settings'
     );
+  });
+
+  it('matches Windows native paths against the normalized review set', async () => {
+    Object.defineProperty(path, 'sep', {
+      ...originalSeparator,
+      value: path.win32.sep,
+    });
+    const resolveSpy = vi
+      .spyOn(path, 'resolve')
+      .mockReturnValue('C:\\project\\messages.json');
+    const settings = makeSettings();
+    settings.files.requiresReviewPaths = new Set(['C:/project/messages.json']);
+
+    await warnManualReviewSetup(settings, [normalFile('messages.json')]);
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    resolveSpy.mockRestore();
   });
 
   it('does not warn when the review-gated file is not part of the upload', async () => {

--- a/packages/cli/src/translation/reviewSetupWarning.ts
+++ b/packages/cli/src/translation/reviewSetupWarning.ts
@@ -4,6 +4,7 @@ import type { FileToUpload } from 'generaltranslation/types';
 import { logger } from '../console/logger.js';
 import { gt } from '../utils/gt.js';
 import { Settings } from '../types/index.js';
+import { toPosixPath } from '../utils/paths.js';
 
 const PROJECT_INFO_TIMEOUT_MS = 10_000;
 
@@ -34,7 +35,9 @@ export async function warnManualReviewSetup(
           (metadata as { requires_review?: boolean })?.requires_review === true
       );
     }
-    return requiresReviewPaths?.has(path.resolve(process.cwd(), file.fileName));
+    return requiresReviewPaths?.has(
+      toPosixPath(path.resolve(process.cwd(), file.fileName))
+    );
   });
   if (!hasReviewGatedFile) return;
 

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -247,7 +247,7 @@ export type Settings = {
     transformFormats: TransformFormats; // Output file format transforms keyed by config file type
     publishPaths: Set<string>; // Absolute paths explicitly opted IN to publishing
     unpublishPaths: Set<string>; // Absolute paths explicitly opted OUT of publishing
-    requiresReviewPaths: Set<string>; // Absolute paths whose effective requiresReview policy is true
+    requiresReviewPaths: Set<string>; // Slash-normalized absolute paths whose effective requiresReview policy is true
     parsingFlags: ParseFlagsByFileType;
     gtJson: {
       publish?: boolean; // if true, publish gtjson translations to the CDN

--- a/packages/cli/src/utils/__tests__/resolveMintlifyRefs.test.ts
+++ b/packages/cli/src/utils/__tests__/resolveMintlifyRefs.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { afterEach, describe, it, expect, vi, beforeEach } from 'vitest';
 import path from 'node:path';
 import { resolveMintlifyRefs } from '../resolveMintlifyRefs';
 
@@ -23,6 +23,7 @@ import { logger } from '../../console/logger.js';
 
 const mockExists = vi.mocked(fs.existsSync);
 const mockRead = vi.mocked(fs.readFileSync);
+const originalSeparator = Object.getOwnPropertyDescriptor(path, 'sep')!;
 
 function setupFiles(files: Record<string, unknown>) {
   const resolvedFiles: Record<string, string> = {};
@@ -43,6 +44,10 @@ function setupFiles(files: Record<string, unknown>) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+});
+
+afterEach(() => {
+  Object.defineProperty(path, 'sep', originalSeparator);
 });
 
 describe('resolveMintlifyRefs', () => {
@@ -479,5 +484,15 @@ describe('resolveMintlifyRefs', () => {
         jsonSchema: { './other.json': { composite: {} } },
       })
     ).toBe(false);
+
+    Object.defineProperty(path, 'sep', {
+      ...originalSeparator,
+      value: path.win32.sep,
+    });
+    expect(
+      shouldResolveRefs('src\\content\\docs.json', {
+        jsonSchema: { 'src/**/*.json': { resolveRefs: true } },
+      })
+    ).toBe(true);
   });
 });

--- a/packages/cli/src/utils/__tests__/sharedStaticAssets.test.ts
+++ b/packages/cli/src/utils/__tests__/sharedStaticAssets.test.ts
@@ -33,6 +33,7 @@ vi.mock('node:path', () => ({
     dirname: vi.fn(),
     normalize: vi.fn(),
     basename: vi.fn(),
+    isAbsolute: vi.fn(),
     sep: '/',
   },
 }));
@@ -75,6 +76,7 @@ describe('processSharedStaticAssets', () => {
       const parts = p.split('/');
       return parts[parts.length - 1];
     });
+    vi.mocked(path.isAbsolute).mockImplementation((p) => p.startsWith('/'));
   });
 
   afterEach(() => {

--- a/packages/cli/src/utils/localizeRelativeAssets.ts
+++ b/packages/cli/src/utils/localizeRelativeAssets.ts
@@ -10,6 +10,7 @@ import type { Literal, Root } from 'mdast';
 import { escapeHtmlInTextNodes, normalizeCJKCharacters } from 'gt-remark';
 import type { StaticLocalizationSettings } from '../types/index.js';
 import { createFileMapping } from '../formats/files/fileMapping.js';
+import { toPosixPath } from './paths.js';
 
 type RewriteResult = { content: string; hasChanges: boolean };
 export type RelativeAssetSettings = StaticLocalizationSettings;
@@ -43,10 +44,6 @@ function isSkippableUrl(url: string): boolean {
   if (url.startsWith('mailto:')) return true;
   if (url.startsWith('tel:')) return true;
   return false;
-}
-
-function toPosix(p: string): string {
-  return p.replace(/\\/g, '/');
 }
 
 function isSubPath(child: string, parent: string): boolean {
@@ -93,10 +90,10 @@ export function localizeRelativeAssetsForContent(
 
     let newPath: string;
     if (isSubPath(sourceResolved, cwd)) {
-      newPath = '/' + toPosix(path.relative(cwd, sourceResolved));
+      newPath = '/' + toPosixPath(path.relative(cwd, sourceResolved));
     } else {
-      const rel = toPosix(path.relative(targetDir, sourceResolved));
-      newPath = rel || toPosix(path.basename(sourceResolved));
+      const rel = toPosixPath(path.relative(targetDir, sourceResolved));
+      newPath = rel || toPosixPath(path.basename(sourceResolved));
     }
 
     if (newPath === base) return null;

--- a/packages/cli/src/utils/resolveMintlifyRefs.ts
+++ b/packages/cli/src/utils/resolveMintlifyRefs.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { logger } from '../console/logger.js';
 import chalk from 'chalk';
 import micromatch from 'micromatch';
+import { toPosixGlob, toPosixPath } from './paths.js';
 
 export type RefMapEntry = {
   sourceFile: string;
@@ -182,10 +183,13 @@ export function shouldResolveRefs(
 ): boolean {
   if (!options?.jsonSchema) return false;
 
-  const relative = path.relative(process.cwd(), filePath);
+  const relative = toPosixPath(path.relative(process.cwd(), filePath));
   for (const [glob, schema] of Object.entries(options.jsonSchema)) {
     const jsonSchema = schema as { resolveRefs?: boolean };
-    if (jsonSchema.resolveRefs && micromatch.isMatch(relative, glob)) {
+    if (
+      jsonSchema.resolveRefs &&
+      micromatch.isMatch(relative, toPosixGlob(glob))
+    ) {
       return true;
     }
   }

--- a/packages/cli/src/utils/sharedStaticAssets.ts
+++ b/packages/cli/src/utils/sharedStaticAssets.ts
@@ -12,6 +12,7 @@ import { escapeHtmlInTextNodes, normalizeCJKCharacters } from 'gt-remark';
 import type { Settings } from '../types/index.js';
 import { createFileMapping } from '../formats/files/fileMapping.js';
 import { TEMPLATE_FILE_NAME } from './constants.js';
+import { resolvePosixGlob, toPosixPath } from './paths.js';
 
 type MdxAssetNode = {
   type?: string;
@@ -222,7 +223,9 @@ function resolveAssetPaths(include: string[], cwd: string): Set<string> {
   const assetPaths = new Set<string>();
   for (let pattern of include) {
     if (pattern.startsWith('/')) pattern = pattern.slice(1);
-    const matches = fg.sync(path.resolve(cwd, pattern), { absolute: true });
+    const matches = fg.sync(resolvePosixGlob(cwd, pattern), {
+      absolute: true,
+    });
     for (const m of matches) assetPaths.add(path.normalize(m));
   }
   return assetPaths;
@@ -368,7 +371,7 @@ export default async function processSharedStaticAssets(settings: Settings) {
   // Map original absolute path -> public URL
   const originalToPublic = new Map<string, string>();
   for (const abs of assetPaths) {
-    const relFromRoot = path.relative(cwd, abs).replace(/\\/g, '/');
+    const relFromRoot = toPosixPath(path.relative(cwd, abs));
     const publicUrl =
       (publicPath.endsWith('/') ? publicPath.slice(0, -1) : publicPath) +
       '/' +

--- a/packages/cli/src/utils/splitMintlifyLanguageRefs.ts
+++ b/packages/cli/src/utils/splitMintlifyLanguageRefs.ts
@@ -5,6 +5,7 @@ import { Settings, JsonSchema, SourceObjectOptions } from '../types/index.js';
 import type { RefMap } from './resolveMintlifyRefs.js';
 import { validateJsonSchema } from '../formats/json/utils.js';
 import { getStoredRefMap, clearStoredRefMap } from '../state/mintlifyRefMap.js';
+import { toPosixPath } from './paths.js';
 import { JSONPath } from 'jsonpath-plus';
 import { getLocaleProperties } from '@generaltranslation/format';
 
@@ -502,7 +503,7 @@ function writeJsonFile(filePath: string, data: unknown): void {
  * languages array to a written entry file.
  */
 function toRelativeRefPath(fromDir: string, toPath: string): string {
-  const rel = path.relative(fromDir, toPath).split(path.sep).join('/');
+  const rel = toPosixPath(path.relative(fromDir, toPath));
   return rel.startsWith('.') || rel.startsWith('/') ? rel : `./${rel}`;
 }
 

--- a/packages/cli/src/workflows/steps/DownloadStep.ts
+++ b/packages/cli/src/workflows/steps/DownloadStep.ts
@@ -12,6 +12,7 @@ import { recordWarning } from '../../state/translateWarnings.js';
 import { FileStatusTracker } from './PollJobsStep.js';
 import { TEMPLATE_FILE_NAME } from '../../utils/constants.js';
 import type { InlineLibrary } from '../../types/libraries.js';
+import { toPosixPath } from '../../utils/paths.js';
 
 export type DownloadTranslationsInput = {
   fileTracker: FileStatusTracker;
@@ -116,7 +117,7 @@ export class DownloadTranslationsStep {
             process.cwd(),
             fileProperties.fileName
           );
-          if (!requiresReviewPaths.has(absolutePath)) continue;
+          if (!requiresReviewPaths.has(toPosixPath(absolutePath))) continue;
           reviewGatedKeys.add(fileKey);
           fileTracker.completed.delete(fileKey);
           fileTracker.skipped.set(fileKey, fileProperties);

--- a/packages/cli/src/workflows/steps/__tests__/DownloadStep.test.ts
+++ b/packages/cli/src/workflows/steps/__tests__/DownloadStep.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import path from 'node:path';
 import type { GT } from 'generaltranslation';
 import type { Settings } from '../../../types/index.js';
@@ -10,6 +10,7 @@ import {
 } from '../../../state/translateWarnings.js';
 import { DownloadTranslationsStep } from '../DownloadStep.js';
 import { TEMPLATE_FILE_NAME } from '../../../utils/constants.js';
+import { toPosixPath } from '../../../utils/paths.js';
 
 vi.mock('../../../console/logger.js', () => ({
   logger: {
@@ -96,6 +97,7 @@ describe('DownloadTranslationsStep', () => {
 });
 
 describe('DownloadTranslationsStep review gating', () => {
+  const originalSeparator = Object.getOwnPropertyDescriptor(path, 'sep')!;
   const mockGt = {
     queryFileData: vi.fn(),
   };
@@ -136,7 +138,7 @@ describe('DownloadTranslationsStep review gating', () => {
     ({
       files: {
         requiresReviewPaths: new Set(
-          reviewPaths.map((p) => path.resolve(process.cwd(), p))
+          reviewPaths.map((p) => toPosixPath(path.resolve(process.cwd(), p)))
         ),
       },
     }) as unknown as Settings;
@@ -172,6 +174,10 @@ describe('DownloadTranslationsStep review gating', () => {
     clearWarnings();
   });
 
+  afterEach(() => {
+    Object.defineProperty(path, 'sep', originalSeparator);
+  });
+
   it('skips unapproved review-gated files without failing', async () => {
     const { success, fileTracker } = await runStep('messages.json', null, [
       'messages.json',
@@ -190,6 +196,25 @@ describe('DownloadTranslationsStep review gating', () => {
           'Translation for locale fr requires review and is not approved yet',
       },
     ]);
+  });
+
+  it('matches Windows native paths against the normalized review set', async () => {
+    Object.defineProperty(path, 'sep', {
+      ...originalSeparator,
+      value: path.win32.sep,
+    });
+    const resolveSpy = vi
+      .spyOn(path, 'resolve')
+      .mockReturnValue('C:\\project\\messages.json');
+
+    const { fileTracker } = await runStep('messages.json', null, [
+      'messages.json',
+    ]);
+
+    expect(downloadFileBatch).not.toHaveBeenCalled();
+    expect(fileTracker.completed.size).toBe(0);
+    expect(fileTracker.skipped.size).toBe(1);
+    resolveSpy.mockRestore();
   });
 
   it('downloads approved review-gated files', async () => {


### PR DESCRIPTION
- apply helper

## Summary

- Apply the portable path and glob helpers to file expansion, schema matching, review gates, font discovery, generated imports, localized assets, and source metadata.
- Preserve escaped route-group and bracket globs on POSIX, including destructive `clearLocaleDirsExclude` paths.
- Normalize every Windows review-path comparison and consolidate equivalent native-path conversions on the shared helper.

## Testing

- Focused path/glob regression suites — passed, including escaped include and exclude patterns
- Top-of-stack `pnpm --filter gt test` — passed (123 files, 2,295 tests)
- `pnpm --filter gt typecheck` — passed
- `pnpm exec oxlint packages/cli/src` — passed with 9 pre-existing warnings
- `pnpm exec oxfmt --check packages/cli/src` — passed

## Notes

- Stack: 2 of 4; depends on #2158 and continues in #2162.
- Changeset deferred to the top PR so the stack produces one release note.
- File-mapping `transform.match` expressions now evaluate slash-separated relative paths on Windows.








<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The path-normalization update improves cross-platform file handling, but Windows configurations that reference literal square-bracket directories can still produce malformed glob boundaries. This can prevent translation files from being discovered and can cause review or publish rules to miss matching files.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Not ready to merge until Windows glob normalization preserves literal-bracket escapes without treating a directory separator as part of that escape.

One reproduced reliability failure remains in Windows glob handling: a separator immediately before a literal bracket directory is retained as an escape, so file discovery and policy matching can target the wrong path.

**Files Needing Attention:** packages/cli/src/utils/paths.ts
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex reproduced the failing Windows literal-bracket glob normalization run for the P1 finding.
- T-Rex captured the Windows glob reproduction harness and its source to enable review.
- T-Rex applied corrected portable glob normalization control to produce portable include, exclude, and requiresReview patterns.
- T-Rex observed a narrow Vitest command blocked by an unavailable dependency store.
- T-Rex validated the contract behavior, confirming that the retained backslash escapes the \[ character in glob matching and that the corrected-normalization control yields portable patterns.

<a href="https://app.greptile.com/trex/runs/20517228/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/cli/src/utils/paths.ts`, line 25 ([link](https://github.com/generaltranslation/gt/blob/424be3da4d321b024f49b1853741cbaca4e7dc6a/packages/cli/src/utils/paths.ts#L25)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Windows separator before literal bracket directories is mistaken for a glob escape**

   On Windows, a configuration such as `locales\\[slug]\\[locale]\\*.json` is normalized to `locales\\[slug]/en/*.json`. The first backslash is a directory separator, but `toPosixGlob` retains it as though it escaped `[`. Glob consumers therefore interpret it as part of the literal-bracket escape instead of a path boundary: file discovery can skip files below `[slug]`, and matching exclude or `requiresReview` policies can be applied incorrectly. Normalize the separator while retaining the escape for the literal bracket, and cover this complete Windows-style pattern in discovery and policy tests.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Failing Windows literal-bracket glob normalization run](https://app.greptile.com/trex/artifacts/39372d16-7823-42e3-82af-5d518c28b500)**

   - Executed the review harness against the changed helper with Windows separators; it retains the separator before \`\[slug\]\`, proving the discovery and policy-match defect.

   **[Corrected portable glob normalization control](https://app.greptile.com/trex/artifacts/f903c36f-5a11-4e6b-850c-931a2ac2a183)**

   - Executed a minimal corrected-normalization control for the same include, exclude, and requiresReview patterns; all outputs retain the literal-bracket escape while converting the directory separator.

   **[Review-authored Windows glob reproduction harness](https://app.greptile.com/trex/artifacts/ae17e3a9-9429-487f-a888-c893f5dbb6e1)**

   - Minimal executable source that loads the checked-out helper and asserts the expected include, exclude, and requiresReview pattern outputs under simulated Windows separators.

   **[Captured source of the Windows glob reproduction harness](https://app.greptile.com/trex/artifacts/979059f8-72ba-4c61-816c-7a4b99c9181e)**

   - Captured command output containing the exact review-authored harness source used for the failing execution.

   **[Narrow Vitest command blocked by unavailable dependency store](https://app.greptile.com/trex/artifacts/10b84f8e-eb87-4bf0-9361-995270794fb9)**

   - Captured the requested narrow Vitest command and its module-resolution failure caused by stale pnpm symlinks to an unavailable temporary store; direct Node execution was used instead.

   <a href="https://app.greptile.com/trex/runs/20517228/artifacts?artifact=39372d16-7823-42e3-82af-5d518c28b500"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/cli/src/utils/paths.ts
   Line: 25

   Comment:
   **Windows separator before literal bracket directories is mistaken for a glob escape**

   On Windows, a configuration such as `locales\\[slug]\\[locale]\\*.json` is normalized to `locales\\[slug]/en/*.json`. The first backslash is a directory separator, but `toPosixGlob` retains it as though it escaped `[`. Glob consumers therefore interpret it as part of the literal-bracket escape instead of a path boundary: file discovery can skip files below `[slug]`, and matching exclude or `requiresReview` policies can be applied incorrectly. Normalize the separator while retaining the escape for the literal bracket, and cover this complete Windows-style pattern in discovery and policy tests.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcli%2Fsrc%2Futils%2Fpaths.ts%0ALine%3A%2025%0A%0AComment%3A%0A**Windows%20separator%20before%20literal%20bracket%20directories%20is%20mistaken%20for%20a%20glob%20escape**%0A%0AOn%20Windows%2C%20a%20configuration%20such%20as%20%60locales%5C%5C%5Bslug%5D%5C%5C%5Blocale%5D%5C%5C*.json%60%20is%20normalized%20to%20%60locales%5C%5C%5Bslug%5D%2Fen%2F*.json%60.%20The%20first%20backslash%20is%20a%20directory%20separator%2C%20but%20%60toPosixGlob%60%20retains%20it%20as%20though%20it%20escaped%20%60%5B%60.%20Glob%20consumers%20therefore%20interpret%20it%20as%20part%20of%20the%20literal-bracket%20escape%20instead%20of%20a%20path%20boundary%3A%20file%20discovery%20can%20skip%20files%20below%20%60%5Bslug%5D%60%2C%20and%20matching%20exclude%20or%20%60requiresReview%60%20policies%20can%20be%20applied%20incorrectly.%20Normalize%20the%20separator%20while%20retaining%20the%20escape%20for%20the%20literal%20bracket%2C%20and%20cover%20this%20complete%20Windows-style%20pattern%20in%20discovery%20and%20policy%20tests.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2159&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fcli%2Fnormalize-windows-path-consumers%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fcli%2Fnormalize-windows-path-consumers%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcli%2Fsrc%2Futils%2Fpaths.ts%0ALine%3A%2025%0A%0AComment%3A%0A**Windows%20separator%20before%20literal%20bracket%20directories%20is%20mistaken%20for%20a%20glob%20escape**%0A%0AOn%20Windows%2C%20a%20configuration%20such%20as%20%60locales%5C%5C%5Bslug%5D%5C%5C%5Blocale%5D%5C%5C*.json%60%20is%20normalized%20to%20%60locales%5C%5C%5Bslug%5D%2Fen%2F*.json%60.%20The%20first%20backslash%20is%20a%20directory%20separator%2C%20but%20%60toPosixGlob%60%20retains%20it%20as%20though%20it%20escaped%20%60%5B%60.%20Glob%20consumers%20therefore%20interpret%20it%20as%20part%20of%20the%20literal-bracket%20escape%20instead%20of%20a%20path%20boundary%3A%20file%20discovery%20can%20skip%20files%20below%20%60%5Bslug%5D%60%2C%20and%20matching%20exclude%20or%20%60requiresReview%60%20policies%20can%20be%20applied%20incorrectly.%20Normalize%20the%20separator%20while%20retaining%20the%20escape%20for%20the%20literal%20bracket%2C%20and%20cover%20this%20complete%20Windows-style%20pattern%20in%20discovery%20and%20policy%20tests.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2159&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Windows separator before literal bracket directories is mistaken for a glob escape**

   - **Bug**
     - On Windows, `toPosixGlob` preserves every backslash immediately before `[` so a configuration such as `locales\\[slug]\\[locale]\\*.json` normalizes to `locales\\[slug]/en/*.json`. The first backslash was a Windows directory separator, not an author-supplied glob escape. Consequently fast-glob can fail to discover files under a literal `[slug]` directory, while micromatch exclude and requiresReview rules can fail to match those resolved files.
   - **Cause**
     - `toPosixGlob` cannot distinguish a Windows separator before a literal-bracket path segment from an intentional glob escape. Its negative lookahead preserves `\\[` unconditionally.
   - **Fix**
     - Normalize Windows separators based on path-segment context, preserving an escape only when the backslash is genuinely author-supplied within an already slash-delimited glob segment. Add real Windows-path regression cases for include discovery and requiresReview include/exclude classification with `locales\\[slug]\\[locale]` patterns.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20generaltranslation%2Fgt%20PR%20%232159%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=generaltranslation%2Fgt&pr=2159&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fcli%2Fsrc%2Futils%2Fpaths.ts%3A25%0A**Windows%20separator%20before%20literal%20bracket%20directories%20is%20mistaken%20for%20a%20glob%20escape**%0A%0AOn%20Windows%2C%20a%20configuration%20such%20as%20%60locales%5C%5C%5Bslug%5D%5C%5C%5Blocale%5D%5C%5C*.json%60%20is%20normalized%20to%20%60locales%5C%5C%5Bslug%5D%2Fen%2F*.json%60.%20The%20first%20backslash%20is%20a%20directory%20separator%2C%20but%20%60toPosixGlob%60%20retains%20it%20as%20though%20it%20escaped%20%60%5B%60.%20Glob%20consumers%20therefore%20interpret%20it%20as%20part%20of%20the%20literal-bracket%20escape%20instead%20of%20a%20path%20boundary%3A%20file%20discovery%20can%20skip%20files%20below%20%60%5Bslug%5D%60%2C%20and%20matching%20exclude%20or%20%60requiresReview%60%20policies%20can%20be%20applied%20incorrectly.%20Normalize%20the%20separator%20while%20retaining%20the%20escape%20for%20the%20literal%20bracket%2C%20and%20cover%20this%20complete%20Windows-style%20pattern%20in%20discovery%20and%20policy%20tests.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2159&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fcli%2Fnormalize-windows-path-consumers%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fcli%2Fnormalize-windows-path-consumers%22.%0A%0A%23%23%23%20Issue%201%0Apackages%2Fcli%2Fsrc%2Futils%2Fpaths.ts%3A25%0A**Windows%20separator%20before%20literal%20bracket%20directories%20is%20mistaken%20for%20a%20glob%20escape**%0A%0AOn%20Windows%2C%20a%20configuration%20such%20as%20%60locales%5C%5C%5Bslug%5D%5C%5C%5Blocale%5D%5C%5C*.json%60%20is%20normalized%20to%20%60locales%5C%5C%5Bslug%5D%2Fen%2F*.json%60.%20The%20first%20backslash%20is%20a%20directory%20separator%2C%20but%20%60toPosixGlob%60%20retains%20it%20as%20though%20it%20escaped%20%60%5B%60.%20Glob%20consumers%20therefore%20interpret%20it%20as%20part%20of%20the%20literal-bracket%20escape%20instead%20of%20a%20path%20boundary%3A%20file%20discovery%20can%20skip%20files%20below%20%60%5Bslug%5D%60%2C%20and%20matching%20exclude%20or%20%60requiresReview%60%20policies%20can%20be%20applied%20incorrectly.%20Normalize%20the%20separator%20while%20retaining%20the%20escape%20for%20the%20literal%20bracket%2C%20and%20cover%20this%20complete%20Windows-style%20pattern%20in%20discovery%20and%20policy%20tests.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2159&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/cli/src/utils/paths.ts:25
**Windows separator before literal bracket directories is mistaken for a glob escape**

On Windows, a configuration such as `locales\\[slug]\\[locale]\\*.json` is normalized to `locales\\[slug]/en/*.json`. The first backslash is a directory separator, but `toPosixGlob` retains it as though it escaped `[`. Glob consumers therefore interpret it as part of the literal-bracket escape instead of a path boundary: file discovery can skip files below `[slug]`, and matching exclude or `requiresReview` policies can be applied incorrectly. Normalize the separator while retaining the escape for the literal bracket, and cover this complete Windows-style pattern in discovery and policy tests.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(cli): normalize Windows path consume..."](https://github.com/generaltranslation/gt/commit/424be3da4d321b024f49b1853741cbaca4e7dc6a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56346376)</sub>

<!-- /greptile_comment -->