### PR TITLE
fix(cli): settle generated file postprocessors

### DIFF
--- a/packages/cli/src/utils/__tests__/settleAll.test.ts
+++ b/packages/cli/src/utils/__tests__/settleAll.test.ts
@@ -17,4 +17,16 @@ describe('settleAll', () => {
     );
     expect(siblingFinished).toBe(true);
   });
+
+  it('rethrows the first observed failure', async () => {
+    const firstFailure = new Error('failed first');
+    const laterFailure = new Error('failed later');
+    const earlierOperation = new Promise<void>((_resolve, reject) => {
+      setTimeout(() => reject(laterFailure), 5);
+    });
+
+    await expect(
+      settleAll([earlierOperation, Promise.reject(firstFailure)])
+    ).rejects.toBe(firstFailure);
+  });
 });

--- a/packages/cli/src/utils/__tests__/settleAll.test.ts
+++ b/packages/cli/src/utils/__tests__/settleAll.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { settleAll } from '../settleAll.js';
+
+describe('settleAll', () => {
+  it('waits for sibling operations before rethrowing a failure', async () => {
+    const failure = new Error('failed');
+    let siblingFinished = false;
+    const sibling = new Promise<void>((resolve) => {
+      setTimeout(() => {
+        siblingFinished = true;
+        resolve();
+      }, 5);
+    });
+
+    await expect(settleAll([Promise.reject(failure), sibling])).rejects.toBe(
+      failure
+    );
+    expect(siblingFinished).toBe(true);
+  });
+});

--- a/packages/cli/src/utils/flattenJsonFiles.ts
+++ b/packages/cli/src/utils/flattenJsonFiles.ts
@@ -1,6 +1,7 @@
 import { createFileMapping } from '../formats/files/fileMapping.js';
 import fs from 'node:fs';
 import { Settings } from '../types/index.js';
+import { settleAll } from './settleAll.js';
 
 export default async function flattenJsonFiles(
   settings: Settings,
@@ -24,13 +25,13 @@ export default async function flattenJsonFiles(
     settings.defaultLocale
   );
 
-  await Promise.all(
+  await settleAll(
     Object.values(fileMapping).map(async (filesMap) => {
       const targetFiles = Object.values(filesMap).filter(
         (p) => p.endsWith('.json') && (!includeFiles || includeFiles.has(p))
       );
 
-      await Promise.all(
+      await settleAll(
         targetFiles.map(async (file) => {
           // Read each json file
           const json = JSON.parse(fs.readFileSync(file, 'utf8'));

--- a/packages/cli/src/utils/localizeMintlifyFrontmatterUrls.ts
+++ b/packages/cli/src/utils/localizeMintlifyFrontmatterUrls.ts
@@ -7,6 +7,7 @@ import YAML, { isMap, isScalar } from 'yaml';
 import type { Content, Root, Yaml } from 'mdast';
 import { createFileMapping } from '../formats/files/fileMapping.js';
 import type { Settings } from '../types/index.js';
+import { settleAll } from './settleAll.js';
 
 const SKIPPABLE_URL_REGEX = /^(?:[a-z][a-z0-9+.-]*:|\/\/|#|\.\/|\.\.\/)/i;
 
@@ -140,7 +141,7 @@ export default async function localizeMintlifyFrontmatterUrls(
         shouldProcessFile(filePath, includeFiles)
     );
 
-    await Promise.all(
+    await settleAll(
       targetFiles.map(async (filePath) => {
         if (!fs.existsSync(filePath)) return;
 

--- a/packages/cli/src/utils/localizeRelativeAssets.ts
+++ b/packages/cli/src/utils/localizeRelativeAssets.ts
@@ -10,6 +10,7 @@ import type { Literal, Root } from 'mdast';
 import { escapeHtmlInTextNodes, normalizeCJKCharacters } from 'gt-remark';
 import type { StaticLocalizationSettings } from '../types/index.js';
 import { createFileMapping } from '../formats/files/fileMapping.js';
+import { settleAll } from './settleAll.js';
 
 type RewriteResult = { content: string; hasChanges: boolean };
 export type RelativeAssetSettings = StaticLocalizationSettings;
@@ -193,7 +194,7 @@ export default async function localizeRelativeAssets(
           (!includeFiles || includeFiles.has(p))
       );
 
-      await Promise.all(
+      await settleAll(
         targetFiles.map(async (targetPath) => {
           if (!fs.existsSync(targetPath)) return;
           const sourcePath = reverseMap.get(targetPath);
@@ -214,5 +215,5 @@ export default async function localizeRelativeAssets(
       );
     });
 
-  await Promise.all(processPromises);
+  await settleAll(processPromises);
 }

--- a/packages/cli/src/utils/localizeStaticImports.ts
+++ b/packages/cli/src/utils/localizeStaticImports.ts
@@ -13,6 +13,7 @@ import remarkFrontmatter from 'remark-frontmatter';
 import { visit } from 'unist-util-visit';
 import type { Root } from 'mdast';
 import type { MdxjsEsm } from 'mdast-util-mdxjs-esm';
+import { settleAll } from './settleAll.js';
 
 const { isMatch } = micromatch;
 
@@ -70,7 +71,7 @@ export default async function localizeStaticImports(
     }
 
     if (defaultLocaleFiles.length > 0) {
-      const defaultPromise = Promise.all(
+      const defaultPromise = settleAll(
         defaultLocaleFiles.map(async (filePath: string) => {
           // Check if file exists before processing
           if (!fs.existsSync(filePath)) {
@@ -108,7 +109,7 @@ export default async function localizeStaticImports(
       );
 
       // Replace the placeholder path with the target path
-      await Promise.all(
+      await settleAll(
         targetFiles.map(async (filePath) => {
           // Check if file exists before processing
           if (!fs.existsSync(filePath)) {
@@ -135,7 +136,7 @@ export default async function localizeStaticImports(
   );
   processPromises.push(...mappingPromises);
 
-  await Promise.all(processPromises);
+  await settleAll(processPromises);
 }
 
 interface ImportTransformResult {

--- a/packages/cli/src/utils/localizeStaticUrls.ts
+++ b/packages/cli/src/utils/localizeStaticUrls.ts
@@ -12,6 +12,7 @@ import type { Root, Link, Literal } from 'mdast';
 import type { MdxJsxFlowElement, MdxJsxTextElement } from 'mdast-util-mdx-jsx';
 import { escapeHtmlInTextNodes, normalizeCJKCharacters } from 'gt-remark';
 import { parse as parseBabel } from '@babel/parser';
+import { settleAll } from './settleAll.js';
 
 const { isMatch } = micromatch;
 
@@ -223,7 +224,7 @@ export default async function localizeStaticUrls(
     }
 
     if (defaultLocaleFiles.length > 0) {
-      const defaultPromise = Promise.all(
+      const defaultPromise = settleAll(
         defaultLocaleFiles.map(async (filePath: string) => {
           // Check if file exists before processing
           if (!fs.existsSync(filePath)) {
@@ -263,7 +264,7 @@ export default async function localizeStaticUrls(
       );
 
       // Replace the placeholder path with the target path
-      await Promise.all(
+      await settleAll(
         targetFiles.map(async (filePath) => {
           // Check if file exists before processing
           if (!fs.existsSync(filePath)) {
@@ -290,7 +291,7 @@ export default async function localizeStaticUrls(
     });
   processPromises.push(...mappingPromises);
 
-  await Promise.all(processPromises);
+  await settleAll(processPromises);
 }
 
 interface UrlTransformResult {

--- a/packages/cli/src/utils/processAnchorIds.ts
+++ b/packages/cli/src/utils/processAnchorIds.ts
@@ -6,6 +6,7 @@ import { getRelative, readFile } from '../fs/findFilepath.js';
 import { createFileMapping } from '../formats/files/fileMapping.js';
 import { Settings } from '../types/index.js';
 import * as fs from 'fs';
+import { settleAll } from './settleAll.js';
 
 /**
  * Processes all translated MD/MDX files to add explicit anchor IDs
@@ -85,5 +86,5 @@ export default async function processAnchorIds(
       }
     });
 
-  await Promise.all(processPromises);
+  await settleAll(processPromises);
 }

--- a/packages/cli/src/utils/settleAll.ts
+++ b/packages/cli/src/utils/settleAll.ts
@@ -1,0 +1,10 @@
+/** Waits for every operation before rethrowing the first failure. */
+export async function settleAll(
+  operations: Iterable<unknown | PromiseLike<unknown>>
+): Promise<void> {
+  const results = await Promise.allSettled(operations);
+  const failure = results.find(
+    (result): result is PromiseRejectedResult => result.status === 'rejected'
+  );
+  if (failure) throw failure.reason;
+}

--- a/packages/cli/src/utils/settleAll.ts
+++ b/packages/cli/src/utils/settleAll.ts
@@ -2,9 +2,15 @@
 export async function settleAll(
   operations: Iterable<unknown | PromiseLike<unknown>>
 ): Promise<void> {
-  const results = await Promise.allSettled(operations);
-  const failure = results.find(
-    (result): result is PromiseRejectedResult => result.status === 'rejected'
+  const noFailure = Symbol('no failure');
+  let firstFailure: unknown = noFailure;
+  const trackedOperations = Array.from(operations, (operation) =>
+    Promise.resolve(operation).catch((error) => {
+      if (firstFailure === noFailure) firstFailure = error;
+      throw error;
+    })
   );
-  if (failure) throw failure.reason;
+
+  await Promise.allSettled(trackedOperations);
+  if (firstFailure !== noFailure) throw firstFailure;
 }


### PR DESCRIPTION
## Summary

- Add a small `settleAll()` helper that waits for every sibling operation before rethrowing the first failure.
- Use it across generated-file postprocessors so rollback cannot race operations that are still mutating files.
- Preserve the existing first-error behavior while removing background work after rejection.

## Testing

- `pnpm --filter gt test` — passed
- `pnpm --filter gt typecheck` — passed
- `pnpm --filter compiler-cli-parity test` — passed (517 matched, 0 mismatches)
- `GT_TEST_APPS=vite-react pnpm --filter gt-test-apps-e2e test:e2e` — passed (Chromium 1/1 with local packages)

## Notes

- Changeset: inherited from the foundation PR.
- Stack: 4 of 6. Base: [#2167](https://github.com/generaltranslation/gt/pull/2167). Next: [#2166](https://github.com/generaltranslation/gt/pull/2166) hardens template generation.




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The CLI now waits for concurrent generated-file postprocessing work before returning an error. The earlier flat-batch ordering issue is fixed: the focused test confirms that a directly observed rejection is preserved. However, nested postprocessing batches can still report a later outer failure instead of the operation that failed first.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The error reported for a failed generated-file processing run can be misleading when postprocessing batches are nested.

One reproduced non-security failure remains in nested error propagation.

**Files Needing Attention:** packages/cli/src/utils/settleAll.ts
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex posted a P1 finding proof and attached focused reproduction artifacts to support the claim.
- T-Rex posted a second P1 finding proof, noting the same finding in a separate proof entry.
- T-Rex documented the general contract validation, describing the exact order of rejection events and the relevant settleAll.ts behavior.
- T-Rex linked the reproduction control points and tests that exercise settleAll's nested ordering and outer rejection, including the test files and reproduction sources.

<a href="https://app.greptile.com/trex/runs/20440138/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. General comment 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **settleAll throws a later rejection when a lower-index operation fails later**

   - **Bug**
     - With index 1 rejecting first and index 0 rejecting later, the helper throws index 0's error. The executed repro captured the temporal order as index 1 then index 0, while the thrown message was index 0.
   - **Cause**
     - `Promise.allSettled(operations)` returns settlement results in input iteration order. `results.find(result => result.status === 'rejected')` at lines 6-8 therefore selects the lowest-index rejected operation, regardless of when it rejected.
   - **Fix**
     - If the intended contract is to rethrow the earliest rejection in time while still waiting for all operations, record rejection timing/order as operations settle and throw the first recorded rejection after all operations finish.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Nested settleAll reports a later outer rejection instead of the first temporal failure**

   - **Bug**
     - When an inner operation rejects while a sibling in the same inner `settleAll` remains pending, the inner call does not reject until that sibling settles. If an outer sibling rejects during that interval, outer `settleAll` records and eventually throws that later error. The executed reproduction observed `outer failure (later in time)`, despite `inner failure (first in time)` rejecting first; it also showed all operations settled before completion.
   - **Cause**
     - `settleAll` captures an error in each invocation-local `firstFailure` only in the rejection handler attached to that invocation's direct operations (`packages/cli/src/utils/settleAll.ts:7-11`). A nested invocation exposes its failure to the parent only after awaiting `Promise.allSettled` (`:14-15`), so its earlier internal rejection is not observable by the outer invocation while an inner sibling is pending.
   - **Fix**
     - Preserve failure time across nesting rather than treating a nested `settleAll` as an opaque promise. For example, carry shared failure-order state through nested batches or return/throw a failure record containing the original observation sequence so an outer batch can select the earliest observed failure after all work settles. Add this exact nested-pending-sibling regression test to the CLI suite.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20generaltranslation%2Fgt%20PR%20%232168%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=generaltranslation%2Fgt&pr=2168&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fcli%2Fsrc%2Futils%2FsettleAll.ts%3A14-15%0A**Nested%20batches%20reorder%20failures**%0A%0AAn%20inner%20%60settleAll%60%20records%20its%20first%20failure%20but%20does%20not%20reject%20until%20its%20remaining%20inner%20operations%20settle.%20That%20makes%20the%20inner%20batch%20opaque%20to%20an%20outer%20%60settleAll%60%20during%20that%20interval%3A%20if%20an%20outer%20sibling%20rejects%20after%20the%20inner%20failure%20but%20before%20the%20inner%20sibling%20completes%2C%20the%20outer%20batch%20records%20and%20throws%20the%20later%20outer%20error%20instead.%20The%20CLI%20can%20therefore%20report%20a%20postprocessor%20error%20that%20did%20not%20initiate%20the%20failed%20run.%20Preserve%20the%20original%20failure%20observation%20order%20across%20nested%20batches%2C%20then%20add%20the%20nested%20pending-sibling%20regression%20case.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2168&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fcli%2Fsettle-file-postprocessors%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fcli%2Fsettle-file-postprocessors%22.%0A%0A%23%23%23%20Issue%201%0Apackages%2Fcli%2Fsrc%2Futils%2FsettleAll.ts%3A14-15%0A**Nested%20batches%20reorder%20failures**%0A%0AAn%20inner%20%60settleAll%60%20records%20its%20first%20failure%20but%20does%20not%20reject%20until%20its%20remaining%20inner%20operations%20settle.%20That%20makes%20the%20inner%20batch%20opaque%20to%20an%20outer%20%60settleAll%60%20during%20that%20interval%3A%20if%20an%20outer%20sibling%20rejects%20after%20the%20inner%20failure%20but%20before%20the%20inner%20sibling%20completes%2C%20the%20outer%20batch%20records%20and%20throws%20the%20later%20outer%20error%20instead.%20The%20CLI%20can%20therefore%20report%20a%20postprocessor%20error%20that%20did%20not%20initiate%20the%20failed%20run.%20Preserve%20the%20original%20failure%20observation%20order%20across%20nested%20batches%2C%20then%20add%20the%20nested%20pending-sibling%20regression%20case.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2168&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/cli/src/utils/settleAll.ts:14-15
**Nested batches reorder failures**

An inner `settleAll` records its first failure but does not reject until its remaining inner operations settle. That makes the inner batch opaque to an outer `settleAll` during that interval: if an outer sibling rejects after the inner failure but before the inner sibling completes, the outer batch records and throws the later outer error instead. The CLI can therefore report a postprocessor error that did not initiate the failed run. Preserve the original failure observation order across nested batches, then add the nested pending-sibling regression case.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;e/cli/share-file-source-me..."](https://github.com/generaltranslation/gt/commit/e1a238c44a7db5548414b782dfe92b624a7e8c3b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56375385)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->