### PR TITLE
fix(cli): [3/4] add lockfile path normalizer

### DIFF
--- a/packages/cli/src/fs/config/__tests__/normalizeLockfilePaths.test.ts
+++ b/packages/cli/src/fs/config/__tests__/normalizeLockfilePaths.test.ts
@@ -1,0 +1,128 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { hashStringSync } from '../../../utils/hash.js';
+import {
+  type DownloadedVersions,
+  normalizeLockfilePaths,
+} from '../downloadedVersions.js';
+
+function lockfile(fileId: string, fileName: string): DownloadedVersions {
+  return {
+    version: 2,
+    branchId: 'brc_test',
+    entries: [
+      {
+        fileId,
+        versionId: 'v1',
+        fileName,
+        translations: {
+          es: { fileName: 'content\\es\\page.mdx' },
+        },
+      },
+    ],
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('normalizeLockfilePaths', () => {
+  it('normalizes source and translation paths from any host platform', () => {
+    const data = lockfile('opaque-id', 'src\\content\\page.mdx');
+
+    normalizeLockfilePaths(data);
+
+    expect(data.entries[0]).toMatchObject({
+      fileId: 'opaque-id',
+      fileName: 'src/content/page.mdx',
+      translations: {
+        es: { fileName: 'content/es/page.mdx' },
+      },
+    });
+  });
+
+  it('re-keys a legacy ID derived from the backslash path', () => {
+    const windowsPath = 'src\\content\\page.mdx';
+    const data = lockfile(hashStringSync(windowsPath), windowsPath);
+
+    normalizeLockfilePaths(data);
+    normalizeLockfilePaths(data);
+
+    expect(data.entries[0]).toMatchObject({
+      fileId: hashStringSync('src/content/page.mdx'),
+      previousFileId: hashStringSync(windowsPath),
+      fileName: 'src/content/page.mdx',
+    });
+  });
+
+  it('does not create a duplicate ID when both path styles exist', () => {
+    const windowsPath = 'src\\content\\page.mdx';
+    const portablePath = 'src/content/page.mdx';
+    const data = lockfile(hashStringSync(windowsPath), windowsPath);
+    data.entries.push({
+      fileId: hashStringSync(portablePath),
+      versionId: 'v1',
+      fileName: portablePath,
+      translations: {},
+    });
+
+    normalizeLockfilePaths(data);
+
+    expect(data.entries.map((entry) => entry.fileId)).toEqual([
+      hashStringSync(windowsPath),
+      hashStringSync(portablePath),
+    ]);
+    expect(data.entries[0].fileName).toBe(windowsPath);
+  });
+
+  it('preserves POSIX paths containing literal backslashes', () => {
+    const literalPath = 'src/literal\\page.mdx';
+    const data = lockfile(hashStringSync(literalPath), literalPath);
+    data.entries[0].translations.es.fileName = 'content/es/literal\\page.mdx';
+
+    normalizeLockfilePaths(data);
+
+    expect(data.entries[0]).toEqual({
+      fileId: hashStringSync(literalPath),
+      versionId: 'v1',
+      fileName: literalPath,
+      translations: {
+        es: { fileName: 'content/es/literal\\page.mdx' },
+      },
+    });
+  });
+
+  it('preserves an existing all-backslash POSIX filename', () => {
+    const literalPath = 'literal\\page.mdx';
+    const data = lockfile(hashStringSync(literalPath), literalPath);
+    vi.spyOn(fs, 'existsSync').mockImplementation(
+      (candidate) => candidate === path.resolve(literalPath)
+    );
+
+    normalizeLockfilePaths(data);
+
+    expect(data.entries[0]).toMatchObject({
+      fileId: hashStringSync(literalPath),
+      fileName: literalPath,
+    });
+  });
+
+  it('leaves portable paths and their IDs unchanged', () => {
+    const portablePath = 'src/content/page.mdx';
+    const data = lockfile(hashStringSync(portablePath), portablePath);
+    data.entries[0].translations.es.fileName = 'content/es/page.mdx';
+
+    normalizeLockfilePaths(data);
+
+    expect(data.entries[0]).toEqual({
+      fileId: hashStringSync(portablePath),
+      versionId: 'v1',
+      fileName: portablePath,
+      translations: {
+        es: { fileName: 'content/es/page.mdx' },
+      },
+    });
+  });
+});

--- a/packages/cli/src/fs/config/downloadedVersions.ts
+++ b/packages/cli/src/fs/config/downloadedVersions.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { logger } from '../../console/logger.js';
 import type { Settings } from '../../types/index.js';
+import { hashStringSync } from '../../utils/hash.js';
 
 const GT_LOCK_FILE = 'gt-lock.json';
 
@@ -15,6 +16,7 @@ export type DownloadedTranslation = {
 
 export type DownloadedVersionEntry = {
   fileId: string;
+  previousFileId?: string; // server ID retained until a path migration succeeds
   versionId: string;
   fileName?: string; // source file path
   staged?: boolean; // true if this entry was staged but not yet downloaded
@@ -48,6 +50,82 @@ export type DownloadedVersionsV1 = {
     };
   };
 };
+
+/**
+ * Normalizes serialized v2 lockfile paths to portable forward slashes.
+ * This is intentionally platform-independent because a lockfile written on
+ * Windows may later be read on POSIX. Legacy file IDs are re-keyed only when
+ * they can be proven to be the hash of the original backslash path, and the
+ * previous server identity is retained until the migration succeeds.
+ */
+export function normalizeLockfilePaths(data: DownloadedVersions): void {
+  const existingFileIds = new Set(data.entries.map((entry) => entry.fileId));
+  const plannedFileIds = new Map<string, number>();
+  const plans = data.entries.map((entry) => {
+    const originalFileName = entry.fileName;
+    const normalizedFileName =
+      typeof originalFileName === 'string'
+        ? normalizeSerializedLockfilePath(originalFileName)
+        : originalFileName;
+    const nextFileId =
+      typeof originalFileName === 'string' &&
+      typeof normalizedFileName === 'string' &&
+      originalFileName !== normalizedFileName &&
+      entry.fileId === hashStringSync(originalFileName)
+        ? hashStringSync(normalizedFileName)
+        : undefined;
+
+    if (nextFileId) {
+      plannedFileIds.set(nextFileId, (plannedFileIds.get(nextFileId) ?? 0) + 1);
+    }
+
+    return { entry, normalizedFileName, nextFileId };
+  });
+
+  for (const { entry, normalizedFileName, nextFileId } of plans) {
+    if (typeof entry.fileName === 'string') {
+      const collides =
+        nextFileId !== undefined &&
+        ((existingFileIds.has(nextFileId) && nextFileId !== entry.fileId) ||
+          (plannedFileIds.get(nextFileId) ?? 0) > 1);
+
+      if (!collides) {
+        if (nextFileId) {
+          entry.previousFileId ??= entry.fileId;
+          entry.fileId = nextFileId;
+        }
+        entry.fileName = normalizedFileName;
+      }
+    }
+    if (!entry.translations || typeof entry.translations !== 'object') {
+      continue;
+    }
+    for (const translation of Object.values(entry.translations)) {
+      if (translation && typeof translation.fileName === 'string') {
+        translation.fileName = normalizeSerializedLockfilePath(
+          translation.fileName
+        );
+      }
+    }
+  }
+}
+
+function normalizeSerializedLockfilePath(fileName: string): string {
+  if (!fileName.includes('\\')) return fileName;
+
+  // A pre-normalization Windows CLI emitted only native separators. Mixed
+  // separators therefore indicate a POSIX filename containing a literal
+  // backslash, which must not be rewritten.
+  if (path.sep !== '\\' && fileName.includes('/')) return fileName;
+
+  // The all-backslash form is ambiguous on POSIX. Prefer a real literal path
+  // over a speculative Windows migration when the file still exists.
+  if (path.sep !== '\\' && fs.existsSync(path.resolve(fileName))) {
+    return fileName;
+  }
+
+  return fileName.replace(/\\/g, '/');
+}
 
 // ── Conversion helpers ──────────────────────────────────────────────
 


### PR DESCRIPTION
- add helper

## Summary

- Add the standalone `normalizeLockfilePaths()` helper for serialized v2 lockfiles.
- Normalize unambiguous legacy Windows source and translation paths and re-key only IDs proven to be hashes of the original path.
- Retain the previous server ID for later migration, avoid converging-ID collisions, and preserve literal POSIX backslashes, including existing all-backslash filenames.

## Testing

- `pnpm --filter gt exec vitest run src/fs/config/__tests__/normalizeLockfilePaths.test.ts` — passed (6 tests)
- `pnpm --filter gt typecheck` — passed
- Top-of-stack `pnpm exec turbo run build --filter=gt...` — passed (8 packages)

## Notes

- Stack: 3 of 4; depends on #2159 and continues in #2163.
- This PR intentionally adds and tests the normalizer without integrating it into lockfile reads or writes; #2163 owns those consumers.
- Changeset deferred to the top PR so the stack produces one release note.










<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds a lockfile-path normalizer for portable serialized v2 lockfiles and focused unit coverage. The helper correctly normalizes unambiguous Windows paths, safely migrates hash-derived IDs without collisions, retains prior server identity, and preserves literal POSIX filenames containing backslashes. No blocking failure remains.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge.

No blocking failure remains.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused normalizeLockfilePaths Vitest suite on the reviewed commit; all 6 tests passed.
- Ran an authored supplemental Vitest test for preserving an existing server ID and a real all-backslash POSIX filename; both tests passed.
- Compared against the parent commit to verify the helper did not exist before this PR; the baseline worktree run failed with normalizeLockfilePaths is not a function.
- Reviewed the supplemental test source normalizeLockfile-paths runtime test to confirm explicit runtime coverage for edge cases.
- Verified the supplemental test suite on the PR commit passes two additional edge-case tests.

<a href="https://app.greptile.com/trex/runs/20712730/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (6): Last reviewed commit: ["fix(cli): add lockfile path normalizer"](https://github.com/generaltranslation/gt/commit/a6610b15a7737e2a8ced4e8fac3ef79f7579a6d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56346408)</sub>

<!-- /greptile_comment -->