### PR TITLE
refactor(cli): share file source merging

### DIFF
--- a/packages/cli/src/api/downloadFileBatch.ts
+++ b/packages/cli/src/api/downloadFileBatch.ts
@@ -5,10 +5,7 @@ import { logger } from '../console/logger.js';
 import { gt } from '../utils/gt.js';
 import { Settings } from '../types/index.js';
 import { validateJsonSchema } from '../formats/json/utils.js';
-import { validateYamlSchema } from '../formats/yaml/utils.js';
-import { mergeJson } from '../formats/json/mergeJson.js';
 import { extractJson } from '../formats/json/extractJson.js';
-import mergeYaml from '../formats/yaml/mergeYaml.js';
 import { extractYaml } from '../formats/yaml/extractYaml.js';
 import {
   resolveMintlifyRefs,
@@ -23,9 +20,8 @@ import { recordDownloaded, recordRemerged } from '../state/recentDownloads.js';
 import { recordWarning } from '../state/translateWarnings.js';
 import stringify from 'fast-json-stable-stringify';
 import type { FileStatusTracker } from '../workflows/steps/PollJobsStep.js';
-import { SUPPORTED_FILE_EXTENSIONS } from '../formats/files/supportedFiles.js';
-import { hasNonIdentityFileFormatTransformForType } from '../formats/files/transformFormat.js';
 import { getRelative } from '../fs/findFilepath.js';
+import { mergeWithSource } from '../formats/files/mergeWithSource.js';
 import {
   getInlineElementsLabel,
   type InlineLibrary,
@@ -83,90 +79,6 @@ function countGtJsonEntries(content: string): number | undefined {
 function sortJsonString(data: string): string {
   const sortedData = stringify(JSON.parse(data));
   return JSON.stringify(JSON.parse(sortedData), null, 2);
-}
-
-/**
- * Merges translated content with the current source file for schema-based formats.
- */
-function mergeWithSource(
-  translatedContent: string,
-  locale: string,
-  inputPath: string,
-  options: Settings
-): string {
-  if (shouldSkipSourceFormatMerge(inputPath, options)) {
-    return translatedContent;
-  }
-  if (!options.options) return translatedContent;
-
-  const jsonSchema = options.options.jsonSchema
-    ? validateJsonSchema(options.options, inputPath)
-    : null;
-  const yamlSchema =
-    !jsonSchema && options.options.yamlSchema
-      ? validateYamlSchema(options.options, inputPath)
-      : null;
-
-  if (!jsonSchema && !yamlSchema) return translatedContent;
-
-  const sourceContent = fs.readFileSync(inputPath, 'utf8');
-  if (!sourceContent) return translatedContent;
-
-  if (jsonSchema) {
-    // Resolve $ref before merging if configured
-    let resolvedSourceContent = sourceContent;
-    if (shouldResolveRefs(inputPath, options.options)) {
-      try {
-        const json = JSON.parse(sourceContent);
-        const { resolved } = resolveMintlifyRefs(json, inputPath);
-        resolvedSourceContent = JSON.stringify(resolved, null, 2);
-      } catch {
-        // Fall through with original content
-      }
-    }
-    return mergeJson(
-      resolvedSourceContent,
-      inputPath,
-      options.options,
-      [{ translatedContent, targetLocale: locale }],
-      options.defaultLocale,
-      options.locales
-    )[0];
-  } else {
-    return mergeYaml(
-      sourceContent,
-      inputPath,
-      options.options,
-      [{ translatedContent, targetLocale: locale }],
-      options.defaultLocale
-    )[0];
-  }
-}
-
-/**
- * Determines whether a source file should be skipped for schema re-merging.
- * @param inputPath - The path of the source file
- * @param options - The settings for the project
- * @returns True if the source file should be skipped for schema re-merging, false otherwise
- */
-function shouldSkipSourceFormatMerge(
-  inputPath: string,
-  options: Settings
-): boolean {
-  for (const fileType of SUPPORTED_FILE_EXTENSIONS) {
-    if (!hasNonIdentityFileFormatTransformForType(options, fileType)) continue;
-
-    const transformedSourcePaths = options.files.resolvedPaths[fileType] || [];
-    if (
-      transformedSourcePaths.some(
-        (sourcePath) => getRelative(sourcePath) === inputPath
-      )
-    ) {
-      return true;
-    }
-  }
-
-  return false;
 }
 
 export type BatchedFiles = {

--- a/packages/cli/src/formats/files/mergeWithSource.ts
+++ b/packages/cli/src/formats/files/mergeWithSource.ts
@@ -1,0 +1,151 @@
+import * as fs from 'fs';
+import type { Settings } from '../../types/index.js';
+import { getRelative } from '../../fs/findFilepath.js';
+import {
+  resolveMintlifyRefs,
+  shouldResolveRefs,
+} from '../../utils/resolveMintlifyRefs.js';
+import { extractJson } from '../json/extractJson.js';
+import { mergeJson } from '../json/mergeJson.js';
+import { validateJsonSchema } from '../json/utils.js';
+import { extractYaml } from '../yaml/extractYaml.js';
+import mergeYaml from '../yaml/mergeYaml.js';
+import { validateYamlSchema } from '../yaml/utils.js';
+import { SUPPORTED_FILE_EXTENSIONS } from './supportedFiles.js';
+import { hasNonIdentityFileFormatTransformForType } from './transformFormat.js';
+
+type SourceSchema = 'json' | 'yaml' | null;
+
+function getSourceSchema(inputPath: string, settings: Settings): SourceSchema {
+  if (!settings.options) return null;
+  if (
+    settings.options.jsonSchema &&
+    validateJsonSchema(settings.options, inputPath)
+  ) {
+    return 'json';
+  }
+  if (
+    settings.options.yamlSchema &&
+    validateYamlSchema(settings.options, inputPath)
+  ) {
+    return 'yaml';
+  }
+  return null;
+}
+
+function mergeWithSchema(
+  translatedContent: string,
+  locale: string,
+  inputPath: string,
+  settings: Settings,
+  schema: Exclude<SourceSchema, null>,
+  sourceContent = getSourceContent(inputPath, settings, schema)
+): string {
+  if (!sourceContent || !settings.options) return translatedContent;
+
+  if (schema === 'yaml') {
+    return mergeYaml(
+      sourceContent,
+      inputPath,
+      settings.options,
+      [{ translatedContent, targetLocale: locale }],
+      settings.defaultLocale
+    )[0];
+  }
+
+  return mergeJson(
+    sourceContent,
+    inputPath,
+    settings.options,
+    [{ translatedContent, targetLocale: locale }],
+    settings.defaultLocale,
+    settings.locales
+  )[0];
+}
+
+function getSourceContent(
+  inputPath: string,
+  settings: Settings,
+  schema: Exclude<SourceSchema, null>
+): string {
+  const sourceContent = fs.readFileSync(inputPath, 'utf8');
+  if (schema === 'yaml' || !shouldResolveRefs(inputPath, settings.options)) {
+    return sourceContent;
+  }
+
+  try {
+    const { resolved } = resolveMintlifyRefs(
+      JSON.parse(sourceContent),
+      inputPath
+    );
+    return JSON.stringify(resolved, null, 2);
+  } catch {
+    return sourceContent;
+  }
+}
+
+/** Merges translated schema data with its current source file. */
+export function mergeWithSource(
+  translatedContent: string,
+  locale: string,
+  inputPath: string,
+  settings: Settings
+): string {
+  if (shouldSkipSourceFormatMerge(inputPath, settings)) {
+    return translatedContent;
+  }
+  const schema = getSourceSchema(inputPath, settings);
+  return schema
+    ? mergeWithSchema(translatedContent, locale, inputPath, settings, schema)
+    : translatedContent;
+}
+
+/** Creates source-populated content when a file has schema transformations. */
+export function createSourceTemplate(
+  locale: string,
+  inputPath: string,
+  settings: Settings
+): string | undefined {
+  if (shouldSkipSourceFormatMerge(inputPath, settings)) return undefined;
+  const schema = getSourceSchema(inputPath, settings);
+  if (!schema || !settings.options) return undefined;
+
+  const sourceContent = getSourceContent(inputPath, settings, schema);
+  const extractedSource =
+    schema === 'json'
+      ? extractJson(
+          sourceContent,
+          inputPath,
+          settings.options,
+          settings.defaultLocale,
+          settings.defaultLocale
+        )
+      : extractYaml(sourceContent, inputPath, settings.options);
+  return mergeWithSchema(
+    extractedSource ?? '{}',
+    locale,
+    inputPath,
+    settings,
+    schema,
+    sourceContent
+  );
+}
+
+function shouldSkipSourceFormatMerge(
+  inputPath: string,
+  settings: Settings
+): boolean {
+  for (const fileType of SUPPORTED_FILE_EXTENSIONS) {
+    if (!hasNonIdentityFileFormatTransformForType(settings, fileType)) continue;
+
+    const transformedSourcePaths = settings.files.resolvedPaths[fileType] || [];
+    if (
+      transformedSourcePaths.some(
+        (sourcePath) => getRelative(sourcePath) === inputPath
+      )
+    ) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/packages/cli/src/formats/files/transformFormat.ts
+++ b/packages/cli/src/formats/files/transformFormat.ts
@@ -141,18 +141,6 @@ export function replaceFileExtensionForFormat(
 }
 
 /**
- * Detects whether any configured format transform changes the output file type.
- */
-export function hasNonIdentityFileFormatTransform(settings: Settings): boolean {
-  return Object.entries(settings.files?.transformFormats || {}).some(
-    ([fileType, transformFormat]) =>
-      transformFormat &&
-      CONFIG_FILE_TYPE_TO_FILE_FORMAT[fileType as SupportedFileExtension] !==
-        transformFormat
-  );
-}
-
-/**
  * Returns true when the configured transform for a file type changes its format.
  */
 export function hasNonIdentityFileFormatTransformForType(


### PR DESCRIPTION
## Summary

- Extract the download workflow's source-aware JSON/YAML merge logic into a shared file-format helper.
- Keep download behavior unchanged while making the same merge operation reusable by generated file templates.
- Remove the superseded merge exports from the format-transform module.

## Testing

- `pnpm --filter gt exec vitest run src/api/__tests__/downloadFileBatch.test.ts src/cli/commands/__tests__/generate.test.ts` — passed (20 tests)
- `pnpm --filter gt typecheck` — passed
- `pnpm --filter compiler-cli-parity test` — passed (517 matched, 0 mismatches)
- `GT_TEST_APPS=vite-react pnpm --filter gt-test-apps-e2e test:e2e` — passed (Chromium 1/1 with local packages)

## Notes

- Changeset: inherited from the foundation PR.
- Stack: 3 of 6. Base: [#2165](https://github.com/generaltranslation/gt/pull/2165). Next: [#2168](https://github.com/generaltranslation/gt/pull/2168) settles sibling postprocessors.
- This refactor does not change generation behavior; schema-aware template creation is added by required stack PR [#2166](https://github.com/generaltranslation/gt/pull/2166).




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change extracts schema-aware source merging into a shared helper for JSON and YAML localization files.

Generated locale files still copy the source file directly instead of using the new template helper. As a result, schema-configured JSON and YAML outputs can be created with the source locale's structure and values rather than the requested locale's template.

## T-Rex validation blocked

The focused checks could not start because the required `vitest` and `yaml` packages are missing from the workspace. Both the existing generator test and the authored reproduction stopped during dependency resolution before exercising generation.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Generated schema-based locale files can retain source-locale content instead of being initialized as target-locale templates.

One non-security correctness issue remains in the generated-file path.

**Files Needing Attention:** packages/cli/src/cli/commands/generate.ts
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted focused generator tests and an authored reproduction for JSON composite schemas and YAML locale transforms, but test collection could not start due to missing vitest.
- The direct runtime reproduction stopped while loading because the yaml package cannot be resolved.
- The investigation documented execution blockers: dependency installation is blocked due to missing vitest modules in multiple node\_modules paths and an unresolved yaml package.
- It points to the generation workflow's code paths, including generate.ts and the uncalled template construction path in mergeWithSource.ts, to show what would run when dependencies are available.
- Artifacts were prepared to aid review, including previews of TypeScript and JavaScript sources and three logs with accessible URLs that capture the blocker state.

<a href="https://app.greptile.com/trex/runs/20440115/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;e/cli/generate-output-safe..."](https://github.com/generaltranslation/gt/commit/848c86a223ff3232e165b990b15251a90146ed1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56375364)</sub>

<!-- /greptile_comment -->