### PR TITLE
fix(cli): [4/4] apply lockfile path normalization

### DIFF
--- a/.changeset/calm-windows-paths.md
+++ b/.changeset/calm-windows-paths.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Normalize file paths and glob patterns on Windows while preserving POSIX glob escapes. Existing Windows `gt-lock.json` paths and path-derived file IDs are migrated to portable forward slashes, and review gates, source metadata, and font globs now resolve consistently.

--- a/packages/cli/src/api/__tests__/collectUserEditDiffs.test.ts
+++ b/packages/cli/src/api/__tests__/collectUserEditDiffs.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
-import * as path from 'node:path';
+import path from 'node:path';
 import os from 'node:os';
 import { collectAndSendUserEditDiffs } from '../collectUserEditDiffs.js';
 import { createMockSettings } from '../__mocks__/settings.js';
@@ -9,6 +9,8 @@ import { getGitUnifiedDiff } from '../../utils/gitDiff.js';
 import { hashStringSync } from '../../utils/hash.js';
 import {
   readLockfile,
+  migrateLockfileFileIds,
+  DownloadedVersions,
   DownloadedVersionsV1,
 } from '../../fs/config/downloadedVersions.js';
 import { createFileMapping } from '../../formats/files/fileMapping.js';
@@ -62,7 +64,9 @@ describe('collectAndSendUserEditDiffs', () => {
       },
     });
 
-  const writeLockFile = (content: DownloadedVersionsV1) => {
+  const writeLockFile = (
+    content: DownloadedVersions | DownloadedVersionsV1
+  ) => {
     fs.writeFileSync(
       path.join(tempDir, 'gt-lock.json'),
       JSON.stringify(content, null, 2)
@@ -190,6 +194,350 @@ describe('collectAndSendUserEditDiffs', () => {
     expect(getGitUnifiedDiff).toHaveBeenCalledTimes(1);
     expect(gt.submitUserEditDiffs).toHaveBeenCalledTimes(1);
   });
+
+  it.skipIf(path.sep === '\\')(
+    'skips a tentative V2 alias on POSIX until the server accepts the move',
+    async () => {
+      const settings = buildSettings();
+      const translatedPath = path.join(tempDir, 'docs', 'ja', 'doc.md');
+      fs.mkdirSync(path.dirname(translatedPath), { recursive: true });
+      fs.writeFileSync(translatedPath, 'changed content');
+
+      const windowsFileName = 'docs\\doc.md';
+      const windowsFileId = hashStringSync(windowsFileName);
+      writeLockFile({
+        version: 2,
+        branchId: 'branch1',
+        entries: [
+          {
+            fileId: windowsFileId,
+            versionId: 'version1',
+            fileName: windowsFileName,
+            translations: {
+              ja: {
+                updatedAt: new Date().toISOString(),
+                postProcessHash: hashStringSync('original content'),
+              },
+            },
+          },
+        ],
+      });
+
+      await collectAndSendUserEditDiffs(
+        [
+          {
+            fileName: 'docs/doc.md',
+            fileFormat: 'MD',
+            branchId: 'branch1',
+            fileId: hashStringSync('docs/doc.md'),
+            versionId: 'version2',
+          },
+        ],
+        settings
+      );
+
+      expect(gt.queryFileData).not.toHaveBeenCalled();
+      expect(gt.downloadFileBatch).not.toHaveBeenCalled();
+      expect(gt.submitUserEditDiffs).not.toHaveBeenCalled();
+    }
+  );
+
+  it('uses a V2 legacy alias for standalone save-local on Windows', async () => {
+    const originalSeparator = Object.getOwnPropertyDescriptor(path, 'sep')!;
+    const settings = buildSettings();
+    const translatedPath = path.join(tempDir, 'docs', 'ja', 'doc.md');
+    fs.mkdirSync(path.dirname(translatedPath), { recursive: true });
+    fs.writeFileSync(translatedPath, 'changed content');
+
+    const windowsFileName = 'docs\\doc.md';
+    const windowsFileId = hashStringSync(windowsFileName);
+    const portableFileId = hashStringSync('docs/doc.md');
+    writeLockFile({
+      version: 2,
+      branchId: 'branch1',
+      entries: [
+        {
+          fileId: windowsFileId,
+          versionId: 'version1',
+          fileName: windowsFileName,
+          translations: {
+            ja: { postProcessHash: hashStringSync('original content') },
+          },
+        },
+      ],
+    });
+    vi.mocked(gt.queryFileData).mockResolvedValue({
+      translatedFiles: [
+        {
+          branchId: 'branch1',
+          fileId: windowsFileId,
+          versionId: 'version1',
+          locale: 'ja',
+          completedAt: new Date().toISOString(),
+        },
+      ],
+    });
+    vi.mocked(gt.downloadFileBatch).mockResolvedValue({
+      files: [
+        {
+          branchId: 'branch1',
+          fileId: windowsFileId,
+          versionId: 'version1',
+          locale: 'ja',
+          data: 'server content',
+        },
+      ],
+    });
+    vi.mocked(getGitUnifiedDiff).mockResolvedValue('mock-diff');
+
+    try {
+      Object.defineProperty(path, 'sep', {
+        ...originalSeparator,
+        value: path.win32.sep,
+      });
+      await collectAndSendUserEditDiffs(
+        [
+          {
+            fileName: 'docs/doc.md',
+            fileFormat: 'MD',
+            branchId: 'branch1',
+            fileId: portableFileId,
+            versionId: 'version2',
+          },
+        ],
+        settings
+      );
+    } finally {
+      Object.defineProperty(path, 'sep', originalSeparator);
+    }
+
+    expect(gt.queryFileData).toHaveBeenCalledWith({
+      translatedFiles: [
+        {
+          branchId: 'branch1',
+          fileId: windowsFileId,
+          versionId: 'version1',
+          locale: 'ja',
+        },
+      ],
+    });
+    expect(gt.submitUserEditDiffs).toHaveBeenCalledWith({
+      diffs: [expect.objectContaining({ fileId: windowsFileId })],
+    });
+  });
+
+  it('finds a V1 legacy ID for standalone save-local on Windows', async () => {
+    const originalSeparator = Object.getOwnPropertyDescriptor(path, 'sep')!;
+    const settings = buildSettings();
+    const translatedPath = path.join(tempDir, 'docs', 'ja', 'doc.md');
+    fs.mkdirSync(path.dirname(translatedPath), { recursive: true });
+    fs.writeFileSync(translatedPath, 'changed content');
+
+    const windowsFileId = hashStringSync('docs\\doc.md');
+    const portableFileId = hashStringSync('docs/doc.md');
+    writeLockFile({
+      version: 1,
+      entries: {
+        branch1: {
+          [windowsFileId]: {
+            version1: {
+              ja: { postProcessHash: hashStringSync('original content') },
+            },
+          },
+        },
+      },
+    });
+    vi.mocked(gt.queryFileData).mockResolvedValue({
+      translatedFiles: [
+        {
+          branchId: 'branch1',
+          fileId: windowsFileId,
+          versionId: 'version1',
+          locale: 'ja',
+          completedAt: new Date().toISOString(),
+        },
+      ],
+    });
+    vi.mocked(gt.downloadFileBatch).mockResolvedValue({
+      files: [
+        {
+          branchId: 'branch1',
+          fileId: windowsFileId,
+          versionId: 'version1',
+          locale: 'ja',
+          data: 'server content',
+        },
+      ],
+    });
+    vi.mocked(getGitUnifiedDiff).mockResolvedValue('mock-diff');
+
+    try {
+      Object.defineProperty(path, 'sep', {
+        ...originalSeparator,
+        value: path.win32.sep,
+      });
+      await collectAndSendUserEditDiffs(
+        [
+          {
+            fileName: 'docs/doc.md',
+            fileFormat: 'MD',
+            branchId: 'branch1',
+            fileId: portableFileId,
+            versionId: 'version2',
+          },
+        ],
+        settings
+      );
+    } finally {
+      Object.defineProperty(path, 'sep', originalSeparator);
+    }
+
+    expect(gt.queryFileData).toHaveBeenCalledWith({
+      translatedFiles: [
+        {
+          branchId: 'branch1',
+          fileId: windowsFileId,
+          versionId: 'version1',
+          locale: 'ja',
+        },
+      ],
+    });
+    expect(gt.submitUserEditDiffs).toHaveBeenCalledWith({
+      diffs: [expect.objectContaining({ fileId: windowsFileId })],
+    });
+  });
+
+  it('uses migrated V1 history after the server accepts the move', async () => {
+    const settings = buildSettings();
+    const translatedPath = path.join(tempDir, 'docs', 'ja', 'doc.md');
+    fs.mkdirSync(path.dirname(translatedPath), { recursive: true });
+    fs.writeFileSync(translatedPath, 'changed content');
+
+    const windowsFileId = hashStringSync('docs\\doc.md');
+    writeLockFile({
+      version: 1,
+      entries: {
+        branch1: {
+          [windowsFileId]: {
+            version1: {
+              ja: {
+                updatedAt: new Date().toISOString(),
+                postProcessHash: hashStringSync('original content'),
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const portableFileId = hashStringSync('docs/doc.md');
+    expect(
+      migrateLockfileFileIds('branch1', [
+        {
+          oldFileId: windowsFileId,
+          newFileId: portableFileId,
+          newFileName: 'docs/doc.md',
+        },
+      ])
+    ).toBe(1);
+
+    vi.mocked(gt.queryFileData).mockResolvedValue({
+      translatedFiles: [
+        {
+          branchId: 'branch1',
+          fileId: portableFileId,
+          versionId: 'version1',
+          locale: 'ja',
+          completedAt: new Date().toISOString(),
+        },
+      ],
+    });
+    vi.mocked(gt.downloadFileBatch).mockResolvedValue({
+      files: [
+        {
+          branchId: 'branch1',
+          fileId: portableFileId,
+          versionId: 'version1',
+          locale: 'ja',
+          data: 'server content',
+        },
+      ],
+    });
+    vi.mocked(getGitUnifiedDiff).mockResolvedValue('mock-diff');
+
+    await collectAndSendUserEditDiffs(
+      [
+        {
+          fileName: 'docs/doc.md',
+          fileFormat: 'MD',
+          branchId: 'branch1',
+          fileId: portableFileId,
+          versionId: 'version2',
+        },
+      ],
+      settings
+    );
+
+    expect(gt.queryFileData).toHaveBeenCalledWith({
+      translatedFiles: [
+        {
+          branchId: 'branch1',
+          fileId: portableFileId,
+          versionId: 'version1',
+          locale: 'ja',
+        },
+      ],
+    });
+    expect(gt.submitUserEditDiffs).toHaveBeenCalledWith({
+      diffs: [expect.objectContaining({ fileId: portableFileId })],
+    });
+  });
+
+  it.skipIf(path.sep === '\\')(
+    'does not borrow an unconfirmed V1 ID for an absent literal POSIX path',
+    async () => {
+      const settings = buildSettings();
+      const translatedPath = path.join(tempDir, 'docs', 'ja', 'doc.md');
+      fs.mkdirSync(path.dirname(translatedPath), { recursive: true });
+      fs.writeFileSync(translatedPath, 'changed content');
+      const literalFileId = hashStringSync('docs\\doc.md');
+      writeLockFile({
+        version: 1,
+        entries: {
+          branch1: {
+            [literalFileId]: {
+              version1: {
+                ja: {
+                  updatedAt: new Date().toISOString(),
+                  postProcessHash: hashStringSync('original content'),
+                },
+              },
+            },
+          },
+        },
+      });
+
+      vi.mocked(gt.queryFileData).mockResolvedValue({ translatedFiles: [] });
+      vi.mocked(gt.downloadFileBatch).mockResolvedValue({ files: [] });
+
+      await collectAndSendUserEditDiffs(
+        [
+          {
+            fileName: 'docs/doc.md',
+            fileFormat: 'MD',
+            branchId: 'branch1',
+            fileId: hashStringSync('docs/doc.md'),
+            versionId: 'version2',
+          },
+        ],
+        settings
+      );
+
+      expect(gt.queryFileData).not.toHaveBeenCalled();
+      expect(gt.downloadFileBatch).not.toHaveBeenCalled();
+      expect(gt.submitUserEditDiffs).not.toHaveBeenCalled();
+    }
+  );
 
   it('uses the latest downloaded version when the uploaded version has changed', async () => {
     const settings = buildSettings();

--- a/packages/cli/src/api/__tests__/downloadFileBatch.test.ts
+++ b/packages/cli/src/api/__tests__/downloadFileBatch.test.ts
@@ -52,15 +52,22 @@ vi.mock('path', async () => {
   };
 });
 
-vi.mock('../../fs/config/downloadedVersions.js', () => ({
-  readLockfile: vi.fn(() => ({
-    data: { entries: [] },
-    entryMap: new Map(),
-    originalV1: false,
-  })),
-  writeLockfile: vi.fn(),
-  findOrCreateEntry: vi.fn(() => ({ translations: {} })),
-}));
+vi.mock('../../fs/config/downloadedVersions.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('../../fs/config/downloadedVersions.js')
+    >();
+  return {
+    ...actual,
+    readLockfile: vi.fn(() => ({
+      data: { entries: [] },
+      entryMap: new Map(),
+      originalV1: false,
+    })),
+    writeLockfile: vi.fn(),
+    findOrCreateEntry: vi.fn(() => ({ translations: {} })),
+  };
+});
 
 vi.mock('../../console/logger.js', () => ({
   logger: {
@@ -544,6 +551,117 @@ describe('downloadFileBatch', () => {
 
     expect(result.successful).toHaveLength(1);
     expect(lockEntry.translations.es.fileName).toBe('public/gt/es.json');
+  });
+
+  it('retires legacy identity metadata after a current-ID download succeeds', async () => {
+    const files = createBatchedFiles(1, { locale: 'es' });
+    const fileTracker = createMockFileTracker(files);
+    const lockEntry: DownloadedVersionEntry = {
+      fileId: 'file-1',
+      previousFileId: 'windows-file-1',
+      versionId: 'version-1',
+      translations: {
+        es: { postProcessHash: 'old-es-hash' },
+        fr: { postProcessHash: 'old-fr-hash' },
+      },
+    };
+    const entryMap = new Map([
+      ['file-1', lockEntry],
+      ['windows-file-1', lockEntry],
+    ]);
+    vi.mocked(readLockfile).mockReturnValue({
+      data: {
+        version: 2,
+        branchId: 'branch-1',
+        entries: [lockEntry],
+      },
+      entryMap,
+      originalV1: null,
+    });
+    vi.mocked(findOrCreateEntry).mockReturnValue(lockEntry);
+    vi.mocked(gt.downloadFileBatch).mockResolvedValue({
+      files: [
+        {
+          id: 'translation-1',
+          branchId: 'branch-1',
+          fileId: 'file-1',
+          versionId: 'version-1',
+          locale: 'es',
+          fileFormat: 'GTJSON' as FileFormat,
+          data: '{"hello":"Hola"}',
+          fileName: 'es.json',
+          metadata: {},
+        },
+      ],
+      count: 1,
+    });
+    setupFileSystemMocks();
+
+    const result = await downloadFileBatch(
+      fileTracker,
+      files,
+      createMockSettings()
+    );
+
+    expect(result.successful).toHaveLength(1);
+    expect(lockEntry.previousFileId).toBeUndefined();
+    expect(Object.keys(lockEntry.translations)).toEqual(['es']);
+    expect(entryMap.has('windows-file-1')).toBe(false);
+  });
+
+  it('still trusts legacy metadata when downloading by the legacy server ID', async () => {
+    const files = createBatchedFiles(1, {
+      fileId: 'windows-file-1',
+      locale: 'es',
+    });
+    const fileTracker = createMockFileTracker(files);
+    const lockEntry: DownloadedVersionEntry = {
+      fileId: 'file-1',
+      previousFileId: 'windows-file-1',
+      versionId: 'version-1',
+      translations: {
+        es: { postProcessHash: 'legacy-es-hash' },
+      },
+    };
+    vi.mocked(readLockfile).mockReturnValue({
+      data: {
+        version: 2,
+        branchId: 'branch-1',
+        entries: [lockEntry],
+      },
+      entryMap: new Map([
+        ['file-1', lockEntry],
+        ['windows-file-1', lockEntry],
+      ]),
+      originalV1: null,
+    });
+    vi.mocked(gt.downloadFileBatch).mockResolvedValue({
+      files: [
+        {
+          id: 'translation-1',
+          branchId: 'branch-1',
+          fileId: 'windows-file-1',
+          versionId: 'version-1',
+          locale: 'es',
+          fileFormat: 'GTJSON' as FileFormat,
+          data: '{"hello":"Hola"}',
+          fileName: 'es.json',
+          metadata: {},
+        },
+      ],
+      count: 1,
+    });
+    setupFileSystemMocks();
+
+    const result = await downloadFileBatch(
+      fileTracker,
+      files,
+      createMockSettings()
+    );
+
+    expect(result.skipped).toHaveLength(1);
+    expect(result.successful).toHaveLength(0);
+    expect(lockEntry.previousFileId).toBe('windows-file-1');
   });
 
   it.each([

--- a/packages/cli/src/api/collectUserEditDiffs.ts
+++ b/packages/cli/src/api/collectUserEditDiffs.ts
@@ -1,5 +1,5 @@
 import * as fs from 'node:fs';
-import * as path from 'node:path';
+import path from 'node:path';
 import {
   readLockfile,
   EntryMap,
@@ -17,6 +17,7 @@ import { extractJson } from '../formats/json/extractJson.js';
 import { extractYaml } from '../formats/yaml/extractYaml.js';
 
 type LatestDownloadedVersion = {
+  serverFileId: string;
   versionId: string;
   entry: DownloadedTranslation;
 };
@@ -24,15 +25,36 @@ type LatestDownloadedVersion = {
 const findLatestDownloadedVersion = (
   entryMap: EntryMap,
   fileId: string,
+  fileName: string,
   locale: string
 ): LatestDownloadedVersion | null => {
-  const entry = entryMap.get(fileId);
-  if (!entry) return null;
+  const candidates = [entryMap.get(fileId)];
+  // A V1 lockfile has no filename to normalize. On Windows, reconstructing
+  // its old native-separator ID is unambiguous and keeps standalone
+  // `gt save-local` working before any upload/move workflow runs.
+  if (path.sep === '\\' && !fileName.includes('\\')) {
+    const legacyWindowsFileId = hashStringSync(fileName.replace(/\//g, '\\'));
+    if (legacyWindowsFileId !== fileId) {
+      const legacyEntry = entryMap.get(legacyWindowsFileId);
+      if (!candidates.includes(legacyEntry)) candidates.push(legacyEntry);
+    }
+  }
 
-  const translation = entry.translations[locale];
-  if (!translation) return null;
-
-  return { versionId: entry.versionId, entry: translation };
+  for (const entry of candidates) {
+    // On POSIX, previousFileId is only a tentative alias: an absent literal
+    // backslash path is indistinguishable from a legacy Windows path. Windows
+    // has no such ambiguity, so standalone save-local may use the old ID.
+    if (!entry || (entry.previousFileId && path.sep !== '\\')) continue;
+    const translation = entry.translations[locale];
+    if (translation) {
+      return {
+        serverFileId: entry.previousFileId ?? entry.fileId,
+        versionId: entry.versionId,
+        entry: translation,
+      };
+    }
+  }
+  return null;
 };
 
 /**
@@ -83,6 +105,7 @@ export async function collectAndSendUserEditDiffs(
       const latestDownloaded = findLatestDownloadedVersion(
         entryMap,
         uploadedFile.fileId,
+        uploadedFile.fileName,
         locale
       );
 
@@ -105,7 +128,7 @@ export async function collectAndSendUserEditDiffs(
       candidates.push({
         branchId: uploadedFile.branchId,
         fileName: uploadedFile.fileName,
-        fileId: uploadedFile.fileId,
+        fileId: latestDownloaded.serverFileId,
         versionId: latestDownloaded.versionId,
         locale: locale,
         outputPath,

--- a/packages/cli/src/api/downloadFileBatch.ts
+++ b/packages/cli/src/api/downloadFileBatch.ts
@@ -15,6 +15,7 @@ import {
   shouldResolveRefs,
 } from '../utils/resolveMintlifyRefs.js';
 import {
+  activateCurrentFileIdentity,
   readLockfile,
   writeLockfile,
   findOrCreateEntry,
@@ -277,8 +278,12 @@ export async function downloadFileBatch(
         }
         // If a local translation already exists for the same source version, skip overwrite
         const existingEntry = entryMap.get(fileId);
+        const metadataMatchesServerIdentity =
+          !existingEntry?.previousFileId ||
+          fileId === existingEntry.previousFileId;
         const downloadedTranslation =
-          existingEntry?.versionId === versionId
+          existingEntry?.versionId === versionId &&
+          metadataMatchesServerIdentity
             ? existingEntry.translations[locale]
             : undefined;
         const fileExists = fs.existsSync(outputPath);
@@ -310,6 +315,7 @@ export async function downloadFileBatch(
               fileId,
               versionId
             );
+            activateCurrentFileIdentity(entry, fileId, entryMap);
             entry.fileName = inputPath;
             entry.translations[locale] = {
               updatedAt: new Date().toISOString(),
@@ -452,6 +458,7 @@ export async function downloadFileBatch(
             fileId,
             versionId
           );
+          activateCurrentFileIdentity(entry, fileId, entryMap);
           entry.fileName = inputPath;
           entry.translations[locale] = {
             updatedAt: new Date().toISOString(),

--- a/packages/cli/src/cli/commands/__tests__/stage.test.ts
+++ b/packages/cli/src/cli/commands/__tests__/stage.test.ts
@@ -258,4 +258,27 @@ describe('handleStage config ids', () => {
     expect(writeStagedEntries).not.toHaveBeenCalled();
     expect(updateConfig).not.toHaveBeenCalled();
   });
+
+  it('does not accept a source confirmation from another branch', async () => {
+    vi.mocked(runStageFilesWorkflow).mockResolvedValue({
+      branchData,
+      uploadedFiles: [
+        {
+          ...templateFile,
+          branchId: 'branch-2',
+        },
+      ],
+      enqueueResult: {
+        jobData: {},
+        locales: ['es'],
+        message: 'No files need to be enqueued',
+      },
+    });
+
+    const result = await handleStage(options, settings(), 'gt-react', true);
+
+    expect(result?.fileVersionData).toBeUndefined();
+    expect(writeStagedEntries).not.toHaveBeenCalled();
+    expect(updateConfig).not.toHaveBeenCalled();
+  });
 });

--- a/packages/cli/src/cli/commands/__tests__/stage.test.ts
+++ b/packages/cli/src/cli/commands/__tests__/stage.test.ts
@@ -10,6 +10,7 @@ import { handleStage } from '../stage.js';
 import { collectFiles } from '../../../formats/files/collectFiles.js';
 import { runStageFilesWorkflow } from '../../../workflows/stage.js';
 import updateConfig from '../../../fs/config/updateConfig.js';
+import { writeStagedEntries } from '../../../fs/config/downloadedVersions.js';
 
 vi.mock('../../../formats/files/collectFiles.js', () => ({
   collectFiles: vi.fn(),
@@ -92,6 +93,12 @@ describe('handleStage config ids', () => {
     });
     vi.mocked(runStageFilesWorkflow).mockResolvedValue({
       branchData,
+      uploadedFiles: [
+        {
+          ...templateFile,
+          branchId: branchData.currentBranch.id,
+        },
+      ],
       enqueueResult: {
         jobData: {},
         locales: ['es'],
@@ -194,6 +201,61 @@ describe('handleStage config ids', () => {
       false
     );
 
+    expect(updateConfig).not.toHaveBeenCalled();
+  });
+
+  it('stages and returns only source versions confirmed by the API', async () => {
+    const omittedFile = {
+      fileName: 'src/omitted.json',
+      content: '{}',
+      fileFormat: 'JSON',
+      fileId: 'omitted-file',
+      versionId: 'omitted-version',
+      locale: 'en',
+    } satisfies FileToUpload;
+    vi.mocked(collectFiles).mockResolvedValue({
+      files: [templateFile, omittedFile],
+      reactComponents: 1,
+      publishMap: new Map(),
+    });
+
+    const result = await handleStage(options, settings(), 'gt-react', true);
+
+    expect(result?.fileVersionData).toEqual({
+      [TEMPLATE_FILE_ID]: {
+        versionId: templateFile.versionId,
+        fileName: templateFile.fileName,
+        componentCount: 0,
+      },
+    });
+    expect(writeStagedEntries).toHaveBeenCalledWith(
+      expect.any(Object),
+      [
+        {
+          fileId: TEMPLATE_FILE_ID,
+          versionId: templateFile.versionId,
+          fileName: templateFile.fileName,
+        },
+      ],
+      branchData.currentBranch.id
+    );
+  });
+
+  it('does not stage, download, or pin an unconfirmed source version', async () => {
+    vi.mocked(runStageFilesWorkflow).mockResolvedValue({
+      branchData,
+      uploadedFiles: [],
+      enqueueResult: {
+        jobData: {},
+        locales: ['es'],
+        message: 'No files need to be enqueued',
+      },
+    });
+
+    const result = await handleStage(options, settings(), 'gt-react', true);
+
+    expect(result?.fileVersionData).toBeUndefined();
+    expect(writeStagedEntries).not.toHaveBeenCalled();
     expect(updateConfig).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/cli/commands/stage.ts
+++ b/packages/cli/src/cli/commands/stage.ts
@@ -62,20 +62,34 @@ export async function handleStage(
   let jobData: EnqueueFilesResult | undefined;
   let branchData: BranchData | undefined;
   if (allFiles.length > 0) {
-    const { branchData: branchDataResult, enqueueResult } =
-      await runStageFilesWorkflow({
-        files: allFiles,
-        options,
-        settings,
-        inlineLibrary,
-      });
+    const {
+      branchData: branchDataResult,
+      enqueueResult,
+      uploadedFiles,
+    } = await runStageFilesWorkflow({
+      files: allFiles,
+      options,
+      settings,
+      inlineLibrary,
+    });
     jobData = enqueueResult;
     branchData = branchDataResult;
 
-    fileVersionData = convertToFileTranslationData(allFiles);
+    // Continue only with the exact source versions that the API confirmed.
+    // A partial upload response must not create staged/download state for a
+    // source version that does not exist on the server.
+    const uploadedFileKeys = new Set(
+      uploadedFiles.map((file) => `${file.fileId}:${file.versionId}`)
+    );
+    const confirmedFiles = allFiles.filter((file) =>
+      uploadedFileKeys.has(`${file.fileId}:${file.versionId}`)
+    );
+    if (confirmedFiles.length > 0) {
+      fileVersionData = convertToFileTranslationData(confirmedFiles);
+    }
 
     // Write staged entries to the lockfile
-    if (stage) {
+    if (stage && fileVersionData) {
       const stagedFiles = Object.entries(fileVersionData).map(
         ([fileId, data]) => ({
           fileId,
@@ -85,10 +99,10 @@ export async function handleStage(
       );
       writeStagedEntries(settings, stagedFiles, branchData.currentBranch.id);
     }
-    const templateData = allFiles.find(
+    const templateData = confirmedFiles.find(
       (file) => file.fileId === TEMPLATE_FILE_ID
     );
-    if (settings.omitConfigIds) {
+    if (settings.omitConfigIds && confirmedFiles.length > 0) {
       // Remove persisted config IDs only after staging has succeeded, so
       // failed and empty runs keep the previous pinned version/branch state
       await updateConfig(settings.config, {

--- a/packages/cli/src/cli/commands/stage.ts
+++ b/packages/cli/src/cli/commands/stage.ts
@@ -75,14 +75,18 @@ export async function handleStage(
     jobData = enqueueResult;
     branchData = branchDataResult;
 
-    // Continue only with the exact source versions that the API confirmed.
-    // A partial upload response must not create staged/download state for a
-    // source version that does not exist on the server.
+    // Continue only with exact source versions confirmed on the active branch.
+    // A partial or cross-branch upload response must not create staged/download
+    // state for a source version that does not exist on this branch.
     const uploadedFileKeys = new Set(
-      uploadedFiles.map((file) => `${file.fileId}:${file.versionId}`)
+      uploadedFiles.map(
+        (file) => `${file.branchId}:${file.fileId}:${file.versionId}`
+      )
     );
     const confirmedFiles = allFiles.filter((file) =>
-      uploadedFileKeys.has(`${file.fileId}:${file.versionId}`)
+      uploadedFileKeys.has(
+        `${branchDataResult.currentBranch.id}:${file.fileId}:${file.versionId}`
+      )
     );
     if (confirmedFiles.length > 0) {
       fileVersionData = convertToFileTranslationData(confirmedFiles);

--- a/packages/cli/src/fs/config/__tests__/downloadedVersions.test.ts
+++ b/packages/cli/src/fs/config/__tests__/downloadedVersions.test.ts
@@ -7,11 +7,14 @@ import {
   writeLockfile,
   findOrCreateEntry,
   buildEntryMap,
+  activateCurrentFileIdentity,
   writeStagedEntries,
   getStagedEntriesFromLockfile,
+  migrateLockfileFileIds,
   DownloadedVersionEntry,
 } from '../downloadedVersions.js';
 import { createMockSettings } from '../../../api/__mocks__/settings.js';
+import { hashStringSync } from '../../../utils/hash.js';
 
 describe('readLockfile / writeLockfile', () => {
   const originalCwd = process.cwd();
@@ -79,6 +82,101 @@ describe('readLockfile / writeLockfile', () => {
         '2025-01-01T00:00:00Z'
       );
       expect(originalV1).toBeNull();
+    });
+
+    it('normalizes Windows paths from a v2 lockfile', () => {
+      writeLockFile({
+        version: 2,
+        branchId: 'brc_abc',
+        entries: [
+          {
+            fileId: 'f1',
+            versionId: 'v1',
+            fileName: 'src\\content\\page.mdx',
+            staged: true,
+            translations: {
+              es: { fileName: 'content\\es\\page.mdx' },
+            },
+          },
+        ],
+      });
+
+      const { data } = readLockfile(settings('brc_abc'));
+
+      expect(data.entries[0].fileName).toBe('src/content/page.mdx');
+      expect(data.entries[0].translations.es.fileName).toBe(
+        'content/es/page.mdx'
+      );
+    });
+
+    it('re-keys path-derived file IDs when normalizing Windows paths', () => {
+      const windowsFileName = 'src\\content\\page.mdx';
+      const posixFileName = 'src/content/page.mdx';
+      writeLockFile({
+        version: 2,
+        branchId: 'brc_abc',
+        entries: [
+          {
+            fileId: hashStringSync(windowsFileName),
+            versionId: 'v1',
+            fileName: windowsFileName,
+            translations: {
+              es: {
+                fileName: 'content\\es\\page.mdx',
+                postProcessHash: 'translation-hash',
+              },
+            },
+          },
+        ],
+      });
+
+      const { data, entryMap } = readLockfile(settings('brc_abc'));
+      const normalizedFileId = hashStringSync(posixFileName);
+
+      expect(data.entries[0]).toMatchObject({
+        fileId: normalizedFileId,
+        previousFileId: hashStringSync(windowsFileName),
+        fileName: posixFileName,
+        translations: {
+          es: {
+            fileName: 'content/es/page.mdx',
+            postProcessHash: 'translation-hash',
+          },
+        },
+      });
+      expect(entryMap.get(normalizedFileId)).toBe(data.entries[0]);
+      expect(entryMap.get(hashStringSync(windowsFileName))).toBe(
+        data.entries[0]
+      );
+    });
+
+    it('does not mutate caller data while normalizing a write', () => {
+      const windowsFileName = 'src\\content\\page.mdx';
+      const data = {
+        version: 2 as const,
+        branchId: 'brc_abc',
+        entries: [
+          {
+            fileId: hashStringSync(windowsFileName),
+            versionId: 'v1',
+            fileName: windowsFileName,
+            translations: {},
+          },
+        ],
+      };
+
+      writeLockfile(data, null);
+
+      expect(data.entries[0]).toEqual({
+        fileId: hashStringSync(windowsFileName),
+        versionId: 'v1',
+        fileName: windowsFileName,
+        translations: {},
+      });
+      expect(readLockFile().entries[0]).toMatchObject({
+        fileId: hashStringSync('src/content/page.mdx'),
+        previousFileId: hashStringSync(windowsFileName),
+      });
     });
 
     it('updates branchId on v2 file to current branch', () => {
@@ -186,6 +284,125 @@ describe('readLockfile / writeLockfile', () => {
       expect(written.version).toBe(2);
       expect(written.branchId).toBe('brc_123');
       expect(written.entries).toHaveLength(1);
+    });
+
+    it('writes lockfile paths with forward slashes', () => {
+      writeLockfile(
+        {
+          version: 2,
+          branchId: 'brc_123',
+          entries: [
+            {
+              fileId: 'f1',
+              versionId: 'v1',
+              fileName: 'src\\content\\page.mdx',
+              translations: {
+                es: { fileName: 'content\\es\\page.mdx' },
+              },
+            },
+          ],
+        },
+        null
+      );
+
+      const written = readLockFile();
+      expect(written.entries[0].fileName).toBe('src/content/page.mdx');
+      expect(written.entries[0].translations.es.fileName).toBe(
+        'content/es/page.mdx'
+      );
+    });
+
+    it('keeps migrated entry key order stable across no-op writes', () => {
+      const windowsFileName = 'src\\content\\page.mdx';
+      writeLockfile(
+        {
+          version: 2,
+          branchId: 'brc_main',
+          entries: [
+            {
+              fileId: hashStringSync(windowsFileName),
+              versionId: 'v1',
+              fileName: windowsFileName,
+              staged: true,
+              translations: {
+                es: { fileName: 'content\\es\\page.mdx' },
+              },
+            },
+          ],
+        },
+        null
+      );
+      const firstWrite = fs.readFileSync(
+        path.join(tempDir, 'gt-lock.json'),
+        'utf8'
+      );
+
+      const { data, originalV1 } = readLockfile(settings('brc_main'));
+      writeLockfile(data, originalV1);
+
+      expect(fs.readFileSync(path.join(tempDir, 'gt-lock.json'), 'utf8')).toBe(
+        firstWrite
+      );
+    });
+
+    it('preserves malformed translation maps while writing unrelated entries', () => {
+      writeLockFile({
+        version: 2,
+        branchId: 'brc_main',
+        entries: [
+          {
+            fileId: 'malformed',
+            versionId: 'v1',
+            translations: null,
+          },
+        ],
+      });
+
+      writeStagedEntries(settings('brc_main'), [
+        { fileId: 'valid', versionId: 'v2', fileName: 'src/valid.md' },
+      ]);
+
+      expect(readLockFile().entries).toEqual([
+        {
+          fileId: 'malformed',
+          versionId: 'v1',
+          translations: null,
+        },
+        {
+          fileId: 'valid',
+          versionId: 'v2',
+          translations: {},
+          fileName: 'src/valid.md',
+          staged: true,
+        },
+      ]);
+    });
+
+    it('does not mutate malformed translation arrays while cloning', () => {
+      const malformedTranslations = [
+        { fileName: 'content\\es\\page.mdx' },
+      ] as unknown as DownloadedVersionEntry['translations'];
+      const data = {
+        version: 2 as const,
+        branchId: 'brc_main',
+        entries: [
+          {
+            fileId: 'malformed',
+            versionId: 'v1',
+            fileName: 'src/page.mdx',
+            translations: malformedTranslations,
+          },
+        ],
+      };
+
+      writeLockfile(data, null);
+
+      expect(
+        (malformedTranslations as unknown as { fileName: string }[])[0].fileName
+      ).toBe('content\\es\\page.mdx');
+      expect(readLockFile().entries[0].translations[0].fileName).toBe(
+        'content/es/page.mdx'
+      );
     });
 
     it('writes v1 format when originalV1 is provided, preserving other branches', () => {
@@ -302,6 +519,19 @@ describe('readLockfile / writeLockfile', () => {
       expect(map.get('c')).toBeUndefined();
     });
 
+    it('indexes a migrated entry by both current and previous file IDs', () => {
+      const entry: DownloadedVersionEntry = {
+        fileId: 'current',
+        previousFileId: 'previous',
+        versionId: 'v1',
+        translations: {},
+      };
+      const map = buildEntryMap([entry]);
+
+      expect(map.get('current')).toBe(entry);
+      expect(map.get('previous')).toBe(entry);
+    });
+
     it('findOrCreateEntry creates a new entry if not found', () => {
       const entries: DownloadedVersionEntry[] = [];
       const map = buildEntryMap(entries);
@@ -349,6 +579,46 @@ describe('readLockfile / writeLockfile', () => {
       expect(entry.translations).toEqual({});
       // Map should return the updated entry
       expect(map.get('f1')?.versionId).toBe('v2');
+    });
+
+    it('activates the current identity and removes the legacy map alias', () => {
+      const entry: DownloadedVersionEntry = {
+        fileId: 'current',
+        previousFileId: 'legacy',
+        versionId: 'v1',
+        translations: {
+          es: { postProcessHash: 'legacy-hash' },
+        },
+      };
+      const map = buildEntryMap([entry]);
+
+      activateCurrentFileIdentity(entry, 'current', map);
+
+      expect(entry.previousFileId).toBeUndefined();
+      expect(entry.translations).toEqual({});
+      expect(map.get('current')).toBe(entry);
+      expect(map.has('legacy')).toBe(false);
+    });
+
+    it('does not remove a distinct entry that owns the legacy map key', () => {
+      const current: DownloadedVersionEntry = {
+        fileId: 'current',
+        previousFileId: 'legacy',
+        versionId: 'v2',
+        translations: { es: { postProcessHash: 'old-hash' } },
+      };
+      const legacy: DownloadedVersionEntry = {
+        fileId: 'legacy',
+        versionId: 'v1',
+        translations: {},
+      };
+      const map = buildEntryMap([current, legacy]);
+
+      activateCurrentFileIdentity(current, 'current', map);
+
+      expect(map.get('legacy')).toBe(legacy);
+      expect(current.previousFileId).toBeUndefined();
+      expect(current.translations).toEqual({});
     });
   });
 
@@ -486,6 +756,51 @@ describe('readLockfile / writeLockfile', () => {
       );
       expect(newEntry?.staged).toBe(true);
     });
+
+    it('drops legacy metadata after staging succeeds for the current identity', () => {
+      writeLockFile({
+        version: 2,
+        branchId: 'brc_main',
+        entries: [
+          {
+            fileId: 'portable-id',
+            previousFileId: 'windows-id',
+            versionId: 'v1',
+            fileName: 'src/page.mdx',
+            translations: {
+              es: {
+                updatedAt: '2025-01-01T00:00:00Z',
+                postProcessHash: 'legacy-hash',
+              },
+            },
+          },
+        ],
+      });
+
+      writeStagedEntries(settings('brc_main'), [
+        {
+          fileId: 'portable-id',
+          versionId: 'v1',
+          fileName: 'src/page.mdx',
+        },
+      ]);
+
+      expect(readLockFile().entries).toEqual([
+        {
+          fileId: 'portable-id',
+          versionId: 'v1',
+          translations: {},
+          fileName: 'src/page.mdx',
+          staged: true,
+        },
+      ]);
+      expect(getStagedEntriesFromLockfile(settings('brc_main'))).toEqual({
+        'portable-id': {
+          versionId: 'v1',
+          fileName: 'src/page.mdx',
+        },
+      });
+    });
   });
 
   describe('getStagedEntriesFromLockfile', () => {
@@ -553,9 +868,120 @@ describe('readLockfile / writeLockfile', () => {
       expect(Object.keys(result)).toHaveLength(0);
     });
 
+    it('uses the previous server ID for a migrated staged entry', () => {
+      writeLockFile({
+        version: 2,
+        branchId: 'brc_main',
+        entries: [
+          {
+            fileId: 'portable-id',
+            previousFileId: 'windows-id',
+            versionId: 'v1',
+            fileName: 'src/page.mdx',
+            staged: true,
+            translations: {},
+          },
+        ],
+      });
+
+      expect(getStagedEntriesFromLockfile(settings('brc_main'))).toEqual({
+        'windows-id': {
+          versionId: 'v1',
+          fileName: 'src/page.mdx',
+        },
+      });
+    });
+
     it('returns empty object when lockfile does not exist', () => {
       const result = getStagedEntriesFromLockfile(settings('brc_main'));
       expect(Object.keys(result)).toHaveLength(0);
+    });
+  });
+
+  describe('migrateLockfileFileIds', () => {
+    it('clears a V2 legacy alias after the server accepts the move', () => {
+      writeLockFile({
+        version: 2,
+        branchId: 'brc_main',
+        entries: [
+          {
+            fileId: 'portable-id',
+            previousFileId: 'windows-id',
+            versionId: 'v1',
+            fileName: 'src/page.mdx',
+            translations: {
+              ja: { updatedAt: '2025-01-01T00:00:00Z' },
+            },
+          },
+        ],
+      });
+
+      expect(
+        migrateLockfileFileIds('brc_main', [
+          {
+            oldFileId: 'windows-id',
+            newFileId: 'portable-id',
+            newFileName: 'src/page.mdx',
+          },
+        ])
+      ).toBe(1);
+
+      expect(readLockFile().entries).toEqual([
+        {
+          fileId: 'portable-id',
+          versionId: 'v1',
+          translations: {
+            ja: { updatedAt: '2025-01-01T00:00:00Z' },
+          },
+          fileName: 'src/page.mdx',
+        },
+      ]);
+    });
+
+    it('removes a stale legacy entry when the accepted target has a newer version', () => {
+      writeLockFile({
+        version: 2,
+        branchId: 'brc_main',
+        entries: [
+          {
+            fileId: 'windows-id',
+            versionId: 'old-version',
+            fileName: 'src\\page.mdx',
+            translations: {
+              ja: { updatedAt: '2025-01-01T00:00:00Z' },
+            },
+          },
+          {
+            fileId: 'portable-id',
+            versionId: 'new-version',
+            fileName: 'src/page.mdx',
+            translations: {
+              fr: { updatedAt: '2026-01-01T00:00:00Z' },
+            },
+          },
+        ],
+      });
+
+      expect(
+        migrateLockfileFileIds('brc_main', [
+          {
+            oldFileId: 'windows-id',
+            newFileId: 'portable-id',
+            newFileName: 'src/page.mdx',
+          },
+        ])
+      ).toBe(1);
+
+      expect(readLockFile().entries).toEqual([
+        {
+          fileId: 'portable-id',
+          versionId: 'new-version',
+          translations: {
+            fr: { updatedAt: '2026-01-01T00:00:00Z' },
+          },
+          fileName: 'src/page.mdx',
+        },
+      ]);
     });
   });
 
@@ -655,6 +1081,127 @@ describe('readLockfile / writeLockfile', () => {
       // Should stay V1 since no staged entries
       expect(written.version).toBe(1);
       expect(written.entries.brc_other).toBeDefined();
+    });
+
+    it('migrates a V1 lock key after the server accepts a path move', () => {
+      writeLockFile({
+        version: 1,
+        entries: {
+          brc_main: {
+            'windows-id': {
+              ver1: {
+                ja: { updatedAt: '2025-01-01T00:00:00Z' },
+              },
+            },
+          },
+        },
+      });
+
+      expect(
+        migrateLockfileFileIds('brc_main', [
+          {
+            oldFileId: 'windows-id',
+            newFileId: 'portable-id',
+            newFileName: 'src/page.mdx',
+          },
+        ])
+      ).toBe(1);
+
+      const written = readLockFile();
+      expect(written.version).toBe(1);
+      expect(written.entries.brc_main['windows-id']).toBeUndefined();
+      expect(written.entries.brc_main['portable-id'].ver1.ja.updatedAt).toBe(
+        '2025-01-01T00:00:00Z'
+      );
+    });
+
+    it('migrates V1 keys without dropping versions, locales, or legacy fields', () => {
+      writeLockFile({
+        version: 1,
+        entries: {
+          brc_main: {
+            'windows-id': {
+              version1: {
+                ja: {
+                  updatedAt: '2026-01-02T00:00:00Z',
+                  fileName: 'ja\\page.md',
+                  sourceHash: 'source-ja',
+                },
+                es: {
+                  updatedAt: '2025-01-01T00:00:00Z',
+                  postProcessHash: 'post-es',
+                },
+              },
+              version2: {
+                fr: {
+                  updatedAt: '2026-02-01T00:00:00Z',
+                  sourceHash: 'source-fr',
+                },
+              },
+            },
+            'portable-id': {
+              version1: {
+                ja: {
+                  updatedAt: '2026-01-01T00:00:00Z',
+                  postProcessHash: 'target-post-ja',
+                },
+              },
+              version3: {
+                de: { updatedAt: '2026-03-01T00:00:00Z' },
+              },
+            },
+          },
+          brc_other: {
+            untouched: {
+              otherVersion: {
+                ko: { updatedAt: '2026-04-01T00:00:00Z' },
+              },
+            },
+          },
+        },
+      });
+
+      expect(
+        migrateLockfileFileIds('brc_main', [
+          {
+            oldFileId: 'windows-id',
+            newFileId: 'portable-id',
+            newFileName: 'src/page.md',
+          },
+        ])
+      ).toBe(1);
+
+      const written = readLockFile();
+      expect(written.version).toBe(1);
+      expect(written.entries.brc_main['windows-id']).toBeUndefined();
+      expect(written.entries.brc_main['portable-id']).toEqual({
+        version1: {
+          ja: {
+            updatedAt: '2026-01-02T00:00:00Z',
+            postProcessHash: 'target-post-ja',
+            fileName: 'ja\\page.md',
+            sourceHash: 'source-ja',
+          },
+          es: {
+            updatedAt: '2025-01-01T00:00:00Z',
+            postProcessHash: 'post-es',
+          },
+        },
+        version2: {
+          fr: {
+            updatedAt: '2026-02-01T00:00:00Z',
+            sourceHash: 'source-fr',
+          },
+        },
+        version3: {
+          de: { updatedAt: '2026-03-01T00:00:00Z' },
+        },
+      });
+      expect(written.entries.brc_other.untouched).toEqual({
+        otherVersion: {
+          ko: { updatedAt: '2026-04-01T00:00:00Z' },
+        },
+      });
     });
   });
 });

--- a/packages/cli/src/fs/config/__tests__/normalizeLockfilePaths.test.ts
+++ b/packages/cli/src/fs/config/__tests__/normalizeLockfilePaths.test.ts
@@ -94,6 +94,19 @@ describe('normalizeLockfilePaths', () => {
     });
   });
 
+  it('preserves a mixed translation path when its source path is migrated', () => {
+    const windowsPath = 'src\\content\\page.mdx';
+    const data = lockfile(hashStringSync(windowsPath), windowsPath);
+    data.entries[0].translations.es.fileName = 'content/es/literal\\page.mdx';
+
+    normalizeLockfilePaths(data);
+
+    expect(data.entries[0].fileName).toBe('src/content/page.mdx');
+    expect(data.entries[0].translations.es.fileName).toBe(
+      'content/es/literal\\page.mdx'
+    );
+  });
+
   it('preserves an existing all-backslash POSIX filename', () => {
     const literalPath = 'literal\\page.mdx';
     const data = lockfile(hashStringSync(literalPath), literalPath);

--- a/packages/cli/src/fs/config/downloadedVersions.ts
+++ b/packages/cli/src/fs/config/downloadedVersions.ts
@@ -31,6 +31,12 @@ export type DownloadedVersions = {
   entries: DownloadedVersionEntry[];
 };
 
+export type NormalizeLockfilePathOptions = {
+  portableSourcePathEvidence?: ReadonlySet<string>;
+  portableTranslationPathEvidence?: ReadonlySet<string>;
+  preserveAmbiguousPaths?: boolean;
+};
+
 // ── V1 types (backwards compatibility) ──────────────────────────────
 
 export type DownloadedVersionEntryV1 = {
@@ -58,14 +64,21 @@ export type DownloadedVersionsV1 = {
  * they can be proven to be the hash of the original backslash path, and the
  * previous server identity is retained until the migration succeeds.
  */
-export function normalizeLockfilePaths(data: DownloadedVersions): void {
+export function normalizeLockfilePaths(
+  data: DownloadedVersions,
+  options: NormalizeLockfilePathOptions = {}
+): void {
   const existingFileIds = new Set(data.entries.map((entry) => entry.fileId));
   const plannedFileIds = new Map<string, number>();
   const plans = data.entries.map((entry) => {
     const originalFileName = entry.fileName;
     const normalizedFileName =
       typeof originalFileName === 'string'
-        ? normalizeSerializedLockfilePath(originalFileName)
+        ? normalizeSerializedLockfilePath(
+            originalFileName,
+            options,
+            options.portableSourcePathEvidence
+          )
         : originalFileName;
     const nextFileId =
       typeof originalFileName === 'string' &&
@@ -83,6 +96,7 @@ export function normalizeLockfilePaths(data: DownloadedVersions): void {
   });
 
   for (const { entry, normalizedFileName, nextFileId } of plans) {
+    let normalizedSourcePath = false;
     if (typeof entry.fileName === 'string') {
       const collides =
         nextFileId !== undefined &&
@@ -94,6 +108,7 @@ export function normalizeLockfilePaths(data: DownloadedVersions): void {
           entry.previousFileId ??= entry.fileId;
           entry.fileId = nextFileId;
         }
+        normalizedSourcePath = entry.fileName !== normalizedFileName;
         entry.fileName = normalizedFileName;
       }
     }
@@ -103,28 +118,51 @@ export function normalizeLockfilePaths(data: DownloadedVersions): void {
     for (const translation of Object.values(entry.translations)) {
       if (translation && typeof translation.fileName === 'string') {
         translation.fileName = normalizeSerializedLockfilePath(
-          translation.fileName
+          translation.fileName,
+          options,
+          options.portableTranslationPathEvidence,
+          normalizedSourcePath
         );
       }
     }
   }
 }
 
-function normalizeSerializedLockfilePath(fileName: string): string {
+function normalizeSerializedLockfilePath(
+  fileName: string,
+  options: NormalizeLockfilePathOptions,
+  portablePathEvidence: ReadonlySet<string> | undefined,
+  forceWindowsPath: boolean = false
+): string {
   if (!fileName.includes('\\')) return fileName;
 
   // A pre-normalization Windows CLI emitted only native separators. Mixed
   // separators therefore indicate a POSIX filename containing a literal
   // backslash, which must not be rewritten.
-  if (path.sep !== '\\' && fileName.includes('/')) return fileName;
+  if (fileName.includes('/')) return fileName;
+
+  if (forceWindowsPath) {
+    return fileName.replace(/\\/g, '/');
+  }
+
+  const portableFileName = fileName.replace(/\\/g, '/');
+  if (portablePathEvidence?.has(portableFileName)) {
+    return portableFileName;
+  }
+
+  // Merge drivers must produce the same result on every host. Without
+  // evidence in the three lockfile inputs, keep an ambiguous path unchanged.
+  if (options.preserveAmbiguousPaths) return fileName;
+
+  if (path.sep === '\\') return portableFileName;
 
   // The all-backslash form is ambiguous on POSIX. Prefer a real literal path
   // over a speculative Windows migration when the file still exists.
-  if (path.sep !== '\\' && fs.existsSync(path.resolve(fileName))) {
+  if (fs.existsSync(path.resolve(fileName))) {
     return fileName;
   }
 
-  return fileName.replace(/\\/g, '/');
+  return portableFileName;
 }
 
 // ── Conversion helpers ──────────────────────────────────────────────
@@ -213,7 +251,7 @@ function convertV2ToV1Branch(
  * If the file is v1, `originalV1` contains the full v1 data so that
  * `writeLockfile` can merge changes back without losing other branches.
  */
-export function readLockfile(settings: Settings): {
+export function readLockfile(settings: Pick<Settings, '_branchId'>): {
   data: DownloadedVersions;
   entryMap: EntryMap;
   originalV1: DownloadedVersionsV1 | null;
@@ -248,6 +286,8 @@ export function readLockfile(settings: Settings): {
     data = { version: 2, branchId, entries: [] };
   }
 
+  normalizeLockfilePaths(data);
+
   return { data, entryMap: buildEntryMap(data.entries), originalV1 };
 }
 
@@ -261,25 +301,208 @@ export function writeLockfile(
   originalV1: DownloadedVersionsV1 | null
 ): void {
   try {
+    const normalizedData = cloneDownloadedVersions(data);
+    normalizeLockfilePaths(normalizedData);
+    // Normalization can add previousFileId to an existing object. Re-clone so
+    // migrated and already-normalized entries serialize in the same key order.
+    const serializedData = cloneDownloadedVersions(normalizedData);
     const filepath = path.join(process.cwd(), GT_LOCK_FILE);
     fs.mkdirSync(path.dirname(filepath), { recursive: true });
 
     // V1 format can't represent the staged flag — upgrade to V2 if any entries are staged
-    if (originalV1 && !data.entries.some((e) => e.staged)) {
+    if (originalV1 && !serializedData.entries.some((e) => e.staged)) {
       const mergedV1: DownloadedVersionsV1 = {
         ...originalV1,
         entries: {
           ...originalV1.entries,
-          [data.branchId]: convertV2ToV1Branch(data),
+          [serializedData.branchId]: convertV2ToV1Branch(serializedData),
         },
       };
       fs.writeFileSync(filepath, JSON.stringify(mergedV1, null, 2));
     } else {
-      fs.writeFileSync(filepath, JSON.stringify(data, null, 2));
+      fs.writeFileSync(filepath, JSON.stringify(serializedData, null, 2));
     }
   } catch (error) {
     logger.error(`An error occurred while updating ${GT_LOCK_FILE}: ${error}`);
   }
+}
+
+function cloneDownloadedVersions(data: DownloadedVersions): DownloadedVersions {
+  return {
+    ...data,
+    entries: data.entries.map((entry) => {
+      const cloned: DownloadedVersionEntry = {
+        fileId: entry.fileId,
+        ...(entry.previousFileId
+          ? { previousFileId: entry.previousFileId }
+          : {}),
+        versionId: entry.versionId,
+        translations: cloneDownloadedTranslations(entry.translations),
+      };
+      if (entry.fileName !== undefined) cloned.fileName = entry.fileName;
+      if (entry.staged !== undefined) cloned.staged = entry.staged;
+      return cloned;
+    }),
+  };
+}
+
+function cloneDownloadedTranslations(
+  translations: DownloadedVersionEntry['translations']
+): DownloadedVersionEntry['translations'] {
+  return cloneLockfileValue(
+    translations as unknown
+  ) as DownloadedVersionEntry['translations'];
+}
+
+function cloneLockfileValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(cloneLockfileValue);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, child]) => [
+        key,
+        cloneLockfileValue(child),
+      ])
+    );
+  }
+  return value;
+}
+
+export type FileIdMigration = {
+  oldFileId: string;
+  newFileId: string;
+  newFileName: string;
+};
+
+/**
+ * Updates lockfile identities after the server accepts the corresponding file
+ * move. V1 entries without source filenames are migrated here as well.
+ */
+export function migrateLockfileFileIds(
+  branchId: string,
+  migrations: FileIdMigration[]
+): number {
+  if (migrations.length === 0) return 0;
+
+  const { data, originalV1 } = readLockfile({ _branchId: branchId });
+  if (originalV1) {
+    return migrateV1LockfileFileIds(originalV1, data.branchId, migrations);
+  }
+  let migrated = 0;
+
+  for (const migration of migrations) {
+    const source = data.entries.find(
+      (entry) =>
+        entry.fileId === migration.oldFileId ||
+        entry.previousFileId === migration.oldFileId
+    );
+    if (!source) continue;
+
+    const target = data.entries.find(
+      (entry) => entry !== source && entry.fileId === migration.newFileId
+    );
+    if (target) {
+      if (target.versionId === source.versionId) {
+        target.translations = mergeDownloadedTranslations(
+          target.translations,
+          source.translations
+        );
+        target.staged = target.staged || source.staged || undefined;
+      }
+      target.fileName = migration.newFileName;
+      delete target.previousFileId;
+      data.entries.splice(data.entries.indexOf(source), 1);
+    } else {
+      source.fileId = migration.newFileId;
+      source.fileName = migration.newFileName;
+      delete source.previousFileId;
+    }
+    migrated++;
+  }
+
+  if (migrated > 0) writeLockfile(data, originalV1);
+  return migrated;
+}
+
+function migrateV1LockfileFileIds(
+  data: DownloadedVersionsV1,
+  branchId: string,
+  migrations: FileIdMigration[]
+): number {
+  const branchEntries = data.entries?.[branchId];
+  if (!branchEntries) return 0;
+
+  let migrated = 0;
+  for (const migration of migrations) {
+    if (migration.oldFileId === migration.newFileId) continue;
+    const source = branchEntries[migration.oldFileId];
+    if (!source) continue;
+
+    const target = branchEntries[migration.newFileId];
+    branchEntries[migration.newFileId] = target
+      ? mergeV1FileVersions(target, source)
+      : source;
+    delete branchEntries[migration.oldFileId];
+    migrated++;
+  }
+
+  if (migrated > 0) {
+    try {
+      const filepath = path.join(process.cwd(), GT_LOCK_FILE);
+      fs.mkdirSync(path.dirname(filepath), { recursive: true });
+      fs.writeFileSync(filepath, JSON.stringify(data, null, 2));
+    } catch (error) {
+      logger.error(
+        `An error occurred while updating ${GT_LOCK_FILE}: ${error}`
+      );
+    }
+  }
+  return migrated;
+}
+
+function mergeV1FileVersions(
+  target: DownloadedVersionsV1['entries'][string][string],
+  source: DownloadedVersionsV1['entries'][string][string]
+): DownloadedVersionsV1['entries'][string][string] {
+  const merged = { ...source, ...target };
+  for (const [versionId, sourceLocales] of Object.entries(source)) {
+    const targetLocales = target[versionId];
+    if (!targetLocales) continue;
+
+    const locales = { ...sourceLocales, ...targetLocales };
+    for (const [locale, sourceEntry] of Object.entries(sourceLocales)) {
+      const targetEntry = targetLocales[locale];
+      if (!targetEntry) continue;
+      const sourceTimestamp = Date.parse(sourceEntry.updatedAt ?? '');
+      const targetTimestamp = Date.parse(targetEntry.updatedAt ?? '');
+      const sourceIsNewer =
+        !Number.isNaN(sourceTimestamp) &&
+        (Number.isNaN(targetTimestamp) || sourceTimestamp > targetTimestamp);
+      locales[locale] = sourceIsNewer
+        ? { ...targetEntry, ...sourceEntry }
+        : { ...sourceEntry, ...targetEntry };
+    }
+    merged[versionId] = locales;
+  }
+  return merged;
+}
+
+function mergeDownloadedTranslations(
+  target: Record<string, DownloadedTranslation>,
+  source: Record<string, DownloadedTranslation>
+): Record<string, DownloadedTranslation> {
+  const merged = { ...source, ...target };
+  for (const locale of Object.keys(source)) {
+    const targetTimestamp = Date.parse(target[locale]?.updatedAt ?? '');
+    const sourceTimestamp = Date.parse(source[locale]?.updatedAt ?? '');
+    if (
+      !target[locale] ||
+      (!Number.isNaN(sourceTimestamp) &&
+        (Number.isNaN(targetTimestamp) || sourceTimestamp > targetTimestamp))
+    ) {
+      merged[locale] = source[locale];
+    }
+  }
+  return merged;
 }
 
 // ── Lookup helpers ──────────────────────────────────────────────────
@@ -287,7 +510,30 @@ export function writeLockfile(
 export type EntryMap = Map<string, DownloadedVersionEntry>;
 
 export function buildEntryMap(entries: DownloadedVersionEntry[]): EntryMap {
-  return new Map(entries.map((e) => [e.fileId, e]));
+  const entryMap = new Map(entries.map((entry) => [entry.fileId, entry]));
+  for (const entry of entries) {
+    if (entry.previousFileId && !entryMap.has(entry.previousFileId)) {
+      entryMap.set(entry.previousFileId, entry);
+    }
+  }
+  return entryMap;
+}
+
+/**
+ * Marks metadata as belonging to the current server file identity. Until this
+ * point, translations on an aliased entry describe the legacy server file.
+ */
+export function activateCurrentFileIdentity(
+  entry: DownloadedVersionEntry,
+  fileId: string,
+  entryMap?: EntryMap
+): void {
+  if (!entry.previousFileId || entry.fileId !== fileId) return;
+  if (entryMap?.get(entry.previousFileId) === entry) {
+    entryMap.delete(entry.previousFileId);
+  }
+  delete entry.previousFileId;
+  entry.translations = {};
 }
 
 /**
@@ -305,13 +551,18 @@ export function findOrCreateEntry(
     if (existing.versionId === versionId) return existing;
     // Version changed — replace in array and map
     const updated: DownloadedVersionEntry = {
-      fileId,
+      fileId: existing.fileId,
+      ...(existing.previousFileId
+        ? { previousFileId: existing.previousFileId }
+        : {}),
       versionId,
       translations: {},
     };
     const idx = entries.indexOf(existing);
     if (idx !== -1) entries[idx] = updated;
-    entryMap.set(fileId, updated);
+    for (const [key, entry] of entryMap) {
+      if (entry === existing) entryMap.set(key, updated);
+    }
     return updated;
   }
   const entry: DownloadedVersionEntry = {
@@ -348,6 +599,7 @@ export function writeStagedEntries(
       file.fileId,
       file.versionId
     );
+    activateCurrentFileIdentity(entry, file.fileId, entryMap);
     entry.fileName = file.fileName;
     entry.staged = true;
   }
@@ -368,7 +620,7 @@ export function getStagedEntriesFromLockfile(
 
   for (const entry of data.entries) {
     if (entry.staged && entry.fileName) {
-      result[entry.fileId] = {
+      result[entry.previousFileId ?? entry.fileId] = {
         versionId: entry.versionId,
         fileName: entry.fileName,
       };

--- a/packages/cli/src/fs/findFilepath.ts
+++ b/packages/cli/src/fs/findFilepath.ts
@@ -115,5 +115,5 @@ export function findFileInDir(dir: string, file: string): string {
 
 export function getRelative(absolutePath: string): string {
   const path2 = path.resolve(absolutePath);
-  return path.relative(process.cwd(), path2);
+  return toPosixPath(path.relative(process.cwd(), path2));
 }

--- a/packages/cli/src/git/__tests__/mergeDrivers.test.ts
+++ b/packages/cli/src/git/__tests__/mergeDrivers.test.ts
@@ -1,12 +1,13 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   mergeGtJson,
   mergeGtLockJson,
   runMergeDriver,
 } from '../mergeDrivers.js';
+import { hashStringSync } from '../../utils/hash.js';
 
 const json = (value: unknown) => JSON.stringify(value, null, 2);
 
@@ -410,6 +411,241 @@ describe('mergeGtLockJson', () => {
         ],
       }) + '\n'
     );
+  });
+
+  it('preserves a previous server file ID during unrelated merges', () => {
+    const migratedEntry = {
+      ...entry('portable-id', 'version-a', 'es'),
+      previousFileId: 'windows-id',
+      fileName: 'src/a.json',
+    };
+    const result = mergeGtLockJson(
+      lock({ entries: [migratedEntry] }),
+      lock({ entries: [migratedEntry] }),
+      lock({
+        entries: [
+          {
+            ...migratedEntry,
+            translations: {
+              ...migratedEntry.translations,
+              fr: { updatedAt: '2026-01-02T00:00:00.000Z' },
+            },
+          },
+        ],
+      })
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(JSON.parse(result.content).entries[0].previousFileId).toBe(
+      'windows-id'
+    );
+  });
+
+  it('merges a legacy Windows side with its migrated counterpart', () => {
+    const windowsFileName = 'src\\content\\a.mdx';
+    const posixFileName = 'src/content/a.mdx';
+    const legacyEntry = {
+      fileId: hashStringSync(windowsFileName),
+      versionId: 'version-a',
+      fileName: windowsFileName,
+      translations: {
+        es: { updatedAt: '2026-01-01T00:00:00.000Z' },
+      },
+    };
+    const migratedEntry = {
+      ...legacyEntry,
+      fileId: hashStringSync(posixFileName),
+      fileName: posixFileName,
+    };
+    const result = mergeGtLockJson(
+      lock({ entries: [legacyEntry] }),
+      lock({ entries: [migratedEntry] }),
+      lock({
+        entries: [
+          {
+            ...legacyEntry,
+            translations: {
+              ...legacyEntry.translations,
+              fr: {
+                updatedAt: '2026-01-02T00:00:00.000Z',
+                fileName: 'content\\fr\\a.mdx',
+              },
+            },
+          },
+        ],
+      })
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(JSON.parse(result.content).entries).toEqual([
+      {
+        fileId: hashStringSync(posixFileName),
+        versionId: 'version-a',
+        translations: {
+          es: { updatedAt: '2026-01-01T00:00:00.000Z' },
+          fr: {
+            updatedAt: '2026-01-02T00:00:00.000Z',
+            fileName: 'content/fr/a.mdx',
+          },
+        },
+        fileName: posixFileName,
+      },
+    ]);
+  });
+
+  it('merges literal backslash paths independently of working-tree files', () => {
+    const literalFileName = 'docs\\page.md';
+    const literalEntry = {
+      ...entry(hashStringSync(literalFileName), 'version-a', 'es'),
+      fileName: literalFileName,
+    };
+    const input = lock({ entries: [literalEntry] });
+    const existsSync = vi.spyOn(fs, 'existsSync');
+    const originalSeparator = Object.getOwnPropertyDescriptor(path, 'sep')!;
+
+    let posixWithoutLiteralFile;
+    let posixWithLiteralFile;
+    let windowsResult;
+    try {
+      Object.defineProperty(path, 'sep', {
+        ...originalSeparator,
+        value: path.posix.sep,
+      });
+      existsSync.mockReturnValue(false);
+      posixWithoutLiteralFile = mergeGtLockJson(input, input, input);
+      existsSync.mockReturnValue(true);
+      posixWithLiteralFile = mergeGtLockJson(input, input, input);
+      Object.defineProperty(path, 'sep', {
+        ...originalSeparator,
+        value: path.win32.sep,
+      });
+      windowsResult = mergeGtLockJson(input, input, input);
+    } finally {
+      existsSync.mockRestore();
+      Object.defineProperty(path, 'sep', originalSeparator);
+    }
+
+    expect(posixWithLiteralFile).toEqual(posixWithoutLiteralFile);
+    expect(windowsResult).toEqual(posixWithoutLiteralFile);
+    expect(windowsResult.ok).toBe(true);
+    if (!windowsResult.ok) return;
+    expect(JSON.parse(windowsResult.content).entries[0]).toMatchObject({
+      fileId: hashStringSync(literalFileName),
+      fileName: literalFileName,
+    });
+  });
+
+  it('does not coalesce distinct path styles added after the merge base', () => {
+    const literalFileName = 'docs\\page.md';
+    const portableFileName = 'docs/page.md';
+    const literalEntry = {
+      ...entry(hashStringSync(literalFileName), 'literal-version', 'es'),
+      fileName: literalFileName,
+    };
+    const portableEntry = {
+      ...entry(hashStringSync(portableFileName), 'portable-version', 'fr'),
+      fileName: portableFileName,
+    };
+
+    const result = mergeGtLockJson(
+      lock(),
+      lock({ entries: [literalEntry] }),
+      lock({ entries: [portableEntry] })
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(JSON.parse(result.content).entries).toEqual([
+      literalEntry,
+      portableEntry,
+    ]);
+  });
+
+  it('preserves a deliberate rename from a portable base to a literal path', () => {
+    const literalFileName = 'docs\\page.md';
+    const portableFileName = 'docs/page.md';
+    const literalEntry = {
+      ...entry(hashStringSync(literalFileName), 'version-a', 'es'),
+      fileName: literalFileName,
+    };
+    const portableEntry = {
+      ...entry(hashStringSync(portableFileName), 'version-a', 'es'),
+      fileName: portableFileName,
+    };
+
+    const result = mergeGtLockJson(
+      lock({ entries: [portableEntry] }),
+      lock({ entries: [literalEntry] }),
+      lock({ entries: [portableEntry] })
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(JSON.parse(result.content).entries).toEqual([literalEntry]);
+  });
+
+  it('preserves both path styles when one side adds the portable path', () => {
+    const literalFileName = 'docs\\page.md';
+    const portableFileName = 'docs/page.md';
+    const literalEntry = {
+      ...entry(hashStringSync(literalFileName), 'literal-version', 'es'),
+      fileName: literalFileName,
+    };
+    const portableEntry = {
+      ...entry(hashStringSync(portableFileName), 'portable-version', 'fr'),
+      fileName: portableFileName,
+    };
+
+    const result = mergeGtLockJson(
+      lock({ entries: [literalEntry] }),
+      lock({ entries: [literalEntry] }),
+      lock({ entries: [literalEntry, portableEntry] })
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(JSON.parse(result.content).entries).toEqual([
+      literalEntry,
+      portableEntry,
+    ]);
+  });
+
+  it('does not borrow translation-path evidence from another entry', () => {
+    const literalEntry = {
+      ...entry('literal-source', 'literal-version', 'es'),
+      fileName: 'literal-source.md',
+      translations: {
+        es: {
+          updatedAt: '2026-01-01T00:00:00.000Z',
+          fileName: 'locale\\page.md',
+        },
+      },
+    };
+    const portableEntry = {
+      ...entry('portable-source', 'portable-version', 'fr'),
+      fileName: 'portable-source.md',
+      translations: {
+        fr: {
+          updatedAt: '2026-01-02T00:00:00.000Z',
+          fileName: 'locale/page.md',
+        },
+      },
+    };
+
+    const result = mergeGtLockJson(
+      lock({ entries: [literalEntry] }),
+      lock({ entries: [literalEntry] }),
+      lock({ entries: [literalEntry, portableEntry] })
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(JSON.parse(result.content).entries).toEqual([
+      literalEntry,
+      portableEntry,
+    ]);
   });
 
   it('fails on malformed JSON', () => {

--- a/packages/cli/src/git/mergeDrivers.ts
+++ b/packages/cli/src/git/mergeDrivers.ts
@@ -5,6 +5,7 @@ import type {
   DownloadedVersionEntry,
   DownloadedVersions,
 } from '../fs/config/downloadedVersions.js';
+import { normalizeLockfilePaths } from '../fs/config/downloadedVersions.js';
 
 export type MergeDriverName = 'gt-lock' | 'gtjson';
 
@@ -26,6 +27,7 @@ type ValueState = {
 const LOCK_TOP_LEVEL_KEYS = new Set(['version', 'branchId', 'entries']);
 const LOCK_ENTRY_KEYS = new Set([
   'fileId',
+  'previousFileId',
   'versionId',
   'fileName',
   'staged',
@@ -123,6 +125,23 @@ export function mergeGtLockJson(
   if (!ours.ok) return ours;
   if (!theirs.ok) return theirs;
 
+  // A side written by a pre-normalization Windows CLI stores backslash
+  // fileNames and fileIds hashed from them; normalize all three sides so
+  // separator-only differences don't read as changes and legacy entries
+  // merge under the same fileId as their migrated counterparts.
+  const pathEvidence = collectPortableLockfilePathEvidence(
+    base.value,
+    ours.value,
+    theirs.value
+  );
+  const normalizationOptions = {
+    ...pathEvidence,
+    preserveAmbiguousPaths: true,
+  };
+  normalizeLockfilePaths(base.value, normalizationOptions);
+  normalizeLockfilePaths(ours.value, normalizationOptions);
+  normalizeLockfilePaths(theirs.value, normalizationOptions);
+
   const baseMap = buildEntryMap(base.value.entries);
   const oursMap = buildEntryMap(ours.value.entries);
   const theirsMap = buildEntryMap(theirs.value.entries);
@@ -157,10 +176,152 @@ export function mergeGtLockJson(
   return { ok: true, content: `${JSON.stringify(merged, null, 2)}\n` };
 }
 
+function collectPortableLockfilePathEvidence(
+  base: DownloadedVersions,
+  ours: DownloadedVersions,
+  theirs: DownloadedVersions
+): {
+  portableSourcePathEvidence: Set<string>;
+  portableTranslationPathEvidence: Set<string>;
+} {
+  const lockfiles = [base, ours, theirs];
+  const ambiguousSourcePaths = collectCoexistingPathStyles(
+    lockfiles,
+    (lockfile) => lockfile.entries.map((entry) => entry.fileName)
+  );
+  const ambiguousTranslationPaths = collectCoexistingPathStyles(
+    lockfiles,
+    (lockfile) =>
+      lockfile.entries.flatMap((entry) =>
+        Object.values(entry.translations).map(
+          (translation) => translation.fileName
+        )
+      )
+  );
+  const portableSourcePaths = new Set<string>();
+  const portableTranslationPaths = new Set<string>();
+  for (const lockfile of lockfiles) {
+    for (const entry of lockfile.entries) {
+      addPortablePath(entry.fileName, portableSourcePaths);
+      for (const translation of Object.values(entry.translations)) {
+        addPortablePath(translation.fileName, portableTranslationPaths);
+      }
+    }
+  }
+
+  const portableSourcePathEvidence = collectBasePathEvidence(
+    base.entries.map((entry) => entry.fileName),
+    portableSourcePaths,
+    ambiguousSourcePaths
+  );
+  const portableTranslationPathEvidence = collectBasePathEvidence(
+    base.entries.flatMap((entry) =>
+      Object.values(entry.translations).map(
+        (translation) => translation.fileName
+      )
+    ),
+    portableTranslationPaths,
+    ambiguousTranslationPaths
+  );
+
+  // previousFileId is explicit evidence that the portable entry replaced a
+  // legacy Windows identity, even when that entry was added after the merge
+  // base. Its serialized translation paths came from that same identity.
+  for (const lockfile of lockfiles) {
+    for (const entry of lockfile.entries) {
+      if (!entry.previousFileId) continue;
+      addPortablePath(
+        entry.fileName,
+        portableSourcePathEvidence,
+        ambiguousSourcePaths
+      );
+      for (const translation of Object.values(entry.translations)) {
+        addNormalizedWindowsPath(
+          translation.fileName,
+          portableTranslationPathEvidence,
+          ambiguousTranslationPaths
+        );
+      }
+    }
+  }
+
+  return { portableSourcePathEvidence, portableTranslationPathEvidence };
+}
+
+function collectBasePathEvidence(
+  basePaths: (string | undefined)[],
+  portablePaths: ReadonlySet<string>,
+  ambiguousPaths: ReadonlySet<string>
+): Set<string> {
+  const evidence = new Set<string>();
+  for (const basePath of basePaths) {
+    if (!basePath) continue;
+    // A portable base does not prove that a later backslash path is legacy;
+    // on POSIX it may be a deliberate rename to a distinct literal filename.
+    if (!basePath.includes('\\')) continue;
+    if (basePath.includes('/')) continue;
+    const portablePath = basePath.replace(/\\/g, '/');
+    if (portablePaths.has(portablePath) && !ambiguousPaths.has(portablePath)) {
+      evidence.add(portablePath);
+    }
+  }
+  return evidence;
+}
+
+function collectCoexistingPathStyles(
+  lockfiles: DownloadedVersions[],
+  getPaths: (lockfile: DownloadedVersions) => (string | undefined)[]
+): Set<string> {
+  const ambiguousPaths = new Set<string>();
+  for (const lockfile of lockfiles) {
+    const portablePaths = new Set<string>();
+    const normalizedBackslashPaths = new Set<string>();
+    for (const fileName of getPaths(lockfile)) {
+      if (!fileName) continue;
+      if (!fileName.includes('\\')) {
+        portablePaths.add(fileName);
+      } else if (!fileName.includes('/')) {
+        normalizedBackslashPaths.add(fileName.replace(/\\/g, '/'));
+      }
+    }
+    for (const portablePath of portablePaths) {
+      if (normalizedBackslashPaths.has(portablePath)) {
+        ambiguousPaths.add(portablePath);
+      }
+    }
+  }
+  return ambiguousPaths;
+}
+
+function addPortablePath(
+  fileName: string | undefined,
+  paths: Set<string>,
+  ambiguousPaths?: ReadonlySet<string>
+): void {
+  if (fileName && !fileName.includes('\\') && !ambiguousPaths?.has(fileName)) {
+    paths.add(fileName);
+  }
+}
+
+function addNormalizedWindowsPath(
+  fileName: string | undefined,
+  paths: Set<string>,
+  ambiguousPaths: ReadonlySet<string>
+): void {
+  if (!fileName) return;
+  if (!fileName.includes('\\')) {
+    if (!ambiguousPaths.has(fileName)) paths.add(fileName);
+  } else if (!fileName.includes('/')) {
+    const portablePath = fileName.replace(/\\/g, '/');
+    if (!ambiguousPaths.has(portablePath)) paths.add(portablePath);
+  }
+}
+
 // Matches the key order findOrCreateEntry/writeStagedEntries produce
 function normalizeEntry(entry: DownloadedVersionEntry): DownloadedVersionEntry {
   const normalized: DownloadedVersionEntry = {
     fileId: entry.fileId,
+    ...(entry.previousFileId ? { previousFileId: entry.previousFileId } : {}),
     versionId: entry.versionId,
     translations: entry.translations,
   };
@@ -199,6 +360,16 @@ function mergeLockEntry(
       theirs.translations
     ),
   };
+
+  const previousFileId = mergeScalarField(
+    base?.previousFileId,
+    ours.previousFileId,
+    theirs.previousFileId,
+    latest.previousFileId
+  );
+  if (previousFileId !== undefined) {
+    merged.previousFileId = previousFileId;
+  }
 
   const fileName = mergeScalarField(
     base?.fileName,
@@ -349,6 +520,12 @@ function validateLockfile(
     }
     if (typeof entry.fileId !== 'string') {
       return `${label} gt-lock.json entry must contain a fileId string`;
+    }
+    if (
+      entry.previousFileId !== undefined &&
+      typeof entry.previousFileId !== 'string'
+    ) {
+      return `${label} gt-lock.json entry previousFileId must be a string`;
     }
     if (typeof entry.versionId !== 'string') {
       return `${label} gt-lock.json entry must contain a versionId string`;

--- a/packages/cli/src/react/jsx/utils/__tests__/surroundingLines.integration.test.ts
+++ b/packages/cli/src/react/jsx/utils/__tests__/surroundingLines.integration.test.ts
@@ -8,6 +8,7 @@ import os from 'node:os';
 import { parseStrings } from '../parseStringFunction.js';
 import { parseTranslationComponent } from '../jsxParsing/parseJsx.js';
 import { Updates } from '../../../../types/index.js';
+import { getRelative } from '../../../../fs/findFilepath.js';
 
 describe('sourceCode metadata integration', () => {
   const tempFiles: string[] = [];
@@ -46,7 +47,7 @@ describe('sourceCode metadata integration', () => {
     ].join('\n');
 
     const filePath = writeTempFile(code);
-    const relativeFilePath = path.relative(process.cwd(), filePath);
+    const relativeFilePath = getRelative(filePath);
     const ast = parse(code, {
       sourceType: 'module',
       plugins: ['jsx', 'typescript'],
@@ -113,7 +114,7 @@ describe('sourceCode metadata integration', () => {
     ].join('\n');
 
     const filePath = writeTempFile(code);
-    const relativeFilePath = path.relative(process.cwd(), filePath);
+    const relativeFilePath = getRelative(filePath);
     const ast = parse(code, {
       sourceType: 'module',
       plugins: ['jsx', 'typescript'],
@@ -174,7 +175,7 @@ describe('sourceCode metadata integration', () => {
     ].join('\n');
 
     const filePath = writeTempFile(code);
-    const relativeFilePath = path.relative(process.cwd(), filePath);
+    const relativeFilePath = getRelative(filePath);
     const ast = parse(code, {
       sourceType: 'module',
       plugins: ['jsx', 'typescript'],

--- a/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
@@ -52,11 +52,11 @@ import {
   autoInsertJsxComponents,
 } from './autoInsertion.js';
 import { GTLibrary } from '../../../../types/libraries.js';
-import path from 'node:path';
 import { extractSourceCode } from '../extractSourceCode.js';
 import { SURROUNDING_LINE_COUNT } from '../../../../utils/constants.js';
 import { handleDerivation } from '../stringParsing/derivation/handleDerivation.js';
 import { parseStringExpression, nodeToStrings } from '../parseString.js';
+import { getRelative } from '../../../../fs/findFilepath.js';
 
 // Handle CommonJS/ESM interop
 const traverse = traverseModule.default || traverseModule;
@@ -694,7 +694,7 @@ function parseJSXElement({
   const componentErrors: string[] = [];
   const componentWarnings: Set<string> = new Set();
   const metadata: Metadata = {};
-  const relativeFilepath = path.relative(process.cwd(), config.file);
+  const relativeFilepath = getRelative(config.file);
   metadata.filePaths = [relativeFilepath];
 
   // Extract surrounding lines from source file

--- a/packages/cli/src/react/jsx/utils/stringParsing/processTaggedTemplateCall/__tests__/processTaggedTemplateCall.test.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/processTaggedTemplateCall/__tests__/processTaggedTemplateCall.test.ts
@@ -5,6 +5,7 @@ import * as t from '@babel/types';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { getRelative } from '../../../../../../fs/findFilepath.js';
 import { processTaggedTemplateCall } from '../index.js';
 import { ParsingConfig, ParsingOutput } from '../../types.js';
 import { Updates } from '../../../../../../types/index.js';
@@ -188,7 +189,7 @@ describe('processTaggedTemplateCall', () => {
       'const sentence = t`The ${derive(getSubject())} is playing in the park.`;',
     ].join('\n');
     const filePath = writeTempFile(code);
-    const relativeFilePath = path.relative(process.cwd(), filePath);
+    const relativeFilePath = getRelative(filePath);
 
     const output = runProcessTaggedTemplateCall(code, 't', {
       file: filePath,

--- a/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/__tests__/processTranslationCall.test.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/__tests__/processTranslationCall.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import { afterEach, describe, it, expect } from 'vitest';
 import { parse } from '@babel/parser';
 import traverse, { NodePath } from '@babel/traverse';
 import * as t from '@babel/types';
@@ -7,6 +8,11 @@ import { ParsingConfig, ParsingOutput } from '../../types.js';
 import { Updates } from '../../../../../../types/index.js';
 
 const FILE_PATH = 'test.tsx';
+const originalSeparator = Object.getOwnPropertyDescriptor(path, 'sep')!;
+
+afterEach(() => {
+  Object.defineProperty(path, 'sep', originalSeparator);
+});
 
 function createConfig(overrides?: Partial<ParsingConfig>): ParsingConfig {
   return {
@@ -62,6 +68,23 @@ function runProcessTranslationCall(
 
   return output;
 }
+
+describe('processTranslationCall - path metadata', () => {
+  it('uses slash-separated metadata paths on Windows', () => {
+    Object.defineProperty(path, 'sep', {
+      ...originalSeparator,
+      value: path.win32.sep,
+    });
+
+    const output = runProcessTranslationCall(`t('hello')`, 't', {
+      file: 'src\\components\\Page.tsx',
+    });
+
+    expect(output.updates[0].metadata.filePaths).toEqual([
+      'src/components/Page.tsx',
+    ]);
+  });
+});
 
 describe('processTranslationCall - array support', () => {
   it('should extract each string literal in an array', () => {

--- a/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/extractStringEntryMetadata.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/extractStringEntryMetadata.ts
@@ -10,11 +10,11 @@ import { GT_ATTRIBUTES_WITH_SUGAR } from '../../constants.js';
 import { containsDeriveCall } from '../derivation/containsDeriveCall.js';
 import generateModule from '@babel/generator';
 import { mapAttributeName } from '../../mapAttributeName.js';
-import pathModule from 'node:path';
 import { isNumberLiteral } from '../../isNumberLiteral.js';
 import { extractSourceCode } from '../../extractSourceCode.js';
 import type { SourceCode } from '../../extractSourceCode.js';
 import { SURROUNDING_LINE_COUNT } from '../../../../../utils/constants.js';
+import { getRelative } from '../../../../../fs/findFilepath.js';
 
 // Handle CommonJS/ESM interop
 const generate = generateModule.default || generateModule;
@@ -62,7 +62,7 @@ export function extractStringEntryMetadata({
   surroundingLineCount?: number;
 }): InlineMetadata {
   // extract filepath for entry
-  const relativeFilepath = pathModule.relative(process.cwd(), config.file);
+  const relativeFilepath = getRelative(config.file);
 
   // extract inline metadata
   const inlineMetadata = extractInlineMetadata({

--- a/packages/cli/src/workflows/__tests__/stage.test.ts
+++ b/packages/cli/src/workflows/__tests__/stage.test.ts
@@ -95,6 +95,7 @@ describe('runStageFilesWorkflow font sync', () => {
     expect(collectFonts).toHaveBeenCalledWith(settings);
     expect(gt.uploadFonts).toHaveBeenCalledWith(fonts);
     expect(result.enqueueResult).toEqual({ message: 'enqueued', jobData: {} });
+    expect(result.uploadedFiles).toEqual([]);
   });
 
   it('skips the upload when no fonts are configured', async () => {

--- a/packages/cli/src/workflows/__tests__/stage.test.ts
+++ b/packages/cli/src/workflows/__tests__/stage.test.ts
@@ -1,7 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { FileToUpload } from 'generaltranslation/types';
+import type { FileReference, FileToUpload } from 'generaltranslation/types';
 import type { Settings, TranslateFlags } from '../../types/index.js';
 import { runStageFilesWorkflow } from '../stage.js';
+
+const stepMocks = vi.hoisted(() => ({
+  uploadSourcesRun: vi.fn(
+    async (_input: unknown): Promise<FileReference[]> => []
+  ),
+  activateConfirmedFileIdentities: vi.fn(
+    (_files: FileReference[], _branchId: string) => {}
+  ),
+  userEditDiffsRun: vi.fn(
+    async (uploadedFiles: FileReference[]): Promise<FileReference[]> =>
+      uploadedFiles
+  ),
+}));
 
 vi.mock('../../console/logger.js', () => ({
   logger: {
@@ -32,7 +45,8 @@ vi.mock('../steps/BranchStep.js', () => ({
 }));
 vi.mock('../steps/UploadSourcesStep.js', () => ({
   UploadSourcesStep: vi.fn(() => ({
-    run: vi.fn(async () => []),
+    run: stepMocks.uploadSourcesRun,
+    activateConfirmedFileIdentities: stepMocks.activateConfirmedFileIdentities,
     wait: vi.fn(),
   })),
 }));
@@ -49,7 +63,10 @@ vi.mock('../steps/TagStep.js', () => ({
   TagStep: vi.fn(() => ({ run: vi.fn(), wait: vi.fn() })),
 }));
 vi.mock('../steps/UserEditDiffsStep.js', () => ({
-  UserEditDiffsStep: vi.fn(() => ({ run: vi.fn(), wait: vi.fn() })),
+  UserEditDiffsStep: vi.fn(() => ({
+    run: stepMocks.userEditDiffsRun,
+    wait: vi.fn(),
+  })),
 }));
 vi.mock('../utils/filterFilesForEnqueue.js', () => ({
   filterFilesForEnqueue: vi.fn(async ({ files }: { files: unknown[] }) => ({
@@ -118,5 +135,40 @@ describe('runStageFilesWorkflow font sync', () => {
       expect.stringContaining('Font sync failed')
     );
     expect(result.enqueueResult).toEqual({ message: 'enqueued', jobData: {} });
+  });
+
+  it('collects local edits before retiring confirmed legacy identities', async () => {
+    const uploadedFiles: FileReference[] = [
+      {
+        branchId: 'branch-1',
+        fileId: 'file-1',
+        versionId: 'version-1',
+        fileName: 'src/en/anim.lottie',
+        fileFormat: 'LOTTIE',
+      },
+    ];
+    stepMocks.uploadSourcesRun.mockResolvedValueOnce(uploadedFiles);
+
+    await runStageFilesWorkflow({
+      files,
+      options: { ...options, saveLocal: true },
+      settings,
+    });
+
+    expect(stepMocks.uploadSourcesRun).toHaveBeenCalledWith({
+      files,
+      branchData: expect.objectContaining({
+        currentBranch: expect.objectContaining({ id: 'branch-1' }),
+      }),
+      deferIdentityActivation: true,
+    });
+    expect(stepMocks.userEditDiffsRun).toHaveBeenCalledWith(uploadedFiles);
+    expect(stepMocks.activateConfirmedFileIdentities).toHaveBeenCalledWith(
+      uploadedFiles,
+      'branch-1'
+    );
+    expect(stepMocks.userEditDiffsRun.mock.invocationCallOrder[0]).toBeLessThan(
+      stepMocks.activateConfirmedFileIdentities.mock.invocationCallOrder[0]
+    );
   });
 });

--- a/packages/cli/src/workflows/stage.ts
+++ b/packages/cli/src/workflows/stage.ts
@@ -3,7 +3,11 @@ import { branchResolutionError, withOriginalError } from '../console/index.js';
 import { logger } from '../console/logger.js';
 import { Settings, TranslateFlags } from '../types/index.js';
 import { gt } from '../utils/gt.js';
-import { EnqueueFilesResult, FileToUpload } from 'generaltranslation/types';
+import type {
+  EnqueueFilesResult,
+  FileReference,
+  FileToUpload,
+} from 'generaltranslation/types';
 import { UploadSourcesStep } from './steps/UploadSourcesStep.js';
 import { SetupStep } from './steps/SetupStep.js';
 import { EnqueueStep } from './steps/EnqueueStep.js';
@@ -36,6 +40,7 @@ export async function runStageFilesWorkflow({
 }): Promise<{
   branchData: BranchData;
   enqueueResult: EnqueueFilesResult;
+  uploadedFiles: FileReference[];
 }> {
   try {
     // Log files to be translated
@@ -98,7 +103,7 @@ export async function runStageFilesWorkflow({
 
     const enqueueResult = await enqueueStep.run(filesToEnqueue);
 
-    return { branchData, enqueueResult };
+    return { branchData, enqueueResult, uploadedFiles };
   } catch (error) {
     return logErrorAndExit(
       withOriginalError(

--- a/packages/cli/src/workflows/stage.ts
+++ b/packages/cli/src/workflows/stage.ts
@@ -67,11 +67,19 @@ export async function runStageFilesWorkflow({
     }
 
     // then run the upload step
-    const uploadedFiles = await uploadStep.run({ files, branchData });
+    const uploadedFiles = await uploadStep.run({
+      files,
+      branchData,
+      deferIdentityActivation: options?.saveLocal === true,
+    });
 
     // optionally run the user edit diffs step
     if (options?.saveLocal) {
       await userEditDiffsStep.run(uploadedFiles);
+      uploadStep.activateConfirmedFileIdentities(
+        uploadedFiles,
+        branchData.currentBranch.id
+      );
     }
 
     // then run the tag step (non-fatal — tagging failure should not block translations)

--- a/packages/cli/src/workflows/steps/UploadSourcesStep.ts
+++ b/packages/cli/src/workflows/steps/UploadSourcesStep.ts
@@ -148,9 +148,11 @@ export class UploadSourcesStep {
   async run({
     files,
     branchData,
+    deferIdentityActivation = false,
   }: {
     files: FileToUpload[];
     branchData: BranchData;
+    deferIdentityActivation?: boolean;
   }): Promise<FileReference[]> {
     if (files.length === 0) {
       logger.info('No files to upload found... skipping upload step');
@@ -281,20 +283,27 @@ export class UploadSourcesStep {
       }
     );
 
+    // Accept only records that confirm an exact file requested in this upload.
     // The API may not echo transformFormat, so preserve it from local inputs.
     const localFileMap = new Map(
-      files.map((f) => [`${f.fileId}:${f.versionId}`, f])
+      filesToUpload.map((file) => [
+        `${file.branchId ?? currentBranchId}:${file.fileId}:${file.versionId}`,
+        file,
+      ])
     );
 
-    const result = response.uploadedFiles.map((uploadedFile) => {
+    const result = response.uploadedFiles.flatMap((uploadedFile) => {
       const localFile = localFileMap.get(
-        `${uploadedFile.fileId}:${uploadedFile.versionId}`
+        `${uploadedFile.branchId}:${uploadedFile.fileId}:${uploadedFile.versionId}`
       );
-      return {
-        ...uploadedFile,
-        transformFormat:
-          localFile?.transformFormat ?? uploadedFile.transformFormat,
-      };
+      if (!localFile) return [];
+      return [
+        {
+          ...uploadedFile,
+          transformFormat:
+            localFile.transformFormat ?? uploadedFile.transformFormat,
+        },
+      ];
     });
 
     // Merge files that were already uploaded into the result
@@ -311,17 +320,27 @@ export class UploadSourcesStep {
       }))
     );
 
-    // A query hit, accepted move, or upload response confirms that this exact
-    // source version exists under the current ID. Retire tentative legacy
-    // aliases here so every caller (including `gt upload` and setup) observes
-    // the same identity transition. Ignore unexpected response records.
-    const resultKeys = new Set(
-      result.map((file) => `${file.branchId}:${file.fileId}:${file.versionId}`)
-    );
-    const confirmedCurrentFiles = files.filter((file) =>
-      resultKeys.has(
-        `${file.branchId ?? currentBranchId}:${file.fileId}:${file.versionId}`
-      )
+    if (!deferIdentityActivation) {
+      this.activateConfirmedFileIdentities(result, currentBranchId);
+    }
+
+    const moveMsg = moves.length > 0 ? ` (${moves.length} moved)` : '';
+    this.spinner.stop(chalk.green(`Files uploaded successfully${moveMsg}`));
+
+    return result;
+  }
+
+  /**
+   * Retires tentative legacy aliases after the current source identity has
+   * been confirmed. Stage can defer this until local edits use the legacy
+   * translation history; other workflows activate immediately.
+   */
+  activateConfirmedFileIdentities(
+    files: FileReference[],
+    currentBranchId: string
+  ): void {
+    const confirmedCurrentFiles = files.filter(
+      (file) => file.branchId === currentBranchId
     );
     if (confirmedCurrentFiles.length > 0) {
       const lockfile = readLockfile({ _branchId: currentBranchId });
@@ -336,11 +355,6 @@ export class UploadSourcesStep {
         writeLockfile(lockfile.data, lockfile.originalV1);
       }
     }
-
-    const moveMsg = moves.length > 0 ? ` (${moves.length} moved)` : '';
-    this.spinner.stop(chalk.green(`Files uploaded successfully${moveMsg}`));
-
-    return result;
   }
 }
 

--- a/packages/cli/src/workflows/steps/UploadSourcesStep.ts
+++ b/packages/cli/src/workflows/steps/UploadSourcesStep.ts
@@ -1,4 +1,6 @@
 import type { FileToUpload } from 'generaltranslation/types';
+import fs from 'node:fs';
+import path from 'node:path';
 import { logger } from '../../console/logger.js';
 import { recordWarning } from '../../state/translateWarnings.js';
 import type { GT } from 'generaltranslation';
@@ -10,11 +12,17 @@ import type {
   FileReference,
   OrphanedFile,
 } from 'generaltranslation/types';
+import {
+  activateCurrentFileIdentity,
+  type FileIdMigration,
+  migrateLockfileFileIds,
+  readLockfile,
+  writeLockfile,
+} from '../../fs/config/downloadedVersions.js';
 
-type MoveMapping = {
-  oldFileId: string;
-  newFileId: string;
-  newFileName: string;
+type DetectedMove = {
+  mapping: FileIdMigration;
+  contentChanged: boolean;
 };
 
 type UploadSourcesClient = Pick<
@@ -36,33 +44,101 @@ export class UploadSourcesStep {
 
   /**
    * Detects file moves by comparing local files against orphaned files.
-   * A move is detected when a local file has the same versionId (content hash)
-   * as an orphaned file but a different fileId (path hash).
+   * Separator-only path migrations are matched by filename first. Other moves
+   * require a unique versionId (content hash) match on both sides.
    */
   private detectMoves(
     localFiles: FileToUpload[],
     orphanedFiles: OrphanedFile[]
-  ): MoveMapping[] {
-    const moves: MoveMapping[] = [];
+  ): DetectedMove[] {
+    const moves: DetectedMove[] = [];
+    const unmatchedLocalFiles = new Set(localFiles);
+    const unmatchedOrphanedFiles = new Set(orphanedFiles);
 
-    // Build a map of versionId -> orphaned file
-    const orphansByVersionId = new Map<string, OrphanedFile>();
-    for (const orphan of orphanedFiles) {
-      orphansByVersionId.set(orphan.versionId, orphan);
-    }
-
-    // Check each local file against orphaned files
-    for (const local of localFiles) {
-      const orphan = orphansByVersionId.get(local.versionId);
-      if (orphan && orphan.fileId !== local.fileId) {
-        // Same content, different path = move detected
-        moves.push({
+    const addMove = (local: FileToUpload, orphan: OrphanedFile) => {
+      if (orphan.fileId === local.fileId) return;
+      moves.push({
+        mapping: {
           oldFileId: orphan.fileId,
           newFileId: local.fileId,
           newFileName: local.fileName,
-        });
-        // Remove from map to avoid matching same orphan twice
-        orphansByVersionId.delete(local.versionId);
+        },
+        contentChanged: orphan.versionId !== local.versionId,
+      });
+      unmatchedLocalFiles.delete(local);
+      unmatchedOrphanedFiles.delete(orphan);
+    };
+
+    // A separator-only Windows migration is still the same path even when the
+    // source content changed. Match this deterministic case before considering
+    // content hashes.
+    for (const local of localFiles) {
+      const candidates = Array.from(unmatchedOrphanedFiles).filter(
+        (orphan) => serverFileNameRelation(local, orphan) === 'match'
+      );
+      if (candidates.length === 1) addMove(local, candidates[0]);
+    }
+
+    // A path-like pairing that cannot be proven safe must not fall through to
+    // content matching. Otherwise a stale alias whose content changed could
+    // be assigned to a different new file that happens to retain its old hash.
+    const ambiguousLocalFiles = new Set<FileToUpload>();
+    const ambiguousOrphanedFiles = new Set<OrphanedFile>();
+    for (const local of unmatchedLocalFiles) {
+      for (const orphan of unmatchedOrphanedFiles) {
+        const relation = serverFileNameRelation(local, orphan);
+        if (relation === 'match' || relation === 'ambiguous') {
+          ambiguousLocalFiles.add(local);
+          ambiguousOrphanedFiles.add(orphan);
+        }
+      }
+    }
+
+    const localFilesByVersionId = new Map<string, FileToUpload[]>();
+    for (const local of unmatchedLocalFiles) {
+      if (ambiguousLocalFiles.has(local)) continue;
+      const matches = localFilesByVersionId.get(local.versionId) ?? [];
+      matches.push(local);
+      localFilesByVersionId.set(local.versionId, matches);
+    }
+
+    const orphanedFilesByVersionId = new Map<string, OrphanedFile[]>();
+    for (const orphan of unmatchedOrphanedFiles) {
+      if (ambiguousOrphanedFiles.has(orphan)) continue;
+      const matches = orphanedFilesByVersionId.get(orphan.versionId) ?? [];
+      matches.push(orphan);
+      orphanedFilesByVersionId.set(orphan.versionId, matches);
+    }
+
+    // Content hashes still detect real moves, but only when both sides are
+    // unique. Identical boilerplate files are intentionally left unmatched
+    // instead of assigning translation history to an arbitrary path.
+    for (const [versionId, locals] of localFilesByVersionId) {
+      const orphans = orphanedFilesByVersionId.get(versionId) ?? [];
+      if (locals.length === 1 && orphans.length === 1) {
+        const pathHints = Array.from(unmatchedLocalFiles).filter(
+          (local) =>
+            !ambiguousLocalFiles.has(local) &&
+            serverFileNameRelation(local, orphans[0]) === 'path-hint'
+        );
+        if (
+          pathHints.length > 0 &&
+          (pathHints.length !== 1 || pathHints[0] !== locals[0])
+        ) {
+          continue;
+        }
+        const orphanHints = Array.from(unmatchedOrphanedFiles).filter(
+          (orphan) =>
+            !ambiguousOrphanedFiles.has(orphan) &&
+            serverFileNameRelation(locals[0], orphan) === 'path-hint'
+        );
+        if (
+          orphanHints.length > 0 &&
+          (orphanHints.length !== 1 || orphanHints[0] !== orphans[0])
+        ) {
+          continue;
+        }
+        addMove(locals[0], orphans[0]);
       }
     }
 
@@ -102,11 +178,23 @@ export class UploadSourcesStep {
       ),
     ]);
 
-    // Detect file moves
+    // Build a map of branch:fileId:versionId to fileData before move
+    // detection.
+    const fileDataMap = new Map<
+      string,
+      NonNullable<FileDataResult['sourceFiles']>[number]
+    >();
+    fileData.sourceFiles?.forEach((f) => {
+      fileDataMap.set(`${f.branchId}:${f.fileId}:${f.versionId}`, f);
+    });
+    // Confirmed current files still participate in move detection. A failed
+    // legacy-ID move followed by a successful current-ID upload can leave
+    // both identities on the server; excluding the current file would let its
+    // stale orphan be mistaken for another identical-content file.
     const moves = this.detectMoves(files, orphanedFilesResult.orphanedFiles);
 
     // Track successfully moved files
-    let successfullyMovedFileIds = new Set<string>();
+    let successfullyMovedUnchangedFileIds = new Set<string>();
 
     // Process moves if any were detected
     if (moves.length > 0) {
@@ -114,13 +202,31 @@ export class UploadSourcesStep {
         `Detected ${moves.length} moved file${moves.length !== 1 ? 's' : ''}, preserving translations...`
       );
 
-      const moveResult = await this.gt.processFileMoves(moves, {
-        branchId: currentBranchId,
-      });
+      const moveResult = await this.gt.processFileMoves(
+        moves.map((move) => move.mapping),
+        {
+          branchId: currentBranchId,
+        }
+      );
 
-      // Only track files where the move actually succeeded
-      successfullyMovedFileIds = new Set(
-        moveResult.results.filter((r) => r.success).map((r) => r.newFileId)
+      const successfulMoveKeys = new Set(
+        moveResult.results
+          .filter((result) => result.success)
+          .map((result) => `${result.oldFileId}:${result.newFileId}`)
+      );
+      const successfulMoves = moves.filter((move) =>
+        successfulMoveKeys.has(
+          `${move.mapping.oldFileId}:${move.mapping.newFileId}`
+        )
+      );
+      successfullyMovedUnchangedFileIds = new Set(
+        successfulMoves
+          .filter((move) => !move.contentChanged)
+          .map((move) => move.mapping.newFileId)
+      );
+      migrateLockfileFileIds(
+        currentBranchId,
+        successfulMoves.map((move) => move.mapping)
       );
 
       const failed = moveResult.summary.failed;
@@ -131,10 +237,12 @@ export class UploadSourcesStep {
         );
         for (const r of moveResult.results) {
           if (!r.success) {
-            const move = moves.find((m) => m.newFileId === r.newFileId);
+            const move = moves.find(
+              ({ mapping }) => mapping.newFileId === r.newFileId
+            );
             recordWarning(
               'failed_move',
-              move?.newFileName ?? r.newFileId,
+              move?.mapping.newFileName ?? r.newFileId,
               r.error ?? 'Unknown error'
             );
           }
@@ -142,21 +250,15 @@ export class UploadSourcesStep {
       }
     }
 
-    // Build a map of branch:fileId:versionId to fileData
-    const fileDataMap = new Map<
-      string,
-      NonNullable<FileDataResult['sourceFiles']>[number]
-    >();
-    fileData.sourceFiles?.forEach((f) => {
-      fileDataMap.set(`${f.branchId}:${f.fileId}:${f.versionId}`, f);
-    });
-
     // Build a list of files that need to be uploaded
     const filesToUpload: FileToUpload[] = [];
     const filesToSkipUpload: FileToUpload[] = [];
     files.forEach((f) => {
       const key = `${f.branchId ?? currentBranchId}:${f.fileId}:${f.versionId}`;
-      if (fileDataMap.has(key) || successfullyMovedFileIds.has(f.fileId)) {
+      if (
+        fileDataMap.has(key) ||
+        successfullyMovedUnchangedFileIds.has(f.fileId)
+      ) {
         filesToSkipUpload.push(f);
       } else {
         filesToUpload.push(f);
@@ -209,9 +311,64 @@ export class UploadSourcesStep {
       }))
     );
 
+    // A query hit, accepted move, or upload response confirms that this exact
+    // source version exists under the current ID. Retire tentative legacy
+    // aliases here so every caller (including `gt upload` and setup) observes
+    // the same identity transition. Ignore unexpected response records.
+    const resultKeys = new Set(
+      result.map((file) => `${file.branchId}:${file.fileId}:${file.versionId}`)
+    );
+    const confirmedCurrentFiles = files.filter((file) =>
+      resultKeys.has(
+        `${file.branchId ?? currentBranchId}:${file.fileId}:${file.versionId}`
+      )
+    );
+    if (confirmedCurrentFiles.length > 0) {
+      const lockfile = readLockfile({ _branchId: currentBranchId });
+      let didActivateIdentity = false;
+      for (const file of confirmedCurrentFiles) {
+        const entry = lockfile.entryMap.get(file.fileId);
+        if (!entry?.previousFileId || entry.fileId !== file.fileId) continue;
+        activateCurrentFileIdentity(entry, file.fileId, lockfile.entryMap);
+        didActivateIdentity = true;
+      }
+      if (didActivateIdentity) {
+        writeLockfile(lockfile.data, lockfile.originalV1);
+      }
+    }
+
     const moveMsg = moves.length > 0 ? ` (${moves.length} moved)` : '';
     this.spinner.stop(chalk.green(`Files uploaded successfully${moveMsg}`));
 
     return result;
   }
+}
+
+function serverFileNameRelation(
+  local: FileToUpload,
+  orphan: OrphanedFile
+): 'match' | 'path-hint' | 'ambiguous' | 'none' {
+  const localFileName = local.fileName;
+  const orphanedFileName = orphan.fileName;
+  if (orphanedFileName === localFileName) return 'match';
+
+  // A backslash in a current POSIX path is a literal filename character. Only
+  // separator-normalize the server value when the local path is already in the
+  // portable slash form emitted by current CLI versions.
+  if (localFileName.includes('\\')) return 'none';
+  // Pre-normalization Windows paths contained only native separators. Mixed
+  // separators therefore identify a POSIX literal rather than a Windows path.
+  if (orphanedFileName.includes('/') && orphanedFileName.includes('\\')) {
+    return 'none';
+  }
+  if (orphanedFileName.replace(/\\/g, '/') !== localFileName) return 'none';
+  if (path.sep === '\\') return 'match';
+
+  // The all-backslash form is ambiguous on POSIX. A missing literal path does
+  // not prove that it was written on Windows: it may itself be the orphan.
+  // Use it only as a hint when evaluating globally unique content matches.
+  if (fs.existsSync(path.resolve(orphanedFileName))) {
+    return 'ambiguous';
+  }
+  return 'path-hint';
 }

--- a/packages/cli/src/workflows/steps/UploadTranslationsStep.ts
+++ b/packages/cli/src/workflows/steps/UploadTranslationsStep.ts
@@ -3,6 +3,7 @@ import { GT } from 'generaltranslation';
 import { Settings } from '../../types/index.js';
 import chalk from 'chalk';
 import {
+  activateCurrentFileIdentity,
   readLockfile,
   writeLockfile,
   findOrCreateEntry,
@@ -41,6 +42,12 @@ export function partitionTranslationsByLockfile(
       const translations = file.translations.filter((translation) => {
         const entry = entryMap.get(translation.fileId);
         if (!entry || entry.versionId !== translation.versionId) return true;
+        // Translation hashes on an aliased entry belong to the legacy server
+        // identity. A current-ID upload must be confirmed before they can be
+        // used to skip local files.
+        if (entry.previousFileId && translation.fileId === entry.fileId) {
+          return true;
+        }
         const lockHash =
           entry.translations[translation.locale]?.postProcessHash;
         if (!lockHash || lockHash !== hashStringSync(translation.content)) {
@@ -159,6 +166,11 @@ export class UploadTranslationsStep {
           lockfile.data.entries,
           translation.fileId,
           translation.versionId
+        );
+        activateCurrentFileIdentity(
+          entry,
+          translation.fileId,
+          lockfile.entryMap
         );
         entry.translations[translation.locale] = {
           ...entry.translations[translation.locale],

--- a/packages/cli/src/workflows/steps/__tests__/UploadSourcesStep.test.ts
+++ b/packages/cli/src/workflows/steps/__tests__/UploadSourcesStep.test.ts
@@ -999,6 +999,44 @@ describe('UploadSourcesStep', () => {
       );
     });
 
+    it('accepts only exact branch and version confirmations from uploads', async () => {
+      const localFile: FileToUpload = {
+        content: 'content',
+        fileName: 'docs/page.md',
+        fileFormat: 'MD',
+        locale: 'en',
+        fileId: 'file-id',
+        versionId: 'version-id',
+      };
+      mockGt.queryFileData.mockResolvedValue({ sourceFiles: [] });
+      mockGt.getOrphanedFiles.mockResolvedValue({ orphanedFiles: [] });
+      mockGt.uploadSourceFiles.mockResolvedValue({
+        uploadedFiles: [
+          { ...localFile, branchId: 'other-branch' },
+          {
+            ...localFile,
+            branchId: 'branch-123',
+            versionId: 'other-version',
+          },
+          { ...localFile, branchId: 'branch-123' },
+        ],
+        count: 3,
+      });
+
+      const result = await new UploadSourcesStep(mockGt, mockSettings).run({
+        files: [localFile],
+        branchData: mockBranchData,
+      });
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          branchId: 'branch-123',
+          fileId: 'file-id',
+          versionId: 'version-id',
+        }),
+      ]);
+    });
+
     it('retires a legacy alias after the current source is confirmed', async () => {
       const localFile: FileToUpload = {
         content: 'content',
@@ -1050,6 +1088,69 @@ describe('UploadSourcesStep', () => {
       expect(result).toContainEqual(
         expect.objectContaining({ fileId: 'current-id' })
       );
+      expect(entry.previousFileId).toBeUndefined();
+      expect(entry.translations).toEqual({});
+      expect(writeLockfile).toHaveBeenCalledWith(data, null);
+    });
+
+    it('can defer alias retirement until local edits use its history', async () => {
+      const localFile: FileToUpload = {
+        content: 'content',
+        fileName: 'docs/page.md',
+        fileFormat: 'MD',
+        locale: 'en',
+        fileId: 'current-id',
+        versionId: 'current-version',
+      };
+      const entry = {
+        fileId: 'current-id',
+        previousFileId: 'legacy-id',
+        versionId: 'current-version',
+        translations: { es: { postProcessHash: 'legacy-hash' } },
+      };
+      const data = {
+        version: 2 as const,
+        branchId: 'branch-123',
+        entries: [entry],
+      };
+      vi.mocked(readLockfile).mockReturnValue({
+        data,
+        entryMap: new Map([
+          ['current-id', entry],
+          ['legacy-id', entry],
+        ]),
+        originalV1: null,
+      });
+      mockGt.queryFileData.mockResolvedValue({
+        sourceFiles: [
+          {
+            branchId: 'branch-123',
+            fileId: 'current-id',
+            versionId: 'current-version',
+          },
+        ],
+      });
+      mockGt.getOrphanedFiles.mockResolvedValue({ orphanedFiles: [] });
+      mockGt.uploadSourceFiles.mockResolvedValue({
+        uploadedFiles: [],
+        count: 0,
+      });
+
+      const step = new UploadSourcesStep(mockGt, mockSettings);
+      const result = await step.run({
+        files: [localFile],
+        branchData: mockBranchData,
+        deferIdentityActivation: true,
+      });
+
+      expect(entry.previousFileId).toBe('legacy-id');
+      expect(entry.translations).toEqual({
+        es: { postProcessHash: 'legacy-hash' },
+      });
+      expect(writeLockfile).not.toHaveBeenCalled();
+
+      step.activateConfirmedFileIdentities(result, 'branch-123');
+
       expect(entry.previousFileId).toBeUndefined();
       expect(entry.translations).toEqual({});
       expect(writeLockfile).toHaveBeenCalledWith(data, null);

--- a/packages/cli/src/workflows/steps/__tests__/UploadSourcesStep.test.ts
+++ b/packages/cli/src/workflows/steps/__tests__/UploadSourcesStep.test.ts
@@ -1,7 +1,27 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
 import { UploadSourcesStep } from '../UploadSourcesStep.js';
 import type { FileToUpload } from 'generaltranslation/types';
 import type { BranchData } from '../../../types/branch.js';
+import {
+  migrateLockfileFileIds,
+  readLockfile,
+  writeLockfile,
+} from '../../../fs/config/downloadedVersions.js';
+
+vi.mock('../../../fs/config/downloadedVersions.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('../../../fs/config/downloadedVersions.js')
+    >();
+  return {
+    ...actual,
+    migrateLockfileFileIds: vi.fn(),
+    readLockfile: vi.fn(),
+    writeLockfile: vi.fn(),
+  };
+});
 
 // Mock the GT class
 const mockGt = {
@@ -39,6 +59,11 @@ describe('UploadSourcesStep', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(readLockfile).mockReturnValue({
+      data: { version: 2, branchId: 'branch-123', entries: [] },
+      entryMap: new Map(),
+      originalV1: null,
+    });
   });
 
   describe('move detection', () => {
@@ -99,6 +124,621 @@ describe('UploadSourcesStep', () => {
           },
         ],
         { branchId: 'branch-123' }
+      );
+      expect(migrateLockfileFileIds).toHaveBeenCalledWith('branch-123', [
+        {
+          oldFileId: 'old-file-id-hash',
+          newFileId: 'new-file-id-hash',
+          newFileName: 'locales/en.json',
+        },
+      ]);
+    });
+
+    it('migrates a Windows path identity with changed content on Windows', async () => {
+      const originalSeparator = Object.getOwnPropertyDescriptor(path, 'sep')!;
+      const localFiles: FileToUpload[] = [
+        {
+          content: 'new content',
+          fileName: 'src/content/page.mdx',
+          fileFormat: 'MDX',
+          locale: 'en',
+          fileId: 'portable-id',
+          versionId: 'new-version',
+        },
+      ];
+
+      mockGt.queryFileData.mockResolvedValue({ sourceFiles: [] });
+      mockGt.getOrphanedFiles.mockResolvedValue({
+        orphanedFiles: [
+          {
+            fileId: 'windows-id',
+            versionId: 'old-version',
+            fileName: 'src\\content\\page.mdx',
+          },
+        ],
+      });
+      mockGt.processFileMoves.mockResolvedValue({
+        results: [
+          {
+            oldFileId: 'windows-id',
+            newFileId: 'portable-id',
+            success: true,
+          },
+        ],
+        summary: { total: 1, succeeded: 1, failed: 0 },
+      });
+      mockGt.uploadSourceFiles.mockResolvedValue({
+        uploadedFiles: [
+          {
+            fileId: 'portable-id',
+            versionId: 'new-version',
+            branchId: 'branch-123',
+            fileName: 'src/content/page.mdx',
+            fileFormat: 'MDX',
+            locale: 'en',
+          },
+        ],
+        count: 1,
+      });
+
+      try {
+        Object.defineProperty(path, 'sep', {
+          ...originalSeparator,
+          value: path.win32.sep,
+        });
+        const step = new UploadSourcesStep(mockGt, mockSettings);
+        await step.run({ files: localFiles, branchData: mockBranchData });
+      } finally {
+        Object.defineProperty(path, 'sep', originalSeparator);
+      }
+
+      expect(mockGt.processFileMoves).toHaveBeenCalledWith(
+        [
+          {
+            oldFileId: 'windows-id',
+            newFileId: 'portable-id',
+            newFileName: 'src/content/page.mdx',
+          },
+        ],
+        { branchId: 'branch-123' }
+      );
+      expect(mockGt.uploadSourceFiles).toHaveBeenCalledWith(
+        [
+          expect.objectContaining({
+            source: expect.objectContaining({
+              fileId: 'portable-id',
+              versionId: 'new-version',
+            }),
+          }),
+        ],
+        expect.any(Object)
+      );
+      expect(migrateLockfileFileIds).toHaveBeenCalledWith('branch-123', [
+        {
+          oldFileId: 'windows-id',
+          newFileId: 'portable-id',
+          newFileName: 'src/content/page.mdx',
+        },
+      ]);
+    });
+
+    it('does not treat a literal POSIX backslash as a path separator', async () => {
+      const localFiles: FileToUpload[] = [
+        {
+          content: 'literal backslash file',
+          fileName: 'src/literal\\page.mdx',
+          fileFormat: 'MDX',
+          locale: 'en',
+          fileId: 'literal-id',
+          versionId: 'literal-version',
+        },
+      ];
+
+      mockGt.queryFileData.mockResolvedValue({ sourceFiles: [] });
+      mockGt.getOrphanedFiles.mockResolvedValue({
+        orphanedFiles: [
+          {
+            fileId: 'slash-id',
+            versionId: 'different-version',
+            fileName: 'src/literal/page.mdx',
+          },
+        ],
+      });
+      mockGt.uploadSourceFiles.mockResolvedValue({
+        uploadedFiles: [],
+        count: 0,
+      });
+
+      const step = new UploadSourcesStep(mockGt, mockSettings);
+      await step.run({ files: localFiles, branchData: mockBranchData });
+
+      expect(mockGt.processFileMoves).not.toHaveBeenCalled();
+      expect(mockGt.uploadSourceFiles).toHaveBeenCalledWith(
+        [
+          expect.objectContaining({
+            source: expect.objectContaining({ fileId: 'literal-id' }),
+          }),
+        ],
+        expect.any(Object)
+      );
+    });
+
+    it('does not normalize a mixed-separator POSIX orphan path', async () => {
+      const localFiles: FileToUpload[] = [
+        {
+          content: 'portable path',
+          fileName: 'src/content/page.mdx',
+          fileFormat: 'MDX',
+          locale: 'en',
+          fileId: 'portable-id',
+          versionId: 'new-version',
+        },
+      ];
+
+      mockGt.queryFileData.mockResolvedValue({ sourceFiles: [] });
+      mockGt.getOrphanedFiles.mockResolvedValue({
+        orphanedFiles: [
+          {
+            fileId: 'literal-id',
+            versionId: 'old-version',
+            fileName: 'src\\content/page.mdx',
+          },
+        ],
+      });
+      mockGt.uploadSourceFiles.mockResolvedValue({
+        uploadedFiles: [],
+        count: 0,
+      });
+
+      const step = new UploadSourcesStep(mockGt, mockSettings);
+      await step.run({ files: localFiles, branchData: mockBranchData });
+
+      expect(mockGt.processFileMoves).not.toHaveBeenCalled();
+      expect(mockGt.uploadSourceFiles).toHaveBeenCalledWith(
+        [
+          expect.objectContaining({
+            source: expect.objectContaining({ fileId: 'portable-id' }),
+          }),
+        ],
+        expect.any(Object)
+      );
+    });
+
+    it.skipIf(path.sep === '\\')(
+      'does not borrow an all-backslash orphan while that literal POSIX path exists',
+      async () => {
+        const existsSync = vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+        const localFiles: FileToUpload[] = [
+          {
+            content: 'portable path',
+            fileName: 'docs/doc.md',
+            fileFormat: 'MD',
+            locale: 'en',
+            fileId: 'portable-id',
+            versionId: 'new-version',
+          },
+        ];
+
+        mockGt.queryFileData.mockResolvedValue({ sourceFiles: [] });
+        mockGt.getOrphanedFiles.mockResolvedValue({
+          orphanedFiles: [
+            {
+              fileId: 'literal-id',
+              versionId: 'old-version',
+              fileName: 'docs\\doc.md',
+            },
+          ],
+        });
+        mockGt.uploadSourceFiles.mockResolvedValue({
+          uploadedFiles: [],
+          count: 0,
+        });
+
+        try {
+          const step = new UploadSourcesStep(mockGt, mockSettings);
+          await step.run({ files: localFiles, branchData: mockBranchData });
+        } finally {
+          existsSync.mockRestore();
+        }
+
+        expect(mockGt.processFileMoves).not.toHaveBeenCalled();
+      }
+    );
+
+    it.skipIf(path.sep === '\\')(
+      'does not borrow an absent literal POSIX orphan with different content',
+      async () => {
+        const existsSync = vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+        const localFiles: FileToUpload[] = [
+          {
+            content: 'new portable file',
+            fileName: 'docs/doc.md',
+            fileFormat: 'MD',
+            locale: 'en',
+            fileId: 'portable-id',
+            versionId: 'new-version',
+          },
+        ];
+
+        mockGt.queryFileData.mockResolvedValue({ sourceFiles: [] });
+        mockGt.getOrphanedFiles.mockResolvedValue({
+          orphanedFiles: [
+            {
+              fileId: 'literal-id',
+              versionId: 'old-version',
+              fileName: 'docs\\doc.md',
+            },
+          ],
+        });
+        mockGt.uploadSourceFiles.mockResolvedValue({
+          uploadedFiles: [],
+          count: 0,
+        });
+
+        try {
+          const step = new UploadSourcesStep(mockGt, mockSettings);
+          await step.run({ files: localFiles, branchData: mockBranchData });
+        } finally {
+          existsSync.mockRestore();
+        }
+
+        expect(mockGt.processFileMoves).not.toHaveBeenCalled();
+        expect(mockGt.uploadSourceFiles).toHaveBeenCalledWith(
+          [
+            expect.objectContaining({
+              source: expect.objectContaining({ fileId: 'portable-id' }),
+            }),
+          ],
+          expect.any(Object)
+        );
+      }
+    );
+
+    it.skipIf(path.sep === '\\')(
+      'does not reassign an ambiguous stale alias by its old content hash',
+      async () => {
+        const existsSync = vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+        const localFiles: FileToUpload[] = [
+          {
+            content: 'changed current content',
+            fileName: 'existing/a.mdx',
+            fileFormat: 'MDX',
+            locale: 'en',
+            fileId: 'current-a',
+            versionId: 'new-a-version',
+          },
+          {
+            content: 'same as the stale alias',
+            fileName: 'new/b.mdx',
+            fileFormat: 'MDX',
+            locale: 'en',
+            fileId: 'new-b',
+            versionId: 'old-a-version',
+          },
+        ];
+
+        mockGt.queryFileData.mockResolvedValue({
+          sourceFiles: [
+            {
+              branchId: 'branch-123',
+              fileId: 'current-a',
+              versionId: 'new-a-version',
+            },
+          ],
+        });
+        mockGt.getOrphanedFiles.mockResolvedValue({
+          orphanedFiles: [
+            {
+              fileId: 'legacy-a',
+              versionId: 'old-a-version',
+              fileName: 'existing\\a.mdx',
+            },
+          ],
+        });
+        mockGt.uploadSourceFiles.mockResolvedValue({
+          uploadedFiles: [],
+          count: 0,
+        });
+
+        try {
+          const step = new UploadSourcesStep(mockGt, mockSettings);
+          await step.run({ files: localFiles, branchData: mockBranchData });
+        } finally {
+          existsSync.mockRestore();
+        }
+
+        expect(mockGt.processFileMoves).not.toHaveBeenCalled();
+        expect(mockGt.uploadSourceFiles).toHaveBeenCalledWith(
+          [
+            expect.objectContaining({
+              source: expect.objectContaining({ fileId: 'new-b' }),
+            }),
+          ],
+          expect.any(Object)
+        );
+      }
+    );
+
+    it.skipIf(path.sep === '\\')(
+      'does not replace a path-hinted orphan with an unrelated content match',
+      async () => {
+        const existsSync = vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+        const localFile: FileToUpload = {
+          content: 'matches unrelated orphan',
+          fileName: 'docs/page.md',
+          fileFormat: 'MD',
+          locale: 'en',
+          fileId: 'current-id',
+          versionId: 'matching-version',
+        };
+
+        mockGt.queryFileData.mockResolvedValue({ sourceFiles: [] });
+        mockGt.getOrphanedFiles.mockResolvedValue({
+          orphanedFiles: [
+            {
+              fileId: 'path-hinted-id',
+              versionId: 'changed-version',
+              fileName: 'docs\\page.md',
+            },
+            {
+              fileId: 'unrelated-id',
+              versionId: 'matching-version',
+              fileName: 'old/other.md',
+            },
+          ],
+        });
+        mockGt.uploadSourceFiles.mockResolvedValue({
+          uploadedFiles: [],
+          count: 0,
+        });
+
+        try {
+          const step = new UploadSourcesStep(mockGt, mockSettings);
+          await step.run({ files: [localFile], branchData: mockBranchData });
+        } finally {
+          existsSync.mockRestore();
+        }
+
+        expect(mockGt.processFileMoves).not.toHaveBeenCalled();
+        expect(mockGt.uploadSourceFiles).toHaveBeenCalledWith(
+          [
+            expect.objectContaining({
+              source: expect.objectContaining({ fileId: 'current-id' }),
+            }),
+          ],
+          expect.any(Object)
+        );
+      }
+    );
+
+    it.skipIf(path.sep === '\\')(
+      'does not use a POSIX path hint to break a duplicate-content tie',
+      async () => {
+        const existsSync = vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+        const localFiles: FileToUpload[] = [
+          {
+            content: 'same',
+            fileName: 'docs/doc.md',
+            fileFormat: 'MD',
+            locale: 'en',
+            fileId: 'portable-id',
+            versionId: 'same-version',
+          },
+          {
+            content: 'same',
+            fileName: 'other.md',
+            fileFormat: 'MD',
+            locale: 'en',
+            fileId: 'other-id',
+            versionId: 'same-version',
+          },
+        ];
+
+        mockGt.queryFileData.mockResolvedValue({ sourceFiles: [] });
+        mockGt.getOrphanedFiles.mockResolvedValue({
+          orphanedFiles: [
+            {
+              fileId: 'literal-id',
+              versionId: 'same-version',
+              fileName: 'docs\\doc.md',
+            },
+          ],
+        });
+        mockGt.uploadSourceFiles.mockResolvedValue({
+          uploadedFiles: [],
+          count: 0,
+        });
+
+        try {
+          const step = new UploadSourcesStep(mockGt, mockSettings);
+          await step.run({ files: localFiles, branchData: mockBranchData });
+        } finally {
+          existsSync.mockRestore();
+        }
+
+        expect(mockGt.processFileMoves).not.toHaveBeenCalled();
+        expect(mockGt.uploadSourceFiles).toHaveBeenCalledWith(
+          expect.arrayContaining([
+            expect.objectContaining({
+              source: expect.objectContaining({ fileId: 'portable-id' }),
+            }),
+            expect.objectContaining({
+              source: expect.objectContaining({ fileId: 'other-id' }),
+            }),
+          ]),
+          expect.any(Object)
+        );
+      }
+    );
+
+    it('does not guess between identical-content move candidates', async () => {
+      const localFiles: FileToUpload[] = [
+        {
+          content: 'same',
+          fileName: 'new/a.mdx',
+          fileFormat: 'MDX',
+          locale: 'en',
+          fileId: 'new-a',
+          versionId: 'same-version',
+        },
+        {
+          content: 'same',
+          fileName: 'new/b.mdx',
+          fileFormat: 'MDX',
+          locale: 'en',
+          fileId: 'new-b',
+          versionId: 'same-version',
+        },
+      ];
+
+      mockGt.queryFileData.mockResolvedValue({ sourceFiles: [] });
+      mockGt.getOrphanedFiles.mockResolvedValue({
+        orphanedFiles: [
+          {
+            fileId: 'old-a',
+            versionId: 'same-version',
+            fileName: 'old/a.mdx',
+          },
+          {
+            fileId: 'old-b',
+            versionId: 'same-version',
+            fileName: 'old/b.mdx',
+          },
+        ],
+      });
+      mockGt.uploadSourceFiles.mockResolvedValue({
+        uploadedFiles: [],
+        count: 0,
+      });
+
+      const step = new UploadSourcesStep(mockGt, mockSettings);
+      await step.run({ files: localFiles, branchData: mockBranchData });
+
+      expect(mockGt.processFileMoves).not.toHaveBeenCalled();
+      expect(mockGt.uploadSourceFiles).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            source: expect.objectContaining({ fileId: 'new-a' }),
+          }),
+          expect.objectContaining({
+            source: expect.objectContaining({ fileId: 'new-b' }),
+          }),
+        ]),
+        expect.any(Object)
+      );
+    });
+
+    it('keeps server-confirmed locals as content-match ambiguity consumers', async () => {
+      const localFiles: FileToUpload[] = [
+        {
+          content: 'same content',
+          fileName: 'existing/a.mdx',
+          fileFormat: 'MDX',
+          locale: 'en',
+          fileId: 'existing-a',
+          versionId: 'same-version',
+        },
+        {
+          content: 'same content',
+          fileName: 'new/b.mdx',
+          fileFormat: 'MDX',
+          locale: 'en',
+          fileId: 'new-b',
+          versionId: 'same-version',
+        },
+      ];
+
+      mockGt.queryFileData.mockResolvedValue({
+        sourceFiles: [
+          {
+            branchId: 'branch-123',
+            fileId: 'existing-a',
+            versionId: 'same-version',
+          },
+        ],
+      });
+      mockGt.getOrphanedFiles.mockResolvedValue({
+        orphanedFiles: [
+          {
+            fileId: 'old-b',
+            versionId: 'same-version',
+            fileName: 'old/b.mdx',
+          },
+        ],
+      });
+      mockGt.uploadSourceFiles.mockResolvedValue({
+        uploadedFiles: [],
+        count: 0,
+      });
+
+      const step = new UploadSourcesStep(mockGt, mockSettings);
+      await step.run({ files: localFiles, branchData: mockBranchData });
+
+      expect(mockGt.processFileMoves).not.toHaveBeenCalled();
+      expect(mockGt.uploadSourceFiles).toHaveBeenCalledWith(
+        [
+          expect.objectContaining({
+            source: expect.objectContaining({ fileId: 'new-b' }),
+          }),
+        ],
+        expect.any(Object)
+      );
+    });
+
+    it('does not let a stale alias bypass duplicate-content ambiguity', async () => {
+      const localFiles: FileToUpload[] = [
+        {
+          content: 'same content',
+          fileName: 'existing/a.mdx',
+          fileFormat: 'MDX',
+          locale: 'en',
+          fileId: 'current-a',
+          versionId: 'same-version',
+        },
+        {
+          content: 'same content',
+          fileName: 'new/b.mdx',
+          fileFormat: 'MDX',
+          locale: 'en',
+          fileId: 'new-b',
+          versionId: 'same-version',
+        },
+      ];
+
+      mockGt.queryFileData.mockResolvedValue({
+        sourceFiles: [
+          {
+            branchId: 'branch-123',
+            fileId: 'current-a',
+            versionId: 'same-version',
+          },
+        ],
+      });
+      mockGt.getOrphanedFiles.mockResolvedValue({
+        orphanedFiles: [
+          {
+            fileId: 'legacy-a',
+            versionId: 'same-version',
+            fileName: 'existing\\a.mdx',
+          },
+        ],
+      });
+      mockGt.uploadSourceFiles.mockResolvedValue({
+        uploadedFiles: [],
+        count: 0,
+      });
+
+      const step = new UploadSourcesStep(mockGt, mockSettings);
+      await step.run({ files: localFiles, branchData: mockBranchData });
+
+      expect(mockGt.processFileMoves).not.toHaveBeenCalled();
+      expect(mockGt.uploadSourceFiles).toHaveBeenCalledWith(
+        [
+          expect.objectContaining({
+            source: expect.objectContaining({ fileId: 'new-b' }),
+          }),
+        ],
+        expect.any(Object)
       );
     });
 
@@ -298,6 +938,168 @@ describe('UploadSourcesStep', () => {
       expect(result).toContainEqual(
         expect.objectContaining({ fileId: 'new-file-id' })
       );
+    });
+
+    it('falls back to uploading when the server rejects a detected move', async () => {
+      const localFile: FileToUpload = {
+        content: 'content',
+        fileName: 'new/page.mdx',
+        fileFormat: 'MDX',
+        locale: 'en',
+        fileId: 'new-file-id',
+        versionId: 'same-version',
+      };
+      mockGt.queryFileData.mockResolvedValue({ sourceFiles: [] });
+      mockGt.getOrphanedFiles.mockResolvedValue({
+        orphanedFiles: [
+          {
+            fileId: 'old-file-id',
+            versionId: 'same-version',
+            fileName: 'old/page.mdx',
+          },
+        ],
+      });
+      mockGt.processFileMoves.mockResolvedValue({
+        results: [
+          {
+            oldFileId: 'old-file-id',
+            newFileId: 'new-file-id',
+            success: false,
+            error: 'move rejected',
+          },
+        ],
+        summary: { total: 1, succeeded: 0, failed: 1 },
+      });
+      mockGt.uploadSourceFiles.mockResolvedValue({
+        uploadedFiles: [
+          {
+            ...localFile,
+            branchId: 'branch-123',
+          },
+        ],
+        count: 1,
+      });
+
+      const result = await new UploadSourcesStep(mockGt, mockSettings).run({
+        files: [localFile],
+        branchData: mockBranchData,
+      });
+
+      expect(migrateLockfileFileIds).toHaveBeenCalledWith('branch-123', []);
+      expect(mockGt.uploadSourceFiles).toHaveBeenCalledWith(
+        [
+          expect.objectContaining({
+            source: expect.objectContaining({ fileId: 'new-file-id' }),
+          }),
+        ],
+        expect.any(Object)
+      );
+      expect(result).toContainEqual(
+        expect.objectContaining({ fileId: 'new-file-id' })
+      );
+    });
+
+    it('retires a legacy alias after the current source is confirmed', async () => {
+      const localFile: FileToUpload = {
+        content: 'content',
+        fileName: 'docs/page.md',
+        fileFormat: 'MD',
+        locale: 'en',
+        fileId: 'current-id',
+        versionId: 'current-version',
+      };
+      const entry = {
+        fileId: 'current-id',
+        previousFileId: 'legacy-id',
+        versionId: 'current-version',
+        translations: { es: { postProcessHash: 'legacy-hash' } },
+      };
+      const data = {
+        version: 2 as const,
+        branchId: 'branch-123',
+        entries: [entry],
+      };
+      vi.mocked(readLockfile).mockReturnValue({
+        data,
+        entryMap: new Map([
+          ['current-id', entry],
+          ['legacy-id', entry],
+        ]),
+        originalV1: null,
+      });
+      mockGt.queryFileData.mockResolvedValue({
+        sourceFiles: [
+          {
+            branchId: 'branch-123',
+            fileId: 'current-id',
+            versionId: 'current-version',
+          },
+        ],
+      });
+      mockGt.getOrphanedFiles.mockResolvedValue({ orphanedFiles: [] });
+      mockGt.uploadSourceFiles.mockResolvedValue({
+        uploadedFiles: [],
+        count: 0,
+      });
+
+      const result = await new UploadSourcesStep(mockGt, mockSettings).run({
+        files: [localFile],
+        branchData: mockBranchData,
+      });
+
+      expect(result).toContainEqual(
+        expect.objectContaining({ fileId: 'current-id' })
+      );
+      expect(entry.previousFileId).toBeUndefined();
+      expect(entry.translations).toEqual({});
+      expect(writeLockfile).toHaveBeenCalledWith(data, null);
+    });
+
+    it('keeps a legacy alias when the current source upload is omitted', async () => {
+      const localFile: FileToUpload = {
+        content: 'content',
+        fileName: 'docs/page.md',
+        fileFormat: 'MD',
+        locale: 'en',
+        fileId: 'current-id',
+        versionId: 'current-version',
+      };
+      const entry = {
+        fileId: 'current-id',
+        previousFileId: 'legacy-id',
+        versionId: 'current-version',
+        translations: { es: { postProcessHash: 'legacy-hash' } },
+      };
+      vi.mocked(readLockfile).mockReturnValue({
+        data: {
+          version: 2,
+          branchId: 'branch-123',
+          entries: [entry],
+        },
+        entryMap: new Map([
+          ['current-id', entry],
+          ['legacy-id', entry],
+        ]),
+        originalV1: null,
+      });
+      mockGt.queryFileData.mockResolvedValue({ sourceFiles: [] });
+      mockGt.getOrphanedFiles.mockResolvedValue({ orphanedFiles: [] });
+      mockGt.uploadSourceFiles.mockResolvedValue({
+        uploadedFiles: [],
+        count: 0,
+      });
+
+      const result = await new UploadSourcesStep(mockGt, mockSettings).run({
+        files: [localFile],
+        branchData: mockBranchData,
+      });
+
+      expect(result).toEqual([]);
+      expect(entry.previousFileId).toBe('legacy-id');
+      expect(entry.translations).toEqual({
+        es: { postProcessHash: 'legacy-hash' },
+      });
+      expect(writeLockfile).not.toHaveBeenCalled();
     });
 
     it('should handle empty files array', async () => {

--- a/packages/cli/src/workflows/steps/__tests__/UploadTranslationsStep.test.ts
+++ b/packages/cli/src/workflows/steps/__tests__/UploadTranslationsStep.test.ts
@@ -305,6 +305,46 @@ describe('UploadTranslationsStep', () => {
     expect(entry?.translations.fr).toBeUndefined();
   });
 
+  it('retires a legacy alias only after a current-ID translation is confirmed', async () => {
+    const es = makeTranslation('file-1', 'es');
+    const fr = makeTranslation('file-1', 'fr');
+    mockLockfile([
+      {
+        fileId: 'file-1',
+        previousFileId: 'windows-file-1',
+        versionId: 'version-file-1',
+        translations: {
+          es: { postProcessHash: hashStringSync(es.content) },
+          fr: { postProcessHash: hashStringSync(fr.content) },
+        },
+      },
+    ]);
+    mockGt.uploadTranslations.mockResolvedValue({
+      uploadedFiles: [{ fileId: 'file-1', locale: 'es' }],
+    });
+
+    const step = new UploadTranslationsStep(
+      mockGt as unknown as GT,
+      mockSettings
+    );
+    await step.run({
+      files: [{ source: makeSource('file-1'), translations: [es, fr] }],
+    });
+
+    expect(mockGt.uploadTranslations).toHaveBeenCalledWith(
+      [{ source: makeSource('file-1'), translations: [es, fr] }],
+      expect.any(Object)
+    );
+    const [written] = vi.mocked(writeLockfile).mock.calls[0]!;
+    expect(written.entries).toHaveLength(1);
+    expect(written.entries[0].previousFileId).toBeUndefined();
+    expect(written.entries[0].translations).toEqual({
+      es: expect.objectContaining({
+        postProcessHash: hashStringSync(es.content),
+      }),
+    });
+  });
+
   it('reports the server-confirmed number of uploaded translation files', async () => {
     const files = [
       {
@@ -413,6 +453,32 @@ describe('partitionTranslationsByLockfile', () => {
         },
       ])
     );
+    expect(filesToUpload).toEqual(files);
+    expect(skippedCount).toBe(0);
+  });
+
+  it('does not trust legacy hashes for the current server identity', () => {
+    const unchanged = makeTranslation('file-1', 'es');
+    const files = [
+      {
+        source: makeSource('file-1'),
+        translations: [unchanged],
+      },
+    ];
+    const { filesToUpload, skippedCount } = partitionTranslationsByLockfile(
+      files,
+      buildEntryMap([
+        {
+          fileId: 'file-1',
+          previousFileId: 'windows-file-1',
+          versionId: 'version-file-1',
+          translations: {
+            es: { postProcessHash: hashStringSync(unchanged.content) },
+          },
+        },
+      ])
+    );
+
     expect(filesToUpload).toEqual(files);
     expect(skippedCount).toBe(0);
   });


### PR DESCRIPTION
- apply helper
- and fix some edge cases

## Summary

- Apply `normalizeLockfilePaths()` during lockfile reads, cloned writes, and merge-driver comparisons.
- Preserve legacy server identities until a confirmed path move, including v1 entries, staged downloads, and standalone save-local queries.
- Match separator-only server moves by normalized filename before content hashes, avoid ambiguous identical-content pairings, and still upload edited source content after its history is migrated.
- Treat literal POSIX backslashes and mixed separators conservatively, and keep merge-driver normalization deterministic across host platforms.
- Preserve complete v1/v2 history, tolerate malformed legacy values without mutating callers, and add the `gt` patch changeset for the full stack.

## Testing

- Focused lockfile, glob, upload, staged-download, merge-driver, and save-local regression suites — passed
- Randomized normalization and merge-style audit — passed (360 generated edge cases)
- `pnpm --filter gt test` — passed (123 files, 2,330 tests)
- `pnpm exec turbo run build --filter=gt...` — passed (8 packages)
- `pnpm --filter gt typecheck` — passed
- `pnpm exec oxlint packages/cli/src` — passed with 9 pre-existing warnings
- `pnpm exec oxfmt --check packages/cli/src` — passed

## Notes

- Stack: 4 of 4; depends on #2162.
- Changeset: patch release added for `gt`.
- A native Windows runtime and live GT server were not available locally; Windows behavior is covered with platform simulations and server boundaries are mocked.
- Supersedes #2160; the full stack replaces #2057.












<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change makes lockfile path handling portable across Windows and POSIX workflows and tightens staged-upload confirmation to the active branch. One merge case still loses translation progress: when equivalent legacy and portable entries have divergent source versions, an automatic merge can omit a locale added on the non-selected side.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The merge driver can silently remove independently downloaded locale metadata when it resolves normalized entries with different source versions.

One reproduced non-security data-integrity failure remains in the lockfile merge behavior.

**Files Needing Attention:** packages/cli/src/git/mergeDrivers.ts
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the focused legacy and portable lockfile merge to validate the P1 finding, and reviewed the accompanying runtime output that shows locale loss after the merge.
- Validated the general contract behavior by inspecting the reproduction results that report normalizedToOneIdentity: true, mergedLocales: \["en", "fr"\], and discardedLocale: true for the missing es locale.
- Provided an additional P1 finding proof with no artifacts attached, as part of the review trace.

<a href="https://app.greptile.com/trex/runs/20616735/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/cli/src/git/mergeDrivers.ts`, line 344-348 ([link](https://github.com/generaltranslation/gt/blob/4cb7a5c5e0a149c6992784e5cebc62d70d636ab4/packages/cli/src/git/mergeDrivers.ts#L344-L348)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Divergent versions discard locales**

   After legacy and portable lockfile entries normalize to the same file identity, two changed entries with different `versionId` values take the `selectLatestEntry` path wholesale. That bypasses `mergeTranslations`, so independently downloaded locales from the non-selected side are silently removed from the merged `gt-lock.json`. Preserve locale records from both changed entries while resolving the divergent version metadata, or report a merge conflict instead of losing translation state.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Focused legacy and portable lockfile merge reproduction](https://app.greptile.com/trex/artifacts/2b566525-57ab-4cc0-a22e-bf5792a10b9a)**

   - Executes mergeGtLockJson with a legacy backslash entry and portable-path counterpart that normalize to one identity, divergent version IDs, and independently added es and fr locales; it inspects whether a locale is discarded.

   **[Runtime output showing locale loss after normalized divergent-version merge](https://app.greptile.com/trex/artifacts/fb1b8b34-32d8-43fa-b20d-df2b603db23e)**

   - Captures the executed reproduction output: entries normalized to one portable identity and the merged lockfile contains en and fr but omits es, confirming silent locale loss.

   <a href="https://app.greptile.com/trex/runs/20616735/artifacts?artifact=2b566525-57ab-4cc0-a22e-bf5792a10b9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/cli/src/git/mergeDrivers.ts
   Line: 344-348

   Comment:
   **Divergent versions discard locales**

   After legacy and portable lockfile entries normalize to the same file identity, two changed entries with different `versionId` values take the `selectLatestEntry` path wholesale. That bypasses `mergeTranslations`, so independently downloaded locales from the non-selected side are silently removed from the merged `gt-lock.json`. Preserve locale records from both changed entries while resolving the divergent version metadata, or report a merge conflict instead of losing translation state.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcli%2Fsrc%2Fgit%2FmergeDrivers.ts%0ALine%3A%20344-348%0A%0AComment%3A%0A**Divergent%20versions%20discard%20locales**%0A%0AAfter%20legacy%20and%20portable%20lockfile%20entries%20normalize%20to%20the%20same%20file%20identity%2C%20two%20changed%20entries%20with%20different%20%60versionId%60%20values%20take%20the%20%60selectLatestEntry%60%20path%20wholesale.%20That%20bypasses%20%60mergeTranslations%60%2C%20so%20independently%20downloaded%20locales%20from%20the%20non-selected%20side%20are%20silently%20removed%20from%20the%20merged%20%60gt-lock.json%60.%20Preserve%20locale%20records%20from%20both%20changed%20entries%20while%20resolving%20the%20divergent%20version%20metadata%2C%20or%20report%20a%20merge%20conflict%20instead%20of%20losing%20translation%20state.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2163&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fcli%2Fapply-lockfile-path-normalization%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fcli%2Fapply-lockfile-path-normalization%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcli%2Fsrc%2Fgit%2FmergeDrivers.ts%0ALine%3A%20344-348%0A%0AComment%3A%0A**Divergent%20versions%20discard%20locales**%0A%0AAfter%20legacy%20and%20portable%20lockfile%20entries%20normalize%20to%20the%20same%20file%20identity%2C%20two%20changed%20entries%20with%20different%20%60versionId%60%20values%20take%20the%20%60selectLatestEntry%60%20path%20wholesale.%20That%20bypasses%20%60mergeTranslations%60%2C%20so%20independently%20downloaded%20locales%20from%20the%20non-selected%20side%20are%20silently%20removed%20from%20the%20merged%20%60gt-lock.json%60.%20Preserve%20locale%20records%20from%20both%20changed%20entries%20while%20resolving%20the%20divergent%20version%20metadata%2C%20or%20report%20a%20merge%20conflict%20instead%20of%20losing%20translation%20state.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2163&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Divergent-version normalized merge silently drops one added locale**

   - **Bug**
     - A legacy backslash-path entry and portable-path entry normalize to one identity. When their version IDs differ and each side adds a locale, the selected latest entry is emitted wholesale, so the other side’s locale is omitted.
   - **Cause**
     - `mergeGtLockJson` normalizes all three sides at `packages/cli/src/git/mergeDrivers.ts:141-143`; `mergeLockEntry` returns `selectLatestEntry(ours, theirs)` at lines 344-348 when both version IDs differ, bypassing `mergeTranslations`.
   - **Fix**
     - Add a regression test for this normalized divergent-version scenario and merge independently added translations before resolving the version-level fields, or otherwise preserve locales from both changed entries according to an explicit version-consistency policy.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20generaltranslation%2Fgt%20PR%20%232163%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=generaltranslation%2Fgt&pr=2163&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fcli%2Fsrc%2Fgit%2FmergeDrivers.ts%3A344-348%0A**Divergent%20versions%20discard%20locales**%0A%0AAfter%20legacy%20and%20portable%20lockfile%20entries%20normalize%20to%20the%20same%20file%20identity%2C%20two%20changed%20entries%20with%20different%20%60versionId%60%20values%20take%20the%20%60selectLatestEntry%60%20path%20wholesale.%20That%20bypasses%20%60mergeTranslations%60%2C%20so%20independently%20downloaded%20locales%20from%20the%20non-selected%20side%20are%20silently%20removed%20from%20the%20merged%20%60gt-lock.json%60.%20Preserve%20locale%20records%20from%20both%20changed%20entries%20while%20resolving%20the%20divergent%20version%20metadata%2C%20or%20report%20a%20merge%20conflict%20instead%20of%20losing%20translation%20state.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2163&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fcli%2Fapply-lockfile-path-normalization%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fcli%2Fapply-lockfile-path-normalization%22.%0A%0A%23%23%23%20Issue%201%0Apackages%2Fcli%2Fsrc%2Fgit%2FmergeDrivers.ts%3A344-348%0A**Divergent%20versions%20discard%20locales**%0A%0AAfter%20legacy%20and%20portable%20lockfile%20entries%20normalize%20to%20the%20same%20file%20identity%2C%20two%20changed%20entries%20with%20different%20%60versionId%60%20values%20take%20the%20%60selectLatestEntry%60%20path%20wholesale.%20That%20bypasses%20%60mergeTranslations%60%2C%20so%20independently%20downloaded%20locales%20from%20the%20non-selected%20side%20are%20silently%20removed%20from%20the%20merged%20%60gt-lock.json%60.%20Preserve%20locale%20records%20from%20both%20changed%20entries%20while%20resolving%20the%20divergent%20version%20metadata%2C%20or%20report%20a%20merge%20conflict%20instead%20of%20losing%20translation%20state.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2163&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/cli/src/git/mergeDrivers.ts:344-348
**Divergent versions discard locales**

After legacy and portable lockfile entries normalize to the same file identity, two changed entries with different `versionId` values take the `selectLatestEntry` path wholesale. That bypasses `mergeTranslations`, so independently downloaded locales from the non-selected side are silently removed from the merged `gt-lock.json`. Preserve locale records from both changed entries while resolving the divergent version metadata, or report a merge conflict instead of losing translation state.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (7): Last reviewed commit: ["fix(cli): harden source confirmation lif..."](https://github.com/generaltranslation/gt/commit/4cb7a5c5e0a149c6992784e5cebc62d70d636ab4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56346439)</sub>

<!-- /greptile_comment -->