### PR TITLE
fix(cli): [4/7] await file postprocessors

### DIFF
--- a/packages/cli/src/utils/__tests__/flattenJsonFiles.test.ts
+++ b/packages/cli/src/utils/__tests__/flattenJsonFiles.test.ts
@@ -1,0 +1,45 @@
+import fs from 'node:fs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createMockSettings } from '../../api/__mocks__/settings.js';
+import { createFileMapping } from '../../formats/files/fileMapping.js';
+import flattenJsonFiles from '../flattenJsonFiles.js';
+
+vi.mock('../../formats/files/fileMapping.js', () => ({
+  createFileMapping: vi.fn(),
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('flattenJsonFiles', () => {
+  it('rethrows the first observed failure across locale groups', async () => {
+    const firstFailure = new Error('failed first');
+    const laterFailure = new Error('failed later');
+    vi.mocked(createFileMapping).mockReturnValue({
+      en: {
+        first: 'first.json',
+        sibling: 'sibling.json',
+      },
+      fr: {
+        later: 'later.json',
+      },
+    });
+    vi.spyOn(fs, 'readFileSync').mockReturnValue('{"nested":{"key":"value"}}');
+    vi.spyOn(fs.promises, 'writeFile').mockImplementation(async (file) => {
+      if (file === 'first.json') throw firstFailure;
+      if (file === 'later.json') throw laterFailure;
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    });
+
+    const settings = createMockSettings({
+      files: {
+        resolvedPaths: { json: ['source.json'] },
+        placeholderPaths: { json: ['[locale].json'] },
+        transformPaths: {},
+      },
+    });
+
+    await expect(flattenJsonFiles(settings)).rejects.toBe(firstFailure);
+  });
+});

--- a/packages/cli/src/utils/__tests__/settleAll.test.ts
+++ b/packages/cli/src/utils/__tests__/settleAll.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { settleAll } from '../settleAll.js';
+
+describe('settleAll', () => {
+  it('waits for sibling operations before rethrowing a failure', async () => {
+    const failure = new Error('failed');
+    let siblingFinished = false;
+    const sibling = new Promise<void>((resolve) => {
+      setTimeout(() => {
+        siblingFinished = true;
+        resolve();
+      }, 5);
+    });
+
+    await expect(settleAll([Promise.reject(failure), sibling])).rejects.toBe(
+      failure
+    );
+    expect(siblingFinished).toBe(true);
+  });
+
+  it('rethrows the first observed failure', async () => {
+    const firstFailure = new Error('failed first');
+    const laterFailure = new Error('failed later');
+    const earlierOperation = new Promise<void>((_resolve, reject) => {
+      setTimeout(() => reject(laterFailure), 5);
+    });
+
+    await expect(
+      settleAll([earlierOperation, Promise.reject(firstFailure)])
+    ).rejects.toBe(firstFailure);
+  });
+});

--- a/packages/cli/src/utils/flattenJsonFiles.ts
+++ b/packages/cli/src/utils/flattenJsonFiles.ts
@@ -26,13 +26,12 @@ export default async function flattenJsonFiles(
   );
 
   await settleAll(
-    Object.values(fileMapping).map(async (filesMap) => {
-      const targetFiles = Object.values(filesMap).filter(
-        (p) => p.endsWith('.json') && (!includeFiles || includeFiles.has(p))
-      );
-
-      await settleAll(
-        targetFiles.map(async (file) => {
+    Object.values(fileMapping).flatMap((filesMap) =>
+      Object.values(filesMap)
+        .filter(
+          (p) => p.endsWith('.json') && (!includeFiles || includeFiles.has(p))
+        )
+        .map(async (file) => {
           // Read each json file
           const json = JSON.parse(fs.readFileSync(file, 'utf8'));
           // Flatten the json
@@ -45,8 +44,7 @@ export default async function flattenJsonFiles(
           );
           return flattenedJson;
         })
-      );
-    })
+    )
   );
 }
 

--- a/packages/cli/src/utils/flattenJsonFiles.ts
+++ b/packages/cli/src/utils/flattenJsonFiles.ts
@@ -1,6 +1,7 @@
 import { createFileMapping } from '../formats/files/fileMapping.js';
 import fs from 'node:fs';
 import { Settings } from '../types/index.js';
+import { settleAll } from './settleAll.js';
 
 export default async function flattenJsonFiles(
   settings: Settings,
@@ -24,13 +25,13 @@ export default async function flattenJsonFiles(
     settings.defaultLocale
   );
 
-  await Promise.all(
+  await settleAll(
     Object.values(fileMapping).map(async (filesMap) => {
       const targetFiles = Object.values(filesMap).filter(
         (p) => p.endsWith('.json') && (!includeFiles || includeFiles.has(p))
       );
 
-      await Promise.all(
+      await settleAll(
         targetFiles.map(async (file) => {
           // Read each json file
           const json = JSON.parse(fs.readFileSync(file, 'utf8'));

--- a/packages/cli/src/utils/localizeMintlifyFrontmatterUrls.ts
+++ b/packages/cli/src/utils/localizeMintlifyFrontmatterUrls.ts
@@ -7,6 +7,7 @@ import YAML, { isMap, isScalar } from 'yaml';
 import type { Content, Root, Yaml } from 'mdast';
 import { createFileMapping } from '../formats/files/fileMapping.js';
 import type { Settings } from '../types/index.js';
+import { settleAll } from './settleAll.js';
 
 const SKIPPABLE_URL_REGEX = /^(?:[a-z][a-z0-9+.-]*:|\/\/|#|\.\/|\.\.\/)/i;
 
@@ -140,7 +141,7 @@ export default async function localizeMintlifyFrontmatterUrls(
         shouldProcessFile(filePath, includeFiles)
     );
 
-    await Promise.all(
+    await settleAll(
       targetFiles.map(async (filePath) => {
         if (!fs.existsSync(filePath)) return;
 

--- a/packages/cli/src/utils/localizeRelativeAssets.ts
+++ b/packages/cli/src/utils/localizeRelativeAssets.ts
@@ -10,6 +10,7 @@ import type { Literal, Root } from 'mdast';
 import { escapeHtmlInTextNodes, normalizeCJKCharacters } from 'gt-remark';
 import type { StaticLocalizationSettings } from '../types/index.js';
 import { createFileMapping } from '../formats/files/fileMapping.js';
+import { settleAll } from './settleAll.js';
 
 type RewriteResult = { content: string; hasChanges: boolean };
 export type RelativeAssetSettings = StaticLocalizationSettings;
@@ -193,7 +194,7 @@ export default async function localizeRelativeAssets(
           (!includeFiles || includeFiles.has(p))
       );
 
-      await Promise.all(
+      await settleAll(
         targetFiles.map(async (targetPath) => {
           if (!fs.existsSync(targetPath)) return;
           const sourcePath = reverseMap.get(targetPath);
@@ -214,5 +215,5 @@ export default async function localizeRelativeAssets(
       );
     });
 
-  await Promise.all(processPromises);
+  await settleAll(processPromises);
 }

--- a/packages/cli/src/utils/localizeStaticImports.ts
+++ b/packages/cli/src/utils/localizeStaticImports.ts
@@ -13,6 +13,7 @@ import remarkFrontmatter from 'remark-frontmatter';
 import { visit } from 'unist-util-visit';
 import type { Root } from 'mdast';
 import type { MdxjsEsm } from 'mdast-util-mdxjs-esm';
+import { settleAll } from './settleAll.js';
 
 const { isMatch } = micromatch;
 
@@ -70,7 +71,7 @@ export default async function localizeStaticImports(
     }
 
     if (defaultLocaleFiles.length > 0) {
-      const defaultPromise = Promise.all(
+      const defaultPromise = settleAll(
         defaultLocaleFiles.map(async (filePath: string) => {
           // Check if file exists before processing
           if (!fs.existsSync(filePath)) {
@@ -108,7 +109,7 @@ export default async function localizeStaticImports(
       );
 
       // Replace the placeholder path with the target path
-      await Promise.all(
+      await settleAll(
         targetFiles.map(async (filePath) => {
           // Check if file exists before processing
           if (!fs.existsSync(filePath)) {
@@ -135,7 +136,7 @@ export default async function localizeStaticImports(
   );
   processPromises.push(...mappingPromises);
 
-  await Promise.all(processPromises);
+  await settleAll(processPromises);
 }
 
 interface ImportTransformResult {

--- a/packages/cli/src/utils/localizeStaticUrls.ts
+++ b/packages/cli/src/utils/localizeStaticUrls.ts
@@ -12,6 +12,7 @@ import type { Root, Link, Literal } from 'mdast';
 import type { MdxJsxFlowElement, MdxJsxTextElement } from 'mdast-util-mdx-jsx';
 import { escapeHtmlInTextNodes, normalizeCJKCharacters } from 'gt-remark';
 import { parse as parseBabel } from '@babel/parser';
+import { settleAll } from './settleAll.js';
 
 const { isMatch } = micromatch;
 
@@ -223,7 +224,7 @@ export default async function localizeStaticUrls(
     }
 
     if (defaultLocaleFiles.length > 0) {
-      const defaultPromise = Promise.all(
+      const defaultPromise = settleAll(
         defaultLocaleFiles.map(async (filePath: string) => {
           // Check if file exists before processing
           if (!fs.existsSync(filePath)) {
@@ -263,7 +264,7 @@ export default async function localizeStaticUrls(
       );
 
       // Replace the placeholder path with the target path
-      await Promise.all(
+      await settleAll(
         targetFiles.map(async (filePath) => {
           // Check if file exists before processing
           if (!fs.existsSync(filePath)) {
@@ -290,7 +291,7 @@ export default async function localizeStaticUrls(
     });
   processPromises.push(...mappingPromises);
 
-  await Promise.all(processPromises);
+  await settleAll(processPromises);
 }
 
 interface UrlTransformResult {

--- a/packages/cli/src/utils/processAnchorIds.ts
+++ b/packages/cli/src/utils/processAnchorIds.ts
@@ -6,6 +6,7 @@ import { getRelative, readFile } from '../fs/findFilepath.js';
 import { createFileMapping } from '../formats/files/fileMapping.js';
 import { Settings } from '../types/index.js';
 import * as fs from 'fs';
+import { settleAll } from './settleAll.js';
 
 /**
  * Processes all translated MD/MDX files to add explicit anchor IDs
@@ -85,5 +86,5 @@ export default async function processAnchorIds(
       }
     });
 
-  await Promise.all(processPromises);
+  await settleAll(processPromises);
 }

--- a/packages/cli/src/utils/settleAll.ts
+++ b/packages/cli/src/utils/settleAll.ts
@@ -1,0 +1,16 @@
+/** Waits for every operation before rethrowing the first failure. */
+export async function settleAll(
+  operations: Iterable<unknown | PromiseLike<unknown>>
+): Promise<void> {
+  const noFailure = Symbol('no failure');
+  let firstFailure: unknown = noFailure;
+  const trackedOperations = Array.from(operations, (operation) =>
+    Promise.resolve(operation).catch((error) => {
+      if (firstFailure === noFailure) firstFailure = error;
+      throw error;
+    })
+  );
+
+  await Promise.allSettled(trackedOperations);
+  if (firstFailure !== noFailure) throw firstFailure;
+}


### PR DESCRIPTION
## Summary

- Add a small helper that waits for every parallel file operation before rethrowing the first observed failure.
- Use it across file postprocessors so one rejected transform cannot race ahead of still-running sibling writes.
- Preserve successful processing behavior and the original actionable error.

## Testing

- `pnpm --filter gt exec vitest run src/utils/__tests__/settleAll.test.ts src/utils/__tests__/localizeStaticUrls.test.ts src/utils/__tests__/localizeStaticImports.test.ts src/utils/__tests__/localizeRelativeAssets.test.ts src/utils/__tests__/localizeMintlifyFrontmatterUrls.test.ts` — passed (190 tests)
- `pnpm --filter gt typecheck` — passed
- Changed-file oxlint and oxfmt checks — passed
- `GT_TEST_APPS=vite-react pnpm --filter gt-test-apps-e2e test:e2e` — passed (Chromium 1/1 using local packages)

## Notes

- No changeset: this is internal failure-ordering hardening used by the later generation engine.
- Stack: follows #2171 and precedes the recoverable generation-engine PR.






<!-- greptile_comment -->

<h3>Greptile Summary</h3>

JSON file flattening now uses a single settlement boundary across locale groups, so a translation run reports the file operation that failed first after concurrent work has completed.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

The exercised multi-locale failure path now returns the first observed file error and waits for sibling operations to settle.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran a deterministic before-and-after runtime reproduction for concurrent failures across locale groups.
- I observed that the nested failure order reported the later locale-group failure after a sibling, while the current flattened shape reported the original first.json failure.
- Direct execution of the current settleAll implementation retained the identity of the first error object.
- I attempted to start a focused Vitest command, but the workspace symlink resolved to a missing pnpm-store path, blocking startup.
- In the second validation, the before state showed first.json rejection plus later-locale rejection, while the after shape reports the first.json failure and direct execution confirmed the first failure identity via settleAll.

<a href="https://app.greptile.com/trex/runs/20628272/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(cli): preserve postprocessor failure..."](https://github.com/generaltranslation/gt/commit/b821886a67a031e73668da896b85f8a2eeb33823) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56485412)</sub>

<!-- /greptile_comment -->