### PR TITLE
feat(cli): add gt api command for raw API access

### DIFF
--- a/.changeset/bright-api-access.md
+++ b/.changeset/bright-api-access.md
@@ -1,0 +1,5 @@
+---
+'gt': minor
+---
+
+Add `gt api` for raw authenticated API requests and OpenAPI spec discovery.

--- a/.changeset/clean-rivers-translate.md
+++ b/.changeset/clean-rivers-translate.md
@@ -1,0 +1,6 @@
+---
+'generaltranslation': patch
+'gt-sanity': patch
+---
+
+Route runtime and Sanity API requests through the generated General Translation API SDK while preserving the existing public interfaces.

--- a/.changeset/curly-trees-translate.md
+++ b/.changeset/curly-trees-translate.md
@@ -1,0 +1,5 @@
+---
+'generaltranslation': minor
+---
+
+Expose the generated API SDK from the `generaltranslation/api` subpath.

--- a/.changeset/expose-openapi-spec.md
+++ b/.changeset/expose-openapi-spec.md
@@ -1,5 +1,6 @@
 ---
 '@generaltranslation/api': patch
+'generaltranslation': patch
 ---
 
-Expose `spec/openapi.json` through the package exports.
+Expose `spec/openapi.json` through the API and core package exports.

--- a/.changeset/expose-openapi-spec.md
+++ b/.changeset/expose-openapi-spec.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/api': patch
+---
+
+Expose `spec/openapi.json` through the package exports.

--- a/.changeset/smooth-tools-translate.md
+++ b/.changeset/smooth-tools-translate.md
@@ -3,4 +3,4 @@
 '@generaltranslation/api': minor
 ---
 
-Add `gt project create` and `gt project status` commands, and migrate CLI API requests to the generated SDK.
+Add `gt project create` and `gt project status` commands, and migrate CLI API requests to the generated SDK through `generaltranslation/api`.

--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -84,6 +84,7 @@ const reactNativeNode = (name, file) =>
 
 module.exports = [
   core('generaltranslation', 'index'),
+  core('generaltranslation/api', 'api'),
   core('generaltranslation/runtime', 'runtime'),
   core('generaltranslation/id', 'id'),
   core('generaltranslation/internal', 'internal'),

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -22,7 +22,8 @@
         "types": "./dist/index.d.mts",
         "default": "./dist/index.mjs"
       }
-    }
+    },
+    "./spec/openapi.json": "./spec/openapi.json"
   },
   "scripts": {
     "build": "tsdown",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -114,7 +114,6 @@
     "@babel/traverse": "^7.25.7",
     "@babel/types": "^7.25.7",
     "@clack/prompts": "1.0.0-alpha.6",
-    "@generaltranslation/api": "workspace:*",
     "@generaltranslation/icu": "workspace:*",
     "@generaltranslation/format": "workspace:*",
     "@generaltranslation/python-extractor": "workspace:*",

--- a/packages/cli/src/cli/__tests__/vueBuilt.test.ts
+++ b/packages/cli/src/cli/__tests__/vueBuilt.test.ts
@@ -1262,6 +1262,7 @@ import { LocalT } from '@gt';
         'upload',
         'auth',
         'save-local',
+        'api',
         'project',
         'git',
       ];

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -80,6 +80,7 @@ import { createDiagnosticMessage } from 'generaltranslation/internal';
 import { setupViteSPA } from '../setup/setupViteSPA.js';
 import { manifestDirectlyDeclaresGTVue } from '@generaltranslation/vue-extractor/integration';
 import { api } from '../utils/api.js';
+import { handleApiCommand, type ApiCommandOptions } from './commands/api.js';
 
 const ID_COMPATIBILITY_WARNING_COMMANDS = new Set([
   'download',
@@ -197,6 +198,7 @@ export class BaseCLI {
     this.setupUploadCommand();
     this.setupLoginCommand();
     this.setupSendDiffsCommand();
+    this.setupApiCommand();
     this.setupProjectCommands();
     this.setupGitCommand();
   }
@@ -310,6 +312,28 @@ export class BaseCLI {
         await saveLocalEdits(settings);
         logger.endCommand('Saved local edits');
       });
+  }
+
+  protected setupApiCommand(): void {
+    attachSharedFlags(
+      this.program
+        .command('api [endpoint]')
+        .description('Make an authenticated request to the GT API')
+        .option('-X, --method <method>', 'HTTP method', 'GET')
+        .option('--input <file>', 'Request body file, or - for standard input')
+        .option(
+          '-H, --header <header>',
+          'Request header in "Key: Value" format',
+          (header, headers: string[] | undefined) => [
+            ...(headers ?? []),
+            header,
+          ]
+        )
+        .option('-i, --include', 'Include response status and headers')
+        .option('--spec', 'Print the bundled OpenAPI specification')
+    ).action((endpoint, options: ApiCommandOptions) =>
+      handleApiCommand(endpoint, options)
+    );
   }
 
   protected setupProjectCommands(): void {

--- a/packages/cli/src/cli/commands/__tests__/api.test.ts
+++ b/packages/cli/src/cli/commands/__tests__/api.test.ts
@@ -6,6 +6,12 @@ import { handleApiCommand } from '../api.js';
 
 const temporaryDirectories: string[] = [];
 
+type OutputChunk = string | Uint8Array;
+
+function outputText(chunks: OutputChunk[]): string {
+  return Buffer.concat(chunks.map((chunk) => Buffer.from(chunk))).toString();
+}
+
 function writeInput(content: string): string {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'gt-api-test-'));
   temporaryDirectories.push(directory);
@@ -29,20 +35,20 @@ describe('gt api', () => {
       expect(request.method).toBe('POST');
       expect(request.headers.get('authorization')).toBe('Bearer api-key');
       expect(request.headers.get('gt-project-id')).toBe('project-id');
-      expect(request.headers.get('x-test')).toBe('value');
+      expect(request.headers.get('x-test')).toBe('value, second');
       expect(request.headers.get('content-type')).toBe('application/json');
       expect(await request.text()).toBe(requestBody);
       return new Response(responseBody, {
         headers: { 'Content-Type': 'application/json' },
       });
     });
-    const stdout: string[] = [];
+    const stdout: OutputChunk[] = [];
 
     await handleApiCommand(
       'v2/example',
       {
         apiKey: 'api-key',
-        header: ['X-Test: value'],
+        header: ['X-Test: value', 'X-Test: second'],
         input: writeInput(requestBody),
         method: 'post',
         projectId: 'project-id',
@@ -54,7 +60,29 @@ describe('gt api', () => {
     );
 
     expect(fetchMock).toHaveBeenCalledOnce();
-    expect(stdout.join('')).toBe(responseBody);
+    expect(outputText(stdout)).toBe(responseBody);
+  });
+
+  it('preserves binary response bodies', async () => {
+    const responseBody = Uint8Array.from([0, 255, 1, 128]);
+    const stdout: OutputChunk[] = [];
+
+    await handleApiCommand(
+      '/v2/binary',
+      {
+        apiKey: 'api-key',
+        method: 'GET',
+        projectId: 'project-id',
+      },
+      {
+        fetch: async () => new Response(responseBody),
+        writeStdout: (output) => stdout.push(output),
+      }
+    );
+
+    expect(Buffer.concat(stdout.map((chunk) => Buffer.from(chunk)))).toEqual(
+      Buffer.from(responseBody)
+    );
   });
 
   it('writes error bodies verbatim and exits once on HTTP errors', async () => {
@@ -67,7 +95,7 @@ describe('gt api', () => {
         })
       )
     );
-    const stdout: string[] = [];
+    const stdout: OutputChunk[] = [];
     const stderr: string[] = [];
     const exit = vi.fn((code: number): never => {
       throw new Error(`exit ${code}`);
@@ -91,7 +119,7 @@ describe('gt api', () => {
       )
     ).rejects.toThrow('exit 1');
 
-    expect(stdout.join('')).toBe(responseBody);
+    expect(outputText(stdout)).toBe(responseBody);
     expect(stderr.join('')).toBe(
       'GET /v2/missing returned HTTP 404 Not Found\n'
     );

--- a/packages/cli/src/cli/commands/__tests__/api.test.ts
+++ b/packages/cli/src/cli/commands/__tests__/api.test.ts
@@ -1,0 +1,101 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { handleApiCommand } from '../api.js';
+
+const temporaryDirectories: string[] = [];
+
+function writeInput(content: string): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'gt-api-test-'));
+  temporaryDirectories.push(directory);
+  const inputPath = path.join(directory, 'body.json');
+  fs.writeFileSync(inputPath, content);
+  return inputPath;
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe('gt api', () => {
+  it('passes the method, headers, and raw body to a normalized endpoint', async () => {
+    const responseBody = '{\n  "ok": true\n}';
+    const requestBody = '{"message":"hello"}';
+    const fetchMock = vi.fn<typeof fetch>(async (request) => {
+      expect(new URL(request.url).pathname).toBe('/v2/example');
+      expect(request.method).toBe('POST');
+      expect(request.headers.get('authorization')).toBe('Bearer api-key');
+      expect(request.headers.get('gt-project-id')).toBe('project-id');
+      expect(request.headers.get('x-test')).toBe('value');
+      expect(request.headers.get('content-type')).toBe('application/json');
+      expect(await request.text()).toBe(requestBody);
+      return new Response(responseBody, {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+    const stdout: string[] = [];
+
+    await handleApiCommand(
+      'v2/example',
+      {
+        apiKey: 'api-key',
+        header: ['X-Test: value'],
+        input: writeInput(requestBody),
+        method: 'post',
+        projectId: 'project-id',
+      },
+      {
+        fetch: fetchMock,
+        writeStdout: (output) => stdout.push(output),
+      }
+    );
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(stdout.join('')).toBe(responseBody);
+  });
+
+  it('writes error bodies verbatim and exits once on HTTP errors', async () => {
+    const responseBody = '{\n  "error": "missing"\n}';
+    const fetchMock = vi.fn<typeof fetch>(async () =>
+      Promise.resolve(
+        new Response(responseBody, {
+          status: 404,
+          statusText: 'Not Found',
+        })
+      )
+    );
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const exit = vi.fn((code: number): never => {
+      throw new Error(`exit ${code}`);
+    });
+
+    await expect(
+      handleApiCommand(
+        '/v2/missing',
+        {
+          apiKey: 'api-key',
+          header: [],
+          method: 'GET',
+          projectId: 'project-id',
+        },
+        {
+          exit,
+          fetch: fetchMock,
+          writeStderr: (output) => stderr.push(output),
+          writeStdout: (output) => stdout.push(output),
+        }
+      )
+    ).rejects.toThrow('exit 1');
+
+    expect(stdout.join('')).toBe(responseBody);
+    expect(stderr.join('')).toBe(
+      'GET /v2/missing returned HTTP 404 Not Found\n'
+    );
+    expect(exit).toHaveBeenCalledOnce();
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/cli/src/cli/commands/__tests__/api.test.ts
+++ b/packages/cli/src/cli/commands/__tests__/api.test.ts
@@ -85,6 +85,34 @@ describe('gt api', () => {
     );
   });
 
+  it('includes network errors when no response is received', async () => {
+    const stderr: string[] = [];
+    const exit = vi.fn((code: number): never => {
+      throw new Error(`exit ${code}`);
+    });
+
+    await expect(
+      handleApiCommand(
+        '/v2/unreachable',
+        {
+          apiKey: 'api-key',
+          method: 'GET',
+          projectId: 'project-id',
+        },
+        {
+          exit,
+          fetch: async () => {
+            throw new Error('getaddrinfo ENOTFOUND api.example');
+          },
+          writeStderr: (output) => stderr.push(output),
+        }
+      )
+    ).rejects.toThrow('exit 1');
+
+    expect(stderr.join('')).toContain('getaddrinfo ENOTFOUND api.example');
+    expect(exit).toHaveBeenCalledOnce();
+  });
+
   it('writes error bodies verbatim and exits once on HTTP errors', async () => {
     const responseBody = '{\n  "error": "missing"\n}';
     const fetchMock = vi.fn<typeof fetch>(async () =>

--- a/packages/cli/src/cli/commands/api.ts
+++ b/packages/cli/src/cli/commands/api.ts
@@ -1,0 +1,206 @@
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import type { ApiClientConfig, Client } from '@generaltranslation/api';
+import {
+  createDiagnosticMessage,
+  formatDiagnosticErrorDetails,
+} from 'generaltranslation/internal';
+import { generateSettings } from '../../config/generateSettings.js';
+import { exitSync } from '../../console/logging.js';
+import type { SharedFlags } from '../../types/index.js';
+import { createNonRetryingApiClient } from '../../utils/api.js';
+
+export type ApiCommandOptions = SharedFlags & {
+  header?: string[];
+  include?: boolean;
+  input?: string;
+  method: string;
+  spec?: boolean;
+};
+
+type ApiCommandDependencies = {
+  exit?: (code: number) => never;
+  fetch?: ApiClientConfig['fetch'];
+  writeStderr?: (output: string) => void;
+  writeStdout?: (output: string) => void;
+};
+
+type ApiRequestOptions = Parameters<Client['request']>[0];
+
+const require = createRequire(import.meta.url);
+
+function fail(
+  diagnostic: string,
+  {
+    exit = exitSync,
+    writeStderr = (output) => process.stderr.write(output),
+  }: ApiCommandDependencies
+): never {
+  writeStderr(`${diagnostic}\n`);
+  return exit(1);
+}
+
+function parseHeaders(
+  values: string[],
+  dependencies: ApiCommandDependencies
+): Headers {
+  const headers = new Headers();
+  for (const header of values) {
+    const separator = header.indexOf(':');
+    if (separator < 1) {
+      fail(
+        createDiagnosticMessage({
+          source: 'gt',
+          severity: 'Error',
+          whatHappened: `The API request header is invalid: ${header}`,
+          fix: 'Pass headers as `--header "Key: Value"`',
+        }),
+        dependencies
+      );
+    }
+    headers.set(
+      header.slice(0, separator).trim(),
+      header.slice(separator + 1).trim()
+    );
+  }
+  return headers;
+}
+
+function readInput(
+  input: string,
+  dependencies: ApiCommandDependencies
+): string {
+  try {
+    return fs.readFileSync(input === '-' ? 0 : input, 'utf8');
+  } catch (error) {
+    return fail(
+      createDiagnosticMessage({
+        source: 'gt',
+        severity: 'Error',
+        whatHappened: 'The API request body could not be read',
+        fix:
+          input === '-'
+            ? 'Pipe a request body to standard input or remove `--input -`'
+            : 'Check the `--input` file path and permissions',
+        details: formatDiagnosticErrorDetails(error),
+      }),
+      dependencies
+    );
+  }
+}
+
+function writeResponseMetadata(
+  response: Response,
+  writeStdout: (output: string) => void
+): void {
+  writeStdout(
+    `HTTP/1.1 ${response.status}${response.statusText ? ` ${response.statusText}` : ''}\n`
+  );
+  response.headers.forEach((value, name) => {
+    writeStdout(`${name}: ${value}\n`);
+  });
+  writeStdout('\n');
+}
+
+export async function handleApiCommand(
+  endpoint: string | undefined,
+  options: ApiCommandOptions,
+  dependencies: ApiCommandDependencies = {}
+): Promise<void> {
+  if (!dependencies.writeStdout) {
+    process.stdout.once('error', (error: NodeJS.ErrnoException) => {
+      if (error.code === 'EPIPE') process.exit(0);
+      throw error;
+    });
+  }
+  const writeStdout =
+    dependencies.writeStdout ?? ((output) => process.stdout.write(output));
+  const writeStderr =
+    dependencies.writeStderr ?? ((output) => process.stderr.write(output));
+
+  if (options.spec) {
+    const specPath =
+      require.resolve('@generaltranslation/api/spec/openapi.json');
+    writeStdout(fs.readFileSync(specPath, 'utf8'));
+    return;
+  }
+
+  if (!endpoint) {
+    fail(
+      createDiagnosticMessage({
+        source: 'gt',
+        severity: 'Error',
+        whatHappened: 'No API endpoint was provided',
+        fix: 'Pass an endpoint or use `gt api --spec` to inspect the OpenAPI specification',
+      }),
+      dependencies
+    );
+  }
+
+  const settings = await generateSettings(options, undefined, {
+    suppressOutput: true,
+  });
+  const client = createNonRetryingApiClient({
+    apiKey: settings.apiKey,
+    baseUrl: settings.baseUrl,
+    fetch: dependencies.fetch,
+    projectId: settings.projectId,
+  });
+  const normalizedEndpoint = endpoint.startsWith('/')
+    ? endpoint
+    : `/${endpoint}`;
+  const method = options.method.toUpperCase();
+  const headers = parseHeaders(options.header ?? [], dependencies);
+  const body = options.input
+    ? readInput(options.input, dependencies)
+    : undefined;
+  let rawResponse: Response | undefined;
+
+  client.interceptors.response.use((response) => {
+    rawResponse = response.clone();
+    return response;
+  });
+
+  try {
+    await client.request({
+      body,
+      bodySerializer: body === undefined ? undefined : () => body,
+      headers,
+      method: method as ApiRequestOptions['method'],
+      parseAs: 'stream',
+      throwOnError: false,
+      url: normalizedEndpoint,
+    });
+  } catch (error) {
+    fail(
+      createDiagnosticMessage({
+        source: 'gt',
+        severity: 'Error',
+        whatHappened: 'The API request failed before a response was received',
+        details: formatDiagnosticErrorDetails(error),
+      }),
+      dependencies
+    );
+  }
+
+  if (!rawResponse) {
+    fail(
+      createDiagnosticMessage({
+        source: 'gt',
+        severity: 'Error',
+        whatHappened: 'The API request did not return a response',
+      }),
+      dependencies
+    );
+  }
+
+  if (options.include) writeResponseMetadata(rawResponse, writeStdout);
+  writeStdout(await rawResponse.text());
+
+  if (!rawResponse.ok) {
+    writeStderr(
+      `${method} ${normalizedEndpoint} returned HTTP ${rawResponse.status}${rawResponse.statusText ? ` ${rawResponse.statusText}` : ''}\n`
+    );
+    (dependencies.exit ?? exitSync)(1);
+  }
+}

--- a/packages/cli/src/cli/commands/api.ts
+++ b/packages/cli/src/cli/commands/api.ts
@@ -1,10 +1,10 @@
 import fs from 'node:fs';
-import type { ApiClientConfig, Client } from '@generaltranslation/api';
-import openApiSpec from '@generaltranslation/api/spec/openapi.json' with { type: 'json' };
+import type { ApiClientConfig, Client } from 'generaltranslation/api';
+import openApiSpec from 'generaltranslation/api/openapi.json' with { type: 'json' };
 import {
   createDiagnosticMessage,
   formatDiagnosticErrorDetails,
-} from '@generaltranslation/utils/diagnostics';
+} from 'generaltranslation/internal';
 import { generateSettings } from '../../config/generateSettings.js';
 import { exitSync } from '../../console/logging.js';
 import type { SharedFlags } from '../../types/index.js';

--- a/packages/cli/src/cli/commands/api.ts
+++ b/packages/cli/src/cli/commands/api.ts
@@ -4,7 +4,7 @@ import openApiSpec from '@generaltranslation/api/spec/openapi.json' with { type:
 import {
   createDiagnosticMessage,
   formatDiagnosticErrorDetails,
-} from 'generaltranslation/internal';
+} from '@generaltranslation/utils/diagnostics';
 import { generateSettings } from '../../config/generateSettings.js';
 import { exitSync } from '../../console/logging.js';
 import type { SharedFlags } from '../../types/index.js';
@@ -50,7 +50,8 @@ function parseHeaders(
         createDiagnosticMessage({
           source: 'gt',
           severity: 'Error',
-          whatHappened: `The API request header is invalid: ${header}`,
+          whatHappened: 'The API request header is invalid',
+          details: header,
           fix: 'Pass headers as `--header "Key: Value"`',
         }),
         dependencies
@@ -158,8 +159,8 @@ export async function handleApiCommand(
     return response;
   });
 
-  try {
-    await client.request({
+  const result = await client
+    .request({
       body,
       bodySerializer: body === undefined ? undefined : () => body,
       headers,
@@ -167,18 +168,18 @@ export async function handleApiCommand(
       parseAs: 'stream',
       throwOnError: false,
       url: normalizedEndpoint,
-    });
-  } catch (error) {
-    fail(
-      createDiagnosticMessage({
-        source: 'gt',
-        severity: 'Error',
-        whatHappened: 'The API request failed before a response was received',
-        details: formatDiagnosticErrorDetails(error),
-      }),
-      dependencies
+    })
+    .catch((error) =>
+      fail(
+        createDiagnosticMessage({
+          source: 'gt',
+          severity: 'Error',
+          whatHappened: 'The API request failed before a response was received',
+          details: formatDiagnosticErrorDetails(error),
+        }),
+        dependencies
+      )
     );
-  }
 
   if (!rawResponse) {
     fail(
@@ -186,6 +187,7 @@ export async function handleApiCommand(
         source: 'gt',
         severity: 'Error',
         whatHappened: 'The API request did not return a response',
+        details: formatDiagnosticErrorDetails(result?.error),
       }),
       dependencies
     );

--- a/packages/cli/src/cli/commands/api.ts
+++ b/packages/cli/src/cli/commands/api.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
-import { createRequire } from 'node:module';
 import type { ApiClientConfig, Client } from '@generaltranslation/api';
+import openApiSpec from '@generaltranslation/api/spec/openapi.json' with { type: 'json' };
 import {
   createDiagnosticMessage,
   formatDiagnosticErrorDetails,
@@ -22,12 +22,10 @@ type ApiCommandDependencies = {
   exit?: (code: number) => never;
   fetch?: ApiClientConfig['fetch'];
   writeStderr?: (output: string) => void;
-  writeStdout?: (output: string) => void;
+  writeStdout?: (output: string | Uint8Array) => void;
 };
 
 type ApiRequestOptions = Parameters<Client['request']>[0];
-
-const require = createRequire(import.meta.url);
 
 function fail(
   diagnostic: string,
@@ -58,7 +56,7 @@ function parseHeaders(
         dependencies
       );
     }
-    headers.set(
+    headers.append(
       header.slice(0, separator).trim(),
       header.slice(separator + 1).trim()
     );
@@ -91,10 +89,10 @@ function readInput(
 
 function writeResponseMetadata(
   response: Response,
-  writeStdout: (output: string) => void
+  writeStdout: (output: string | Uint8Array) => void
 ): void {
   writeStdout(
-    `HTTP/1.1 ${response.status}${response.statusText ? ` ${response.statusText}` : ''}\n`
+    `HTTP ${response.status}${response.statusText ? ` ${response.statusText}` : ''}\n`
   );
   response.headers.forEach((value, name) => {
     writeStdout(`${name}: ${value}\n`);
@@ -119,9 +117,7 @@ export async function handleApiCommand(
     dependencies.writeStderr ?? ((output) => process.stderr.write(output));
 
   if (options.spec) {
-    const specPath =
-      require.resolve('@generaltranslation/api/spec/openapi.json');
-    writeStdout(fs.readFileSync(specPath, 'utf8'));
+    writeStdout(`${JSON.stringify(openApiSpec, null, 2)}\n`);
     return;
   }
 
@@ -157,6 +153,7 @@ export async function handleApiCommand(
   let rawResponse: Response | undefined;
 
   client.interceptors.response.use((response) => {
+    // Keep a clone because the generated client consumes non-2xx bodies.
     rawResponse = response.clone();
     return response;
   });
@@ -195,7 +192,7 @@ export async function handleApiCommand(
   }
 
   if (options.include) writeResponseMetadata(rawResponse, writeStdout);
-  writeStdout(await rawResponse.text());
+  writeStdout(Buffer.from(await rawResponse.arrayBuffer()));
 
   if (!rawResponse.ok) {
     writeStderr(

--- a/packages/cli/src/config/generateSettings.ts
+++ b/packages/cli/src/config/generateSettings.ts
@@ -86,12 +86,13 @@ function hasConfiguredTranslationFiles(files: unknown): boolean {
  * @param cwd - The current working directory
  * @param options - Additional options
  * @param options.requireConfig - If true, exit with an error when no config file is found
+ * @param options.suppressOutput - If true, suppress non-error settings output
  * @returns The generated settings
  */
 export async function generateSettings(
   flags: GenerateSettingsInput,
   cwd: string = process.cwd(),
-  options?: { requireConfig?: boolean }
+  options?: { requireConfig?: boolean; suppressOutput?: boolean }
 ): Promise<Settings> {
   // Load config file
   let gtConfig: GenerateSettingsInput = {};
@@ -171,7 +172,10 @@ export async function generateSettings(
 
   // Warn on deprecated includeSourceCodeContext
   const configuredFiles = gtConfig.files as FilesOptions | undefined;
-  if (configuredFiles?.gt?.includeSourceCodeContext != null) {
+  if (
+    !options?.suppressOutput &&
+    configuredFiles?.gt?.includeSourceCodeContext != null
+  ) {
     warnDeprecatedField(
       'files.gt.includeSourceCodeContext',
       'files.gt.parsingFlags.includeSourceCodeContext'
@@ -182,6 +186,7 @@ export async function generateSettings(
   const mergedOptions: Settings = { ...gtConfig, ...flags } as Settings;
 
   if (
+    !options?.suppressOutput &&
     determineLibrary().library === 'base' &&
     !hasConfiguredTranslationFiles(mergedOptions.files)
   ) {
@@ -228,7 +233,9 @@ export async function generateSettings(
   }
 
   // Display projectId if present
-  if (mergedOptions.projectId) displayProjectId(mergedOptions.projectId);
+  if (!options?.suppressOutput && mergedOptions.projectId) {
+    displayProjectId(mergedOptions.projectId);
+  }
 
   // Add stageTranslations if not provided
   // For human review, always stage the project
@@ -323,6 +330,7 @@ export async function generateSettings(
   };
 
   if (
+    !options?.suppressOutput &&
     mergedOptions.omitConfigIds &&
     (mergedOptions.publish === true ||
       mergedOptions.files.gtJson.publish === true)

--- a/packages/cli/src/utils/__tests__/api.test.ts
+++ b/packages/cli/src/utils/__tests__/api.test.ts
@@ -229,7 +229,7 @@ describe('CLI API client', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(requestBodies[0].data).toHaveLength(100);
     expect(requestBodies[0].data[0].source.content).toBe('bWVzc2FnZS0w');
-    expect(result.count).toBe(101);
+    expect(result.uploadedFiles).toHaveLength(101);
   });
 
   it('base64-encodes and uploads translation files through the SDK', async () => {

--- a/packages/cli/src/utils/api.ts
+++ b/packages/cli/src/utils/api.ts
@@ -42,8 +42,7 @@ import {
   type UploadSourceFilesData,
   type UploadTranslationsData,
 } from 'generaltranslation/api';
-import { ApiError } from 'generaltranslation/errors';
-import { defaultBaseUrl } from 'generaltranslation/internal';
+import { defaultBaseUrl, unwrapApiResult } from 'generaltranslation/internal';
 
 let client = createApiClient({ baseUrl: defaultBaseUrl });
 let customMapping: CustomMapping | undefined;
@@ -56,51 +55,21 @@ export function configureApiClient(
   customMapping = mapping;
 }
 
-type ApiResult<T> = {
-  data: T | undefined;
-  error: unknown;
-  response?: Response;
-};
-
-function isErrorResponse(error: unknown): error is { error: string } {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    'error' in error &&
-    typeof error.error === 'string'
-  );
-}
-
 function batchCount(items: readonly unknown[]): number {
   return Math.ceil(items.length / DEFAULT_BATCH_SIZE);
 }
 
-function responseData<T>(result: ApiResult<T>): Exclude<T, undefined> {
-  if (result.data !== undefined) {
-    return result.data as Exclude<T, undefined>;
-  }
-  if (result.response) {
-    const message = isErrorResponse(result.error)
-      ? result.error.error
-      : typeof result.error === 'string'
-        ? result.error
-        : result.response.statusText;
-    throw new ApiError(message, result.response.status, message);
-  }
-  throw result.error;
-}
-
 export const api = {
   async queryBranchData(body: GetBranchInfoData['body']) {
-    return responseData(await getBranchInfo({ body, client }));
+    return unwrapApiResult(await getBranchInfo({ body, client }));
   },
 
   async createBranch(body: CreateBranchData['body']) {
-    return responseData(await createBranch({ body, client }));
+    return unwrapApiResult(await createBranch({ body, client }));
   },
 
   async queryFileData(body: GetFileInfoData['body']) {
-    const result = responseData(
+    const result = unwrapApiResult(
       await getFileInfo({
         body: {
           ...body,
@@ -129,7 +98,7 @@ export const api = {
   },
 
   async checkJobStatus(jobIds: string[]) {
-    return responseData(
+    return unwrapApiResult(
       await getTranslationJobInfo({ body: { jobIds }, client })
     );
   },
@@ -142,7 +111,7 @@ export const api = {
     if (files.length === 0) return { files: [], count: 0, pending: [] };
 
     const request = async (batch: DownloadFilesData['body']) =>
-      responseData(
+      unwrapApiResult(
         await downloadFiles({
           body: batch.map((file) => ({
             ...file,
@@ -172,12 +141,12 @@ export const api = {
   },
 
   async publishFiles(files: PublishFilesData['body']['files']) {
-    return responseData(await publishFiles({ body: { files }, client }));
+    return unwrapApiResult(await publishFiles({ body: { files }, client }));
   },
 
   async submitUserEditDiffs(body: SubmitUserEditDiffsData['body']) {
     return processBatches(body.diffs, async (diffs) => [
-      responseData(
+      unwrapApiResult(
         await submitUserEditDiffs({
           body: {
             projectId: body.projectId,
@@ -193,11 +162,11 @@ export const api = {
   },
 
   async createTag(body: CreateTagData['body']) {
-    return responseData(await createTag({ body, client }));
+    return unwrapApiResult(await createTag({ body, client }));
   },
 
   async createProject(body: CreateProjectData['body']) {
-    return responseData(
+    return unwrapApiResult(
       await createProject({
         body: {
           ...body,
@@ -212,7 +181,7 @@ export const api = {
   },
 
   async getSetupStatus(jobId: string) {
-    const statuses = responseData(
+    const statuses = unwrapApiResult(
       await getTranslationJobInfo({ body: { jobIds: [jobId] }, client })
     );
     return (
@@ -225,7 +194,7 @@ export const api = {
 
   async getOrphanedFiles(branchId: string, fileIds: string[]) {
     const request = async (batch: string[]) =>
-      responseData(
+      unwrapApiResult(
         await getOrphanedFiles({
           body: { branchId, fileIds: batch },
           client,
@@ -237,18 +206,18 @@ export const api = {
     const results = await processBatches(fileIds, async (batch) => [
       await request(batch),
     ]);
-    const orphanedFiles = new Map(
-      results[0].orphanedFiles.map((file) => [file.fileId, file])
-    );
+    // A file is orphaned only if every batch (which each sees a subset of
+    // fileIds) reports it orphaned — intersect across batches.
+    let orphanedFiles = results[0].orphanedFiles;
     for (const result of results.slice(1)) {
       const batchFileIds = new Set(
         result.orphanedFiles.map((file) => file.fileId)
       );
-      for (const fileId of orphanedFiles.keys()) {
-        if (!batchFileIds.has(fileId)) orphanedFiles.delete(fileId);
-      }
+      orphanedFiles = orphanedFiles.filter((file) =>
+        batchFileIds.has(file.fileId)
+      );
     }
-    return { orphanedFiles: [...orphanedFiles.values()] };
+    return { orphanedFiles };
   },
 
   async processFileMoves(
@@ -256,7 +225,7 @@ export const api = {
     options: Pick<ProcessFileMovesData['body'], 'branchId'>
   ) {
     const result = await processBatches(moves, async (batch) => {
-      const response = responseData(
+      const response = unwrapApiResult(
         await processFileMoves({
           body: { branchId: options.branchId, moves: batch },
           client,
@@ -280,7 +249,7 @@ export const api = {
     files: GenerateProjectContextData['body']['files'],
     options: Omit<GenerateProjectContextData['body'], 'files'> = {}
   ) {
-    return responseData(
+    return unwrapApiResult(
       await generateProjectContext({
         body: {
           files: files.map(({ branchId, fileId, versionId }) => ({
@@ -299,12 +268,12 @@ export const api = {
   },
 
   async awaitJobs(jobIds: readonly string[], options?: AwaitJobsOptions) {
-    // Poll through responseData so HTTP failures throw ApiError with the
+    // Poll through unwrapApiResult so HTTP failures throw ApiError with the
     // status code instead of the decoded response body.
     return pollJobs(
       jobIds,
       async (pendingJobIds, signal) =>
-        responseData(
+        unwrapApiResult(
           await getTranslationJobInfo({
             body: { jobIds: pendingJobIds },
             client,
@@ -332,7 +301,7 @@ export const api = {
       { jobData: unknown }
     >;
     const result = await processBatches(files, async (batch) => {
-      const response = responseData(
+      const response = unwrapApiResult(
         await enqueueFileTranslations({
           body: {
             files: batch.map(
@@ -374,7 +343,7 @@ export const api = {
       customMapping
     );
     const result = await processBatches(files, async (batch) => {
-      const response = responseData(
+      const response = unwrapApiResult(
         await uploadSourceFiles({
           body: {
             data: batch.map(({ source }) => ({
@@ -392,11 +361,7 @@ export const api = {
       return response.uploadedFiles;
     });
 
-    return {
-      uploadedFiles: result,
-      count: result.length,
-      message: `Successfully uploaded ${result.length} files in ${batchCount(files)} batch(es)`,
-    };
+    return { uploadedFiles: result };
   },
 
   async uploadTranslations(
@@ -404,7 +369,7 @@ export const api = {
     options: { sourceLocale: string; modelProvider?: string }
   ) {
     const result = await processBatches(files, async (batch) => {
-      const response = responseData(
+      const response = unwrapApiResult(
         await uploadTranslations({
           body: {
             data: batch.map(({ source, translations }) => ({
@@ -435,11 +400,7 @@ export const api = {
       return response.uploadedFiles;
     });
 
-    return {
-      uploadedFiles: result,
-      count: result.length,
-      message: `Successfully uploaded ${result.length} files in ${batchCount(files)} batch(es)`,
-    };
+    return { uploadedFiles: result };
   },
 };
 

--- a/packages/cli/src/utils/api.ts
+++ b/packages/cli/src/utils/api.ts
@@ -41,7 +41,7 @@ import {
   type SubmitUserEditDiffsData,
   type UploadSourceFilesData,
   type UploadTranslationsData,
-} from '@generaltranslation/api';
+} from 'generaltranslation/api';
 import { ApiError } from 'generaltranslation/errors';
 import { defaultBaseUrl } from 'generaltranslation/internal';
 

--- a/packages/cli/src/utils/api.ts
+++ b/packages/cli/src/utils/api.ts
@@ -55,6 +55,10 @@ export function configureApiClient(
   customMapping = mapping;
 }
 
+export function createNonRetryingApiClient(config: ApiClientConfig) {
+  return createApiClient({ ...config, retryPolicy: 'none' });
+}
+
 function batchCount(items: readonly unknown[]): number {
   return Math.ceil(items.length / DEFAULT_BATCH_SIZE);
 }

--- a/packages/cli/src/workflows/steps/UploadSourcesStep.ts
+++ b/packages/cli/src/workflows/steps/UploadSourcesStep.ts
@@ -1,4 +1,4 @@
-import type { GetFileInfoResponse } from '@generaltranslation/api';
+import type { GetFileInfoResponse } from 'generaltranslation/api';
 import type { FileToUpload } from 'generaltranslation/types';
 import { logger } from '../../console/logger.js';
 import { recordWarning } from '../../state/translateWarnings.js';

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2022",
-    "module": "node16",
+    "module": "node18",
     "moduleResolution": "node16",
     "outDir": "./dist",
     "rootDir": "./src",

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -13,9 +13,6 @@
   "exclude": ["**/__tests__/**/*", "**/__mocks__/**/*"],
   "references": [
     {
-      "path": "../api"
-    },
-    {
       "path": "../core"
     }
   ]

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build:release": "pnpm run build:clean",
     "build:clean": "sh ../../scripts/clean.sh && pnpm run build",
-    "build": "tsdown",
+    "build": "tsdown && node -e \"require('node:fs').copyFileSync('../api/spec/openapi.json', 'dist/openapi.json')\"",
     "test": "vitest run --config=./vitest.config.ts",
     "test:watch": "vitest --config=./vitest.config.ts",
     "release": "pnpm run build:clean && pnpm publish",
@@ -87,6 +87,7 @@
         "default": "./dist/api.mjs"
       }
     },
+    "./api/openapi.json": "./dist/openapi.json",
     "./id": {
       "require": {
         "types": "./dist/id.d.cts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -77,6 +77,16 @@
         "default": "./dist/runtime.mjs"
       }
     },
+    "./api": {
+      "require": {
+        "types": "./dist/api.d.cts",
+        "default": "./dist/api.cjs"
+      },
+      "import": {
+        "types": "./dist/api.d.mts",
+        "default": "./dist/api.mjs"
+      }
+    },
     "./id": {
       "require": {
         "types": "./dist/id.d.cts",
@@ -122,6 +132,9 @@
     "*": {
       "internal": [
         "./dist/internal.d.cts"
+      ],
+      "api": [
+        "./dist/api.d.cts"
       ],
       "id": [
         "./dist/id.d.cts"

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -1,0 +1,1 @@
+export * from '@generaltranslation/api';

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -27,6 +27,10 @@ export { minifyVariableType } from './utils/minify';
 export { encode, decode } from './utils/base64';
 export { isSupportedFileFormatTransform } from './utils/isSupportedFileFormatTransform';
 export { API_VERSION } from './translate/api';
+export {
+  isErrorResult,
+  unwrapApiResult,
+} from './translate/utils/unwrapApiResult';
 
 // derive
 export { decodeVars } from './derive/decodeVars';

--- a/packages/core/src/translate/api.ts
+++ b/packages/core/src/translate/api.ts
@@ -1,1 +1,1 @@
-export const API_VERSION = '2026-03-06.v1';
+export { API_VERSION } from '@generaltranslation/api';

--- a/packages/core/src/translate/utils/__tests__/apiRequest.test.ts
+++ b/packages/core/src/translate/utils/__tests__/apiRequest.test.ts
@@ -78,6 +78,26 @@ describe.sequential('apiRequest', () => {
     expect(fetchWithTimeout).not.toHaveBeenCalled();
   });
 
+  it('preserves linear retries for runtime translation', async () => {
+    vi.mocked(createApiClient).mockReturnValue(
+      {} as ReturnType<typeof createApiClient>
+    );
+    vi.mocked(translate).mockResolvedValue({
+      data: { hash: { success: false, error: 'failed', code: 500 } },
+      request: {} as Request,
+      response: createResponse(),
+    });
+
+    await apiRequest(config, '/v2/translate', {
+      body: {},
+      retryPolicy: 'linear',
+    });
+
+    expect(createApiClient).toHaveBeenCalledWith(
+      expect.objectContaining({ retryPolicy: 'linear' })
+    );
+  });
+
   it('preserves runtime translation API error details', async () => {
     vi.mocked(createApiClient).mockReturnValue(
       {} as ReturnType<typeof createApiClient>

--- a/packages/core/src/translate/utils/__tests__/apiRequest.test.ts
+++ b/packages/core/src/translate/utils/__tests__/apiRequest.test.ts
@@ -1,9 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createApiClient, translate } from '@generaltranslation/api';
 
 import { apiRequest } from '../apiRequest';
 import { fetchWithTimeout } from '../fetchWithTimeout';
 import { validateResponse } from '../validateResponse';
 
+vi.mock('@generaltranslation/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@generaltranslation/api')>()),
+  createApiClient: vi.fn(),
+  translate: vi.fn(),
+}));
 vi.mock('../fetchWithTimeout');
 vi.mock('../validateResponse');
 
@@ -32,6 +38,70 @@ describe.sequential('apiRequest', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it('routes runtime translation through the SDK without retries', async () => {
+    const client = {} as ReturnType<typeof createApiClient>;
+    vi.mocked(createApiClient).mockReturnValue(client);
+    vi.mocked(translate).mockResolvedValue({
+      data: { hash: { success: false, error: 'failed', code: 500 } },
+      request: {} as Request,
+      response: createResponse(),
+    });
+
+    await expect(
+      apiRequest(
+        { ...config, baseUrl: 'https://runtime.example.com' },
+        '/v2/translate',
+        {
+          body: {
+            requests: {},
+            sourceLocale: 'en',
+            targetLocale: 'es',
+            metadata: {},
+          },
+          retryPolicy: 'none',
+        }
+      )
+    ).resolves.toHaveProperty('hash');
+
+    expect(createApiClient).toHaveBeenCalledWith({
+      apiKey: 'api-key',
+      baseUrl: 'https://runtime.example.com',
+      fetch: expect.any(Function),
+      projectId: 'project-id',
+      retryPolicy: 'none',
+    });
+    expect(translate).toHaveBeenCalledWith(
+      expect.objectContaining({ client, body: expect.any(Object) })
+    );
+    expect(fetchWithTimeout).not.toHaveBeenCalled();
+  });
+
+  it('preserves runtime translation API error details', async () => {
+    vi.mocked(createApiClient).mockReturnValue(
+      {} as ReturnType<typeof createApiClient>
+    );
+    vi.mocked(translate).mockResolvedValue({
+      data: undefined,
+      error: { error: 'invalid translation request' },
+      request: {} as Request,
+      response: createResponse({
+        ok: false,
+        status: 400,
+        statusText: 'Bad Request',
+      }),
+    });
+
+    await expect(
+      apiRequest(config, '/v2/translate', { body: {} })
+    ).rejects.toEqual(
+      expect.objectContaining({
+        code: 400,
+        message: 'invalid translation request',
+      })
+    );
+    expect(validateResponse).not.toHaveBeenCalled();
   });
 
   it('retries 429 responses after the rate limit window', async () => {

--- a/packages/core/src/translate/utils/apiRequest.ts
+++ b/packages/core/src/translate/utils/apiRequest.ts
@@ -118,7 +118,7 @@ export async function apiRequest<T>(
       baseUrl: config.baseUrl || defaultBaseUrl,
       fetch: (input, init) => fetchWithTimeout(input, init ?? {}, timeout),
       projectId: config.projectId,
-      retryPolicy: retryPolicy === 'none' ? 'none' : 'exponential',
+      retryPolicy,
     });
     const result = await translate({
       body: options?.body as TranslateData['body'],

--- a/packages/core/src/translate/utils/apiRequest.ts
+++ b/packages/core/src/translate/utils/apiRequest.ts
@@ -12,6 +12,7 @@ import { handleFetchError } from './handleFetchError';
 import { generateRequestHeaders } from './generateRequestHeaders';
 import { apiError } from '../../logging/errors';
 import { ApiError } from '../../errors/ApiError';
+import { isErrorResult } from './unwrapApiResult';
 
 const MAX_RETRIES = 3;
 const INITIAL_DELAY_MS = 500;
@@ -125,13 +126,7 @@ export async function apiRequest<T>(
       client,
     });
     if (result.data !== undefined) return result.data as T;
-    if (
-      result.response &&
-      typeof result.error === 'object' &&
-      result.error !== null &&
-      'error' in result.error &&
-      typeof result.error.error === 'string'
-    ) {
+    if (result.response && isErrorResult(result.error)) {
       throw new ApiError(
         apiError(
           result.response.status,

--- a/packages/core/src/translate/utils/apiRequest.ts
+++ b/packages/core/src/translate/utils/apiRequest.ts
@@ -1,3 +1,8 @@
+import {
+  createApiClient,
+  translate,
+  type TranslateData,
+} from '@generaltranslation/api';
 import { TranslationRequestConfig } from '../../types';
 import { defaultBaseUrl } from '../../settings/settingsUrls';
 import { defaultTimeout } from '../../settings/settings';
@@ -5,6 +10,8 @@ import { fetchWithTimeout } from './fetchWithTimeout';
 import { validateResponse } from './validateResponse';
 import { handleFetchError } from './handleFetchError';
 import { generateRequestHeaders } from './generateRequestHeaders';
+import { apiError } from '../../logging/errors';
+import { ApiError } from '../../errors/ApiError';
 
 const MAX_RETRIES = 3;
 const INITIAL_DELAY_MS = 500;
@@ -103,9 +110,44 @@ export async function apiRequest<T>(
   }
 ): Promise<T> {
   const timeout = options?.timeout ?? defaultTimeout;
+  const retryPolicy = options?.retryPolicy ?? 'exponential';
+
+  if (endpoint === '/v2/translate') {
+    const client = createApiClient({
+      apiKey: config.apiKey,
+      baseUrl: config.baseUrl || defaultBaseUrl,
+      fetch: (input, init) => fetchWithTimeout(input, init ?? {}, timeout),
+      projectId: config.projectId,
+      retryPolicy: retryPolicy === 'none' ? 'none' : 'exponential',
+    });
+    const result = await translate({
+      body: options?.body as TranslateData['body'],
+      client,
+    });
+    if (result.data !== undefined) return result.data as T;
+    if (
+      result.response &&
+      typeof result.error === 'object' &&
+      result.error !== null &&
+      'error' in result.error &&
+      typeof result.error.error === 'string'
+    ) {
+      throw new ApiError(
+        apiError(
+          result.response.status,
+          result.response.statusText,
+          result.error.error
+        ),
+        result.response.status,
+        result.error.error
+      );
+    }
+    if (result.response) await validateResponse(result.response);
+    throw result.error;
+  }
+
   const url = `${config.baseUrl || defaultBaseUrl}${endpoint}`;
   const method = options?.method ?? 'POST';
-  const retryPolicy = options?.retryPolicy ?? 'exponential';
   const maxRetries = retryPolicy === 'none' ? 0 : MAX_RETRIES;
 
   const requestInit: RequestInit = {

--- a/packages/core/src/translate/utils/unwrapApiResult.ts
+++ b/packages/core/src/translate/utils/unwrapApiResult.ts
@@ -1,0 +1,33 @@
+import { ApiError } from '../../errors/ApiError';
+
+export function isErrorResult(error: unknown): error is { error: string } {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'error' in error &&
+    typeof error.error === 'string'
+  );
+}
+
+/**
+ * Unwraps a `@generaltranslation/api` SDK result, returning its data or
+ * throwing an `ApiError` built from the failed response.
+ */
+export function unwrapApiResult<T>(result: {
+  data: T | undefined;
+  error: unknown;
+  response?: Response;
+}): Exclude<T, undefined> {
+  if (result.data !== undefined) {
+    return result.data as Exclude<T, undefined>;
+  }
+  if (result.response) {
+    const message = isErrorResult(result.error)
+      ? result.error.error
+      : typeof result.error === 'string'
+        ? result.error
+        : result.response.statusText;
+    throw new ApiError(message, result.response.status, message);
+  }
+  throw result.error;
+}

--- a/packages/core/tsdown.config.mts
+++ b/packages/core/tsdown.config.mts
@@ -5,6 +5,7 @@ export default defineConfig(
   createTsdownConfig(
     [
       'src/index.ts',
+      'src/api.ts',
       'src/runtime.ts',
       'src/id.ts',
       'src/internal.ts',

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -64,6 +64,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@generaltranslation/api": "workspace:*",
+    "@generaltranslation/format": "workspace:*",
     "@portabletext/block-tools": "^5.1.1",
     "@portabletext/to-html": "^2.0.14",
     "@sanity/document-internationalization": "^6.2.30",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -64,8 +64,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@generaltranslation/api": "workspace:*",
-    "@generaltranslation/format": "workspace:*",
     "@portabletext/block-tools": "^5.1.1",
     "@portabletext/to-html": "^2.0.14",
     "@sanity/document-internationalization": "^6.2.30",

--- a/packages/sanity/src/adapter/api.test.ts
+++ b/packages/sanity/src/adapter/api.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { enqueueFileTranslations } from '@generaltranslation/api';
+import { enqueueFileTranslations } from 'generaltranslation/api';
 
 import { api, configureApiClient } from './api';
 
-vi.mock('@generaltranslation/api', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@generaltranslation/api')>()),
+vi.mock('generaltranslation/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('generaltranslation/api')>()),
   enqueueFileTranslations: vi.fn(),
 }));
 

--- a/packages/sanity/src/adapter/api.test.ts
+++ b/packages/sanity/src/adapter/api.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { enqueueFileTranslations } from '@generaltranslation/api';
+
+import { api, configureApiClient } from './api';
+
+vi.mock('@generaltranslation/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@generaltranslation/api')>()),
+  enqueueFileTranslations: vi.fn(),
+}));
+
+describe('Sanity API adapter', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    configureApiClient({
+      baseUrl: 'https://api.example.com',
+      customMapping: {
+        source: { code: 'en-US' },
+      },
+    });
+  });
+
+  it('canonicalizes the optional source locale when enqueueing files', async () => {
+    vi.mocked(enqueueFileTranslations).mockResolvedValue({
+      data: { jobData: {}, locales: [], message: 'Enqueued files' },
+      request: {} as Request,
+      response: new Response(),
+    });
+
+    await api.enqueueFiles([{ fileId: 'file-id', versionId: 'version-id' }], {
+      sourceLocale: 'source',
+      targetLocales: ['es'],
+    });
+
+    expect(enqueueFileTranslations).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({ sourceLocale: 'en-US' }),
+      })
+    );
+  });
+});

--- a/packages/sanity/src/adapter/api.ts
+++ b/packages/sanity/src/adapter/api.ts
@@ -2,9 +2,6 @@ import {
   awaitJobs as awaitApiJobs,
   createApiClient,
   createBranch,
-  createBatches,
-  createJobStatusLoader,
-  createTimeoutFetch,
   decodeFileContent,
   downloadFile,
   downloadFiles,
@@ -31,9 +28,7 @@ import { ApiError } from 'generaltranslation/errors';
 import { defaultBaseUrl } from 'generaltranslation/internal';
 import type { DownloadedFile, FileFormat } from 'generaltranslation/types';
 
-const timeoutFetch = createTimeoutFetch();
-
-let client = createApiClient({ baseUrl: defaultBaseUrl, fetch: timeoutFetch });
+let client = createApiClient({ baseUrl: defaultBaseUrl });
 let customMapping: CustomMapping | undefined;
 
 export function configureApiClient(
@@ -45,7 +40,6 @@ export function configureApiClient(
   const { customMapping: mapping, ...clientConfig } = config;
   client = createApiClient({
     baseUrl: defaultBaseUrl,
-    fetch: timeoutFetch,
     ...clientConfig,
   });
   customMapping = mapping;
@@ -107,7 +101,7 @@ export const api = {
       );
       return response.uploadedFiles;
     });
-    return { uploadedFiles: result.data, count: result.count };
+    return { uploadedFiles: result, count: result.length };
   },
 
   async uploadTranslations(
@@ -141,7 +135,7 @@ export const api = {
       );
       return response.uploadedFiles;
     });
-    return { uploadedFiles: result.data, count: result.count };
+    return { uploadedFiles: result, count: result.length };
   },
 
   async enqueueFiles(
@@ -171,7 +165,7 @@ export const api = {
         'jobData' in response ? response.jobData : response.data
       );
     });
-    return { jobData: Object.fromEntries(result.data), locales: targetLocales };
+    return { jobData: Object.fromEntries(result), locales: targetLocales };
   },
 
   async querySourceFile(query: {
@@ -205,11 +199,10 @@ export const api = {
   async downloadFileBatch(files: DownloadFilesData['body']) {
     const request = async (batch: DownloadFilesData['body']) =>
       responseData(await downloadFiles({ body: batch, client }));
-    const responses = await Promise.all(
+    const responses =
       files.length === 0
-        ? [request([])]
-        : createBatches(files).map((batch) => request(batch))
-    );
+        ? [await request([])]
+        : await processBatches(files, async (batch) => [await request(batch)]);
     return {
       files: responses.flatMap((response) =>
         response.files.map((file) => ({
@@ -236,7 +229,7 @@ export const api = {
     jobIds: readonly string[],
     options?: Parameters<typeof awaitApiJobs>[2]
   ) {
-    return awaitApiJobs(jobIds, createJobStatusLoader(client), options);
+    return awaitApiJobs(client, jobIds, options);
   },
 
   async queryFileData(body: GetFileInfoData['body']) {

--- a/packages/sanity/src/adapter/api.ts
+++ b/packages/sanity/src/adapter/api.ts
@@ -24,8 +24,7 @@ import {
 } from '@generaltranslation/api';
 import { resolveCanonicalLocale } from '@generaltranslation/format';
 import type { CustomMapping } from '@generaltranslation/format/types';
-import { ApiError } from 'generaltranslation/errors';
-import { defaultBaseUrl } from 'generaltranslation/internal';
+import { defaultBaseUrl, unwrapApiResult } from 'generaltranslation/internal';
 import type { DownloadedFile, FileFormat } from 'generaltranslation/types';
 
 let client = createApiClient({ baseUrl: defaultBaseUrl });
@@ -45,33 +44,6 @@ export function configureApiClient(
   customMapping = mapping;
 }
 
-type ApiResult<T> = {
-  data: T | undefined;
-  error: unknown;
-  response?: Response;
-};
-
-function isErrorResponse(error: unknown): error is { error: string } {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    'error' in error &&
-    typeof error.error === 'string'
-  );
-}
-
-function responseData<T>(result: ApiResult<T>): Exclude<T, undefined> {
-  if (result.data !== undefined) return result.data as Exclude<T, undefined>;
-  if (result.response && isErrorResponse(result.error)) {
-    throw new ApiError(
-      result.error.error,
-      result.response.status,
-      result.error.error
-    );
-  }
-  throw result.error;
-}
-
 export const api = {
   async uploadSourceFiles(
     files: Array<{
@@ -84,7 +56,7 @@ export const api = {
       customMapping
     );
     const result = await processBatches(files, async (batch) => {
-      const response = responseData(
+      const response = unwrapApiResult(
         await uploadSourceFiles({
           body: {
             data: batch.map(({ source }) => ({
@@ -101,7 +73,7 @@ export const api = {
       );
       return response.uploadedFiles;
     });
-    return { uploadedFiles: result, count: result.length };
+    return { uploadedFiles: result };
   },
 
   async uploadTranslations(
@@ -109,7 +81,7 @@ export const api = {
     options: { sourceLocale: string }
   ) {
     const result = await processBatches(files, async (batch) => {
-      const response = responseData(
+      const response = unwrapApiResult(
         await uploadTranslations({
           body: {
             data: batch.map(({ source, translations }) => ({
@@ -135,7 +107,7 @@ export const api = {
       );
       return response.uploadedFiles;
     });
-    return { uploadedFiles: result, count: result.length };
+    return { uploadedFiles: result };
   },
 
   async enqueueFiles(
@@ -153,7 +125,7 @@ export const api = {
       resolveCanonicalLocale(locale, customMapping)
     );
     const result = await processBatches(files, async (batch) => {
-      const response = responseData(
+      const response = unwrapApiResult(
         await enqueueFileTranslations({
           body: {
             files: batch,
@@ -177,7 +149,7 @@ export const api = {
     branchId?: string;
   }) {
     const { fileId, ...queryParams } = query;
-    return responseData(
+    return unwrapApiResult(
       await getTranslationStatus({
         path: { fileId },
         query: queryParams,
@@ -193,7 +165,7 @@ export const api = {
     locale?: string;
   }) {
     const { fileId, ...queryParams } = query;
-    const response = responseData(
+    const response = unwrapApiResult(
       await downloadFile({ path: { fileId }, query: queryParams, client })
     );
     return decodeFileContent(response.data, 'HTML');
@@ -201,7 +173,7 @@ export const api = {
 
   async downloadFileBatch(files: DownloadFilesData['body']) {
     const request = async (batch: DownloadFilesData['body']) =>
-      responseData(await downloadFiles({ body: batch, client }));
+      unwrapApiResult(await downloadFiles({ body: batch, client }));
     const responses =
       files.length === 0
         ? [await request([])]
@@ -223,7 +195,7 @@ export const api = {
     files: GenerateProjectContextData['body']['files'],
     options: Omit<GenerateProjectContextData['body'], 'files'> = {}
   ) {
-    return responseData(
+    return unwrapApiResult(
       await generateProjectContext({ body: { files, ...options }, client })
     );
   },
@@ -236,10 +208,10 @@ export const api = {
   },
 
   async queryFileData(body: GetFileInfoData['body']) {
-    return responseData(await getFileInfo({ body, client }));
+    return unwrapApiResult(await getFileInfo({ body, client }));
   },
 
   async createBranch(body: CreateBranchData['body']) {
-    return responseData(await createBranch({ body, client }));
+    return unwrapApiResult(await createBranch({ body, client }));
   },
 };

--- a/packages/sanity/src/adapter/api.ts
+++ b/packages/sanity/src/adapter/api.ts
@@ -1,0 +1,249 @@
+import {
+  awaitJobs as awaitApiJobs,
+  createApiClient,
+  createBranch,
+  createBatches,
+  createJobStatusLoader,
+  createTimeoutFetch,
+  decodeFileContent,
+  downloadFile,
+  downloadFiles,
+  encodeFileContent,
+  enqueueFileTranslations,
+  generateProjectContext,
+  getFileInfo,
+  getTranslationStatus,
+  processBatches,
+  uploadSourceFiles,
+  uploadTranslations,
+  type ApiClientConfig,
+  type CreateBranchData,
+  type DownloadFilesData,
+  type EnqueueFileTranslationsData,
+  type GenerateProjectContextData,
+  type GetFileInfoData,
+  type UploadSourceFilesData,
+  type UploadTranslationsData,
+} from '@generaltranslation/api';
+import { resolveCanonicalLocale } from '@generaltranslation/format';
+import type { CustomMapping } from '@generaltranslation/format/types';
+import { ApiError } from 'generaltranslation/errors';
+import { defaultBaseUrl } from 'generaltranslation/internal';
+import type { DownloadedFile, FileFormat } from 'generaltranslation/types';
+
+const timeoutFetch = createTimeoutFetch();
+
+let client = createApiClient({ baseUrl: defaultBaseUrl, fetch: timeoutFetch });
+let customMapping: CustomMapping | undefined;
+
+export function configureApiClient(
+  config: Omit<ApiClientConfig, 'baseUrl'> & {
+    baseUrl?: string;
+    customMapping?: CustomMapping;
+  }
+): void {
+  const { customMapping: mapping, ...clientConfig } = config;
+  client = createApiClient({
+    baseUrl: defaultBaseUrl,
+    fetch: timeoutFetch,
+    ...clientConfig,
+  });
+  customMapping = mapping;
+}
+
+type ApiResult<T> = {
+  data: T | undefined;
+  error: unknown;
+  response?: Response;
+};
+
+function isErrorResponse(error: unknown): error is { error: string } {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'error' in error &&
+    typeof error.error === 'string'
+  );
+}
+
+function responseData<T>(result: ApiResult<T>): Exclude<T, undefined> {
+  if (result.data !== undefined) return result.data as Exclude<T, undefined>;
+  if (result.response && isErrorResponse(result.error)) {
+    throw new ApiError(
+      result.error.error,
+      result.response.status,
+      result.error.error
+    );
+  }
+  throw result.error;
+}
+
+export const api = {
+  async uploadSourceFiles(
+    files: Array<{
+      source: UploadSourceFilesData['body']['data'][number]['source'];
+    }>,
+    options: { sourceLocale: string }
+  ) {
+    const sourceLocale = resolveCanonicalLocale(
+      options.sourceLocale,
+      customMapping
+    );
+    const result = await processBatches(files, async (batch) => {
+      const response = responseData(
+        await uploadSourceFiles({
+          body: {
+            data: batch.map(({ source }) => ({
+              source: {
+                ...source,
+                content: encodeFileContent(source.content, source.fileFormat),
+                locale: resolveCanonicalLocale(source.locale, customMapping),
+              },
+            })),
+            sourceLocale,
+          },
+          client,
+        })
+      );
+      return response.uploadedFiles;
+    });
+    return { uploadedFiles: result.data, count: result.count };
+  },
+
+  async uploadTranslations(
+    files: UploadTranslationsData['body']['data'],
+    options: { sourceLocale: string }
+  ) {
+    const result = await processBatches(files, async (batch) => {
+      const response = responseData(
+        await uploadTranslations({
+          body: {
+            data: batch.map(({ source, translations }) => ({
+              source: {
+                ...source,
+                content: encodeFileContent(source.content, source.fileFormat),
+              },
+              translations: translations.map((translation) => ({
+                ...translation,
+                content: encodeFileContent(
+                  translation.content,
+                  translation.fileFormat
+                ),
+              })),
+            })),
+            sourceLocale: resolveCanonicalLocale(
+              options.sourceLocale,
+              customMapping
+            ),
+          },
+          client,
+        })
+      );
+      return response.uploadedFiles;
+    });
+    return { uploadedFiles: result.data, count: result.count };
+  },
+
+  async enqueueFiles(
+    files: EnqueueFileTranslationsData['body']['files'],
+    options: {
+      sourceLocale?: string;
+      targetLocales: string[];
+      force?: boolean;
+    }
+  ) {
+    const targetLocales = options.targetLocales.map((locale) =>
+      resolveCanonicalLocale(locale, customMapping)
+    );
+    const result = await processBatches(files, async (batch) => {
+      const response = responseData(
+        await enqueueFileTranslations({
+          body: {
+            files: batch,
+            sourceLocale: options.sourceLocale,
+            targetLocales,
+            force: options.force,
+          },
+          client,
+        })
+      );
+      return Object.entries(
+        'jobData' in response ? response.jobData : response.data
+      );
+    });
+    return { jobData: Object.fromEntries(result.data), locales: targetLocales };
+  },
+
+  async querySourceFile(query: {
+    fileId: string;
+    versionId?: string;
+    branchId?: string;
+  }) {
+    const { fileId, ...queryParams } = query;
+    return responseData(
+      await getTranslationStatus({
+        path: { fileId },
+        query: queryParams,
+        client,
+      })
+    );
+  },
+
+  async downloadFile(query: {
+    fileId: string;
+    versionId?: string;
+    branchId?: string;
+    locale?: string;
+  }) {
+    const { fileId, ...queryParams } = query;
+    const response = responseData(
+      await downloadFile({ path: { fileId }, query: queryParams, client })
+    );
+    return decodeFileContent(response.data, 'HTML');
+  },
+
+  async downloadFileBatch(files: DownloadFilesData['body']) {
+    const request = async (batch: DownloadFilesData['body']) =>
+      responseData(await downloadFiles({ body: batch, client }));
+    const responses = await Promise.all(
+      files.length === 0
+        ? [request([])]
+        : createBatches(files).map((batch) => request(batch))
+    );
+    return {
+      files: responses.flatMap((response) =>
+        response.files.map((file) => ({
+          ...file,
+          data: decodeFileContent(file.data, file.fileFormat),
+          fileFormat: file.fileFormat as FileFormat,
+          metadata: file.metadata as DownloadedFile['metadata'],
+        }))
+      ),
+      count: responses.reduce((count, response) => count + response.count, 0),
+    };
+  },
+
+  async setupProject(
+    files: GenerateProjectContextData['body']['files'],
+    options: Omit<GenerateProjectContextData['body'], 'files'> = {}
+  ) {
+    return responseData(
+      await generateProjectContext({ body: { files, ...options }, client })
+    );
+  },
+
+  async awaitJobs(
+    jobIds: readonly string[],
+    options?: Parameters<typeof awaitApiJobs>[2]
+  ) {
+    return awaitApiJobs(jobIds, createJobStatusLoader(client), options);
+  },
+
+  async queryFileData(body: GetFileInfoData['body']) {
+    return responseData(await getFileInfo({ body, client }));
+  },
+
+  async createBranch(body: CreateBranchData['body']) {
+    return responseData(await createBranch({ body, client }));
+  },
+};

--- a/packages/sanity/src/adapter/api.ts
+++ b/packages/sanity/src/adapter/api.ts
@@ -21,11 +21,14 @@ import {
   type GetFileInfoData,
   type UploadSourceFilesData,
   type UploadTranslationsData,
-} from '@generaltranslation/api';
-import { resolveCanonicalLocale } from '@generaltranslation/format';
-import type { CustomMapping } from '@generaltranslation/format/types';
+} from 'generaltranslation/api';
+import { resolveCanonicalLocale } from 'generaltranslation';
 import { defaultBaseUrl, unwrapApiResult } from 'generaltranslation/internal';
-import type { DownloadedFile, FileFormat } from 'generaltranslation/types';
+import type {
+  CustomMapping,
+  DownloadedFile,
+  FileFormat,
+} from 'generaltranslation/types';
 
 let client = createApiClient({ baseUrl: defaultBaseUrl });
 let customMapping: CustomMapping | undefined;

--- a/packages/sanity/src/adapter/api.ts
+++ b/packages/sanity/src/adapter/api.ts
@@ -146,6 +146,9 @@ export const api = {
       force?: boolean;
     }
   ) {
+    const sourceLocale = options.sourceLocale
+      ? resolveCanonicalLocale(options.sourceLocale, customMapping)
+      : undefined;
     const targetLocales = options.targetLocales.map((locale) =>
       resolveCanonicalLocale(locale, customMapping)
     );
@@ -154,7 +157,7 @@ export const api = {
         await enqueueFileTranslations({
           body: {
             files: batch,
-            sourceLocale: options.sourceLocale,
+            sourceLocale,
             targetLocales,
             force: options.force,
           },

--- a/packages/sanity/src/adapter/core.ts
+++ b/packages/sanity/src/adapter/core.ts
@@ -1,4 +1,7 @@
 import { GT } from 'generaltranslation';
+import { configureApiClient } from './api';
+
+export { api } from './api';
 import { libraryDefaultLocale } from 'generaltranslation/internal';
 import type { Secrets } from '../types';
 import type {
@@ -38,10 +41,12 @@ export const DEFAULT_TRANSLATION_PREFERENCES: TranslationPreferences = {
 };
 
 export function overrideConfig(secrets: Secrets | null) {
-  gt.setConfig({
-    ...(secrets?.project && { projectId: secrets?.project }),
-    ...(secrets?.secret && { apiKey: secrets?.secret }),
-  });
+  const config = {
+    ...(secrets?.project && { projectId: secrets.project }),
+    ...(secrets?.secret && { apiKey: secrets.secret }),
+  };
+  gt.setConfig(config);
+  configureApiClient({ ...config, customMapping: gt.customMapping });
 }
 
 export class GTConfig {

--- a/packages/sanity/src/adapter/createTask.ts
+++ b/packages/sanity/src/adapter/createTask.ts
@@ -1,6 +1,6 @@
 import type { Adapter, GTFile, GTSerializedDocument, Secrets } from '../types';
 import { getTranslationTask } from './getTranslationTask';
-import { gt, overrideConfig } from './core';
+import { api, gt, overrideConfig } from './core';
 import { libraryDefaultLocale } from 'generaltranslation/internal';
 
 // note: this function is used to create a new translation task
@@ -15,7 +15,7 @@ export const createTask: Adapter['createTask'] = async (
 ) => {
   const fileName = `sanity/${documentInfo.documentId}`;
   overrideConfig(secrets);
-  const uploadResult = await gt.uploadSourceFiles(
+  const uploadResult = await api.uploadSourceFiles(
     [
       {
         source: {
@@ -32,7 +32,7 @@ export const createTask: Adapter['createTask'] = async (
       sourceLocale: gt.sourceLocale || libraryDefaultLocale,
     }
   );
-  await gt.enqueueFiles(uploadResult.uploadedFiles, {
+  await api.enqueueFiles(uploadResult.uploadedFiles, {
     sourceLocale: gt.sourceLocale || libraryDefaultLocale,
     targetLocales: localeIds,
   });

--- a/packages/sanity/src/adapter/getTranslation.ts
+++ b/packages/sanity/src/adapter/getTranslation.ts
@@ -1,5 +1,5 @@
 import type { Adapter, GTFile, Secrets } from '../types';
-import { gt, overrideConfig } from './core';
+import { api, overrideConfig } from './core';
 
 // note: downloads the translation for a given task and locale
 export const getTranslation: Adapter['getTranslation'] = async (
@@ -11,7 +11,7 @@ export const getTranslation: Adapter['getTranslation'] = async (
     return '';
   }
   overrideConfig(secrets);
-  const text = await gt.downloadFile({
+  const text = await api.downloadFile({
     fileId: documentInfo.documentId,
     versionId: documentInfo.versionId || undefined,
     locale: localeId,

--- a/packages/sanity/src/adapter/getTranslationTask.ts
+++ b/packages/sanity/src/adapter/getTranslationTask.ts
@@ -1,5 +1,5 @@
 import type { Adapter, GTFile, Secrets } from '../types';
-import { gt, overrideConfig } from './core';
+import { api, overrideConfig } from './core';
 
 // note: this function is used to get the status of a current translation task
 export const getTranslationTask: Adapter['getTranslationTask'] = async (
@@ -13,7 +13,7 @@ export const getTranslationTask: Adapter['getTranslationTask'] = async (
     };
   }
   overrideConfig(secrets);
-  const task = await gt.querySourceFile({
+  const task = await api.querySourceFile({
     fileId: documentInfo.documentId,
     versionId: documentInfo.versionId || undefined,
   });

--- a/packages/sanity/src/components/TranslationsProvider.tsx
+++ b/packages/sanity/src/components/TranslationsProvider.tsx
@@ -17,7 +17,7 @@ import {
   TranslationLocale,
   TranslationFunctionContext,
 } from '../types';
-import { gt, overrideConfig, pluginConfig } from '../adapter/core';
+import { api, overrideConfig, pluginConfig } from '../adapter/core';
 import { getTranslationStrategy } from '../translation/strategy';
 import { uploadFiles } from '../translation/uploadFiles';
 import { initProject } from '../translation/initProject';
@@ -896,7 +896,7 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
   const handleGetBranchId = useCallback(
     async (secrets: Secrets) => {
       overrideConfig(secrets);
-      const defaultBranch = await gt.createBranch({
+      const defaultBranch = await api.createBranch({
         branchName: 'main',
         defaultBranch: true,
       });

--- a/packages/sanity/src/translation/__tests__/captureExistingTranslations.test.ts
+++ b/packages/sanity/src/translation/__tests__/captureExistingTranslations.test.ts
@@ -14,6 +14,8 @@ vi.mock('../../adapter/core', async () => {
     ...actual,
     gt: {
       sourceLocale: 'en',
+    },
+    api: {
       downloadFileBatch: (...args: unknown[]) => downloadFileBatch(...args),
       uploadTranslations: (...args: unknown[]) => uploadTranslations(...args),
     },

--- a/packages/sanity/src/translation/__tests__/initProject.test.ts
+++ b/packages/sanity/src/translation/__tests__/initProject.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { gt, overrideConfig, pluginConfig } from '../../adapter/core';
+import { api, overrideConfig, pluginConfig } from '../../adapter/core';
 import type { Secrets } from '../../types';
 import { initProject } from '../initProject';
 
 vi.mock('../../adapter/core', () => ({
-  gt: {
+  api: {
     setupProject: vi.fn(),
     awaitJobs: vi.fn(),
   },
@@ -32,13 +32,13 @@ const secrets: Secrets = {
 const consoleLog = vi.fn();
 
 async function runWithAwaitResult(
-  awaitResult: Awaited<ReturnType<typeof gt.awaitJobs>>
+  awaitResult: Awaited<ReturnType<typeof api.awaitJobs>>
 ) {
-  vi.mocked(gt.setupProject).mockResolvedValue({
+  vi.mocked(api.setupProject).mockResolvedValue({
     status: 'queued',
     setupJobId: 'setup-job',
   });
-  vi.mocked(gt.awaitJobs).mockResolvedValue(awaitResult);
+  vi.mocked(api.awaitJobs).mockResolvedValue(awaitResult);
 
   return initProject(uploadResult, { timeout: 30 }, secrets);
 }
@@ -62,7 +62,7 @@ describe('initProject', () => {
 
     expect(consoleLog).toHaveBeenCalledWith('Setup successfully completed');
     expect(overrideConfig).toHaveBeenCalledWith(secrets);
-    expect(gt.awaitJobs).toHaveBeenCalledWith(['setup-job'], {
+    expect(api.awaitJobs).toHaveBeenCalledWith(['setup-job'], {
       pollingIntervalSeconds: 2,
       timeoutSeconds: 30,
     });

--- a/packages/sanity/src/translation/captureExistingTranslations.ts
+++ b/packages/sanity/src/translation/captureExistingTranslations.ts
@@ -1,6 +1,6 @@
 import type { SanityDocument } from 'sanity';
 import { libraryDefaultLocale } from 'generaltranslation/internal';
-import { gt, overrideConfig } from '../adapter/core';
+import { api, gt, overrideConfig } from '../adapter/core';
 import { getDocumentPublishedId } from '../utils/documentIds';
 import { collectExistingTranslations } from './collectExistingTranslations';
 
@@ -49,7 +49,7 @@ export async function captureExistingTranslations({
   overrideConfig(secrets);
   const sourceLocale = gt.sourceLocale || libraryDefaultLocale;
 
-  const seedFiles = await gt.downloadFileBatch(
+  const seedFiles = await api.downloadFileBatch(
     documents.map((document) => ({
       fileId: getDocumentPublishedId(document),
       branchId,
@@ -99,7 +99,7 @@ export async function captureExistingTranslations({
     return EMPTY_RESULT;
   }
 
-  await gt.uploadTranslations(files, { sourceLocale });
+  await api.uploadTranslations(files, { sourceLocale });
 
   return {
     capturedCount: files.reduce(

--- a/packages/sanity/src/translation/checkTranslationStatus.ts
+++ b/packages/sanity/src/translation/checkTranslationStatus.ts
@@ -1,5 +1,5 @@
 import type { Secrets } from '../types';
-import { gt, overrideConfig } from '../adapter/core';
+import { api, overrideConfig } from '../adapter/core';
 import { FileProperties } from '../adapter/types';
 import {
   createStableTranslationKey,
@@ -45,7 +45,7 @@ export async function checkTranslationStatus(
       return true;
     }
     // Check for translations
-    const responseData = await gt.queryFileData({
+    const responseData = await api.queryFileData({
       translatedFiles: currentQueryData,
     });
 

--- a/packages/sanity/src/translation/createJobs.ts
+++ b/packages/sanity/src/translation/createJobs.ts
@@ -1,9 +1,9 @@
 import { libraryDefaultLocale } from 'generaltranslation/internal';
-import { gt, overrideConfig } from '../adapter/core';
+import { api, gt, overrideConfig } from '../adapter/core';
 import type { Secrets } from '../types';
 
 export async function createJobs(
-  uploadResult: Awaited<ReturnType<typeof gt.uploadSourceFiles>>,
+  uploadResult: Awaited<ReturnType<typeof api.uploadSourceFiles>>,
   localeIds: string[],
   secrets: Secrets,
   // Discard any translation GT already holds for these files and retranslate
@@ -11,9 +11,9 @@ export async function createJobs(
   // translations captured from the Studio — so a bad translation can never be
   // regenerated.
   force: boolean = false
-): Promise<Awaited<ReturnType<typeof gt.enqueueFiles>>> {
+): Promise<Awaited<ReturnType<typeof api.enqueueFiles>>> {
   overrideConfig(secrets);
-  const enqueueResult = await gt.enqueueFiles(uploadResult.uploadedFiles, {
+  const enqueueResult = await api.enqueueFiles(uploadResult.uploadedFiles, {
     sourceLocale: gt.sourceLocale || libraryDefaultLocale,
     targetLocales: localeIds,
     force,

--- a/packages/sanity/src/translation/downloadTranslations.ts
+++ b/packages/sanity/src/translation/downloadTranslations.ts
@@ -1,4 +1,4 @@
-import { gt, overrideConfig } from '../adapter/core';
+import { api, overrideConfig } from '../adapter/core';
 import { FileProperties } from '../adapter/types';
 import { DownloadedFile } from 'generaltranslation/types';
 import type { Secrets } from '../types';
@@ -22,7 +22,7 @@ export async function downloadTranslations(
   while (retries <= maxRetries) {
     try {
       // Download the files
-      const responseData = await gt.downloadFileBatch(
+      const responseData = await api.downloadFileBatch(
         files.map((file) => ({
           fileId: file.fileId,
           branchId: file.branchId,

--- a/packages/sanity/src/translation/initProject.ts
+++ b/packages/sanity/src/translation/initProject.ts
@@ -1,8 +1,8 @@
-import { gt, overrideConfig, pluginConfig } from '../adapter/core';
+import { api, overrideConfig, pluginConfig } from '../adapter/core';
 import type { Secrets } from '../types';
 
 export async function initProject(
-  uploadResult: Awaited<ReturnType<typeof gt.uploadSourceFiles>>,
+  uploadResult: Awaited<ReturnType<typeof api.uploadSourceFiles>>,
   options: { timeout?: number },
   secrets: Secrets
 ): Promise<boolean> {
@@ -13,12 +13,12 @@ export async function initProject(
     options?.timeout !== undefined ? Number(options.timeout) : 600;
   const setupTimeoutSeconds = Number.isFinite(timeoutVal) ? timeoutVal : 600;
 
-  const setupResult = await gt.setupProject(uploadResult.uploadedFiles, {
+  const setupResult = await api.setupProject(uploadResult.uploadedFiles, {
     locales: pluginConfig.getLocales(),
   });
 
   if (setupResult.status === 'queued') {
-    const { complete, jobs } = await gt.awaitJobs([setupResult.setupJobId], {
+    const { complete, jobs } = await api.awaitJobs([setupResult.setupJobId], {
       pollingIntervalSeconds: 2,
       timeoutSeconds: setupTimeoutSeconds,
     });

--- a/packages/sanity/src/translation/uploadFiles.ts
+++ b/packages/sanity/src/translation/uploadFiles.ts
@@ -1,5 +1,5 @@
 import type { GTFile, Secrets } from '../types';
-import { gt, overrideConfig } from '../adapter/core';
+import { api, gt, overrideConfig } from '../adapter/core';
 import { libraryDefaultLocale } from 'generaltranslation/internal';
 import type { SerializedDocument } from '../serialization/types';
 
@@ -11,9 +11,9 @@ export async function uploadFiles(
     serializedDocument: SerializedDocument;
   }[],
   secrets: Secrets | null
-): Promise<Awaited<ReturnType<typeof gt.uploadSourceFiles>>> {
+): Promise<Awaited<ReturnType<typeof api.uploadSourceFiles>>> {
   overrideConfig(secrets);
-  const uploadResult = await gt.uploadSourceFiles(
+  const uploadResult = await api.uploadSourceFiles(
     documents.map(({ info, serializedDocument }) => ({
       source: {
         content: serializedDocument.content,

--- a/packages/sanity/src/translation/uploadTranslations.ts
+++ b/packages/sanity/src/translation/uploadTranslations.ts
@@ -1,5 +1,5 @@
 import type { GTFile, Secrets } from '../types';
-import { gt, overrideConfig } from '../adapter/core';
+import { api, gt, overrideConfig } from '../adapter/core';
 import { libraryDefaultLocale } from 'generaltranslation/internal';
 import type { SerializedDocument } from '../serialization/types';
 import type { ExistingTranslation } from './collectExistingTranslations';
@@ -20,7 +20,7 @@ export async function uploadTranslations(
     translations: ExistingTranslation[];
   }[],
   secrets: Secrets | null
-): Promise<Awaited<ReturnType<typeof gt.uploadTranslations>> | null> {
+): Promise<Awaited<ReturnType<typeof api.uploadTranslations>> | null> {
   const withTranslations = documents.filter(
     (document) => document.translations.length > 0
   );
@@ -30,7 +30,7 @@ export async function uploadTranslations(
 
   overrideConfig(secrets);
   const sourceLocale = gt.sourceLocale || libraryDefaultLocale;
-  return await gt.uploadTranslations(
+  return await api.uploadTranslations(
     withTranslations.map(({ info, serializedDocument, translations }) => ({
       source: {
         content: serializedDocument.content,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -810,9 +810,6 @@ importers:
       '@clack/prompts':
         specifier: 1.0.0-alpha.6
         version: 1.0.0-alpha.6
-      '@generaltranslation/api':
-        specifier: workspace:*
-        version: link:../api
       '@generaltranslation/format':
         specifier: workspace:*
         version: link:../format

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,13 +148,13 @@ importers:
         version: 11.4.13
       expo:
         specifier: ~54.0.35
-        version: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+        version: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-dev-client:
         specifier: ~6.0.21
-        version: 6.0.21(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))
+        version: 6.0.21(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))
       expo-status-bar:
         specifier: ~3.0.9
-        version: 3.0.9(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
+        version: 3.0.9(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
       gt-react-native:
         specifier: workspace:*
         version: link:../../packages/react-native
@@ -163,7 +163,7 @@ importers:
         version: 19.1.0
       react-native:
         specifier: 0.81.5
-        version: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
+        version: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
     devDependencies:
       '@babel/core':
         specifier: ^7.28.4
@@ -173,7 +173,7 @@ importers:
         version: 19.2.7
       babel-preset-expo:
         specifier: ~54.0.11
-        version: 54.0.11(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-refresh@0.18.0)
+        version: 54.0.11(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-refresh@0.18.0)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1469,7 +1469,7 @@ importers:
         version: 19.1.0
       react-native:
         specifier: 0.81.1
-        version: 0.81.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
+        version: 0.81.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
       tsdown:
         specifier: 'catalog:'
         version: 0.21.10(synckit@0.11.11)(typescript@5.9.3)
@@ -1574,6 +1574,12 @@ importers:
 
   packages/sanity:
     dependencies:
+      '@generaltranslation/api':
+        specifier: workspace:*
+        version: link:../api
+      '@generaltranslation/format':
+        specifier: workspace:*
+        version: link:../format
       '@portabletext/block-tools':
         specifier: ^5.1.1
         version: 5.1.1(@types/react@19.2.7)
@@ -2331,13 +2337,13 @@ importers:
         version: 11.4.13
       expo:
         specifier: ~54.0.35
-        version: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
+        version: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
       expo-dev-client:
         specifier: ~6.0.21
-        version: 6.0.21(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))
+        version: 6.0.21(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))
       expo-status-bar:
         specifier: ~3.0.9
-        version: 3.0.9(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
+        version: 3.0.9(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
       gt-react-native:
         specifier: workspace:*
         version: link:../../../packages/react-native
@@ -2346,7 +2352,7 @@ importers:
         version: 19.1.0
       react-native:
         specifier: 0.81.5
-        version: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
+        version: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
     devDependencies:
       '@babel/core':
         specifier: ^7.28.4
@@ -2356,7 +2362,7 @@ importers:
         version: 19.2.7
       babel-preset-expo:
         specifier: ~54.0.11
-        version: 54.0.11(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-refresh@0.18.0)
+        version: 54.0.11(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-refresh@0.18.0)
       typescript:
         specifier: ^5
         version: 5.7.3
@@ -24870,7 +24876,7 @@ snapshots:
     optionalDependencies:
       '@noble/hashes': 2.2.0
 
-  '@expo/cli@54.0.25(bufferutil@4.0.9)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(typescript@5.7.3)':
+  '@expo/cli@54.0.25(bufferutil@4.0.9)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(typescript@5.7.3)':
     dependencies:
       '@0no-co/graphql.web': 1.3.2
       '@expo/code-signing-certificates': 0.0.6
@@ -24881,11 +24887,11 @@ snapshots:
       '@expo/image-utils': 0.8.14(typescript@5.7.3)
       '@expo/json-file': 10.2.0
       '@expo/metro': 54.2.0(bufferutil@4.0.9)
-      '@expo/metro-config': 54.0.16(bufferutil@4.0.9)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))
+      '@expo/metro-config': 54.0.16(bufferutil@4.0.9)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))
       '@expo/osascript': 2.6.0
       '@expo/package-manager': 1.12.1
       '@expo/plist': 0.4.9
-      '@expo/prebuild-config': 54.0.8(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(typescript@5.7.3)
+      '@expo/prebuild-config': 54.0.8(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(typescript@5.7.3)
       '@expo/schema-utils': 0.1.8
       '@expo/spawn-async': 1.8.0
       '@expo/ws-tunnel': 1.0.6
@@ -24904,7 +24910,7 @@ snapshots:
       connect: 3.7.0
       debug: 4.4.3(supports-color@5.5.0)
       env-editor: 0.4.2
-      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
+      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
       expo-server: 1.0.7
       freeport-async: 2.0.0
       getenv: 2.0.0
@@ -24938,7 +24944,7 @@ snapshots:
       wrap-ansi: 7.0.0
       ws: 8.20.0(bufferutil@4.0.9)
     optionalDependencies:
-      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
     transitivePeerDependencies:
       - bufferutil
       - graphql
@@ -24946,7 +24952,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@expo/cli@54.0.25(bufferutil@4.0.9)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(typescript@5.9.3)':
+  '@expo/cli@54.0.25(bufferutil@4.0.9)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(typescript@5.9.3)':
     dependencies:
       '@0no-co/graphql.web': 1.3.2
       '@expo/code-signing-certificates': 0.0.6
@@ -24957,11 +24963,11 @@ snapshots:
       '@expo/image-utils': 0.8.14(typescript@5.9.3)
       '@expo/json-file': 10.2.0
       '@expo/metro': 54.2.0(bufferutil@4.0.9)
-      '@expo/metro-config': 54.0.16(bufferutil@4.0.9)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))
+      '@expo/metro-config': 54.0.16(bufferutil@4.0.9)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))
       '@expo/osascript': 2.6.0
       '@expo/package-manager': 1.12.1
       '@expo/plist': 0.4.9
-      '@expo/prebuild-config': 54.0.8(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(typescript@5.9.3)
+      '@expo/prebuild-config': 54.0.8(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(typescript@5.9.3)
       '@expo/schema-utils': 0.1.8
       '@expo/spawn-async': 1.8.0
       '@expo/ws-tunnel': 1.0.6
@@ -24980,7 +24986,7 @@ snapshots:
       connect: 3.7.0
       debug: 4.4.3(supports-color@5.5.0)
       env-editor: 0.4.2
-      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-server: 1.0.7
       freeport-async: 2.0.0
       getenv: 2.0.0
@@ -25014,7 +25020,7 @@ snapshots:
       wrap-ansi: 7.0.0
       ws: 8.20.0(bufferutil@4.0.9)
     optionalDependencies:
-      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
     transitivePeerDependencies:
       - bufferutil
       - graphql
@@ -25072,19 +25078,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/devtools@0.1.8(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)':
+  '@expo/devtools@0.1.8(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)':
     dependencies:
       chalk: 4.1.2
     optionalDependencies:
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
 
-  '@expo/devtools@0.1.8(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)':
+  '@expo/devtools@0.1.8(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)':
     dependencies:
       chalk: 4.1.2
     optionalDependencies:
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
 
   '@expo/env@2.0.11':
     dependencies:
@@ -25148,7 +25154,7 @@ snapshots:
       '@babel/code-frame': 7.29.0
       json5: 2.2.3
 
-  '@expo/metro-config@54.0.16(bufferutil@4.0.9)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))':
+  '@expo/metro-config@54.0.16(bufferutil@4.0.9)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/core': 7.29.0
@@ -25172,13 +25178,13 @@ snapshots:
       postcss: 8.4.49
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
+      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@expo/metro-config@54.0.16(bufferutil@4.0.9)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))':
+  '@expo/metro-config@54.0.16(bufferutil@4.0.9)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/core': 7.29.0
@@ -25202,7 +25208,7 @@ snapshots:
       postcss: 8.4.49
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -25248,7 +25254,7 @@ snapshots:
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 
-  '@expo/prebuild-config@54.0.8(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(typescript@5.7.3)':
+  '@expo/prebuild-config@54.0.8(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(typescript@5.7.3)':
     dependencies:
       '@expo/config': 12.0.13
       '@expo/config-plugins': 54.0.4
@@ -25257,7 +25263,7 @@ snapshots:
       '@expo/json-file': 10.2.0
       '@react-native/normalize-colors': 0.81.5
       debug: 4.4.3(supports-color@5.5.0)
-      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
+      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
       resolve-from: 5.0.0
       semver: 7.8.5
       xml2js: 0.6.0
@@ -25265,7 +25271,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@expo/prebuild-config@54.0.8(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(typescript@5.9.3)':
+  '@expo/prebuild-config@54.0.8(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
       '@expo/config': 12.0.13
       '@expo/config-plugins': 54.0.4
@@ -25274,7 +25280,7 @@ snapshots:
       '@expo/json-file': 10.2.0
       '@react-native/normalize-colors': 0.81.5
       debug: 4.4.3(supports-color@5.5.0)
-      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       resolve-from: 5.0.0
       semver: 7.8.5
       xml2js: 0.6.0
@@ -25312,17 +25318,17 @@ snapshots:
 
   '@expo/sudo-prompt@9.3.2': {}
 
-  '@expo/vector-icons@15.1.1(expo-font@14.0.12(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)':
+  '@expo/vector-icons@15.1.1(expo-font@14.0.12(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)':
     dependencies:
-      expo-font: 14.0.12(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
+      expo-font: 14.0.12(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
 
-  '@expo/vector-icons@15.1.1(expo-font@14.0.12(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)':
+  '@expo/vector-icons@15.1.1(expo-font@14.0.12(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)':
     dependencies:
-      expo-font: 14.0.12(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
+      expo-font: 14.0.12(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
 
   '@expo/ws-tunnel@1.0.6': {}
 
@@ -28641,7 +28647,7 @@ snapshots:
       nullthrows: 1.1.1
       yargs: 17.7.2
 
-  '@react-native/community-cli-plugin@0.81.1(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(bufferutil@4.0.9)':
+  '@react-native/community-cli-plugin@0.81.1(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(bufferutil@4.0.9)':
     dependencies:
       '@react-native/dev-middleware': 0.81.1(bufferutil@4.0.9)
       debug: 4.4.3(supports-color@5.5.0)
@@ -28652,13 +28658,13 @@ snapshots:
       semver: 7.8.5
     optionalDependencies:
       '@react-native-community/cli': 20.0.0(bufferutil@4.0.9)(typescript@5.9.3)
-      '@react-native/metro-config': 0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9)
+      '@react-native/metro-config': 0.81.1(@babel/core@7.29.0)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@react-native/community-cli-plugin@0.81.5(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(bufferutil@4.0.9)':
+  '@react-native/community-cli-plugin@0.81.5(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(bufferutil@4.0.9)':
     dependencies:
       '@react-native/dev-middleware': 0.81.5(bufferutil@4.0.9)
       debug: 4.4.3(supports-color@5.5.0)
@@ -28669,13 +28675,13 @@ snapshots:
       semver: 7.8.5
     optionalDependencies:
       '@react-native-community/cli': 20.0.0(bufferutil@4.0.9)(typescript@5.7.3)
-      '@react-native/metro-config': 0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9)
+      '@react-native/metro-config': 0.81.1(@babel/core@7.29.0)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@react-native/community-cli-plugin@0.81.5(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(bufferutil@4.0.9)':
+  '@react-native/community-cli-plugin@0.81.5(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(bufferutil@4.0.9)':
     dependencies:
       '@react-native/dev-middleware': 0.81.5(bufferutil@4.0.9)
       debug: 4.4.3(supports-color@5.5.0)
@@ -28686,7 +28692,7 @@ snapshots:
       semver: 7.8.5
     optionalDependencies:
       '@react-native-community/cli': 20.0.0(bufferutil@4.0.9)(typescript@5.9.3)
-      '@react-native/metro-config': 0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9)
+      '@react-native/metro-config': 0.81.1(@babel/core@7.29.0)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -28750,7 +28756,7 @@ snapshots:
       - supports-color
     optional: true
 
-  '@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9)':
+  '@react-native/metro-config@0.81.1(@babel/core@7.29.0)':
     dependencies:
       '@react-native/js-polyfills': 0.81.1
       '@react-native/metro-babel-transformer': 0.81.1(@babel/core@7.29.0)
@@ -28758,39 +28764,37 @@ snapshots:
       metro-runtime: 0.83.6
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
     optional: true
 
   '@react-native/normalize-colors@0.81.1': {}
 
   '@react-native/normalize-colors@0.81.5': {}
 
-  '@react-native/virtualized-lists@0.81.1(@types/react@19.2.7)(react-native@0.81.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)':
+  '@react-native/virtualized-lists@0.81.1(@types/react@19.2.7)(react-native@0.81.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)':
     dependencies:
       invariant: 2.2.4
       nullthrows: 1.1.1
       react: 19.1.0
-      react-native: 0.81.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
+      react-native: 0.81.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
     optionalDependencies:
       '@types/react': 19.2.7
 
-  '@react-native/virtualized-lists@0.81.5(@types/react@19.2.7)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)':
+  '@react-native/virtualized-lists@0.81.5(@types/react@19.2.7)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)':
     dependencies:
       invariant: 2.2.4
       nullthrows: 1.1.1
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
     optionalDependencies:
       '@types/react': 19.2.7
 
-  '@react-native/virtualized-lists@0.81.5(@types/react@19.2.7)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)':
+  '@react-native/virtualized-lists@0.81.5(@types/react@19.2.7)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)':
     dependencies:
       invariant: 2.2.4
       nullthrows: 1.1.1
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
     optionalDependencies:
       '@types/react': 19.2.7
 
@@ -32698,7 +32702,7 @@ snapshots:
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.0)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.0)
 
-  babel-preset-expo@54.0.11(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-refresh@0.14.2):
+  babel-preset-expo@54.0.11(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-refresh@0.14.2):
     dependencies:
       '@babel/helper-module-imports': 7.28.6
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
@@ -32725,12 +32729,12 @@ snapshots:
       resolve-from: 5.0.0
     optionalDependencies:
       '@babel/runtime': 7.29.2
-      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
+      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  babel-preset-expo@54.0.11(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-refresh@0.18.0):
+  babel-preset-expo@54.0.11(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-refresh@0.18.0):
     dependencies:
       '@babel/helper-module-imports': 7.28.6
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
@@ -32757,12 +32761,12 @@ snapshots:
       resolve-from: 5.0.0
     optionalDependencies:
       '@babel/runtime': 7.29.2
-      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
+      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  babel-preset-expo@54.0.11(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-refresh@0.14.2):
+  babel-preset-expo@54.0.11(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-refresh@0.14.2):
     dependencies:
       '@babel/helper-module-imports': 7.28.6
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
@@ -32789,12 +32793,12 @@ snapshots:
       resolve-from: 5.0.0
     optionalDependencies:
       '@babel/runtime': 7.29.2
-      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  babel-preset-expo@54.0.11(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-refresh@0.18.0):
+  babel-preset-expo@54.0.11(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-refresh@0.18.0):
     dependencies:
       '@babel/helper-module-imports': 7.28.6
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
@@ -32821,7 +32825,7 @@ snapshots:
       resolve-from: 5.0.0
     optionalDependencies:
       '@babel/runtime': 7.29.2
-      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -35024,152 +35028,152 @@ snapshots:
       jest-message-util: 29.7.0
       jest-util: 29.7.0
 
-  expo-asset@12.0.13(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3):
+  expo-asset@12.0.13(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3):
     dependencies:
       '@expo/image-utils': 0.8.14(typescript@5.7.3)
-      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
-      expo-constants: 18.0.13(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))
+      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
+      expo-constants: 18.0.13(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  expo-asset@12.0.13(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
+  expo-asset@12.0.13(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
     dependencies:
       '@expo/image-utils': 0.8.14(typescript@5.9.3)
-      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      expo-constants: 18.0.13(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))
+      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-constants: 18.0.13(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  expo-constants@18.0.13(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)):
+  expo-constants@18.0.13(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)):
     dependencies:
       '@expo/config': 12.0.13
       '@expo/env': 2.0.11
-      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
-      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
+      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
 
-  expo-constants@18.0.13(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)):
+  expo-constants@18.0.13(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)):
     dependencies:
       '@expo/config': 12.0.13
       '@expo/env': 2.0.11
-      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
+      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
 
-  expo-dev-client@6.0.21(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)):
+  expo-dev-client@6.0.21(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)):
     dependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
-      expo-dev-launcher: 6.0.21(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))
-      expo-dev-menu: 7.0.19(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))
-      expo-dev-menu-interface: 2.0.0(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))
-      expo-manifests: 1.0.11(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))
-      expo-updates-interface: 2.0.0(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))
+      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
+      expo-dev-launcher: 6.0.21(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))
+      expo-dev-menu: 7.0.19(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))
+      expo-dev-menu-interface: 2.0.0(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))
+      expo-manifests: 1.0.11(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))
+      expo-updates-interface: 2.0.0(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))
     transitivePeerDependencies:
       - supports-color
 
-  expo-dev-client@6.0.21(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)):
+  expo-dev-client@6.0.21(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)):
     dependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      expo-dev-launcher: 6.0.21(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))
-      expo-dev-menu: 7.0.19(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))
-      expo-dev-menu-interface: 2.0.0(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))
-      expo-manifests: 1.0.11(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))
-      expo-updates-interface: 2.0.0(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))
+      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-dev-launcher: 6.0.21(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))
+      expo-dev-menu: 7.0.19(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))
+      expo-dev-menu-interface: 2.0.0(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))
+      expo-manifests: 1.0.11(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))
+      expo-updates-interface: 2.0.0(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))
     transitivePeerDependencies:
       - supports-color
 
-  expo-dev-launcher@6.0.21(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)):
+  expo-dev-launcher@6.0.21(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)):
     dependencies:
       ajv: 8.18.0
-      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
-      expo-dev-menu: 7.0.19(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))
-      expo-manifests: 1.0.11(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))
+      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
+      expo-dev-menu: 7.0.19(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))
+      expo-manifests: 1.0.11(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))
     transitivePeerDependencies:
       - supports-color
 
-  expo-dev-launcher@6.0.21(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)):
+  expo-dev-launcher@6.0.21(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)):
     dependencies:
       ajv: 8.18.0
-      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      expo-dev-menu: 7.0.19(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))
-      expo-manifests: 1.0.11(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))
+      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-dev-menu: 7.0.19(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))
+      expo-manifests: 1.0.11(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))
     transitivePeerDependencies:
       - supports-color
 
-  expo-dev-menu-interface@2.0.0(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)):
+  expo-dev-menu-interface@2.0.0(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)):
     dependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
+      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
 
-  expo-dev-menu-interface@2.0.0(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)):
+  expo-dev-menu-interface@2.0.0(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)):
     dependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
-  expo-dev-menu@7.0.19(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)):
+  expo-dev-menu@7.0.19(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)):
     dependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
-      expo-dev-menu-interface: 2.0.0(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))
+      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
+      expo-dev-menu-interface: 2.0.0(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))
 
-  expo-dev-menu@7.0.19(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)):
+  expo-dev-menu@7.0.19(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)):
     dependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      expo-dev-menu-interface: 2.0.0(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))
+      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-dev-menu-interface: 2.0.0(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))
 
-  expo-file-system@19.0.23(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)):
+  expo-file-system@19.0.23(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)):
     dependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
-      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
+      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
 
-  expo-file-system@19.0.23(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)):
+  expo-file-system@19.0.23(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)):
     dependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
+      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
 
-  expo-font@14.0.12(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0):
+  expo-font@14.0.12(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0):
     dependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
+      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
       fontfaceobserver: 2.3.0
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
 
-  expo-font@14.0.12(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0):
+  expo-font@14.0.12(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0):
     dependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       fontfaceobserver: 2.3.0
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
 
   expo-json-utils@0.15.0: {}
 
-  expo-keep-awake@15.0.8(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react@19.1.0):
+  expo-keep-awake@15.0.8(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react@19.1.0):
     dependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
+      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
       react: 19.1.0
 
-  expo-keep-awake@15.0.8(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react@19.1.0):
+  expo-keep-awake@15.0.8(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react@19.1.0):
     dependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       react: 19.1.0
 
-  expo-manifests@1.0.11(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)):
+  expo-manifests@1.0.11(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)):
     dependencies:
       '@expo/config': 12.0.13
-      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
+      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
       expo-json-utils: 0.15.0
     transitivePeerDependencies:
       - supports-color
 
-  expo-manifests@1.0.11(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)):
+  expo-manifests@1.0.11(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)):
     dependencies:
       '@expo/config': 12.0.13
-      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-json-utils: 0.15.0
     transitivePeerDependencies:
       - supports-color
@@ -35182,63 +35186,63 @@ snapshots:
       require-from-string: 2.0.2
       resolve-from: 5.0.0
 
-  expo-modules-core@3.0.30(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0):
+  expo-modules-core@3.0.30(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0):
     dependencies:
       invariant: 2.2.4
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
 
-  expo-modules-core@3.0.30(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0):
+  expo-modules-core@3.0.30(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0):
     dependencies:
       invariant: 2.2.4
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
 
   expo-server@1.0.7: {}
 
-  expo-status-bar@3.0.9(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0):
+  expo-status-bar@3.0.9(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0):
     dependencies:
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
-      react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
 
-  expo-status-bar@3.0.9(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0):
+  expo-status-bar@3.0.9(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0):
     dependencies:
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
-      react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
 
-  expo-updates-interface@2.0.0(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)):
+  expo-updates-interface@2.0.0(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)):
     dependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
+      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
 
-  expo-updates-interface@2.0.0(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)):
+  expo-updates-interface@2.0.0(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)):
     dependencies:
-      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
-  expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3):
+  expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3):
     dependencies:
       '@babel/runtime': 7.29.2
-      '@expo/cli': 54.0.25(bufferutil@4.0.9)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(typescript@5.7.3)
+      '@expo/cli': 54.0.25(bufferutil@4.0.9)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(typescript@5.7.3)
       '@expo/config': 12.0.13
       '@expo/config-plugins': 54.0.4
-      '@expo/devtools': 0.1.8(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
+      '@expo/devtools': 0.1.8(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
       '@expo/fingerprint': 0.15.5
       '@expo/metro': 54.2.0(bufferutil@4.0.9)
-      '@expo/metro-config': 54.0.16(bufferutil@4.0.9)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))
-      '@expo/vector-icons': 15.1.1(expo-font@14.0.12(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
+      '@expo/metro-config': 54.0.16(bufferutil@4.0.9)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))
+      '@expo/vector-icons': 15.1.1(expo-font@14.0.12(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
       '@ungap/structured-clone': 1.3.1
-      babel-preset-expo: 54.0.11(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-refresh@0.14.2)
-      expo-asset: 12.0.13(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
-      expo-constants: 18.0.13(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))
-      expo-file-system: 19.0.23(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))
-      expo-font: 14.0.12(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
-      expo-keep-awake: 15.0.8(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react@19.1.0)
+      babel-preset-expo: 54.0.11(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-refresh@0.14.2)
+      expo-asset: 12.0.13(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
+      expo-constants: 18.0.13(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))
+      expo-file-system: 19.0.23(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))
+      expo-font: 14.0.12(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
+      expo-keep-awake: 15.0.8(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(react@19.1.0)
       expo-modules-autolinking: 3.0.26
-      expo-modules-core: 3.0.30(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
+      expo-modules-core: 3.0.30(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
       pretty-format: 29.7.0
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
       react-refresh: 0.14.2
       whatwg-url-without-unicode: 8.0.0-3
     transitivePeerDependencies:
@@ -35250,29 +35254,29 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
+  expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
     dependencies:
       '@babel/runtime': 7.29.2
-      '@expo/cli': 54.0.25(bufferutil@4.0.9)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(typescript@5.9.3)
+      '@expo/cli': 54.0.25(bufferutil@4.0.9)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(typescript@5.9.3)
       '@expo/config': 12.0.13
       '@expo/config-plugins': 54.0.4
-      '@expo/devtools': 0.1.8(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
+      '@expo/devtools': 0.1.8(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
       '@expo/fingerprint': 0.15.5
       '@expo/metro': 54.2.0(bufferutil@4.0.9)
-      '@expo/metro-config': 54.0.16(bufferutil@4.0.9)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))
-      '@expo/vector-icons': 15.1.1(expo-font@14.0.12(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
+      '@expo/metro-config': 54.0.16(bufferutil@4.0.9)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))
+      '@expo/vector-icons': 15.1.1(expo-font@14.0.12(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
       '@ungap/structured-clone': 1.3.1
-      babel-preset-expo: 54.0.11(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-refresh@0.14.2)
-      expo-asset: 12.0.13(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      expo-constants: 18.0.13(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))
-      expo-file-system: 19.0.23(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))
-      expo-font: 14.0.12(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
-      expo-keep-awake: 15.0.8(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react@19.1.0)
+      babel-preset-expo: 54.0.11(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-refresh@0.14.2)
+      expo-asset: 12.0.13(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-constants: 18.0.13(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))
+      expo-file-system: 19.0.23(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))
+      expo-font: 14.0.12(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
+      expo-keep-awake: 15.0.8(expo@54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react@19.1.0)
       expo-modules-autolinking: 3.0.26
-      expo-modules-core: 3.0.30(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
+      expo-modules-core: 3.0.30(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
       pretty-format: 29.7.0
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
       react-refresh: 0.14.2
       whatwg-url-without-unicode: 8.0.0-3
     transitivePeerDependencies:
@@ -41118,26 +41122,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-native-is-edge-to-edge@1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0):
+  react-native-is-edge-to-edge@1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0):
     dependencies:
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
 
-  react-native-is-edge-to-edge@1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0):
+  react-native-is-edge-to-edge@1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0):
     dependencies:
       react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0)
 
-  react-native@0.81.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0):
+  react-native@0.81.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0):
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
       '@react-native/assets-registry': 0.81.1
       '@react-native/codegen': 0.81.1(@babel/core@7.29.0)
-      '@react-native/community-cli-plugin': 0.81.1(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(bufferutil@4.0.9)
+      '@react-native/community-cli-plugin': 0.81.1(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(bufferutil@4.0.9)
       '@react-native/gradle-plugin': 0.81.1
       '@react-native/js-polyfills': 0.81.1
       '@react-native/normalize-colors': 0.81.1
-      '@react-native/virtualized-lists': 0.81.1(@types/react@19.2.7)(react-native@0.81.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
+      '@react-native/virtualized-lists': 0.81.1(@types/react@19.2.7)(react-native@0.81.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
       abort-controller: 3.0.0
       anser: 1.4.10
       ansi-regex: 5.0.1
@@ -41175,16 +41179,16 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0):
+  react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0):
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
       '@react-native/assets-registry': 0.81.5
       '@react-native/codegen': 0.81.5(@babel/core@7.29.0)
-      '@react-native/community-cli-plugin': 0.81.5(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(bufferutil@4.0.9)
+      '@react-native/community-cli-plugin': 0.81.5(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(bufferutil@4.0.9)
       '@react-native/gradle-plugin': 0.81.5
       '@react-native/js-polyfills': 0.81.5
       '@react-native/normalize-colors': 0.81.5
-      '@react-native/virtualized-lists': 0.81.5(@types/react@19.2.7)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
+      '@react-native/virtualized-lists': 0.81.5(@types/react@19.2.7)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
       abort-controller: 3.0.0
       anser: 1.4.10
       ansi-regex: 5.0.1
@@ -41222,16 +41226,16 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0):
+  react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0):
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
       '@react-native/assets-registry': 0.81.5
       '@react-native/codegen': 0.81.5(@babel/core@7.29.0)
-      '@react-native/community-cli-plugin': 0.81.5(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(bufferutil@4.0.9)
+      '@react-native/community-cli-plugin': 0.81.5(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(bufferutil@4.0.9)
       '@react-native/gradle-plugin': 0.81.5
       '@react-native/js-polyfills': 0.81.5
       '@react-native/normalize-colors': 0.81.5
-      '@react-native/virtualized-lists': 0.81.5(@types/react@19.2.7)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
+      '@react-native/virtualized-lists': 0.81.5(@types/react@19.2.7)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)
       abort-controller: 3.0.0
       anser: 1.4.10
       ansi-regex: 5.0.1
@@ -41998,7 +42002,7 @@ snapshots:
 
   rollup-plugin-terser@7.0.2(rollup@2.80.0):
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       jest-worker: 26.6.2
       rollup: 2.80.0
       serialize-javascript: 4.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1574,12 +1574,6 @@ importers:
 
   packages/sanity:
     dependencies:
-      '@generaltranslation/api':
-        specifier: workspace:*
-        version: link:../api
-      '@generaltranslation/format':
-        specifier: workspace:*
-        version: link:../format
       '@portabletext/block-tools':
         specifier: ^5.1.1
         version: 5.1.1(@types/react@19.2.7)

--- a/scripts/check-library-defaults.mjs
+++ b/scripts/check-library-defaults.mjs
@@ -40,14 +40,10 @@ export function normalizeRepositoryPath(relativePath) {
 
 export const defaultGroups = [
   {
-    // The API package owns the pinned gt-api-version contract value. Core's
-    // copy stays synchronized until it migrates to re-export from
-    // @generaltranslation/api.
+    // The API package owns the pinned gt-api-version contract value; core
+    // re-exports it from @generaltranslation/api.
     name: 'API_VERSION',
-    declarations: [
-      'packages/api/src/wrappers/client.ts',
-      'packages/core/src/translate/api.ts',
-    ],
+    declarations: ['packages/api/src/wrappers/client.ts'],
     exceptions: [],
   },
   {


### PR DESCRIPTION
**Stacked on #2180 (stack 4/4).**

## Outcome

Adds `gt api [endpoint]`, modeled on `gh api`, for raw authenticated API access so agents can inspect the OpenAPI specification and call endpoints directly.

- `-X, --method <method>` selects the HTTP method.
- `--input <file>` reads the request body from a file, or from standard input with `-`.
- `-H, --header <header>` adds repeatable request headers.
- `-i, --include` includes response status and headers.
- `--spec` prints the bundled OpenAPI specification.
- Raw calls use `retryPolicy: 'none'`, write the raw response body to stdout, and write an error summary to stderr with exit status 1 for non-2xx responses.

Also exports the specification as `@generaltranslation/api/spec/openapi.json`.

## Verification

- `pnpm exec turbo build --filter=gt --filter=@generaltranslation/api` — 9/9 tasks passed.
- `cd packages/cli && npx vitest run` — 120 files, 2266 tests passed.
- `cd packages/api && npx vitest run` — 1 file, 21 tests passed.
- `pnpm --filter gt lint` — exited 0 (the package has no lint script); direct `pnpm exec oxlint` and `pnpm exec oxfmt --check` checks passed for the changed CLI files.
- `pnpm --filter gt build:bin:darwin-arm64 && packages/cli/binaries/gt-darwin-arm64 api --spec` — binary built and printed the bundled OpenAPI 3.1 specification (175450 bytes), exit 0.
- `node packages/cli/bin/main.js api --help` — exit 0.
- `node packages/cli/bin/main.js api --spec` — printed the OpenAPI 3.1 specification (175450 bytes), exit 0.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a shared `gt api` command for authenticated raw API requests and exports the bundled OpenAPI specification from `@generaltranslation/api`.

The built CLI was exercised against a local HTTP server using synthetic credentials. It preserved endpoint query strings and request-body bytes, sent the expected authentication and project headers, combined repeated headers, forwarded binary responses unchanged, printed metadata with `--include`, returned the response body and a failing exit status for HTTP 404 responses, and emitted a valid OpenAPI 3.1.0 document with `gt api --spec`.

No review comments were identified.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change is safe to merge based on successful typechecking and local end-to-end coverage of the new command's request and response behavior.

The completed checks exercised authenticated requests, query preservation, repeatable headers, file body forwarding, binary responses, response metadata, HTTP-error handling, and specification output without finding a defect.

**Files Needing Attention:** No files need follow-up attention.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The built GT CLI was run against a local HTTP stub with synthetic credentials to validate request handling.
- The stub observed the expected POST /v2/echo?tag=one&tag=two&empty= with Authorization: Bearer \[REDACTED\], gt-project-id: local-project, repeated header value first, second, and the exact input bytes, and the 404 path emitted a diagnostic and exited with code 1.
- The API specification was generated with gt api --spec, producing an OpenAPI 3.1.0 document with 24 paths.
- Typechecking the gt package completed successfully.
- Artifacts documenting the stub script, the stub-run output, and the typecheck result were created and linked to the review.

<a href="https://app.greptile.com/trex/runs/20725724/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): address gt api review findings"](https://github.com/generaltranslation/gt/commit/e69cf7f3a792f3e7ff2d269aa41738d75d911ee7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56918028)</sub>

<!-- /greptile_comment -->


### Topology rework (2026-08-27)

Core is now the single entry point: CLI and Sanity consume the generated SDK through the new `generaltranslation/api` subpath instead of direct `@generaltranslation/api` dependencies. The separate `@generaltranslation/utils` package has been abandoned (#2187 closed); shared diagnostics, base64, and file-content helpers remain canonical in core. Reviewers should re-check the dependency edges.
