### PR TITLE
fix(cli): migrate Windows lockfile paths

### DIFF
--- a/.changeset/calm-windows-paths.md
+++ b/.changeset/calm-windows-paths.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Normalize file paths and glob patterns on Windows while preserving POSIX glob escapes. Existing Windows `gt-lock.json` paths and path-derived file IDs are migrated to portable forward slashes, and review gates, source metadata, and font globs now resolve consistently.

--- a/packages/cli/src/fs/config/__tests__/downloadedVersions.test.ts
+++ b/packages/cli/src/fs/config/__tests__/downloadedVersions.test.ts
@@ -12,6 +12,7 @@ import {
   DownloadedVersionEntry,
 } from '../downloadedVersions.js';
 import { createMockSettings } from '../../../api/__mocks__/settings.js';
+import { hashStringSync } from '../../../utils/hash.js';
 
 describe('readLockfile / writeLockfile', () => {
   const originalCwd = process.cwd();
@@ -79,6 +80,69 @@ describe('readLockfile / writeLockfile', () => {
         '2025-01-01T00:00:00Z'
       );
       expect(originalV1).toBeNull();
+    });
+
+    it('normalizes Windows paths from a v2 lockfile', () => {
+      writeLockFile({
+        version: 2,
+        branchId: 'brc_abc',
+        entries: [
+          {
+            fileId: 'f1',
+            versionId: 'v1',
+            fileName: 'src\\content\\page.mdx',
+            staged: true,
+            translations: {
+              es: { fileName: 'content\\es\\page.mdx' },
+            },
+          },
+        ],
+      });
+
+      const { data } = readLockfile(settings('brc_abc'));
+
+      expect(data.entries[0].fileName).toBe('src/content/page.mdx');
+      expect(data.entries[0].translations.es.fileName).toBe(
+        'content/es/page.mdx'
+      );
+    });
+
+    it('re-keys path-derived file IDs when normalizing Windows paths', () => {
+      const windowsFileName = 'src\\content\\page.mdx';
+      const posixFileName = 'src/content/page.mdx';
+      writeLockFile({
+        version: 2,
+        branchId: 'brc_abc',
+        entries: [
+          {
+            fileId: hashStringSync(windowsFileName),
+            versionId: 'v1',
+            fileName: windowsFileName,
+            translations: {
+              es: {
+                fileName: 'content\\es\\page.mdx',
+                postProcessHash: 'translation-hash',
+              },
+            },
+          },
+        ],
+      });
+
+      const { data, entryMap } = readLockfile(settings('brc_abc'));
+      const normalizedFileId = hashStringSync(posixFileName);
+
+      expect(data.entries[0]).toMatchObject({
+        fileId: normalizedFileId,
+        fileName: posixFileName,
+        translations: {
+          es: {
+            fileName: 'content/es/page.mdx',
+            postProcessHash: 'translation-hash',
+          },
+        },
+      });
+      expect(entryMap.get(normalizedFileId)).toBe(data.entries[0]);
+      expect(entryMap.has(hashStringSync(windowsFileName))).toBe(false);
     });
 
     it('updates branchId on v2 file to current branch', () => {
@@ -186,6 +250,32 @@ describe('readLockfile / writeLockfile', () => {
       expect(written.version).toBe(2);
       expect(written.branchId).toBe('brc_123');
       expect(written.entries).toHaveLength(1);
+    });
+
+    it('writes lockfile paths with forward slashes', () => {
+      writeLockfile(
+        {
+          version: 2,
+          branchId: 'brc_123',
+          entries: [
+            {
+              fileId: 'f1',
+              versionId: 'v1',
+              fileName: 'src\\content\\page.mdx',
+              translations: {
+                es: { fileName: 'content\\es\\page.mdx' },
+              },
+            },
+          ],
+        },
+        null
+      );
+
+      const written = readLockFile();
+      expect(written.entries[0].fileName).toBe('src/content/page.mdx');
+      expect(written.entries[0].translations.es.fileName).toBe(
+        'content/es/page.mdx'
+      );
     });
 
     it('writes v1 format when originalV1 is provided, preserving other branches', () => {

--- a/packages/cli/src/fs/config/downloadedVersions.ts
+++ b/packages/cli/src/fs/config/downloadedVersions.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { logger } from '../../console/logger.js';
 import type { Settings } from '../../types/index.js';
+import { hashStringSync } from '../../utils/hash.js';
 
 const GT_LOCK_FILE = 'gt-lock.json';
 
@@ -48,6 +49,34 @@ export type DownloadedVersionsV1 = {
     };
   };
 };
+
+export function normalizeLockfilePaths(data: DownloadedVersions): void {
+  for (const entry of data.entries) {
+    if (typeof entry.fileName === 'string') {
+      const originalFileName = entry.fileName;
+      const normalizedFileName = originalFileName.replace(/\\/g, '/');
+
+      // getRelative() historically produced backslashes on Windows, and the
+      // file ID is the hash of that relative path. Re-key legacy entries when
+      // their ID still matches the old path so lookups keep their translations.
+      if (
+        normalizedFileName !== originalFileName &&
+        entry.fileId === hashStringSync(originalFileName)
+      ) {
+        entry.fileId = hashStringSync(normalizedFileName);
+      }
+      entry.fileName = normalizedFileName;
+    }
+    if (!entry.translations || typeof entry.translations !== 'object') {
+      continue;
+    }
+    for (const translation of Object.values(entry.translations)) {
+      if (translation && typeof translation.fileName === 'string') {
+        translation.fileName = translation.fileName.replace(/\\/g, '/');
+      }
+    }
+  }
+}
 
 // ── Conversion helpers ──────────────────────────────────────────────
 
@@ -170,6 +199,8 @@ export function readLockfile(settings: Settings): {
     data = { version: 2, branchId, entries: [] };
   }
 
+  normalizeLockfilePaths(data);
+
   return { data, entryMap: buildEntryMap(data.entries), originalV1 };
 }
 
@@ -183,6 +214,7 @@ export function writeLockfile(
   originalV1: DownloadedVersionsV1 | null
 ): void {
   try {
+    normalizeLockfilePaths(data);
     const filepath = path.join(process.cwd(), GT_LOCK_FILE);
     fs.mkdirSync(path.dirname(filepath), { recursive: true });
 

--- a/packages/cli/src/fs/findFilepath.ts
+++ b/packages/cli/src/fs/findFilepath.ts
@@ -115,5 +115,5 @@ export function findFileInDir(dir: string, file: string): string {
 
 export function getRelative(absolutePath: string): string {
   const path2 = path.resolve(absolutePath);
-  return path.relative(process.cwd(), path2);
+  return toPosixPath(path.relative(process.cwd(), path2));
 }

--- a/packages/cli/src/git/__tests__/mergeDrivers.test.ts
+++ b/packages/cli/src/git/__tests__/mergeDrivers.test.ts
@@ -7,6 +7,7 @@ import {
   mergeGtLockJson,
   runMergeDriver,
 } from '../mergeDrivers.js';
+import { hashStringSync } from '../../utils/hash.js';
 
 const json = (value: unknown) => JSON.stringify(value, null, 2);
 
@@ -410,6 +411,59 @@ describe('mergeGtLockJson', () => {
         ],
       }) + '\n'
     );
+  });
+
+  it('merges a legacy Windows side with its migrated counterpart', () => {
+    const windowsFileName = 'src\\content\\a.mdx';
+    const posixFileName = 'src/content/a.mdx';
+    const legacyEntry = {
+      fileId: hashStringSync(windowsFileName),
+      versionId: 'version-a',
+      fileName: windowsFileName,
+      translations: {
+        es: { updatedAt: '2026-01-01T00:00:00.000Z' },
+      },
+    };
+    const migratedEntry = {
+      ...legacyEntry,
+      fileId: hashStringSync(posixFileName),
+      fileName: posixFileName,
+    };
+    const result = mergeGtLockJson(
+      lock({ entries: [legacyEntry] }),
+      lock({ entries: [migratedEntry] }),
+      lock({
+        entries: [
+          {
+            ...legacyEntry,
+            translations: {
+              ...legacyEntry.translations,
+              fr: {
+                updatedAt: '2026-01-02T00:00:00.000Z',
+                fileName: 'content\\fr\\a.mdx',
+              },
+            },
+          },
+        ],
+      })
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(JSON.parse(result.content).entries).toEqual([
+      {
+        fileId: hashStringSync(posixFileName),
+        versionId: 'version-a',
+        translations: {
+          es: { updatedAt: '2026-01-01T00:00:00.000Z' },
+          fr: {
+            updatedAt: '2026-01-02T00:00:00.000Z',
+            fileName: 'content/fr/a.mdx',
+          },
+        },
+        fileName: posixFileName,
+      },
+    ]);
   });
 
   it('fails on malformed JSON', () => {

--- a/packages/cli/src/git/mergeDrivers.ts
+++ b/packages/cli/src/git/mergeDrivers.ts
@@ -5,6 +5,7 @@ import type {
   DownloadedVersionEntry,
   DownloadedVersions,
 } from '../fs/config/downloadedVersions.js';
+import { normalizeLockfilePaths } from '../fs/config/downloadedVersions.js';
 
 export type MergeDriverName = 'gt-lock' | 'gtjson';
 
@@ -122,6 +123,14 @@ export function mergeGtLockJson(
   if (!base.ok) return base;
   if (!ours.ok) return ours;
   if (!theirs.ok) return theirs;
+
+  // A side written by a pre-normalization Windows CLI stores backslash
+  // fileNames and fileIds hashed from them; normalize all three sides so
+  // separator-only differences don't read as changes and legacy entries
+  // merge under the same fileId as their migrated counterparts.
+  normalizeLockfilePaths(base.value);
+  normalizeLockfilePaths(ours.value);
+  normalizeLockfilePaths(theirs.value);
 
   const baseMap = buildEntryMap(base.value.entries);
   const oursMap = buildEntryMap(ours.value.entries);

--- a/packages/cli/src/react/jsx/utils/__tests__/surroundingLines.integration.test.ts
+++ b/packages/cli/src/react/jsx/utils/__tests__/surroundingLines.integration.test.ts
@@ -8,6 +8,7 @@ import os from 'node:os';
 import { parseStrings } from '../parseStringFunction.js';
 import { parseTranslationComponent } from '../jsxParsing/parseJsx.js';
 import { Updates } from '../../../../types/index.js';
+import { getRelative } from '../../../../fs/findFilepath.js';
 
 describe('sourceCode metadata integration', () => {
   const tempFiles: string[] = [];
@@ -46,7 +47,7 @@ describe('sourceCode metadata integration', () => {
     ].join('\n');
 
     const filePath = writeTempFile(code);
-    const relativeFilePath = path.relative(process.cwd(), filePath);
+    const relativeFilePath = getRelative(filePath);
     const ast = parse(code, {
       sourceType: 'module',
       plugins: ['jsx', 'typescript'],
@@ -113,7 +114,7 @@ describe('sourceCode metadata integration', () => {
     ].join('\n');
 
     const filePath = writeTempFile(code);
-    const relativeFilePath = path.relative(process.cwd(), filePath);
+    const relativeFilePath = getRelative(filePath);
     const ast = parse(code, {
       sourceType: 'module',
       plugins: ['jsx', 'typescript'],
@@ -174,7 +175,7 @@ describe('sourceCode metadata integration', () => {
     ].join('\n');
 
     const filePath = writeTempFile(code);
-    const relativeFilePath = path.relative(process.cwd(), filePath);
+    const relativeFilePath = getRelative(filePath);
     const ast = parse(code, {
       sourceType: 'module',
       plugins: ['jsx', 'typescript'],

--- a/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
@@ -52,11 +52,11 @@ import {
   autoInsertJsxComponents,
 } from './autoInsertion.js';
 import { GTLibrary } from '../../../../types/libraries.js';
-import path from 'node:path';
 import { extractSourceCode } from '../extractSourceCode.js';
 import { SURROUNDING_LINE_COUNT } from '../../../../utils/constants.js';
 import { handleDerivation } from '../stringParsing/derivation/handleDerivation.js';
 import { parseStringExpression, nodeToStrings } from '../parseString.js';
+import { getRelative } from '../../../../fs/findFilepath.js';
 
 // Handle CommonJS/ESM interop
 const traverse = traverseModule.default || traverseModule;
@@ -694,7 +694,7 @@ function parseJSXElement({
   const componentErrors: string[] = [];
   const componentWarnings: Set<string> = new Set();
   const metadata: Metadata = {};
-  const relativeFilepath = path.relative(process.cwd(), config.file);
+  const relativeFilepath = getRelative(config.file);
   metadata.filePaths = [relativeFilepath];
 
   // Extract surrounding lines from source file

--- a/packages/cli/src/react/jsx/utils/stringParsing/processTaggedTemplateCall/__tests__/processTaggedTemplateCall.test.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/processTaggedTemplateCall/__tests__/processTaggedTemplateCall.test.ts
@@ -5,6 +5,7 @@ import * as t from '@babel/types';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { getRelative } from '../../../../../../fs/findFilepath.js';
 import { processTaggedTemplateCall } from '../index.js';
 import { ParsingConfig, ParsingOutput } from '../../types.js';
 import { Updates } from '../../../../../../types/index.js';
@@ -188,7 +189,7 @@ describe('processTaggedTemplateCall', () => {
       'const sentence = t`The ${derive(getSubject())} is playing in the park.`;',
     ].join('\n');
     const filePath = writeTempFile(code);
-    const relativeFilePath = path.relative(process.cwd(), filePath);
+    const relativeFilePath = getRelative(filePath);
 
     const output = runProcessTaggedTemplateCall(code, 't', {
       file: filePath,

--- a/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/__tests__/processTranslationCall.test.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/__tests__/processTranslationCall.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import { afterEach, describe, it, expect } from 'vitest';
 import { parse } from '@babel/parser';
 import traverse, { NodePath } from '@babel/traverse';
 import * as t from '@babel/types';
@@ -7,6 +8,11 @@ import { ParsingConfig, ParsingOutput } from '../../types.js';
 import { Updates } from '../../../../../../types/index.js';
 
 const FILE_PATH = 'test.tsx';
+const originalSeparator = Object.getOwnPropertyDescriptor(path, 'sep')!;
+
+afterEach(() => {
+  Object.defineProperty(path, 'sep', originalSeparator);
+});
 
 function createConfig(overrides?: Partial<ParsingConfig>): ParsingConfig {
   return {
@@ -62,6 +68,23 @@ function runProcessTranslationCall(
 
   return output;
 }
+
+describe('processTranslationCall - path metadata', () => {
+  it('uses slash-separated metadata paths on Windows', () => {
+    Object.defineProperty(path, 'sep', {
+      ...originalSeparator,
+      value: path.win32.sep,
+    });
+
+    const output = runProcessTranslationCall(`t('hello')`, 't', {
+      file: 'src\\components\\Page.tsx',
+    });
+
+    expect(output.updates[0].metadata.filePaths).toEqual([
+      'src/components/Page.tsx',
+    ]);
+  });
+});
 
 describe('processTranslationCall - array support', () => {
   it('should extract each string literal in an array', () => {

--- a/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/extractStringEntryMetadata.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/extractStringEntryMetadata.ts
@@ -10,11 +10,11 @@ import { GT_ATTRIBUTES_WITH_SUGAR } from '../../constants.js';
 import { containsDeriveCall } from '../derivation/containsDeriveCall.js';
 import generateModule from '@babel/generator';
 import { mapAttributeName } from '../../mapAttributeName.js';
-import pathModule from 'node:path';
 import { isNumberLiteral } from '../../isNumberLiteral.js';
 import { extractSourceCode } from '../../extractSourceCode.js';
 import type { SourceCode } from '../../extractSourceCode.js';
 import { SURROUNDING_LINE_COUNT } from '../../../../../utils/constants.js';
+import { getRelative } from '../../../../../fs/findFilepath.js';
 
 // Handle CommonJS/ESM interop
 const generate = generateModule.default || generateModule;
@@ -62,7 +62,7 @@ export function extractStringEntryMetadata({
   surroundingLineCount?: number;
 }): InlineMetadata {
   // extract filepath for entry
-  const relativeFilepath = pathModule.relative(process.cwd(), config.file);
+  const relativeFilepath = getRelative(config.file);
 
   // extract inline metadata
   const inlineMetadata = extractInlineMetadata({


### PR DESCRIPTION
## Summary

- Store portable relative file paths and migrate legacy Windows lockfile paths and path-derived file IDs.
- Normalize lockfiles before read, write, and merge-driver comparisons so migrated and legacy entries retain their translations.
- Emit consistent slash-separated source metadata across Windows and POSIX contributors.

## Testing

- Focused lockfile and metadata regression suite — passed (5 files, 94 tests)
- `pnpm --filter gt test` — passed (122 files, 2,271 tests)
- `pnpm exec turbo run build --filter=gt...` — passed (8 packages)
- `pnpm --filter gt typecheck` — passed
- `pnpm exec oxlint packages/cli/src` — passed with 9 pre-existing warnings
- `pnpm exec oxfmt --check packages/cli/src .changeset/calm-windows-paths.md` — passed

## Notes

- Stack: 3 of 3; depends on #2159.
- Changeset: patch release added for `gt`.
- Windows-native projects adopt slash-derived file IDs on first use after upgrading; legacy v2 lockfile entries are re-keyed locally before lookup and merge.
- A Windows runtime was not available locally; regression tests simulate Windows-native separators and separately verify POSIX glob escapes.
- This stack supersedes #2057.
