### PR TITLE
feat(cli): [3/7] scope file transformations

### DIFF
--- a/packages/cli/src/cli/commands/__tests__/translate.test.ts
+++ b/packages/cli/src/cli/commands/__tests__/translate.test.ts
@@ -5,6 +5,7 @@ import type { Settings } from '../../../types/index.js';
 import flattenJsonFiles from '../../../utils/flattenJsonFiles.js';
 import { postprocessMintlify } from '../../../formats/files/postprocess/mintlify.js';
 import { persistPostProcessHashes } from '../../../utils/persistPostprocessHashes.js';
+import copyFile from '../../../fs/copyFile.js';
 
 vi.mock('../../../utils/flattenJsonFiles.js', () => ({
   default: vi.fn(),
@@ -78,7 +79,8 @@ describe('postProcessTranslations', () => {
 
     expect(postprocessMintlify).toHaveBeenCalledWith(
       expect.anything(),
-      new Set(['locales/fr/messages.json'])
+      new Set(['locales/fr/messages.json']),
+      { processDefaultLocaleFiles: true }
     );
     expect(flattenJsonFiles).toHaveBeenCalledWith(
       expect.anything(),
@@ -89,5 +91,22 @@ describe('postProcessTranslations', () => {
       new Set(['locales/fr/messages.json']),
       expect.anything()
     );
+  });
+
+  it('restricts generated-file postprocessing to included outputs', async () => {
+    const settings = makeSettings();
+    settings.options!.copyFiles = ['assets/[locale]/logo.svg'];
+    const includeFiles = new Set(['locales/fr/messages.json']);
+
+    await postProcessTranslations(settings, includeFiles, {
+      restrictToIncludedFiles: true,
+    });
+
+    expect(postprocessMintlify).toHaveBeenCalledWith(settings, includeFiles, {
+      processDefaultLocaleFiles: false,
+    });
+    expect(flattenJsonFiles).toHaveBeenCalledWith(settings, includeFiles);
+    expect(copyFile).not.toHaveBeenCalled();
+    expect(persistPostProcessHashes).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/cli/commands/translate.ts
+++ b/packages/cli/src/cli/commands/translate.ts
@@ -22,6 +22,10 @@ import { hasNonIdentityFileFormatTransformForType } from '../../formats/files/tr
 import { getRelative } from '../../fs/findFilepath.js';
 import type { InlineLibrary } from '../../types/libraries.js';
 
+type PostProcessTranslationsOptions = {
+  restrictToIncludedFiles?: boolean;
+};
+
 // Downloads translations that were completed
 export async function handleTranslate(
   options: TranslateFlags,
@@ -82,7 +86,8 @@ export async function handleTranslate(
 
 export async function postProcessTranslations(
   settings: Settings,
-  includeFiles?: Set<string>
+  includeFiles?: Set<string>,
+  options: PostProcessTranslationsOptions = {}
 ) {
   const postProcessIncludes = filterPostProcessIncludesForFormatTransforms(
     settings,
@@ -90,7 +95,9 @@ export async function postProcessTranslations(
   );
   if (includeFiles && postProcessIncludes?.size === 0) return;
 
-  await postprocessMintlify(settings, postProcessIncludes);
+  await postprocessMintlify(settings, postProcessIncludes, {
+    processDefaultLocaleFiles: !options.restrictToIncludedFiles,
+  });
 
   // Localize static urls (/docs -> /[locale]/docs) and preserve anchor IDs for non-default locales
   // Default locale is processed earlier in the flow in base.ts
@@ -142,12 +149,18 @@ export async function postProcessTranslations(
   }
 
   // Copy files to the target locale
-  if (settings.options?.copyFiles) {
+  if (!options.restrictToIncludedFiles && settings.options?.copyFiles) {
     await copyFile(settings);
   }
 
   // Record postprocessed content hashes for newly downloaded files
-  persistPostProcessHashes(settings, postProcessIncludes, getDownloadedMeta());
+  if (!options.restrictToIncludedFiles) {
+    persistPostProcessHashes(
+      settings,
+      postProcessIncludes,
+      getDownloadedMeta()
+    );
+  }
 }
 
 /**

--- a/packages/cli/src/formats/files/postprocess/__tests__/mintlify.test.ts
+++ b/packages/cli/src/formats/files/postprocess/__tests__/mintlify.test.ts
@@ -29,7 +29,7 @@ describe('postprocessMintlify', () => {
 
     await postprocessMintlify(settings);
 
-    expect(processOpenApi).toHaveBeenCalledWith(settings, undefined);
+    expect(processOpenApi).toHaveBeenCalledWith(settings, undefined, {});
     expect(localizeMintlifyFrontmatterUrls).not.toHaveBeenCalled();
   });
 
@@ -39,9 +39,13 @@ describe('postprocessMintlify', () => {
     } as Settings;
     const includeFiles = new Set(['ja/sandboxes.mdx']);
 
-    await postprocessMintlify(settings, includeFiles);
+    await postprocessMintlify(settings, includeFiles, {
+      processDefaultLocaleFiles: false,
+    });
 
-    expect(processOpenApi).toHaveBeenCalledWith(settings, includeFiles);
+    expect(processOpenApi).toHaveBeenCalledWith(settings, includeFiles, {
+      processDefaultLocaleFiles: false,
+    });
     expect(localizeMintlifyFrontmatterUrls).toHaveBeenCalledWith(
       settings,
       includeFiles

--- a/packages/cli/src/formats/files/postprocess/mintlify.ts
+++ b/packages/cli/src/formats/files/postprocess/mintlify.ts
@@ -2,17 +2,22 @@ import type { Settings } from '../../../types/index.js';
 import localizeMintlifyFrontmatterUrls from '../../../utils/localizeMintlifyFrontmatterUrls.js';
 import processOpenApi from '../../../utils/processOpenApi.js';
 
+type MintlifyPostprocessOptions = {
+  processDefaultLocaleFiles?: boolean;
+};
+
 /**
  * Runs all Mintlify-specific postprocessing on translated files.
  */
 export async function postprocessMintlify(
   settings: Settings,
-  includeFiles?: Set<string>
+  includeFiles?: Set<string>,
+  options: MintlifyPostprocessOptions = {}
 ) {
   if (settings.framework !== 'mintlify' && !settings.options?.mintlify?.openapi)
     return;
 
-  await processOpenApi(settings, includeFiles);
+  await processOpenApi(settings, includeFiles, options);
 
   if (settings.framework !== 'mintlify') return;
 

--- a/packages/cli/src/utils/processOpenApi.ts
+++ b/packages/cli/src/utils/processOpenApi.ts
@@ -17,6 +17,10 @@ type SpecAnalysis = {
   webhooks: Set<string>;
 };
 
+type ProcessOpenApiOptions = {
+  processDefaultLocaleFiles?: boolean;
+};
+
 type ParsedOpenApiValue =
   | {
       kind: 'operation';
@@ -55,7 +59,8 @@ const OPENAPI_SPEC_EXTENSIONS = new Set(['.json', '.yaml', '.yml']);
  */
 export default async function processOpenApi(
   settings: Settings,
-  includeFiles?: Set<string>
+  includeFiles?: Set<string>,
+  { processDefaultLocaleFiles = true }: ProcessOpenApiOptions = {}
 ) {
   const openapiConfig = settings.options?.mintlify?.openapi;
   if (!openapiConfig || !openapiConfig.files?.length) return;
@@ -87,24 +92,26 @@ export default async function processOpenApi(
   }
 
   // Also rewrite default-locale source files so they use the deterministic spec selection
-  const defaultFiles = [
-    ...(resolvedPaths.mdx || []),
-    ...(resolvedPaths.md || []),
-  ];
-  for (const filePath of defaultFiles) {
-    if (!fs.existsSync(filePath)) continue;
-    const content = fs.readFileSync(filePath, 'utf8');
-    const updated = rewriteFrontmatter(
-      content,
-      filePath,
-      settings.defaultLocale,
-      specAnalyses,
-      fileMappingAbs,
-      warnings,
-      configDir
-    );
-    if (updated?.changed) {
-      await fs.promises.writeFile(filePath, updated.content, 'utf8');
+  if (processDefaultLocaleFiles) {
+    const defaultFiles = [
+      ...(resolvedPaths.mdx || []),
+      ...(resolvedPaths.md || []),
+    ];
+    for (const filePath of defaultFiles) {
+      if (!fs.existsSync(filePath)) continue;
+      const content = fs.readFileSync(filePath, 'utf8');
+      const updated = rewriteFrontmatter(
+        content,
+        filePath,
+        settings.defaultLocale,
+        specAnalyses,
+        fileMappingAbs,
+        warnings,
+        configDir
+      );
+      if (updated?.changed) {
+        await fs.promises.writeFile(filePath, updated.content, 'utf8');
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Allow existing file postprocessors to operate only on an explicit set of outputs.
- Skip default-locale OpenAPI rewriting, copied assets, and postprocess metadata when running in generated-file mode.
- Preserve the current translate and download behavior by keeping unrestricted processing as the default.

## Testing

- `pnpm --filter gt exec vitest run src/cli/commands/__tests__/translate.test.ts src/formats/files/postprocess/__tests__/mintlify.test.ts src/utils/__tests__/processOpenApi.test.ts` — passed (20 tests)
- `pnpm --filter gt typecheck` — passed
- Changed-file oxlint and oxfmt checks — passed
- `GT_TEST_APPS=vite-react pnpm --filter gt-test-apps-e2e test:e2e` — passed (Chromium 1/1 using local packages)

## Notes

- No changeset: this adds an internal processing mode used by the later generation engine.
- Stack: follows #2170 and precedes the recoverable generation-engine PR.








<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds a `gt generate` command and refactors translation postprocessing and source-schema merging. The new command reports success without creating translation files, so it should be implemented, removed from the command surface, or changed to fail explicitly before merge.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The newly exposed generation command can cause automation to proceed after no translation files were produced.

One verified functional failure remains: the command advertises file generation but exits successfully after only logging that it is unimplemented.

**Files Needing Attention:** packages/cli/src/cli/base.ts
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex authored an end-to-end gt generate validation script.
- T-Rex configured the fixture before running gt generate.
- T-Rex ran gt generate with the configured fixture and captured runtime output.
- T-Rex focused the gt generate command test output for review.
- T-Rex validated that the generate command is currently unimplemented in code and returns exit code 0, with the unimplemented message visible in the runtime logs.

<a href="https://app.greptile.com/trex/runs/20628281/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/cli/src/cli/base.ts`, line 293-300 ([link](https://github.com/generaltranslation/gt/blob/7b6e79b10b48c5229d9ea0cf8cc848cfedc9ec52/packages/cli/src/cli/base.ts#L293-L300)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`gt generate` succeeds without generating files**

   The new command is described as “Generate translation files,” but its action only logs that it is not implemented and exits successfully. Running it in a configured project leaves no locale output, allowing scripts and users to treat a failed generation step as successful. Implement the generation workflow, remove the command until it is available, or return a nonzero unsupported-command error.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Authored gt generate end-to-end validation script](https://app.greptile.com/trex/artifacts/2ebacee4-e2ad-4e42-82ef-acfc68c9c9c2)**

   - Creates an isolated configured project, invokes the built CLI, and enumerates files created by the command; it is the exact source used for the runtime validation.

   **[Configured fixture before gt generate](https://app.greptile.com/trex/artifacts/e3bd95f9-51a9-4909-bab8-39d9e9d8f7ab)**

   - Records the configured source fixture and confirms that no generated translation files existed before command execution; it provides the comparison baseline.

   **[gt generate runtime output with configured fixture](https://app.greptile.com/trex/artifacts/0c1a4dc0-e926-45b7-9d27-d26021ef9d79)**

   - Captures the real CLI invocation printing \`gt generate is not implemented yet.\`, returning zero, and listing no generated files; it confirms the documented workflow is a no-op.

   **[Focused gt generate command test output](https://app.greptile.com/trex/artifacts/be4c96eb-70be-4e76-9447-3d20b3884fc4)**

   - Captures the focused Vitest test passing while asserting the same unimplemented log message; it shows the current automated test encodes the no-op behavior.

   <a href="https://app.greptile.com/trex/runs/20628281/artifacts?artifact=2ebacee4-e2ad-4e42-82ef-acfc68c9c9c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/cli/src/cli/base.ts
   Line: 293-300

   Comment:
   **`gt generate` succeeds without generating files**

   The new command is described as “Generate translation files,” but its action only logs that it is not implemented and exits successfully. Running it in a configured project leaves no locale output, allowing scripts and users to treat a failed generation step as successful. Implement the generation workflow, remove the command until it is available, or return a nonzero unsupported-command error.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcli%2Fsrc%2Fcli%2Fbase.ts%0ALine%3A%20293-300%0A%0AComment%3A%0A**%60gt%20generate%60%20succeeds%20without%20generating%20files**%0A%0AThe%20new%20command%20is%20described%20as%20%E2%80%9CGenerate%20translation%20files%2C%E2%80%9D%20but%20its%20action%20only%20logs%20that%20it%20is%20not%20implemented%20and%20exits%20successfully.%20Running%20it%20in%20a%20configured%20project%20leaves%20no%20locale%20output%2C%20allowing%20scripts%20and%20users%20to%20treat%20a%20failed%20generation%20step%20as%20successful.%20Implement%20the%20generation%20workflow%2C%20remove%20the%20command%20until%20it%20is%20available%2C%20or%20return%20a%20nonzero%20unsupported-command%20error.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2171&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fcli%2Fscope-file-transformations%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fcli%2Fscope-file-transformations%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcli%2Fsrc%2Fcli%2Fbase.ts%0ALine%3A%20293-300%0A%0AComment%3A%0A**%60gt%20generate%60%20succeeds%20without%20generating%20files**%0A%0AThe%20new%20command%20is%20described%20as%20%E2%80%9CGenerate%20translation%20files%2C%E2%80%9D%20but%20its%20action%20only%20logs%20that%20it%20is%20not%20implemented%20and%20exits%20successfully.%20Running%20it%20in%20a%20configured%20project%20leaves%20no%20locale%20output%2C%20allowing%20scripts%20and%20users%20to%20treat%20a%20failed%20generation%20step%20as%20successful.%20Implement%20the%20generation%20workflow%2C%20remove%20the%20command%20until%20it%20is%20available%2C%20or%20return%20a%20nonzero%20unsupported-command%20error.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2171&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Documented gt generate command silently performs no generation**

   - **Bug**
     - The newly registered command advertises “Generate translation files.” but, when executed in a project with a GT configuration and source file, only prints `gt generate is not implemented yet.`, exits 0, and leaves no generated locale files.
   - **Cause**
     - `setupGenerateCommand` registers an action containing only a logger call rather than invoking settings resolution, extraction, or a file-writing workflow.
   - **Fix**
     - Implement the intended generation workflow and assert generated catalog output in an end-to-end test; until then, remove/hide the command or fail with a nonzero unsupported-command error instead of documenting it as operational.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20generaltranslation%2Fgt%20PR%20%232171%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=generaltranslation%2Fgt&pr=2171&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fcli%2Fsrc%2Fcli%2Fbase.ts%3A293-300%0A**%60gt%20generate%60%20succeeds%20without%20generating%20files**%0A%0AThe%20new%20command%20is%20described%20as%20%E2%80%9CGenerate%20translation%20files%2C%E2%80%9D%20but%20its%20action%20only%20logs%20that%20it%20is%20not%20implemented%20and%20exits%20successfully.%20Running%20it%20in%20a%20configured%20project%20leaves%20no%20locale%20output%2C%20allowing%20scripts%20and%20users%20to%20treat%20a%20failed%20generation%20step%20as%20successful.%20Implement%20the%20generation%20workflow%2C%20remove%20the%20command%20until%20it%20is%20available%2C%20or%20return%20a%20nonzero%20unsupported-command%20error.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2171&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fcli%2Fscope-file-transformations%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fcli%2Fscope-file-transformations%22.%0A%0A%23%23%23%20Issue%201%0Apackages%2Fcli%2Fsrc%2Fcli%2Fbase.ts%3A293-300%0A**%60gt%20generate%60%20succeeds%20without%20generating%20files**%0A%0AThe%20new%20command%20is%20described%20as%20%E2%80%9CGenerate%20translation%20files%2C%E2%80%9D%20but%20its%20action%20only%20logs%20that%20it%20is%20not%20implemented%20and%20exits%20successfully.%20Running%20it%20in%20a%20configured%20project%20leaves%20no%20locale%20output%2C%20allowing%20scripts%20and%20users%20to%20treat%20a%20failed%20generation%20step%20as%20successful.%20Implement%20the%20generation%20workflow%2C%20remove%20the%20command%20until%20it%20is%20available%2C%20or%20return%20a%20nonzero%20unsupported-command%20error.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2171&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/cli/src/cli/base.ts:293-300
**`gt generate` succeeds without generating files**

The new command is described as “Generate translation files,” but its action only logs that it is not implemented and exits successfully. Running it in a configured project leaves no locale output, allowing scripts and users to treat a failed generation step as successful. Implement the generation workflow, remove the command until it is available, or return a nonzero unsupported-command error.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["chore(cli): update transformation stack ..."](https://github.com/generaltranslation/gt/commit/7b6e79b10b48c5229d9ea0cf8cc848cfedc9ec52) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56485407)</sub>

<!-- /greptile_comment -->